### PR TITLE
Add weasyprint as experimental PDF backend

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,11 +57,14 @@ jobs:
           # once pysam >=0.24 is out.
           pip install --no-binary pysam --force-reinstall \
             git+https://github.com/pysam-developers/pysam.git
-      - name: Install wkthtmltopdf
+      - name: Install wkhtmltopdf
         run: |
           sudo apt-get install -y xfonts-base xfonts-75dpi
           wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
           sudo dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb
+      - name: Install weasyprint system dependencies
+        run: |
+          sudo apt-get install -y libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0
       - name: Lint with Ruff
         run: |
           ./lint.sh

--- a/README.md
+++ b/README.md
@@ -264,19 +264,21 @@ Use `--mhc-predictor <name>` to select one:
 
 ## How It Works
 
-### Pipeline
+### Upstream inputs
 
-Vaxrank sits at the end of a data-processing chain.  Upstream tools
-handle alignment and variant calling; Vaxrank takes their outputs and
-produces vaccine peptide candidates:
+Vaxrank does not perform variant calling or read alignment itself.
+Those steps happen upstream, typically as part of a larger
+bioinformatics pipeline (e.g.
+[neoantigen-vaccine-pipeline](https://github.com/openvax/neoantigen-vaccine-pipeline)):
 
-```
-Tumor DNA-seq ──► Variant Caller ──► VCF ─────────────────────────┐
-                                                                   ▼
-Tumor RNA-seq ──► Aligner ──► BAM ──► Isovar ──► Mutant protein   ├──► Vaxrank ──► Report
-                                      fragments                   │
-Patient HLA typing ────────────────────────────────────────────────┘
-```
+1. Tumor and matched-normal DNA are sequenced and aligned; a variant
+   caller (MuTect, Strelka, etc.) produces a VCF of somatic mutations.
+2. Tumor RNA is sequenced and aligned to produce a BAM file.
+3. The patient's HLA class I alleles are typed (from sequencing data or
+   clinical records).
+
+Vaxrank takes these three inputs — the VCF, the tumor RNA BAM, and the
+HLA alleles — and produces a ranked list of vaccine peptide candidates.
 
 ### Mutant transcript assembly (Isovar)
 

--- a/README.md
+++ b/README.md
@@ -114,11 +114,19 @@ pyensembl install --release 113 --species human
 pyensembl install --release 75 --species human
 ```
 
-To generate PDF reports you also need
-[wkhtmltopdf](http://wkhtmltopdf.org/):
+PDF report generation uses [wkhtmltopdf](http://wkhtmltopdf.org/) by default:
 
 ```
 brew install --cask wkhtmltopdf
+```
+
+Alternatively, pass `--pdf-backend=weasyprint` to use
+[WeasyPrint](https://weasyprint.org/) (experimental), which has no external
+binary dependency:
+
+```
+pip install weasyprint
+# macOS also needs: brew install pango
 ```
 
 ## Configuration
@@ -377,7 +385,7 @@ Vaxrank is built on the [OpenVax](https://github.com/openvax) ecosystem:
 Other key dependencies:
 - `msgspec`: Configuration serialization (YAML/JSON)
 - `pandas`, `numpy`: Data processing
-- `jinja2`, `pdfkit`: Report generation
+- `jinja2`, `pdfkit`/`weasyprint`: Report generation
 
 ## Development
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,10 @@ mhctools>=3.5.0,<4.0.0
 topiary>=4.2.0,<5.0.0
 roman
 jinja2>=3.1
-pdfkit  # needs wkhtmltopdf: brew install Caskroom/cask/wkhtmltopdf
+weasyprint>=62.0
+pdfkit  # legacy: needs wkhtmltopdf, use --pdf-backend=pdfkit to enable
 openpyxl
-xvfbwrapper
+xvfbwrapper  # legacy: only needed with --pdf-backend=pdfkit on headless Linux
 astropy>=6.1
 platformdirs
 pysam>=0.23.0

--- a/tests/test_shell_script.py
+++ b/tests/test_shell_script.py
@@ -147,9 +147,13 @@ def test_html_report():
         assert len(lines) > 1
 
 
-def test_pdf_report():
-    with NamedTemporaryFile(mode="rb") as f:
-        pdf_args = cli_args_for_b16_seqdata + ["--output-pdf-report", f.name]
+@pytest.mark.parametrize("backend", ["weasyprint", "pdfkit"])
+def test_pdf_report(backend):
+    with NamedTemporaryFile(mode="rb", suffix=".pdf") as f:
+        pdf_args = cli_args_for_b16_seqdata + [
+            "--output-pdf-report", f.name,
+            "--pdf-backend", backend,
+        ]
         run_shell_script(pdf_args)
         assert getsize(f.name) > 1
 

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -164,6 +164,13 @@ def add_output_args(arg_parser):
         help="Path to PDF vaccine peptide report")
 
     output_args_group.add_argument(
+        "--pdf-backend",
+        choices=["pdfkit", "weasyprint"],
+        default="pdfkit",
+        help="Library to use for PDF generation. 'weasyprint' is experimental "
+             "and does not require wkhtmltopdf (default: pdfkit)")
+
+    output_args_group.add_argument(
         "--output-json-file",
         default="",
         help="Path to JSON file containing results of vaccine peptide report")

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -247,7 +247,8 @@ def main(args_list=None):
     if args.output_pdf_report:
         make_pdf_report(
             template_data=template_data,
-            pdf_report_path=args.output_pdf_report)
+            pdf_report_path=args.output_pdf_report,
+            backend=args.pdf_backend)
 
 
 def run_vaxrank_from_parsed_args(args):

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -20,7 +20,6 @@ import tempfile
 from astropy.io import ascii as asc
 import jinja2
 import pandas as pd
-import pdfkit
 import roman
 from varcode import load_vcf_fast
 
@@ -382,30 +381,47 @@ def make_html_report(
         _make_report(template_data, f, 'templates/template.html')
     logger.info('Wrote HTML report to %s', html_report_path)
 
+def _pdf_via_pdfkit(html_path, pdf_report_path):
+    import pdfkit
+
+    options = {
+        'zoom': 0.55,
+        'margin-top': '20mm'
+    }
+
+    if sys.platform in ('linux', 'linux2'):
+        # pdfkit uses wkhtmltopdf, which doesn't work on headless servers;
+        # recommended workaround is to use xvfb, as documented here:
+        # https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2037#issuecomment-62019521
+        from xvfbwrapper import Xvfb
+        logger.info('Running pdfkit inside xvfb wrapper')
+        with Xvfb():
+            pdfkit.from_file(html_path, pdf_report_path, options=options)
+    else:
+        pdfkit.from_file(html_path, pdf_report_path, options=options)
+
+
+def _pdf_via_weasyprint(html_path, pdf_report_path):
+    import weasyprint
+    doc = weasyprint.HTML(filename=html_path)
+    doc.write_pdf(pdf_report_path)
+
+
 def make_pdf_report(
         template_data,
-        pdf_report_path):
+        pdf_report_path,
+        backend='pdfkit'):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.html') as f:
         _make_report(template_data, f, 'templates/template.html')
         f.flush()
 
-        options = {
-            'zoom': 0.55,
-            'margin-top': '20mm'
-        }
-
-        if sys.platform in ('linux', 'linux2'):
-            # pdfkit uses wkhtmltopdf, which doesn't work on headless servers;
-            # recommended workaround is to use xvfb, as documented here:
-            # https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2037#issuecomment-62019521
-            from xvfbwrapper import Xvfb
-            logger.info('Running pdfkit inside xvfb wrapper')
-            with Xvfb():
-                pdfkit.from_file(f.name, pdf_report_path, options=options)
-
+        if backend == 'pdfkit':
+            _pdf_via_pdfkit(f.name, pdf_report_path)
+        elif backend == 'weasyprint':
+            _pdf_via_weasyprint(f.name, pdf_report_path)
         else:
-            pdfkit.from_file(f.name, pdf_report_path, options=options)
-    logger.info('Wrote PDF report to %s', pdf_report_path)
+            raise ValueError("Unknown PDF backend: %s (choose 'pdfkit' or 'weasyprint')" % backend)
+    logger.info('Wrote PDF report to %s (backend=%s)', pdf_report_path, backend)
 
 def new_columns():
     columns = OrderedDict([

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Closes #217.

- Add `--pdf-backend` CLI flag (`pdfkit` | `weasyprint`, default: `pdfkit`)
- Split `make_pdf_report()` into lazy-imported backend functions so neither library is required unless used
- Add `weasyprint>=62.0` to requirements; mark `pdfkit`/`xvfbwrapper` as legacy
- Install weasyprint system deps (pango, gdk-pixbuf) in CI
- Parametrize `test_pdf_report` over both backends
- Update README install docs

## Test plan

- [ ] CI passes both `test_pdf_report[pdfkit]` and `test_pdf_report[weasyprint]`
- [ ] `vaxrank --output-pdf-report out.pdf --pdf-backend=weasyprint` produces a valid PDF with b16 test data
- [ ] `vaxrank --output-pdf-report out.pdf` (default) still uses pdfkit as before
- [ ] Compare PDF output from both backends visually for the same input