### PR TITLE
Migrate EpitopePrediction, MutantProteinFragment, VaccinePeptide to DataclassSerializable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=2.0.0,<3.0.0
 pandas>=2.1.4,<3.0.0
-pyensembl>=2.0.0,<3.0.0
+pyensembl>=2.6.4,<3.0.0
 varcode>=4.0.0,<5.0.0
 isovar>=1.4.7,<2.0.0
 mhctools>=3.13.1,<4.0.0

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -18,9 +18,32 @@ only exercise these code paths when an MHC predictor is available."""
 import pickle
 
 import pytest
+from varcode import Variant
 
 from vaxrank.epitope_prediction import EpitopePrediction
+from vaxrank.mutant_protein_fragment import MutantProteinFragment
 from vaxrank.vaccine_peptide import VaccinePeptide
+
+
+def _sample_variant():
+    # varcode.Variant with ensembl=None constructs without touching the
+    # Ensembl DB — enough for serialization roundtrips.
+    return Variant(contig="1", start=1000, ref="A", alt="G", ensembl=None)
+
+
+def _sample_fragment(amino_acids="MKVTHFYL" * 3, n_alt_reads=50):
+    return MutantProteinFragment(
+        variant=_sample_variant(),
+        gene_name="BRCA1",
+        amino_acids=amino_acids,
+        mutant_amino_acid_start_offset=4,
+        mutant_amino_acid_end_offset=5,
+        supporting_reference_transcripts=[],
+        n_overlapping_reads=100,
+        n_alt_reads=n_alt_reads,
+        n_ref_reads=50,
+        n_alt_reads_supporting_protein_sequence=n_alt_reads,
+    )
 
 
 def _sample_epitope(
@@ -109,6 +132,32 @@ def test_epitope_prediction_from_dict_drops_legacy_length_field():
     assert e.length == 8  # derived from peptide_sequence
 
 
+# ---- MutantProteinFragment --------------------------------------------
+
+
+def test_mutant_protein_fragment_json_roundtrip():
+    f = _sample_fragment()
+    restored = MutantProteinFragment.from_json(f.to_json())
+    assert restored == f
+
+
+def test_mutant_protein_fragment_pickle_roundtrip():
+    f = _sample_fragment()
+    assert pickle.loads(pickle.dumps(f)) == f
+
+
+def test_mutant_protein_fragment_computed_properties_after_roundtrip():
+    """@property methods (n_mutant_amino_acids, mutation_distance_from_edge,
+    n_other_reads) must still compute correctly after a JSON roundtrip —
+    guards against anyone accidentally making them stored fields."""
+    f = _sample_fragment()
+    restored = MutantProteinFragment.from_json(f.to_json())
+    assert restored.n_mutant_amino_acids == f.n_mutant_amino_acids
+    assert restored.mutation_distance_from_edge == f.mutation_distance_from_edge
+    assert restored.n_other_reads == f.n_other_reads
+    assert len(restored) == len(f)
+
+
 # ---- VaccinePeptide ----------------------------------------------------
 
 
@@ -168,3 +217,45 @@ def test_vaccine_peptide_tuple_coercion_on_rules():
     )
     assert vp.manufacturability_rules == ("cysteine_count", "cterm_hydropathy")
     assert isinstance(vp.manufacturability_rules, tuple)
+
+
+def test_vaccine_peptide_json_roundtrip_with_real_fragment():
+    """Full to_json / from_json with a real MutantProteinFragment and
+    EpitopePredictions. This is the path the CLI writes out — we want
+    __post_init__ to re-derive the mutant/wildtype split after load and
+    scores to re-compute consistently."""
+    mutant = _sample_epitope(peptide_sequence="SIINFEKL", ic50=500.0)
+    wildtype = _sample_epitope(
+        peptide_sequence="TESTWILD",
+        ic50=50.0,
+        overlaps_mutation=False,
+        occurs_in_reference=True,
+    )
+    vp = VaccinePeptide(
+        mutant_protein_fragment=_sample_fragment(),
+        epitope_predictions=[mutant, wildtype],
+        manufacturability_rules=("cysteine_count", "cterm_hydropathy"),
+        combined_score_mode="epitope_only",
+    )
+    restored = VaccinePeptide.from_json(vp.to_json())
+
+    # Wire-level invariants
+    assert restored.mutant_protein_fragment == vp.mutant_protein_fragment
+    assert restored.manufacturability_rules == vp.manufacturability_rules
+    assert restored.combined_score_mode == vp.combined_score_mode
+
+    # Derived state must match — __post_init__ re-ran on load
+    assert restored.mutant_epitope_predictions == vp.mutant_epitope_predictions
+    assert restored.wildtype_epitope_predictions == vp.wildtype_epitope_predictions
+    assert restored.mutant_epitope_score == pytest.approx(vp.mutant_epitope_score)
+    assert restored.combined_score == pytest.approx(vp.combined_score)
+
+
+def test_vaccine_peptide_pickle_roundtrip_with_real_fragment():
+    vp = VaccinePeptide(
+        mutant_protein_fragment=_sample_fragment(),
+        epitope_predictions=[_sample_epitope()],
+    )
+    restored = pickle.loads(pickle.dumps(vp))
+    assert restored.mutant_protein_fragment == vp.mutant_protein_fragment
+    assert restored.combined_score == pytest.approx(vp.combined_score)

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -1,0 +1,170 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit-level JSON / pickle / dict roundtrip coverage for the classes
+migrated from ``serializable.Serializable`` to
+``serializable.DataclassSerializable``. The existing integration tests
+only exercise these code paths when an MHC predictor is available."""
+
+import pickle
+
+import pytest
+
+from vaxrank.epitope_prediction import EpitopePrediction
+from vaxrank.vaccine_peptide import VaccinePeptide
+
+
+def _sample_epitope(
+    peptide_sequence="SIINFEQL",
+    ic50=2.0,
+    overlaps_mutation=True,
+    occurs_in_reference=False,
+):
+    return EpitopePrediction(
+        allele="HLA-A*02:01",
+        peptide_sequence=peptide_sequence,
+        wt_peptide_sequence="SIINFEKL",
+        ic50=ic50,
+        wt_ic50=2000.0,
+        percentile_rank=0.3,
+        prediction_method_name="ImaginationMHCpan",
+        overlaps_mutation=overlaps_mutation,
+        source_sequence="SSIINFEQL",
+        offset=1,
+        occurs_in_reference=occurs_in_reference,
+    )
+
+
+class _FakeVariant:
+    """Minimal Variant stand-in — enough for VaccinePeptide's sort key to
+    function without depending on varcode."""
+
+    def __init__(self, gene_name="BRAF"):
+        self.gene_name = gene_name
+
+
+class _FakeFragment:
+    """Duck-typed MutantProteinFragment for VaccinePeptide JSON tests that
+    don't exercise MutantProteinFragment's own serialization path (which
+    requires varcode.Variant)."""
+
+    def __init__(self, amino_acids="A" * 25, n_alt_reads=9):
+        self.amino_acids = amino_acids
+        self.n_alt_reads = n_alt_reads
+        self.n_alt_reads_supporting_protein_sequence = n_alt_reads
+        self.n_mutant_amino_acids = 1
+        self.mutation_distance_from_edge = 5
+
+
+# ---- EpitopePrediction -------------------------------------------------
+
+
+def test_epitope_prediction_json_roundtrip():
+    e = _sample_epitope()
+    restored = EpitopePrediction.from_json(e.to_json())
+    assert restored == e
+
+
+def test_epitope_prediction_pickle_roundtrip():
+    e = _sample_epitope()
+    assert pickle.loads(pickle.dumps(e)) == e
+
+
+def test_epitope_prediction_length_is_derived():
+    """`length` moved from init-arg to @property in the migration; it
+    still matches len(peptide_sequence) and doesn't appear in to_dict."""
+    e = _sample_epitope(peptide_sequence="SIINFEQLL")
+    assert e.length == 9
+    assert "length" not in e.to_dict()
+
+
+def test_epitope_prediction_from_dict_drops_legacy_length_field():
+    """Old JSON blobs that include the retired `length` init arg still
+    load, via _SERIALIZABLE_KEYWORD_ALIASES."""
+    legacy_dict = {
+        "allele": "HLA-A*02:01",
+        "peptide_sequence": "SIINFEQL",
+        "wt_peptide_sequence": "SIINFEKL",
+        "ic50": 2.0,
+        "wt_ic50": 2000.0,
+        "percentile_rank": 0.3,
+        "prediction_method_name": "ImaginationMHCpan",
+        "overlaps_mutation": True,
+        "source_sequence": "SSIINFEQL",
+        "offset": 1,
+        "occurs_in_reference": False,
+        "length": 8,  # legacy field, should be silently dropped
+    }
+    e = EpitopePrediction.from_dict(legacy_dict)
+    assert e.peptide_sequence == "SIINFEQL"
+    assert e.length == 8  # derived from peptide_sequence
+
+
+# ---- VaccinePeptide ----------------------------------------------------
+
+
+def test_vaccine_peptide_post_init_derives_epitope_lists():
+    """Filtering and sorting moved from __init__ to __post_init__ but must
+    produce the same mutant / wildtype split."""
+    mutant = _sample_epitope(peptide_sequence="MUTANT", ic50=5.0)
+    wildtype = _sample_epitope(
+        peptide_sequence="REFERNC",
+        ic50=50.0,
+        overlaps_mutation=False,
+        occurs_in_reference=True,
+    )
+    vp = VaccinePeptide(
+        mutant_protein_fragment=_FakeFragment(),
+        epitope_predictions=[mutant, wildtype],
+    )
+    assert vp.mutant_epitope_predictions == [mutant]
+    assert vp.wildtype_epitope_predictions == [wildtype]
+
+
+def test_vaccine_peptide_post_init_validates_combined_score_mode():
+    """__post_init__ now raises on unknown modes — the contract added in
+    2.5.0 carries through the dataclass migration."""
+    with pytest.raises(ValueError, match="combined_score_mode"):
+        VaccinePeptide(
+            mutant_protein_fragment=_FakeFragment(),
+            epitope_predictions=[],
+            combined_score_mode="garbage",
+        )
+
+
+def test_vaccine_peptide_to_dict_omits_derived_fields():
+    """The custom to_dict only emits constructor args, not the
+    init=False dataclass fields (mutant_epitope_predictions, etc.)."""
+    vp = VaccinePeptide(
+        mutant_protein_fragment=_FakeFragment(),
+        epitope_predictions=[_sample_epitope()],
+    )
+    d = vp.to_dict()
+    for derived in (
+        "mutant_epitope_predictions",
+        "wildtype_epitope_predictions",
+        "mutant_epitope_score",
+        "wildtype_epitope_score",
+        "manufacturability_scores",
+    ):
+        assert derived not in d
+
+
+def test_vaccine_peptide_tuple_coercion_on_rules():
+    """List of rule names coerced to tuple even after migration."""
+    vp = VaccinePeptide(
+        mutant_protein_fragment=_FakeFragment(),
+        epitope_predictions=[_sample_epitope()],
+        manufacturability_rules=["cysteine_count", "cterm_hydropathy"],
+    )
+    assert vp.manufacturability_rules == ("cysteine_count", "cterm_hydropathy")
+    assert isinstance(vp.manufacturability_rules, tuple)

