### PR TITLE
Bump varcode to >=2.6.0 and topiary to >=5.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 numpy>=2.0.0,<3.0.0
 pandas>=2.1.4,<3.0.0
 pyensembl>=2.0.0,<3.0.0
-varcode>=2.1.0,<3.0.0
+varcode>=2.6.0,<3.0.0
 isovar>=1.3.0,<2.0.0
 mhctools>=3.7.0,<4.0.0
-topiary>=5.1.0,<6.0.0
+topiary>=5.6.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0


### PR DESCRIPTION
## Summary

Floor-pin bump to pick up the three-day feature + bug-fix wave in both upstream dependencies. No vaxrank source changes — compat already clean.

**varcode 2.1.0 → 2.6.0:**
- Effect-classification bug fixes from v2.0.0 (StopLoss via 3'UTR readthrough, Silent-producing insertion, sequence-aware intronic splice) — previously silently wrong, now correct
- CSV IO for VariantCollection / EffectCollection
- Dedicated `ReferenceMismatchError` with actionable message
- `MutantTranscript` data model + pluggable `EffectAnnotator` initiative in flight (#271)

**topiary 5.1.0 → 5.6.0:**
- `ProteinFragment` / `predict_from_fragments` unification (v5.4.0)
- `CachedPredictor` with predictions-as-data, sharding, NetMHC loaders (v5.5.0–5.6.0)
- `SelfProteome` architecture for cross-reactivity (previewed on PR #135)

**Further feature adoption** (zygosity dropped as not meaningful for somatic callers; MutantTranscript fallback clarified as opt-in) tracked in #227.

## Test plan

- [x] `pip install --upgrade varcode topiary` in the shared venv → varcode 2.6.0, topiary 5.6.0
- [x] `python -m pytest tests/ --ignore=tests/test_shell_script.py --ignore=tests/test_deploy_script.py -q` → **244 passed, 0 failures**
- [ ] CI green on this PR