### PR TITLE
Add --download-reference-genome-data arg to Vaxrank test run script.

### DIFF
--- a/run-vaxrank-b16-test-data.sh
+++ b/run-vaxrank-b16-test-data.sh
@@ -1,4 +1,5 @@
 vaxrank \
+    --download-reference-genome-data \
     --vcf test/data/b16.f10/b16.vcf \
     --bam test/data/b16.f10/b16.combined.bam \
     --vaccine-peptide-length 15 \

--- a/vaxrank/templates/stylesheet.css
+++ b/vaxrank/templates/stylesheet.css
@@ -11,6 +11,7 @@ table, table.th, table.td {
 /* Various headers */
 #report-header {
 	padding-bottom: 1em;
+	margin-top: -2em;
 }
 
 #patient-info {


### PR DESCRIPTION
Also update a CSS param for the PDF report (small whitespace change)