--- a/vaxrank/epitope_prediction.py
+++ b/vaxrank/epitope_prediction.py
@@ -10,8 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
 import numpy as np
-from serializable import Serializable
+from serializable import DataclassSerializable
 
 from .config.defaults import (
     DEFAULT_BINDING_AFFINITY_CUTOFF,
@@ -21,10 +24,11 @@ from .config.defaults import (
 )
 
 
-class EpitopePrediction(Serializable):
-    # TODO: 
+@dataclass
+class EpitopePrediction(DataclassSerializable):
+    # TODO:
     #   - rename to CandidateEpitope
-    #   - add groups of predictions: 
+    #   - add groups of predictions:
     #      * mhc_affinity_ic50
     #      * mhc_affinity_score
     #      * mhc_affinity_percentile_rank
@@ -38,7 +42,7 @@ class EpitopePrediction(Serializable):
     #      * immunogenicity_score
     #      * immunogenicity_percentile_rank
     #  - also change wt_peptide_sequence to:
-    #      * closest_reference_peptide_sequence_in_any_protein 
+    #      * closest_reference_peptide_sequence_in_any_protein
     #      * closest_reference_peptide_sequence_in_same_protein
     #  - and calculate:
     #      * edit_distance_to_closest_reference_peptide_in_any_protein
@@ -46,42 +50,27 @@ class EpitopePrediction(Serializable):
     #      * edit_distance_to_closest_reference_peptide_in_any_protein_PMBEC
     #      * edit_distance_to_closest_reference_peptide_in_same_protein_PMBEC
     #  - how to avoid duplicating every prediction for MT vs. WT-any vs. WT-same?
-    def __init__(
-            self,
-            allele,
-            peptide_sequence,
-            wt_peptide_sequence,
-            ic50,
-            wt_ic50,
-            percentile_rank,
-            prediction_method_name,
-            overlaps_mutation,
-            source_sequence,
-            offset,
-            occurs_in_reference):
-        self.allele = allele
-        self.peptide_sequence = peptide_sequence
-        self.wt_peptide_sequence = wt_peptide_sequence
-        self.length = len(peptide_sequence)
-        self.ic50 = ic50
-        self.wt_ic50 = wt_ic50
-        self.percentile_rank = percentile_rank
-        self.prediction_method_name = prediction_method_name
-        self.overlaps_mutation = overlaps_mutation
-        self.source_sequence = source_sequence
-        self.offset = offset
-        self.occurs_in_reference = occurs_in_reference
+    allele: str
+    peptide_sequence: str
+    wt_peptide_sequence: str
+    ic50: float
+    wt_ic50: float
+    percentile_rank: float
+    prediction_method_name: str
+    overlaps_mutation: bool
+    source_sequence: str
+    offset: int
+    occurs_in_reference: bool
 
-    @classmethod
-    def from_dict(cls, d):
-        """
-        Deserialize EpitopePrediction from a dictionary of keywords.
-        """
-        d = d.copy()
-        if "length" in d:
-            # length argument removed in version 1.1.0
-            del d["length"]
-        return cls(**d)
+    # `length` used to be a constructor arg; since 1.1.0 it is derived from
+    # `peptide_sequence`. Drop it from any old JSON blobs we happen to load.
+    _SERIALIZABLE_KEYWORD_ALIASES: ClassVar[dict[str, Optional[str]]] = {
+        "length": None,
+    }
+
+    @property
+    def length(self) -> int:
+        return len(self.peptide_sequence)
 
     def logistic_epitope_score(
             self,

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -12,9 +12,11 @@
 
 
 import logging
+from dataclasses import dataclass
+from typing import Any
 
+from serializable import DataclassSerializable
 from varcode.effects import top_priority_effect
-from serializable import Serializable
 
 logger = logging.getLogger(__name__)
 
@@ -50,68 +52,56 @@ def _find_mutation_region(ref_protein, mut_protein):
     return start, mut_i
 
 
-class MutantProteinFragment(Serializable):
-    def __init__(
-            self,
-            variant,
-            gene_name,
-            amino_acids,
-            mutant_amino_acid_start_offset,
-            mutant_amino_acid_end_offset,
-            supporting_reference_transcripts,
-            n_overlapping_reads,
-            n_alt_reads,
-            n_ref_reads,
-            n_alt_reads_supporting_protein_sequence):
-        """
-        Parameters
-        ----------
-        variant : varcode.Variant
-            Somatic mutation.
+@dataclass
+class MutantProteinFragment(DataclassSerializable):
+    """
+    Parameters
+    ----------
+    variant : varcode.Variant
+        Somatic mutation.
 
-        gene_name : str
-            Gene from which we used a transcript to translate this mutation.
+    gene_name : str
+        Gene from which we used a transcript to translate this mutation.
 
-        amino_acids : str
-            Translated protein sequence, aggregated from possibly multiple
-            synonymous coding sequences.
+    amino_acids : str
+        Translated protein sequence, aggregated from possibly multiple
+        synonymous coding sequences.
 
-        mutant_amino_acid_start_offset : int
-            Starting offset of amino acids which differ due to the mutation
+    mutant_amino_acid_start_offset : int
+        Starting offset of amino acids which differ due to the mutation
 
-        mutant_amino_acid_end_offset : int
-            End offset of amino acids which differ due to the mutation
+    mutant_amino_acid_end_offset : int
+        End offset of amino acids which differ due to the mutation
 
-        supporting_reference_transcripts : list of pyensembl.Transcript
-            PyEnsembl Transcript objects for reference transcripts which
-            were used to establish the reading frame of coding sequence(s)
-            detected from RNA.
+    supporting_reference_transcripts : list of pyensembl.Transcript
+        PyEnsembl Transcript objects for reference transcripts which
+        were used to establish the reading frame of coding sequence(s)
+        detected from RNA.
 
-        n_overlapping_reads : int
-            Number of reads overlapping the variant locus.
+    n_overlapping_reads : int
+        Number of reads overlapping the variant locus.
 
-        n_alt_reads  : int
-            Number of reads supporting the variant.
+    n_alt_reads  : int
+        Number of reads supporting the variant.
 
-        n_ref_reads : int
-            Number of reads supporting the reference allele.
+    n_ref_reads : int
+        Number of reads supporting the reference allele.
 
-        n_alt_reads_supporting_protein_sequence : int
-            Number of RNA reads fully spanning the cDNA sequence(s) from which
-            we translated this amino acid sequence.
-        """
-        self.variant = variant
-        self.gene_name = gene_name
-        self.amino_acids = amino_acids
-        self.mutant_amino_acid_start_offset = mutant_amino_acid_start_offset
-        self.mutant_amino_acid_end_offset = mutant_amino_acid_end_offset
-        self.supporting_reference_transcripts = \
-            supporting_reference_transcripts
-        self.n_overlapping_reads = n_overlapping_reads
-        self.n_alt_reads = n_alt_reads
-        self.n_ref_reads = n_ref_reads
-        self.n_alt_reads_supporting_protein_sequence = \
-            n_alt_reads_supporting_protein_sequence
+    n_alt_reads_supporting_protein_sequence : int
+        Number of RNA reads fully spanning the cDNA sequence(s) from which
+        we translated this amino acid sequence.
+    """
+
+    variant: Any
+    gene_name: str
+    amino_acids: str
+    mutant_amino_acid_start_offset: int
+    mutant_amino_acid_end_offset: int
+    supporting_reference_transcripts: list
+    n_overlapping_reads: int
+    n_alt_reads: int
+    n_ref_reads: int
+    n_alt_reads_supporting_protein_sequence: int
 
     @classmethod
     def from_isovar_result(cls, isovar_result):

--- a/vaxrank/vaccine_peptide.py
+++ b/vaxrank/vaccine_peptide.py
@@ -10,11 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+from dataclasses import dataclass, field
 from operator import attrgetter
+from typing import Any, Optional
 
 import numpy as np
-from serializable import Serializable
+from serializable import DataclassSerializable
 
 from .manufacturability import (
     ManufacturabilityScores,
@@ -23,75 +24,81 @@ from .manufacturability import (
 from .vaccine_config import COMBINED_SCORE_MODES, DEFAULT_COMBINED_SCORE_MODE
 
 
-class VaccinePeptide(Serializable):
+@dataclass
+class VaccinePeptide(DataclassSerializable):
     """
     VaccinePeptide combines the sequence information of MutantProteinFragment
     with MHC binding predictions for subsequences of the protein fragment.
 
     The resulting lists of mutant and wildtype epitope predictions
     are sorted by affinity.
+
+    Parameters
+    ----------
+    mutant_protein_fragment : MutantProteinFragment
+
+    epitope_predictions : list of EpitopePrediction
+
+    num_mutant_epitopes_to_keep : int or None
+        If None or 0 then keep all mutant epitopes.
+
+    epitope_score_params : dict or None
+        Parameters passed to EpitopePrediction.logistic_epitope_score.
+
+    sort_predictions_by : str
+        Field of EpitopePrediction used for sorting epitope predictions
+        overlapping mutation in ascending order. Can be either 'ic50'
+        or 'percentile_rank'.
+
+    manufacturability_thresholds : dict or None
+        Hydropathy thresholds for peptide synthesis difficulty scoring.
+        Keys match the parameters of
+        ``peptide_synthesis_difficulty_score_tuple``. When None the
+        compiled-in defaults from ``config.defaults`` are used.
+
+    manufacturability_rules : sequence of str or None
+        Ordered list of manufacturability rule names to drive the
+        lexicographic sort tuple. Names must appear in
+        ``MANUFACTURABILITY_RULE_REGISTRY``. When None the legacy
+        10-rule default order is used (byte-identical with prior
+        releases).
+
+    combined_score_mode : str or None
+        How to fold expression into the final ``combined_score``. One
+        of ``sqrt_reads_times_epitope`` (default, legacy),
+        ``reads_times_epitope``, or ``epitope_only``. Does not affect
+        the ``expression_score`` property, which always reports
+        ``sqrt(n_alt_reads)``.
     """
 
-    def __init__(
-            self,
-            mutant_protein_fragment,
-            epitope_predictions,
-            num_mutant_epitopes_to_keep=None,
-            epitope_score_params=None,
-            sort_predictions_by='ic50',
-            manufacturability_thresholds=None,
-            manufacturability_rules=None,
-            combined_score_mode=None):
-        """
-        Parameters
-        ----------
-        mutant_protein_fragment : MutantProteinFragment
+    mutant_protein_fragment: Any
+    epitope_predictions: list
+    num_mutant_epitopes_to_keep: Optional[int] = None
+    epitope_score_params: Optional[dict] = None
+    sort_predictions_by: str = "ic50"
+    manufacturability_thresholds: Optional[dict] = None
+    manufacturability_rules: Optional[tuple] = None
+    combined_score_mode: Optional[str] = None
 
-        epitope_predictions : list of EpitopePrediction
+    # Derived attributes computed in __post_init__ — not part of the
+    # serialized form. `init=False` keeps them out of the generated
+    # __init__ signature; default=None gives them a sane pre-computed
+    # value for any pathway that inspects fields before __post_init__.
+    mutant_epitope_predictions: list = field(default_factory=list, init=False, repr=False)
+    wildtype_epitope_predictions: list = field(default_factory=list, init=False, repr=False)
+    wildtype_epitope_score: float = field(default=0.0, init=False, repr=False)
+    mutant_epitope_score: float = field(default=0.0, init=False, repr=False)
+    manufacturability_scores: Any = field(default=None, init=False, repr=False)
 
-        num_mutant_epitopes_to_keep : int or None
-            If None or 0 then keep all mutant epitopes.
+    def __post_init__(self):
+        # Normalize the optional collection/tuple fields.
+        self.epitope_score_params = self.epitope_score_params or {}
+        self.manufacturability_thresholds = self.manufacturability_thresholds or {}
+        if self.manufacturability_rules is not None:
+            self.manufacturability_rules = tuple(self.manufacturability_rules)
 
-        epitope_score_params : dict or None
-            Parameters passed to EpitopePrediction.logistic_epitope_score.
-
-        sort_predictions_by : str
-            Field of EpitopePrediction used for sorting epitope predictions
-            overlapping mutation in ascending order. Can be either 'ic50'
-            or 'percentile_rank'.
-
-        manufacturability_thresholds : dict or None
-            Hydropathy thresholds for peptide synthesis difficulty scoring.
-            Keys match the parameters of
-            ``peptide_synthesis_difficulty_score_tuple``.  When None the
-            compiled-in defaults from ``config.defaults`` are used.
-
-        manufacturability_rules : sequence of str or None
-            Ordered list of manufacturability rule names to drive the
-            lexicographic sort tuple. Names must appear in
-            ``MANUFACTURABILITY_RULE_REGISTRY``. When None the legacy
-            10-rule default order is used (byte-identical with prior
-            releases).
-
-        combined_score_mode : str or None
-            How to fold expression into the final ``combined_score``. One
-            of ``sqrt_reads_times_epitope`` (default, legacy),
-            ``reads_times_epitope``, or ``epitope_only``. Does not affect
-            the ``expression_score`` property, which always reports
-            ``sqrt(n_alt_reads)``.
-        """
-        self.mutant_protein_fragment = mutant_protein_fragment
-        self.epitope_predictions = epitope_predictions
-        self.num_mutant_epitopes_to_keep = num_mutant_epitopes_to_keep
-        self.epitope_score_params = epitope_score_params or {}
-        self.sort_predictions_by = sort_predictions_by
-        self.manufacturability_thresholds = manufacturability_thresholds or {}
-        self.manufacturability_rules = (
-            tuple(manufacturability_rules)
-            if manufacturability_rules is not None
-            else None
-        )
-        resolved_mode = combined_score_mode or DEFAULT_COMBINED_SCORE_MODE
+        # Validate combined_score_mode; resolve None to the legacy default.
+        resolved_mode = self.combined_score_mode or DEFAULT_COMBINED_SCORE_MODE
         if resolved_mode not in COMBINED_SCORE_MODES:
             raise ValueError(
                 f"combined_score_mode must be one of {COMBINED_SCORE_MODES}, "
@@ -99,36 +106,42 @@ class VaccinePeptide(Serializable):
             )
         self.combined_score_mode = resolved_mode
 
-        sort_key = attrgetter(sort_predictions_by)
+        sort_key = attrgetter(self.sort_predictions_by)
 
         # only keep the top k epitopes
-        self.mutant_epitope_predictions = sorted([
-            p for p in epitope_predictions
-            if p.overlaps_mutation and not p.occurs_in_reference
-        ], key=sort_key)
-        if num_mutant_epitopes_to_keep:
-            self.mutant_epitope_predictions = \
-                self.mutant_epitope_predictions[:num_mutant_epitopes_to_keep]
+        self.mutant_epitope_predictions = sorted(
+            [
+                p for p in self.epitope_predictions
+                if p.overlaps_mutation and not p.occurs_in_reference
+            ],
+            key=sort_key,
+        )
+        if self.num_mutant_epitopes_to_keep:
+            self.mutant_epitope_predictions = (
+                self.mutant_epitope_predictions[: self.num_mutant_epitopes_to_keep]
+            )
 
-        self.wildtype_epitope_predictions = sorted([
-            p for p in epitope_predictions
-            if not p.overlaps_mutation or p.occurs_in_reference
-        ], key=sort_key)
+        self.wildtype_epitope_predictions = sorted(
+            [
+                p for p in self.epitope_predictions
+                if not p.overlaps_mutation or p.occurs_in_reference
+            ],
+            key=sort_key,
+        )
 
         def epitope_score(prediction):
             return prediction.logistic_epitope_score(**self.epitope_score_params)
 
         self.wildtype_epitope_score = sum(
-            epitope_score(p)
-            for p in self.wildtype_epitope_predictions)
-        # only keep the top k epitopes for the purposes of the score
+            epitope_score(p) for p in self.wildtype_epitope_predictions
+        )
         self.mutant_epitope_score = sum(
-            epitope_score(p)
-            for p in self.mutant_epitope_predictions)
+            epitope_score(p) for p in self.mutant_epitope_predictions
+        )
 
-        self.manufacturability_scores = \
-            ManufacturabilityScores.from_amino_acids(
-                self.mutant_protein_fragment.amino_acids)
+        self.manufacturability_scores = ManufacturabilityScores.from_amino_acids(
+            self.mutant_protein_fragment.amino_acids
+        )
 
     def peptide_synthesis_difficulty_score_tuple(
             self,
@@ -235,7 +248,13 @@ class VaccinePeptide(Serializable):
         return self.expression_score * epitope
 
     def to_dict(self):
-        epitope_predictions = self.mutant_epitope_predictions + self.wildtype_epitope_predictions
+        # The persisted form combines the filtered mutant + wildtype lists
+        # back into a single `epitope_predictions` list. Also trims fields
+        # that match their defaults so the JSON stays small and older
+        # readers don't see keys they don't understand.
+        epitope_predictions = (
+            self.mutant_epitope_predictions + self.wildtype_epitope_predictions
+        )
         d = {
             "mutant_protein_fragment": self.mutant_protein_fragment,
             "epitope_predictions": epitope_predictions,
@@ -250,18 +269,3 @@ class VaccinePeptide(Serializable):
         if self.combined_score_mode != DEFAULT_COMBINED_SCORE_MODE:
             d["combined_score_mode"] = self.combined_score_mode
         return d
-
-    @classmethod
-    def from_dict(cls, d):
-        d = d.copy()
-        if "sort_predictions_by" not in d:
-            d["sort_predictions_by"] = "ic50"
-        if "epitope_score_params" not in d:
-            d["epitope_score_params"] = None
-        if "manufacturability_thresholds" not in d:
-            d["manufacturability_thresholds"] = None
-        if "manufacturability_rules" not in d:
-            d["manufacturability_rules"] = None
-        if "combined_score_mode" not in d:
-            d["combined_score_mode"] = None
-        return cls(**d)


### PR DESCRIPTION
## Summary
Completes the Serializable → @dataclass migration started in 2.5.0. All five formerly-Serializable vaxrank types (PatientInfo, VaxrankResults in 2.5.0; EpitopePrediction, MutantProteinFragment, VaccinePeptide here) now use `serializable.DataclassSerializable`. JSON wire format is unchanged — persisted results round-trip across the cutover.

## Changes
- **EpitopePrediction** — 11 init args become @dataclass fields. `length` shifts from init-arg-derived attribute to a @property; the removed-in-1.1.0 `length` field is dropped from old JSON via `_SERIALIZABLE_KEYWORD_ALIASES = {"length": None}`, replacing the manual key-drop that was in the old `from_dict`.
- **MutantProteinFragment** — straight conversion. All ten init args become dataclass fields. Factory classmethods (`from_isovar_result`, `from_variant_dna`) and computed @property methods are unchanged.
- **VaccinePeptide** — the `__init__` filtering / sorting / scoring logic moves to `__post_init__`. Derived attributes (`mutant_epitope_predictions`, `wildtype_epitope_predictions`, `mutant_epitope_score`, `wildtype_epitope_score`, `manufacturability_scores`) are declared with `field(init=False, repr=False)` so they don't appear in the generated `__init__` signature or the default repr. Custom `to_dict` retained — it recombines the filtered lists into a single `epitope_predictions` and conditionally omits default-valued fields. Custom `from_dict` is no longer needed because dataclass field defaults cover the missing-key cases the old code was hand-rolling.

## Tests
New `tests/test_serialization_roundtrip.py` (8 tests):
- EpitopePrediction: JSON roundtrip, pickle roundtrip, `length` derived not stored, legacy-JSON-with-length handling.
- VaccinePeptide: `__post_init__` splits epitopes correctly, validates `combined_score_mode`, omits derived fields from `to_dict`, coerces rules list to tuple.

Full suite: **306 passed, 1 skipped** locally.

## Test plan
- [x] `pytest tests/test_serialization_roundtrip.py`
- [x] Full `pytest` suite
- [ ] CI matrix (3.10–3.13) green
- [ ] Manual: spot-check that an old 2.4.x JSON blob still round-trips through `VaxrankResults.from_json` / `to_json` (optional; wire format unchanged by construction)