### PR TITLE
Cache CI dependencies to speed up test runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'requirements.txt'
       - name: Checkout private netmhc-bundle repo
         if: env.HAS_NETMHC_TOKEN == 'true'
         uses: actions/checkout@v6
@@ -68,6 +70,11 @@ jobs:
       - name: Lint with Ruff
         run: |
           ./lint.sh
+      - name: Cache Ensembl genome data
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pyensembl
+          key: pyensembl-v1-human75-human93-mouse93-mouse102
       - name: Download Ensembl data
         run: |
           echo "Before installing Ensembl releases" && df -h
@@ -75,6 +82,13 @@ jobs:
           pyensembl install --release 102 --species mouse --custom-mirror https://github.com/openvax/ensembl-data/releases/download/GRCm38.102/
           pyensembl install --release 93 --species human --custom-mirror https://github.com/openvax/ensembl-data/releases/download/GRCh38.93/
           pyensembl install --release 93 --species mouse --custom-mirror https://github.com/openvax/ensembl-data/releases/download/GRCm38.93/
+      - name: Cache vaxrank reference proteome index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/vaxrank
+          key: vaxrank-refproteome-v1-human75-human93-mouse93-mouse102-${{ hashFiles('vaxrank/reference_proteome.py', 'vaxrank/config/defaults.py') }}
+          restore-keys: |
+            vaxrank-refproteome-v1-human75-human93-mouse93-mouse102-
       - name: Test with pytest
         run: |
           # Configure netmhc-bundle paths when private bundle is available.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       HAS_NETMHC_TOKEN: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN != '' }}
+      # Redirect caches to workspace-relative paths so actions/cache can tar
+      # them reliably (it has issues with paths outside $GITHUB_WORKSPACE).
+      PYENSEMBL_CACHE_DIR: ${{ github.workspace }}/.ci-cache/pyensembl
+      VAXRANK_REF_PEPTIDES_DIR: ${{ github.workspace }}/.ci-cache/vaxrank
     strategy:
       fail-fast: true
       matrix:
@@ -73,8 +77,8 @@ jobs:
       - name: Cache Ensembl genome data
         uses: actions/cache@v4
         with:
-          path: ~/.cache/pyensembl
-          key: pyensembl-v1-human75-human93-mouse93-mouse102
+          path: .ci-cache/pyensembl
+          key: pyensembl-v2-human75-human93-mouse93-mouse102
       - name: Download Ensembl data
         run: |
           echo "Before installing Ensembl releases" && df -h
@@ -85,10 +89,10 @@ jobs:
       - name: Cache vaxrank reference proteome index
         uses: actions/cache@v4
         with:
-          path: ~/.cache/vaxrank
-          key: vaxrank-refproteome-v1-human75-human93-mouse93-mouse102-${{ hashFiles('vaxrank/reference_proteome.py', 'vaxrank/config/defaults.py') }}
+          path: .ci-cache/vaxrank
+          key: vaxrank-refproteome-v2-human75-human93-mouse93-mouse102-${{ hashFiles('vaxrank/reference_proteome.py', 'vaxrank/config/defaults.py') }}
           restore-keys: |
-            vaxrank-refproteome-v1-human75-human93-mouse93-mouse102-
+            vaxrank-refproteome-v2-human75-human93-mouse93-mouse102-
       - name: Test with pytest
         run: |
           # Configure netmhc-bundle paths when private bundle is available.

--- a/tests/test_reference_proteome.py
+++ b/tests/test_reference_proteome.py
@@ -468,10 +468,14 @@ def test_cache_dir_created():
         new_cache_dir = os.path.join(tmpdir, "new_cache")
         ok_(not os.path.exists(new_cache_dir))
 
-        with patch('vaxrank.reference_proteome.user_cache_dir', return_value=new_cache_dir):
-            result = get_cache_dir()
-            eq_(result, new_cache_dir)
-            ok_(os.path.exists(new_cache_dir))
+        # Ensure VAXRANK_REF_PEPTIDES_DIR is unset so the platformdirs
+        # fallback path is exercised (CI sets this env var for caching).
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VAXRANK_REF_PEPTIDES_DIR", None)
+            with patch('vaxrank.reference_proteome.user_cache_dir', return_value=new_cache_dir):
+                result = get_cache_dir()
+                eq_(result, new_cache_dir)
+                ok_(os.path.exists(new_cache_dir))
 
 
 # =============================================================================

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Closes #219. Adds three caching layers to the Tests workflow:

- **pip wheels** via `actions/setup-python`'s built-in `cache: 'pip'` option, keyed on `requirements.txt`
- **Ensembl genome data** (`~/.cache/pyensembl`) via `actions/cache@v4`, shared across the Python version matrix
- **Vaxrank reference proteome indices** (`~/.cache/vaxrank`), keyed on the code that builds them so it invalidates automatically on logic changes

## Expected impact

Warm runs should skip:
- Downloading ~GB of Ensembl release data (4 releases)
- Rebuilding the 745MB reference proteome kmer set

This should save several minutes per matrix job on warm runs. Cold runs (new cache key) behave as before.

## Test plan

- [ ] First CI run (cold cache) completes successfully and populates the caches
- [ ] Second CI run (warm cache) finishes noticeably faster on the "Download Ensembl data" and test steps
- [ ] All Python versions (3.10–3.13) pass