### PR TITLE
Bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,14 +14,14 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout private netmhc-bundle repo
         if: env.HAS_NETMHC_TOKEN == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: openvax/netmhc-bundle
           token: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN }}
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install netmhc-bundle dependencies
         if: env.HAS_NETMHC_TOKEN == 'true'
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
           packages: tcsh gawk python2-minimal
           version: 1.0
@@ -89,6 +89,6 @@ jobs:
           fi
           ./test.sh
       - name: Publish coverage to Coveralls
-        uses: coverallsapp/github-action@v2.2.3
+        uses: coverallsapp/github-action@v2.3.6
         with:
           parallel: true


### PR DESCRIPTION
## Summary

Addresses the Node.js 20 deprecation warnings that started appearing in CI. Node.js 20 actions will be forced to Node 24 starting June 2, 2026.

- `actions/checkout` v4 → v6
- `actions/setup-python` v5 → v6
- `coverallsapp/github-action` v2.2.3 → v2.3.6
- `awalsh128/cache-apt-pkgs-action` `@latest` → `v1.6.0` (also pinning — `@latest` was unsafe)

## Test plan

- [ ] CI passes across all Python versions (3.10–3.13)
- [ ] Coveralls still receives coverage data
- [ ] Docs workflow still builds and deploys
- [ ] No more Node 20 deprecation warnings on the run