### PR TITLE
Variant-level ranking tiebreak: (combined_score, n_alt_reads, mutant_epitope_score) (closes #151)

### DIFF
--- a/tests/test_variant_ranking.py
+++ b/tests/test_variant_ranking.py
@@ -1,0 +1,87 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the variant-level sort in ``ranked_vaccine_peptides`` —
+verifies the three-level tiebreak (combined_score, n_alt_reads,
+mutant_epitope_score) introduced for vaxrank#151."""
+
+from types import SimpleNamespace
+
+from vaxrank.core_logic import ranked_vaccine_peptides
+
+
+def _fake_peptide(combined_score, n_alt_reads, mutant_epitope_score):
+    return SimpleNamespace(
+        combined_score=combined_score,
+        mutant_epitope_score=mutant_epitope_score,
+        mutant_protein_fragment=SimpleNamespace(n_alt_reads=n_alt_reads),
+    )
+
+
+def test_primary_sort_by_combined_score():
+    v_low = "v_low"
+    v_high = "v_high"
+    d = {
+        v_low: [_fake_peptide(combined_score=1.0, n_alt_reads=100, mutant_epitope_score=0.5)],
+        v_high: [_fake_peptide(combined_score=9.0, n_alt_reads=10, mutant_epitope_score=0.9)],
+    }
+    ranked = ranked_vaccine_peptides(d)
+    assert [variant for variant, _ in ranked] == [v_high, v_low]
+
+
+def test_tiebreak_by_n_alt_reads_when_combined_score_ties():
+    """When combined_score ties (e.g. both zero because one factor is
+    zero), n_alt_reads is the first tiebreak — high RNA support wins."""
+    v_reads = "v_reads"
+    v_no_reads = "v_no_reads"
+    d = {
+        v_no_reads: [_fake_peptide(combined_score=0.0, n_alt_reads=0, mutant_epitope_score=0.5)],
+        v_reads: [_fake_peptide(combined_score=0.0, n_alt_reads=50, mutant_epitope_score=0.5)],
+    }
+    ranked = ranked_vaccine_peptides(d)
+    assert [variant for variant, _ in ranked] == [v_reads, v_no_reads]
+
+
+def test_tiebreak_by_mutant_epitope_score_when_higher_tiers_tie():
+    """When combined_score and n_alt_reads both tie, mutant_epitope_score
+    breaks the tie — higher MHC binding score wins."""
+    v_low_epitope = "v_low_epitope"
+    v_high_epitope = "v_high_epitope"
+    d = {
+        v_low_epitope: [_fake_peptide(combined_score=0.0, n_alt_reads=10, mutant_epitope_score=0.1)],
+        v_high_epitope: [_fake_peptide(combined_score=0.0, n_alt_reads=10, mutant_epitope_score=0.9)],
+    }
+    ranked = ranked_vaccine_peptides(d)
+    assert [variant for variant, _ in ranked] == [v_high_epitope, v_low_epitope]
+
+
+def test_empty_peptide_list_sorts_last():
+    """Variants with no vaccine peptides use a zero sentinel tuple and
+    sort after any variant with at least one peptide and non-zero scores."""
+    v_empty = "v_empty"
+    v_normal = "v_normal"
+    d = {
+        v_empty: [],
+        v_normal: [_fake_peptide(combined_score=1.0, n_alt_reads=5, mutant_epitope_score=0.2)],
+    }
+    ranked = ranked_vaccine_peptides(d)
+    assert [variant for variant, _ in ranked] == [v_normal, v_empty]
+
+
+def test_all_zeros_keep_insertion_order():
+    """Python's sort is stable, so variants tied on every key preserve
+    their original dict insertion order."""
+    v1, v2, v3 = "v1", "v2", "v3"
+    zero = _fake_peptide(combined_score=0.0, n_alt_reads=0, mutant_epitope_score=0.0)
+    d = {v1: [zero], v2: [zero], v3: [zero]}
+    ranked = ranked_vaccine_peptides(d)
+    assert [variant for variant, _ in ranked] == [v1, v2, v3]

--- a/vaxrank/core_logic.py
+++ b/vaxrank/core_logic.py
@@ -399,6 +399,13 @@ def ranked_vaccine_peptides(variant_to_vaccine_peptides_dict):
     This function returns a sorted list whose first element is a Variant and whose second
     element is a list of VaccinePeptide objects.
 
+    Variants are ranked by their top vaccine peptide using a three-level
+    tiebreak (see vaxrank#151): primarily by ``combined_score``, then by
+    ``n_alt_reads`` (RNA support), then by ``mutant_epitope_score`` (MHC
+    binding). The extra tiers matter when ``combined_score`` ties (common
+    when either factor is zero) so that the downstream report order is
+    stable and intuitively favors better-supported variants.
+
     Parameters
     ----------
     variant_to_vaccine_peptides_dict : dict
@@ -411,11 +418,14 @@ def ranked_vaccine_peptides(variant_to_vaccine_peptides_dict):
     def sort_key(variant_and_vaccine_peptides_pair):
         vaccine_peptides = variant_and_vaccine_peptides_pair[1]
         if len(vaccine_peptides) == 0:
-            return 0.0
-        else:
-            top_vaccine_peptide = vaccine_peptides[0]
-            return top_vaccine_peptide.combined_score
+            return (0.0, 0, 0.0)
+        top_vaccine_peptide = vaccine_peptides[0]
+        return (
+            top_vaccine_peptide.combined_score,
+            top_vaccine_peptide.mutant_protein_fragment.n_alt_reads,
+            top_vaccine_peptide.mutant_epitope_score,
+        )
 
-    # sort in descending order of combined (expression * mhc binding) scores
+    # sort in descending order by (combined_score, n_alt_reads, mutant_epitope_score)
     result_list.sort(key=sort_key, reverse=True)
     return result_list


### PR DESCRIPTION
Closes #151.

## Summary
`ranked_vaccine_peptides` previously sorted variants by the top vaccine peptide's `combined_score` alone. Ties (common when either expression or epitope score is zero) collapsed to Python stable-sort insertion order, making report ordering implementation-dependent.

Switches the sort key to the tuple the issue asks for — `(combined_score, n_alt_reads, mutant_epitope_score)` — so that:
- When `combined_score` ties, RNA support breaks the tie.
- When both tie, MHC binding score breaks the tie.
- When all three tie, dict insertion order still applies (stable sort).

Same sort direction (descending by all fields).

## Impact
Report ordering becomes deterministic in a user-meaningful way — fewer \"why is this variant above that one?\" questions when combined scores collide. Existing runs with all-distinct combined_scores are unaffected. Zero-combined-score variants (when either factor is zero) now get ordered by actual RNA / binding quality instead of arbitrarily.

## Tests
New `tests/test_variant_ranking.py` covers each tier:
- Primary sort by combined_score
- Tiebreak by n_alt_reads when combined_score ties
- Tiebreak by mutant_epitope_score when combined_score and n_alt_reads both tie
- Empty peptide list sorts last (zero sentinel tuple)
- Fully tied triples preserve insertion order

Full suite: **319 passed / 1 skipped** locally.

## Test plan
- [x] `pytest tests/test_variant_ranking.py`
- [x] Full `pytest` suite
- [ ] CI matrix green