### PR TITLE
Fix WeasyPrint on macOS arm64 (test skip + deploy.sh DYLD export + README note)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ pip install weasyprint
 # macOS also needs: brew install pango
 ```
 
+On Apple Silicon, WeasyPrint loads Pango via dyld, which doesn't search
+Homebrew's `/opt/homebrew/lib` by default. Add this to your shell profile:
+
+```sh
+export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH"
+```
+
+(Intel macOS doesn't need this — Homebrew's `/usr/local/lib` is in dyld's
+default fallback path.)
+
 ## Configuration
 
 ### YAML config file

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,8 +7,9 @@ set -euo pipefail
 # which on Apple Silicon can't locate Homebrew's /opt/homebrew/lib unless
 # dyld's fallback search path is told about it. Re-export the var inside
 # the script so ./test.sh → pytest → weasyprint see it.
-if [[ "$(uname)" == "Darwin" && -d /opt/homebrew/lib ]]; then
-  export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+if [[ "$(uname)" == "Darwin" && -d /opt/homebrew/lib \
+      && ":${DYLD_FALLBACK_LIBRARY_PATH:-}:" != *":/opt/homebrew/lib:"* ]]; then
+  export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 fi
 
 usage() {

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# macOS SIP strips DYLD_* env vars when exec'ing /bin/bash (how
+# `#!/usr/bin/env bash` resolves). WeasyPrint — used by tests/ and by
+# --pdf-backend=weasyprint — loads Pango/Cairo via ctypes.find_library,
+# which on Apple Silicon can't locate Homebrew's /opt/homebrew/lib unless
+# dyld's fallback search path is told about it. Re-export the var inside
+# the script so ./test.sh → pytest → weasyprint see it.
+if [[ "$(uname)" == "Darwin" && -d /opt/homebrew/lib ]]; then
+  export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+fi
+
 usage() {
   echo "Usage: ./deploy.sh [--dry-run] [version]" >&2
 }

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# See deploy.sh — Apple Silicon Homebrew + macOS SIP combine to strip dyld's
+# search path when bash runs this script, so WeasyPrint can't find pango.
+# Re-export here so direct `./test.sh` runs work the same as deploy-driven ones.
+if [[ "$(uname)" == "Darwin" && -d /opt/homebrew/lib ]]; then
+  export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+fi
+
 pytest --cov=vaxrank/ --cov-report=term-missing tests

--- a/test.sh
+++ b/test.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 # See deploy.sh — Apple Silicon Homebrew + macOS SIP combine to strip dyld's
 # search path when bash runs this script, so WeasyPrint can't find pango.
 # Re-export here so direct `./test.sh` runs work the same as deploy-driven ones.
-if [[ "$(uname)" == "Darwin" && -d /opt/homebrew/lib ]]; then
-  export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+if [[ "$(uname)" == "Darwin" && -d /opt/homebrew/lib \
+      && ":${DYLD_FALLBACK_LIBRARY_PATH:-}:" != *":/opt/homebrew/lib:"* ]]; then
+  export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 fi
 
 pytest --cov=vaxrank/ --cov-report=term-missing tests

--- a/tests/test_shell_script.py
+++ b/tests/test_shell_script.py
@@ -147,8 +147,36 @@ def test_html_report():
         assert len(lines) > 1
 
 
+def _skip_if_pdf_backend_unavailable(backend):
+    """Skip the test cleanly when the backend's native deps aren't loadable.
+
+    WeasyPrint renders via ctypes-loaded Pango/Cairo/HarfBuzz; pdfkit shells
+    out to ``wkhtmltopdf``. Neither is installable via pip alone. Skipping
+    here — instead of letting the CLI fail mid-render — keeps contributors
+    on fresh macOS arm64 / Linux-without-wkhtmltopdf from seeing a confusing
+    failure when the rest of the suite is green.
+    """
+    if backend == "weasyprint":
+        try:
+            import weasyprint
+            # Actually trigger the native-lib load; `import weasyprint`
+            # alone is lazy and won't surface a missing pango.
+            weasyprint.HTML(string="<p>x</p>").write_pdf()
+        except (ImportError, OSError) as exc:
+            pytest.skip(
+                f"WeasyPrint native libs not loadable ({exc}). "
+                f"On macOS arm64: `brew install pango` and "
+                f"`export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib`."
+            )
+    elif backend == "pdfkit":
+        import shutil
+        if shutil.which("wkhtmltopdf") is None:
+            pytest.skip("pdfkit backend requires `wkhtmltopdf` on PATH.")
+
+
 @pytest.mark.parametrize("backend", ["weasyprint", "pdfkit"])
 def test_pdf_report(backend):
+    _skip_if_pdf_backend_unavailable(backend)
     with NamedTemporaryFile(mode="rb", suffix=".pdf") as f:
         pdf_args = cli_args_for_b16_seqdata + [
             "--output-pdf-report", f.name,


### PR DESCRIPTION
Closes #224.

## What

Three stacked fixes so Apple Silicon contributors stop tripping on WeasyPrint:

1. **Self-skipping test** (`tests/test_shell_script.py`) — `test_pdf_report` now calls a `_skip_if_pdf_backend_unavailable(backend)` helper that does a trial \`weasyprint.HTML(...).write_pdf()\` (forces the native pango/cairo load) and \`pytest.skip()\`s with an actionable message on \`OSError\` / \`ImportError\`. Same helper handles \`pdfkit\` by checking for \`wkhtmltopdf\` on PATH. Result: contributors without the right native libs see a clean skip instead of a cryptic \`OSError: cannot load library 'libpango-1.0-0'\`.

2. **\`deploy.sh\` + \`test.sh\` re-export \`DYLD_FALLBACK_LIBRARY_PATH\` on Darwin**. Without this, macOS SIP strips \`DYLD_*\` env vars when \`exec\`'ing \`/bin/bash\` (how \`#!/usr/bin/env bash\` resolves), so a parent-shell export doesn't survive the script hop. Re-setting inside each script is the only reliable fix short of switching to a non-SIP-protected bash. This is what bit the v2.1.0 release this morning.

3. **README one-liner**. Apple Silicon users need to add \`DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib\` to their shell profile — now documented where it belongs (under the WeasyPrint install notes), with the Intel/arm64 distinction called out so Intel users aren't confused.

## Why

Background in #224. TL;DR: \`ctypes.find_library(\"pango-1.0\")\` uses dyld's search chain; dyld doesn't search \`/opt/homebrew/lib\` by default; Intel Homebrew uses \`/usr/local/lib\` which IS in the default fallback, so Intel never sees this; arm64 Homebrew moved to \`/opt/homebrew\` and left downstream tools to cope. Fixing at three layers (test, deploy script, docs) kills the surprise cold.

## Test plan

- [x] \`./test.sh\` with \`DYLD_FALLBACK_LIBRARY_PATH\` unset in parent shell: **253 passed** (weasyprint test runs, doesn't skip — in-script export works).
- [x] \`python -m pytest tests/test_shell_script.py::test_pdf_report -v\` with \`DYLD_FALLBACK_LIBRARY_PATH\` unset and no Pango-discoverable: weasyprint skips cleanly with the DYLD hint, pdfkit runs.
- [ ] CI on this PR (Linux; doesn't hit the issue but should stay green).