### PR TITLE
Add N-terminal methionine manufacturability rule (closes #188)

### DIFF
--- a/tests/test_manufacturability.py
+++ b/tests/test_manufacturability.py
@@ -140,3 +140,34 @@ def test_rule_registry_reorders_and_filters():
     assert len(result) == 2
     # cysteine_count should now be at index 1
     assert result[1] == scores.cysteine_count
+
+
+def test_n_terminal_methionine_flag():
+    """N-terminal Met flagged as True; other residues flagged False.
+    (Manufacturer concern — oxidation risk. See vaxrank#188.)"""
+    assert ManufacturabilityScores.from_amino_acids("M" + "A" * 6).n_terminal_methionine
+    assert not ManufacturabilityScores.from_amino_acids("A" * 7).n_terminal_methionine
+    # Internal M doesn't count
+    assert not ManufacturabilityScores.from_amino_acids("AMAAAAA").n_terminal_methionine
+
+
+def test_n_terminal_methionine_is_opt_in_not_in_default_rules():
+    """Legacy parity: n_terminal_methionine must NOT appear in the default
+    rule tuple. Users opt in through manufacturability.rules config."""
+    assert "n_terminal_methionine" not in DEFAULT_MANUFACTURABILITY_RULES
+    assert "n_terminal_methionine" in MANUFACTURABILITY_RULE_REGISTRY
+
+
+def test_n_terminal_methionine_rule_in_registry_drives_sort():
+    """Using the rule via the registry: N-term M peptide gets a worse
+    score than an otherwise-identical N-term A peptide."""
+    met_scores = ManufacturabilityScores.from_amino_acids("M" + "A" * 24)
+    ala_scores = ManufacturabilityScores.from_amino_acids("A" * 25)
+    met_tuple = compute_manufacturability_tuple(
+        met_scores, DEFAULT_THRESHOLDS, rules=["n_terminal_methionine"],
+    )
+    ala_tuple = compute_manufacturability_tuple(
+        ala_scores, DEFAULT_THRESHOLDS, rules=["n_terminal_methionine"],
+    )
+    # Lexicographic: smaller tuple = better, so methionine peptide sorts worse
+    assert met_tuple > ala_tuple

--- a/vaxrank/manufacturability.py
+++ b/vaxrank/manufacturability.py
@@ -119,6 +119,17 @@ def n_terminal_asparagine(amino_acids):
     return amino_acids[0] == "N"
 
 
+def n_terminal_methionine(amino_acids):
+    """
+    Methionine at the N-terminus is prone to oxidation during synthesis,
+    purification, and storage (per manufacturer guidance, vaxrank#188).
+    Not bundled into the default lexicographic sort to preserve legacy
+    scoring parity — opt in via the ``manufacturability.rules`` config
+    key when this concern matters for your production run.
+    """
+    return amino_acids[0] == "M"
+
+
 def aspartate_proline_bond_count(amino_acids):
     """
     Count the number of Aspartate/Asp/D-Proline/Pro/P bonds.
@@ -176,6 +187,9 @@ ManufacturabilityScores = combine_scoring_functions(
     # avoid N-terminal Asn
     n_terminal_asparagine,
 
+    # avoid N-terminal Met (oxidation risk — opt-in rule, see #188)
+    n_terminal_methionine,
+
     # avoid Asp-Pro bonds
     aspartate_proline_bond_count,
 )
@@ -224,6 +238,10 @@ def _n_terminal_asparagine_rule(scores, _thresholds):
     return scores.n_terminal_asparagine
 
 
+def _n_terminal_methionine_rule(scores, _thresholds):
+    return scores.n_terminal_methionine
+
+
 def _aspartate_proline_rule(scores, _thresholds):
     return scores.aspartate_proline_bond_count
 
@@ -250,6 +268,7 @@ MANUFACTURABILITY_RULE_REGISTRY = {
     "c_terminal_cysteine": _c_terminal_cysteine_rule,
     "c_terminal_proline": _c_terminal_proline_rule,
     "n_terminal_asparagine": _n_terminal_asparagine_rule,
+    "n_terminal_methionine": _n_terminal_methionine_rule,
     "aspartate_proline": _aspartate_proline_rule,
     "max_hydropathy_low": _max_hydropathy_low_rule,
     "min_hydropathy": _min_hydropathy_rule,


### PR DESCRIPTION
Closes #188.

## Summary
Implements the N-terminal methionine check requested on #188, per the manufacturer's advice captured on that issue: *"peptide 1 contains an N-terminal methionine, which is prone to oxidation during synthesis, purification and storage."*

Ships as an **opt-in** rule in the manufacturability rule registry — does not change default scoring.

## Changes
- `n_terminal_methionine(amino_acids)` scoring function + field on `ManufacturabilityScores`, matching the pattern of the existing `n_terminal_asparagine`.
- Registered as `"n_terminal_methionine"` in `MANUFACTURABILITY_RULE_REGISTRY`.
- **Not added to `DEFAULT_MANUFACTURABILITY_RULES`** — legacy scoring parity preserved. The parametrized parity test in `tests/test_manufacturability.py::test_default_rules_match_legacy_tuple` still passes unchanged.
- Users opt in through their YAML config:
  ```yaml
  manufacturability:
    rules:
      - cysteine_count
      - cterm_hydropathy
      - max_hydropathy_high
      - n_terminal_methionine   # new
      - ...
  ```

## Tests
Three new tests:
- `test_n_terminal_methionine_flag` — raw scoring: flags N-term M, not internal M, not other residues.
- `test_n_terminal_methionine_is_opt_in_not_in_default_rules` — guards the legacy-parity invariant.
- `test_n_terminal_methionine_rule_in_registry_drives_sort` — confirms the rule moves an N-term M peptide behind an otherwise-identical N-term A peptide in the lexicographic sort.

All 17 manufacturability tests pass; full vaxrank suite **301 passed / 1 skipped**.

## Test plan
- [x] `pytest tests/test_manufacturability.py`
- [x] Full `pytest` suite
- [ ] CI matrix green