### PR TITLE
Make Vaxrank's epitope/vaccine peptide scoring/filtering/ranking more configurable via YAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-six
-numpy>=1.14.0
-pandas
-pyensembl>=1.5.0
-varcode>=0.5.9
-isovar>=1.1.1
-mhctools>=1.5.0
+numpy>=1.14.0,<2.0.0
+pandas>=2.1.4,<3.0.0
+pyensembl>=2.0.0,<3.0.0
+varcode>=1.1.0,<2.0.0
+isovar>=1.3.0,<2.0.0
+mhctools>=1.8.2,<2.0.0
 roman
 jinja2<3.1
 pdfkit  # needs wkhtmltopdf: brew install Caskroom/cask/wkhtmltopdf
@@ -17,3 +16,4 @@ future>=0.16.0  # needed by pylint
 astropy
 datacache
 pysam>=0.15.2
+msgspec>=0.18.6,<1.0.0

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ with open('vaxrank/__init__.py', 'r') as f:
         f.read(),
         re.MULTILINE).group(1)
 
+with open("requirements.txt")  as f:
+    requirements = [req.strip() for req in f.read().splitlines() if req.strip()]
+
 if not version:
     raise RuntimeError("Cannot find version information")
 
@@ -56,25 +59,7 @@ if __name__ == '__main__':
             'Programming Language :: Python',
             'Topic :: Scientific/Engineering :: Bio-Informatics',
         ],
-        install_requires=[
-            'numpy>=1.14.0,<2.0.0',
-            'pandas>=2.1.4,<3.0.0',
-            'pyensembl>=2.0.0,<3.0.0',
-            'varcode>=1.1.0,<2.0.0',
-            'isovar>=1.3.0,<2.0.0',
-            'mhctools>=1.8.2,<2.0.0',
-            'roman',
-            'jinja2<3.1',
-            'pdfkit',
-            'pypandoc',
-            'shellinford>=0.3.4',
-            'xlrd>=1.0.0,<2.0.0',
-            'xlsxwriter',
-            'xvfbwrapper',
-            'future>=0.16.0',  # needed by pylint
-            'astropy',
-        ],
-
+        install_requires=requirements,
         long_description=readme_markdown,
         long_description_content_type='text/markdown',
         packages=['vaxrank'],

--- a/vaxrank/config.py
+++ b/vaxrank/config.py
@@ -1,0 +1,11 @@
+import msgspec
+
+class Confiug(msgspec.Struct):
+
+    """Parameters for score, filtering, and ranking both epitopes and vaccine peptides"""
+    logistic_epitope_score_midpoint : float =350.0
+    logistic_epitope_score_width : float = 150.0
+    
+    min_epitope_score : float = 0.0
+    binding_affinity_cutoff : float = 5000.0
+    


### PR DESCRIPTION
Vaxrank is currently configured via a mix of commandline arguments, options only accessible within the Python API, and some hardcoded assumptions. 

The purpose of this PR is to reify all options related to scoring/filtering/ranking of epitope predictions and vaccine peptides in a single YAML file which can be thought of as the vaccine selection logic for an experiment or trial. 

