### PR TITLE
Computing some counts for the vaxrank report in the core logic

### DIFF
--- a/test/test_mutant_protein_sequence.py
+++ b/test/test_mutant_protein_sequence.py
@@ -57,7 +57,7 @@ def test_mutant_amino_acids_in_mm10_chrX_8125624_refC_altA_pS460I():
         "--bam", data_path("b16.f10/b16.combined.sorted.bam"),
     ])
     reads_generator = allele_reads_generator_from_args(args)
-    ranked_list = ranked_vaccine_peptides(
+    ranked_list, _ = ranked_vaccine_peptides(
         reads_generator=reads_generator,
         mhc_predictor=RandomBindingPredictor(["H-2-Kb", "H-2-Db"]),
         vaccine_peptide_length=15,
@@ -88,7 +88,7 @@ def test_mutant_amino_acids_in_mm10_chr9_82927102_refGT_altTG_pT441H():
         "--bam", data_path("b16.f10/b16.combined.sorted.bam"),
     ])
     reads_generator = allele_reads_generator_from_args(args)
-    ranked_list = ranked_vaccine_peptides(
+    ranked_list, _ = ranked_vaccine_peptides(
         reads_generator=reads_generator,
         mhc_predictor=RandomBindingPredictor(["H-2-Kb", "H-2-Db"]),
         vaccine_peptide_length=15,
@@ -114,7 +114,7 @@ def test_keep_top_k_epitopes():
     reads_generator = allele_reads_generator_from_args(args)
 
     keep_k_epitopes = 3
-    ranked_list = ranked_vaccine_peptides(
+    ranked_list, _ = ranked_vaccine_peptides(
         reads_generator=reads_generator,
         mhc_predictor=RandomBindingPredictor(["H-2-Kb", "H-2-Db"]),
         vaccine_peptide_length=15,

--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -206,7 +206,7 @@ def add_vaccine_peptide_args(arg_parser):
 
     vaccine_peptide_group.add_argument(
         "--min-epitope-score",
-        default=0.001,
+        default=1e-10,
         type=float,
         help="Ignore epitopes whose normalized score falls below this threshold")
 

--- a/vaxrank/cli.py
+++ b/vaxrank/cli.py
@@ -268,7 +268,7 @@ def ranked_variant_list_with_metadata(args):
     reads_generator = allele_reads_generator_from_args(args)
     mhc_predictor = mhc_binding_predictor_from_args(args)
 
-    ranked_list = ranked_vaccine_peptides(
+    ranked_list, variants_count_dict = ranked_vaccine_peptides(
         reads_generator=reads_generator,
         mhc_predictor=mhc_predictor,
         vaccine_peptide_length=args.vaccine_peptide_length,
@@ -282,15 +282,15 @@ def ranked_variant_list_with_metadata(args):
 
     ranked_list_for_report = ranked_list[:args.max_mutations_in_report]
 
-    num_coding_effect_variants = len(
-        variants.effects().drop_silent_and_noncoding().groupby_variant())
     patient_info = PatientInfo(
         patient_id=args.output_patient_id,
         vcf_paths=variants.sources,
         bam_path=args.bam,
         mhc_alleles=mhc_alleles,
         num_somatic_variants=len(variants),
-        num_coding_effect_variants=num_coding_effect_variants,
+        num_coding_effect_variants=variants_count_dict['num_coding_effect_variants'],
+        num_variants_with_rna_support=variants_count_dict['num_variants_with_rna_support'],
+        num_variants_with_vaccine_peptides=variants_count_dict['num_variants_with_vaccine_peptides']
     )
 
     # return variants, patient info, and command-line args

--- a/vaxrank/core_logic.py
+++ b/vaxrank/core_logic.py
@@ -180,7 +180,7 @@ def generate_vaccine_peptides(
         # do any of this variant's vaccine peptides contain mutant epitopes?
         any_mutant_epitopes = False
         for vaccine_peptide in vaccine_peptides:
-            if vaccine_peptide.contains_epitopes():
+            if vaccine_peptide.contains_mutant_epitopes():
                 any_mutant_epitopes = True
                 break
         if any_mutant_epitopes:
@@ -207,7 +207,8 @@ def ranked_vaccine_peptides(
     Returns a tuple of two values:
     - sorted list whose first element is a Variant and whose second
     element is a list of VaccinePeptide objects
-    - dictionary containing some variant counts for report display
+    - dictionary containing "funnel" variant counts for report display. Keys are e.g.
+    "num_variants_with_rna_support", values are integer counts.
     """
     variants_to_vaccine_peptides_dict, variant_counts_dict = generate_vaccine_peptides(
         reads_generator=reads_generator,
@@ -221,6 +222,7 @@ def ranked_vaccine_peptides(
         num_mutant_epitopes_to_keep=num_mutant_epitopes_to_keep,
         min_epitope_score=min_epitope_score)
     result_list = list(variants_to_vaccine_peptides_dict.items())
+    # TODO: move this sort key into its own function, also make less nuts
     result_list.sort(
         key=lambda x: x[1][0].combined_score if len(x[1]) > 0 else 0.0,
         reverse=True)

--- a/vaxrank/core_logic.py
+++ b/vaxrank/core_logic.py
@@ -156,7 +156,8 @@ def generate_vaccine_peptides(
     result_dict = {}
     counts_dict = defaultdict(int)
     for variant, isovar_protein_sequences in protein_sequences_generator:
-        counts_dict['num_coding_effect_variants'] += 1
+        if len(variant.effects().drop_silent_and_noncoding()) > 0:
+            counts_dict['num_coding_effect_variants'] += 1
         isovar_protein_sequences = list(isovar_protein_sequences)
         if len(isovar_protein_sequences) == 0:
             # this means the variant RNA support is below threshold

--- a/vaxrank/core_logic.py
+++ b/vaxrank/core_logic.py
@@ -176,7 +176,13 @@ def generate_vaccine_peptides(
             num_mutant_epitopes_to_keep=num_mutant_epitopes_to_keep,
             min_epitope_score=min_epitope_score)
 
-        if len(vaccine_peptides) > 0:
+        # do any of this variant's vaccine peptides contain mutant epitopes?
+        any_mutant_epitopes = False
+        for vaccine_peptide in vaccine_peptides:
+            if vaccine_peptide.contains_epitopes():
+                any_mutant_epitopes = True
+                break
+        if any_mutant_epitopes:
             counts_dict['num_variants_with_vaccine_peptides'] += 1
         result_dict[variant] = vaccine_peptides
 

--- a/vaxrank/epitope_prediction.py
+++ b/vaxrank/epitope_prediction.py
@@ -47,7 +47,7 @@ class EpitopePrediction(EpitopePredictionBase):
             self,
             midpoint=350.0,
             width=150.0,
-            ic50_cutoff=2000.0):
+            ic50_cutoff=3000.0):
         """
         Map from IC50 values to score where 1.0 = strong binder, 0.0 = weak binder
         Default midpoint and width for logistic determined by max likelihood fit

--- a/vaxrank/epitope_prediction.py
+++ b/vaxrank/epitope_prediction.py
@@ -47,7 +47,7 @@ class EpitopePrediction(EpitopePredictionBase):
             self,
             midpoint=350.0,
             width=150.0,
-            ic50_cutoff=5000.0):
+            ic50_cutoff=5000.0):  # TODO: add these default values into CLI as arguments
         """
         Map from IC50 values to score where 1.0 = strong binder, 0.0 = weak binder
         Default midpoint and width for logistic determined by max likelihood fit

--- a/vaxrank/epitope_prediction.py
+++ b/vaxrank/epitope_prediction.py
@@ -47,7 +47,7 @@ class EpitopePrediction(EpitopePredictionBase):
             self,
             midpoint=350.0,
             width=150.0,
-            ic50_cutoff=3000.0):
+            ic50_cutoff=5000.0):
         """
         Map from IC50 values to score where 1.0 = strong binder, 0.0 = weak binder
         Default midpoint and width for logistic determined by max likelihood fit

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -122,7 +122,7 @@ class TemplateDataCreator(object):
         """
         variant_data = OrderedDict()
         mutant_protein_fragment = top_vaccine_peptide.mutant_protein_fragment
-        top_score = round(top_vaccine_peptide.combined_score, 7)
+        top_score = _sanitize(top_vaccine_peptide.combined_score)
         variant_data = OrderedDict([
             ('Gene name', mutant_protein_fragment.gene_name),
             ('Top score', top_score),
@@ -189,9 +189,9 @@ class TemplateDataCreator(object):
         peptide_data = OrderedDict([
             ('Transcript name', transcript_name),
             ('Length', len(amino_acids)),
-            ('Expression score', round(vaccine_peptide.expression_score, 7)),
-            ('Mutant epitope score', round(vaccine_peptide.mutant_epitope_score, 7)),
-            ('Combined score', round(vaccine_peptide.combined_score, 7)),
+            ('Expression score', _sanitize(vaccine_peptide.expression_score)),
+            ('Mutant epitope score', _sanitize(vaccine_peptide.mutant_epitope_score)),
+            ('Combined score', _sanitize(vaccine_peptide.combined_score)),
             ('Max coding sequence coverage',
                 mutant_protein_fragment.n_alt_reads_supporting_protein_sequence),
             ('Mutant amino acids', mutant_protein_fragment.n_mutant_amino_acids),
@@ -206,8 +206,8 @@ class TemplateDataCreator(object):
         """
         scores = vaccine_peptide.manufacturability_scores
         manufacturability_data = OrderedDict([
-            ('C-terminal 7mer GRAVY score', round(scores.cterm_7mer_gravy_score, 7)),
-            ('Max 7mer GRAVY score', round(scores.max_7mer_gravy_score, 7)),
+            ('C-terminal 7mer GRAVY score', _sanitize(scores.cterm_7mer_gravy_score)),
+            ('Max 7mer GRAVY score', _sanitize(scores.max_7mer_gravy_score)),
             ('N-terminal Glutamine, Glutamic Acid, or Cysteine',
                 int(scores.difficult_n_terminal_residue)),
             ('C-terminal Cysteine', int(scores.c_terminal_cysteine)),
@@ -230,8 +230,7 @@ class TemplateDataCreator(object):
         epitope_data = OrderedDict([
             ('Sequence', epitope_prediction.peptide_sequence),
             ('IC50', '%.2f nM' % epitope_prediction.ic50),
-            ('Score', round(
-                epitope_prediction.logistic_epitope_score(), 7)),
+            ('Score', _sanitize(epitope_prediction.logistic_epitope_score())),
             ('Allele', epitope_prediction.allele.replace('HLA-', '')),
             ('WT sequence', epitope_prediction.wt_peptide_sequence),
             ('WT IC50', wt_ic50_str),
@@ -455,7 +454,7 @@ def _sanitize(val):
     if type(val) == bool:
         val = int(val)
     elif type(val) == float:
-        val = round(val, 7)
+        val = round(val, 10)
     return val
 
 def resize_columns(worksheet, amino_acids_col, pos_col):
@@ -561,9 +560,9 @@ def make_csv_report(
                 vaccine_peptide.mutant_protein_fragment.mutant_amino_acid_start_offset)
             columns["mutation_end"].append(
                 vaccine_peptide.mutant_protein_fragment.mutant_amino_acid_end_offset)
-            columns["combined_score"].append(round(vaccine_peptide.combined_score, 7))
-            columns["expression_score"].append(round(vaccine_peptide.expression_score, 7))
-            columns["mutant_epitope_score"].append(round(vaccine_peptide.mutant_epitope_score, 7))
+            columns["combined_score"].append(_sanitize(vaccine_peptide.combined_score))
+            columns["expression_score"].append(_sanitize(vaccine_peptide.expression_score))
+            columns["mutant_epitope_score"].append(_sanitize(vaccine_peptide.mutant_epitope_score))
             for field in ManufacturabilityScores._fields:
                 columns[field].append(
                     _sanitize(getattr(vaccine_peptide.manufacturability_scores, field)))

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -111,7 +111,7 @@ class TemplateDataCreator(object):
             ('Somatic variants with predicted coding effects and RNA support',
                 self.patient_info.num_variants_with_rna_support),
             ('Somatic variants with predicted coding effects, RNA support and predicted MHC '
-                'expression',
+                'ligands',
                 self.patient_info.num_variants_with_vaccine_peptides),
         ])
         return patient_info
@@ -126,9 +126,9 @@ class TemplateDataCreator(object):
         variant_data = OrderedDict([
             ('Gene name', mutant_protein_fragment.gene_name),
             ('Top score', top_score),
-            ('Reads supporting variant allele', mutant_protein_fragment.n_alt_reads),
-            ('Reads supporting reference allele', mutant_protein_fragment.n_ref_reads),
-            ('Reads supporting other alleles', mutant_protein_fragment.n_other_reads),
+            ('RNA reads supporting variant allele', mutant_protein_fragment.n_alt_reads),
+            ('RNA reads supporting reference allele', mutant_protein_fragment.n_ref_reads),
+            ('RNA reads supporting other alleles', mutant_protein_fragment.n_other_reads),
         ])
         return variant_data
 
@@ -309,7 +309,7 @@ class TemplateDataCreator(object):
 
             peptides = []
             for j, vaccine_peptide in enumerate(vaccine_peptides):
-                if not vaccine_peptide.contains_epitopes():
+                if not vaccine_peptide.contains_mutant_epitopes():
                     logger.info('No epitopes for peptide: %s', vaccine_peptide)
                     continue
 
@@ -545,7 +545,7 @@ def make_csv_report(
         for j, vaccine_peptide in enumerate(vaccine_peptides):
 
             # if there are no predicted epitopes, exclude this peptide from the report
-            if not vaccine_peptide.contains_epitopes():
+            if not vaccine_peptide.contains_mutant_epitopes():
                 logger.info('No epitopes for peptide: %s', vaccine_peptide)
                 continue
 

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -51,6 +51,8 @@ PatientInfo = namedtuple("PatientInfo", (
     "mhc_alleles",
     "num_somatic_variants",
     "num_coding_effect_variants",
+    "num_variants_with_rna_support",
+    "num_variants_with_vaccine_peptides",
 ))
 
 
@@ -106,6 +108,11 @@ class TemplateDataCreator(object):
             ('Total number of somatic variants', self.patient_info.num_somatic_variants),
             ('Somatic variants with predicted coding effects',
                 self.patient_info.num_coding_effect_variants),
+            ('Somatic variants with predicted coding effects and RNA support',
+                self.patient_info.num_variants_with_rna_support),
+            ('Somatic variants with predicted coding effects, RNA support and predicted MHC '
+                'expression',
+                self.patient_info.num_variants_with_vaccine_peptides),
         ])
         return patient_info
 
@@ -372,6 +379,7 @@ class TemplateDataCreator(object):
             'variants': variants,
             'package_versions': package_versions,
         })
+
         return self.template_data
 
 

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -122,7 +122,7 @@ class TemplateDataCreator(object):
         """
         variant_data = OrderedDict()
         mutant_protein_fragment = top_vaccine_peptide.mutant_protein_fragment
-        top_score = round(top_vaccine_peptide.combined_score, 4)
+        top_score = round(top_vaccine_peptide.combined_score, 7)
         variant_data = OrderedDict([
             ('Gene name', mutant_protein_fragment.gene_name),
             ('Top score', top_score),
@@ -189,9 +189,9 @@ class TemplateDataCreator(object):
         peptide_data = OrderedDict([
             ('Transcript name', transcript_name),
             ('Length', len(amino_acids)),
-            ('Expression score', round(vaccine_peptide.expression_score, 4)),
-            ('Mutant epitope score', round(vaccine_peptide.mutant_epitope_score, 4)),
-            ('Combined score', round(vaccine_peptide.combined_score, 4)),
+            ('Expression score', round(vaccine_peptide.expression_score, 7)),
+            ('Mutant epitope score', round(vaccine_peptide.mutant_epitope_score, 7)),
+            ('Combined score', round(vaccine_peptide.combined_score, 7)),
             ('Max coding sequence coverage',
                 mutant_protein_fragment.n_alt_reads_supporting_protein_sequence),
             ('Mutant amino acids', mutant_protein_fragment.n_mutant_amino_acids),
@@ -206,8 +206,8 @@ class TemplateDataCreator(object):
         """
         scores = vaccine_peptide.manufacturability_scores
         manufacturability_data = OrderedDict([
-            ('C-terminal 7mer GRAVY score', round(scores.cterm_7mer_gravy_score, 4)),
-            ('Max 7mer GRAVY score', round(scores.max_7mer_gravy_score, 4)),
+            ('C-terminal 7mer GRAVY score', round(scores.cterm_7mer_gravy_score, 7)),
+            ('Max 7mer GRAVY score', round(scores.max_7mer_gravy_score, 7)),
             ('N-terminal Glutamine, Glutamic Acid, or Cysteine',
                 int(scores.difficult_n_terminal_residue)),
             ('C-terminal Cysteine', int(scores.c_terminal_cysteine)),
@@ -231,7 +231,7 @@ class TemplateDataCreator(object):
             ('Sequence', epitope_prediction.peptide_sequence),
             ('IC50', '%.2f nM' % epitope_prediction.ic50),
             ('Score', round(
-                epitope_prediction.logistic_epitope_score(), 4)),
+                epitope_prediction.logistic_epitope_score(), 7)),
             ('Allele', epitope_prediction.allele.replace('HLA-', '')),
             ('WT sequence', epitope_prediction.wt_peptide_sequence),
             ('WT IC50', wt_ic50_str),
@@ -455,7 +455,7 @@ def _sanitize(val):
     if type(val) == bool:
         val = int(val)
     elif type(val) == float:
-        val = round(val, 4)
+        val = round(val, 7)
     return val
 
 def resize_columns(worksheet, amino_acids_col, pos_col):
@@ -561,9 +561,9 @@ def make_csv_report(
                 vaccine_peptide.mutant_protein_fragment.mutant_amino_acid_start_offset)
             columns["mutation_end"].append(
                 vaccine_peptide.mutant_protein_fragment.mutant_amino_acid_end_offset)
-            columns["combined_score"].append(round(vaccine_peptide.combined_score, 4))
-            columns["expression_score"].append(round(vaccine_peptide.expression_score, 4))
-            columns["mutant_epitope_score"].append(round(vaccine_peptide.mutant_epitope_score, 4))
+            columns["combined_score"].append(round(vaccine_peptide.combined_score, 7))
+            columns["expression_score"].append(round(vaccine_peptide.expression_score, 7))
+            columns["mutant_epitope_score"].append(round(vaccine_peptide.mutant_epitope_score, 7))
             for field in ManufacturabilityScores._fields:
                 columns[field].append(
                     _sanitize(getattr(vaccine_peptide.manufacturability_scores, field)))

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -310,7 +310,7 @@ class TemplateDataCreator(object):
 
             peptides = []
             for j, vaccine_peptide in enumerate(vaccine_peptides):
-                if not peptide_contains_epitopes(vaccine_peptide):
+                if not vaccine_peptide.contains_epitopes():
                     logger.info('No epitopes for peptide: %s', vaccine_peptide)
                     continue
 
@@ -379,7 +379,6 @@ class TemplateDataCreator(object):
             'variants': variants,
             'package_versions': package_versions,
         })
-
         return self.template_data
 
 
@@ -467,12 +466,6 @@ def resize_columns(worksheet, amino_acids_col, pos_col):
     worksheet.set_column('%s:%s' % (amino_acids_col, amino_acids_col), 40)
     worksheet.set_column('%s:%s' % (pos_col, pos_col), 12)
 
-
-def peptide_contains_epitopes(vaccine_peptide):
-    """Returns true if vaccine peptide contains mutant epitopes."""
-    return len(vaccine_peptide.mutant_epitope_predictions) > 0
-
-
 def make_minimal_neoepitope_report(
         ranked_variants_with_vaccine_peptides,
         num_epitopes_per_peptide=None,
@@ -553,7 +546,7 @@ def make_csv_report(
         for j, vaccine_peptide in enumerate(vaccine_peptides):
 
             # if there are no predicted epitopes, exclude this peptide from the report
-            if not peptide_contains_epitopes(vaccine_peptide):
+            if not vaccine_peptide.contains_epitopes():
                 logger.info('No epitopes for peptide: %s', vaccine_peptide)
                 continue
 

--- a/vaxrank/vaccine_peptide.py
+++ b/vaxrank/vaccine_peptide.py
@@ -177,8 +177,7 @@ class VaccinePeptide(VaccinePeptideBase):
             extra_score_tuple
         )
 
-    def contains_epitopes(self):
-        """Returns true if this vaccine peptide contains mutant epitopes."""
+    def contains_mutant_epitopes(self):
         return len(self.mutant_epitope_predictions) > 0
 
     @property

--- a/vaxrank/vaccine_peptide.py
+++ b/vaxrank/vaccine_peptide.py
@@ -42,8 +42,7 @@ class VaccinePeptide(VaccinePeptideBase):
             cls,
             mutant_protein_fragment,
             epitope_predictions,
-            num_mutant_epitopes_to_keep=10000,
-            min_epitope_score=0):
+            num_mutant_epitopes_to_keep=10000):
         # only keep the top k epitopes
         mutant_epitope_predictions = sorted([
             p for p in epitope_predictions if p.overlaps_mutation and not p.occurs_in_reference
@@ -177,6 +176,10 @@ class VaccinePeptide(VaccinePeptideBase):
             manufacturability_score_tuple +
             extra_score_tuple
         )
+
+    def contains_epitopes(self):
+        """Returns true if this vaccine peptide contains mutant epitopes."""
+        return len(self.mutant_epitope_predictions) > 0
 
     @property
     def expression_score(self):


### PR DESCRIPTION
- number of coding effect variants (moving from the CLI hack)
- number of coding effect variants with RNA support
- number of coding effect variants with RNA support and predicted MHC expression

(This is a somewhat hacky change, meant to be relatively surgical/few LOC. The better way of doing this would involve a larger refactor of how we process variants and store data about them, for another day)

Fixes #144 