### PR TITLE
Use varcode's fast annotator (drop protein_diff coupling, pin to varcode 4.x)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ git tag "v${VERSION}" && git push --tags
 - **Allele parsing**: use `mhcgnomes`. Never `startswith("HLA-")` or other string hacks — alleles aren't always human.
 - **Epitope prediction**: go through `mhctools` / `topiary`, not MHCflurry directly.
 - **Filtering + ranking**: use the topiary DSL (integrated in 2.1.0). Don't add ad-hoc filters inside vaxrank that duplicate topiary predicates.
-- **Variants → peptides**: `varcode` for annotation (>=3.0.0 for `protein_diff`), `isovar` for RNA-backed variant peptides. There's a DNA-only fallback (2.3.0) and a prediction cache — use them, don't bypass.
+- **Variants → peptides**: `varcode` for annotation (>=4.0.0 — uses the `fast` annotator as the registry default), `isovar` for RNA-backed variant peptides. There's a DNA-only fallback (2.3.0) and a prediction cache — use them, don't bypass.
 - **Provenance**: carry gene name, gene ID, transcript, source species wherever peptides flow. Flanking context is not unique — a peptide can map to multiple source genes.
 - **Reports**: Jinja templates → WeasyPrint PDF / ASCII / Excel. Keep report logic in templates + small Python glue, not sprawling formatters.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=2.0.0,<3.0.0
 pandas>=2.1.4,<3.0.0
 pyensembl>=2.0.0,<3.0.0
-varcode>=3.0.0,<4.0.0
+varcode>=4.0.0,<5.0.0
 isovar>=1.4.7,<2.0.0
 mhctools>=3.13.1,<4.0.0
 topiary>=5.8.0,<6.0.0

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -164,7 +164,7 @@ class MutantProteinFragment(Serializable):
         -------
         MutantProteinFragment or None
         """
-        from varcode.annotators.protein_diff import apply_variant_to_transcript
+        from varcode.mutant_transcript import apply_variant_to_transcript
 
         effects = variant.effects()
         coding_effects = [

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.1"
+__version__ = "2.4.2"
 
 
 def print_version():


### PR DESCRIPTION
## Summary
- Drops the only protein_diff-specific import in vaxrank: `apply_variant_to_transcript` now comes from its canonical location `varcode.mutant_transcript` (where both annotators import it).
- Bumps the varcode pin from `>=3.0.0,<4.0.0` to `>=4.0.0,<5.0.0`. varcode 4 exposes the new annotator registry where `"fast"` is the process-wide default; `variant.effects()` inside vaxrank now runs through fast automatically.
- Updates the AGENTS.md domain note.
- Patch bump to 2.4.2 per Golden Rule 2.

## Why no behaviour change
vaxrank was never calling `set_default_annotator("protein_diff")` — only importing a re-exported function from the protein_diff module. `variant.effects()` already used whatever varcode's registry default was (fast in 4.x, legacy in 3.x). This PR just removes a stale import path and moves to the varcode major that makes fast the documented default.

## Test plan
- [x] `./lint.sh` passes
- [x] `./test.sh` passes locally (271 tests, all green)
- [ ] CI green on varcode 4.0.5