### PR TITLE
Extract VaccinePeptide ranking tuple into a rule registry (Phase 1 of #199)

### DIFF
--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,174 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``vaxrank.ranking`` — the rule registry that backs
+``VaccinePeptide.lexicographic_sort_key``. Pinned to the legacy sort
+tuple produced before ranking rules were extracted (Phase 1 of #199)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vaxrank.manufacturability import ManufacturabilityScores
+from vaxrank.ranking import (
+    DEFAULT_RANKING_RULES,
+    MANUFACTURABILITY_SENTINEL,
+    RANKING_RULE_REGISTRY,
+    compute_ranking_tuple,
+)
+
+
+def _fake_peptide(
+    amino_acids="A" * 25,
+    n_alt_reads=7,
+    n_alt_reads_supporting=5,
+    n_mutant_amino_acids=3,
+    mutation_distance_from_edge=9,
+    mutant_epitope_score=0.73,
+    wildtype_epitope_score=0.42,
+    manufacturability_rules=None,
+    manufacturability_thresholds=None,
+):
+    """Minimal duck-typed VaccinePeptide — gives compute_ranking_tuple and
+    the manufacturability expansion everything they read, nothing more."""
+    fragment = SimpleNamespace(
+        amino_acids=amino_acids,
+        n_alt_reads=n_alt_reads,
+        n_alt_reads_supporting_protein_sequence=n_alt_reads_supporting,
+        n_mutant_amino_acids=n_mutant_amino_acids,
+        mutation_distance_from_edge=mutation_distance_from_edge,
+    )
+    manufacturability_scores = ManufacturabilityScores.from_amino_acids(amino_acids)
+    peptide = SimpleNamespace(
+        mutant_protein_fragment=fragment,
+        manufacturability_scores=manufacturability_scores,
+        manufacturability_rules=manufacturability_rules,
+        manufacturability_thresholds=manufacturability_thresholds or {},
+        mutant_epitope_score=mutant_epitope_score,
+        wildtype_epitope_score=wildtype_epitope_score,
+    )
+
+    # Mirror VaccinePeptide.peptide_synthesis_difficulty_score_tuple so the
+    # sentinel expansion in compute_ranking_tuple gets a real tuple back.
+    def _difficulty_tuple(rules=None, **thresholds):
+        from vaxrank.manufacturability import compute_manufacturability_tuple
+
+        filled = {
+            "max_c_terminal_hydropathy": 1.5,
+            "min_kmer_hydropathy": 0.0,
+            "max_kmer_hydropathy_low_priority": 1.5,
+            "max_kmer_hydropathy_high_priority": 2.5,
+        }
+        filled.update(thresholds)
+        return compute_manufacturability_tuple(manufacturability_scores, filled, rules=rules)
+
+    peptide.peptide_synthesis_difficulty_score_tuple = _difficulty_tuple
+    return peptide
+
+
+def _legacy_sort_tuple(peptide):
+    """Inline replica of the pre-refactor VaccinePeptide.lexicographic_sort_key —
+    kept verbatim so the parity test can't accidentally drift with the
+    registry.  If the default order ever changes intentionally, update
+    BOTH this and DEFAULT_RANKING_RULES together."""
+    fragment = peptide.mutant_protein_fragment
+    essential = (
+        -round(peptide.mutant_epitope_score, 6),
+        -fragment.n_alt_reads,
+    )
+    manufacturability = peptide.peptide_synthesis_difficulty_score_tuple(
+        rules=peptide.manufacturability_rules,
+        **peptide.manufacturability_thresholds,
+    )
+    extra = (
+        -fragment.n_alt_reads_supporting_protein_sequence,
+        round(peptide.wildtype_epitope_score, 6),
+        -fragment.n_mutant_amino_acids,
+        -fragment.mutation_distance_from_edge,
+    )
+    return essential + manufacturability + extra
+
+
+@pytest.mark.parametrize("seq", [
+    "A" * 25,
+    "C" * 7 + "A" * 18,
+    "Q" + "A" * 23 + "P",
+    "DP" + "A" * 21 + "NP",
+    "H" * 3 + "A" * 22,
+    "M" + "A" * 24,
+])
+@pytest.mark.parametrize("epitope_score", [0.0, 0.5, 1.2])
+@pytest.mark.parametrize("n_alt_reads", [0, 3, 42])
+def test_default_rules_match_legacy_tuple(seq, epitope_score, n_alt_reads):
+    """Default registry output byte-matches the pre-refactor sort tuple
+    across representative peptides, epitope scores, and read counts."""
+    peptide = _fake_peptide(
+        amino_acids=seq,
+        n_alt_reads=n_alt_reads,
+        mutant_epitope_score=epitope_score,
+    )
+    assert compute_ranking_tuple(peptide) == _legacy_sort_tuple(peptide)
+
+
+def test_registry_covers_every_default_rule():
+    for rule_name in DEFAULT_RANKING_RULES:
+        assert rule_name in RANKING_RULE_REGISTRY
+
+
+def test_manufacturability_sentinel_is_registered():
+    """The sentinel string must sit in the registry so
+    validators / introspection don't flag it as unknown, even though
+    its value is None and expansion is handled specially."""
+    assert MANUFACTURABILITY_SENTINEL in RANKING_RULE_REGISTRY
+    assert RANKING_RULE_REGISTRY[MANUFACTURABILITY_SENTINEL] is None
+
+
+def test_unknown_rule_raises():
+    peptide = _fake_peptide()
+    with pytest.raises(ValueError, match="Unknown ranking rule"):
+        compute_ranking_tuple(peptide, rules=["bogus_rule"])
+
+
+def test_custom_rules_reorder_and_subset():
+    """Users can narrow the sort tuple — lower-priority rules drop out,
+    and order in the list drives lexicographic precedence."""
+    peptide = _fake_peptide()
+    # Two-element tuple, sort first by n_alt_reads then by mutant_epitope_score.
+    result = compute_ranking_tuple(
+        peptide, rules=["n_alt_reads", "mutant_epitope_score"]
+    )
+    fragment = peptide.mutant_protein_fragment
+    assert result == (
+        -fragment.n_alt_reads,
+        -round(peptide.mutant_epitope_score, 6),
+    )
+
+
+def test_custom_rules_can_drop_manufacturability():
+    peptide = _fake_peptide()
+    result = compute_ranking_tuple(
+        peptide, rules=["mutant_epitope_score", "n_alt_reads"]
+    )
+    assert len(result) == 2
+    # None of the manufacturability fields should leak through
+    assert all(isinstance(v, (int, float)) for v in result)
+
+
+def test_manufacturability_sentinel_respects_peptide_manufacturability_rules():
+    """When a peptide uses a subset of manufacturability rules, the
+    sentinel should expand to that subset, not the 10-rule default."""
+    peptide = _fake_peptide(
+        manufacturability_rules=("cysteine_count", "cterm_hydropathy"),
+    )
+    result = compute_ranking_tuple(peptide)
+    # 2 (essential) + 2 (manufacturability subset) + 4 (extra) = 8
+    assert len(result) == 8

--- a/vaxrank/ranking.py
+++ b/vaxrank/ranking.py
@@ -1,0 +1,134 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Registry of vaccine-peptide ranking rules used to build the lexicographic
+sort key on ``VaccinePeptide``. Each rule takes a ``VaccinePeptide`` and
+returns a single numeric value to minimize — Python's ascending sort on
+tuples then gives us the ordering we want.
+
+``DEFAULT_RANKING_RULES`` is pinned byte-for-byte to the legacy
+lexicographic sort produced by ``VaccinePeptide.lexicographic_sort_key``
+before rules became data-driven. Do not reorder without updating the
+parametrized parity test in ``tests/test_ranking.py``.
+
+The special sentinel ``"manufacturability"`` expands in place to the
+peptide's manufacturability sort tuple (respecting whatever
+``manufacturability_rules`` / ``manufacturability_thresholds`` the peptide
+was built with). That lets users compose peptide-level ranking criteria
+with manufacturability criteria in a single flat list, e.g. to
+demote manufacturability below tie-breakers, or drop it entirely.
+"""
+
+
+def _mutant_epitope_score_rule(peptide):
+    # Sum of normalized MHC binding scores across kept mutant epitopes.
+    # Rounded to 6 digits so floating-point noise can't act as a tiebreaker.
+    return -round(peptide.mutant_epitope_score, 6)
+
+
+def _n_alt_reads_rule(peptide):
+    # Number of reads supporting the variant (RNA evidence).
+    return -peptide.mutant_protein_fragment.n_alt_reads
+
+
+def _n_alt_reads_supporting_rule(peptide):
+    # Reads spanning the specific protein-coding sequence selected for
+    # this vaccine peptide (a subset of n_alt_reads).
+    return -peptide.mutant_protein_fragment.n_alt_reads_supporting_protein_sequence
+
+
+def _wildtype_epitope_score_rule(peptide):
+    # Non-mutant MHC binding score — we want this SMALL (already positive-signed).
+    return round(peptide.wildtype_epitope_score, 6)
+
+
+def _n_mutant_amino_acids_rule(peptide):
+    # Prefer peptides containing more mutant residues.
+    return -peptide.mutant_protein_fragment.n_mutant_amino_acids
+
+
+def _mutation_distance_from_edge_rule(peptide):
+    # All else equal, center the mutation inside the vaccine peptide.
+    return -peptide.mutant_protein_fragment.mutation_distance_from_edge
+
+
+RANKING_RULE_REGISTRY = {
+    "mutant_epitope_score": _mutant_epitope_score_rule,
+    "n_alt_reads": _n_alt_reads_rule,
+    "n_alt_reads_supporting": _n_alt_reads_supporting_rule,
+    "wildtype_epitope_score": _wildtype_epitope_score_rule,
+    "n_mutant_amino_acids": _n_mutant_amino_acids_rule,
+    "mutation_distance_from_edge": _mutation_distance_from_edge_rule,
+    # "manufacturability" is a sentinel handled by compute_ranking_tuple
+    # — it expands inline using the peptide's own manufacturability
+    # rules + thresholds. Listed here so registry introspection and
+    # validation can still confirm it's a recognized name.
+    "manufacturability": None,
+}
+
+MANUFACTURABILITY_SENTINEL = "manufacturability"
+
+# Legacy ordering preserved byte-for-byte: this is the exact concatenation
+# `lexicographic_sort_key` produced before rules were made configurable —
+# essential (2 rules) + manufacturability (expanded inline) + extra (4 rules).
+# Do not reorder without updating the parametrized parity test.
+DEFAULT_RANKING_RULES = (
+    "mutant_epitope_score",
+    "n_alt_reads",
+    MANUFACTURABILITY_SENTINEL,
+    "n_alt_reads_supporting",
+    "wildtype_epitope_score",
+    "n_mutant_amino_acids",
+    "mutation_distance_from_edge",
+)
+
+
+def compute_ranking_tuple(peptide, rules=None):
+    """Apply the ordered rule list against a ``VaccinePeptide`` and return
+    the tuple used as a stable lexicographic sort key.
+
+    ``rules`` defaults to ``DEFAULT_RANKING_RULES`` (the legacy order).
+    Each entry must be a key in ``RANKING_RULE_REGISTRY``. The special
+    sentinel ``"manufacturability"`` expands inline to the peptide's
+    manufacturability sort tuple.
+    """
+    if rules is None:
+        rules = DEFAULT_RANKING_RULES
+    values = []
+    for rule_name in rules:
+        if rule_name == MANUFACTURABILITY_SENTINEL:
+            # Let the peptide build its manufacturability sort tuple with
+            # whatever rules / thresholds it was configured with — keep
+            # the two registries decoupled.
+            manufacturability_tuple = peptide.peptide_synthesis_difficulty_score_tuple(
+                rules=peptide.manufacturability_rules,
+                **peptide.manufacturability_thresholds,
+            )
+            values.extend(manufacturability_tuple)
+            continue
+        try:
+            fn = RANKING_RULE_REGISTRY[rule_name]
+        except KeyError:
+            raise ValueError(
+                f"Unknown ranking rule '{rule_name}'. "
+                f"Available: {sorted(RANKING_RULE_REGISTRY)}"
+            ) from None
+        if fn is None:
+            # Defensive: only "manufacturability" has a None mapping and it's
+            # handled above. Any other None is a bug in the registry.
+            raise ValueError(
+                f"Ranking rule '{rule_name}' has no scoring function — "
+                f"likely a registry setup bug."
+            )
+        values.append(fn(peptide))
+    return tuple(values)

--- a/vaxrank/vaccine_peptide.py
+++ b/vaxrank/vaccine_peptide.py
@@ -21,6 +21,7 @@ from .manufacturability import (
     ManufacturabilityScores,
     compute_manufacturability_tuple,
 )
+from .ranking import compute_ranking_tuple
 from .vaccine_config import COMBINED_SCORE_MODES, DEFAULT_COMBINED_SCORE_MODE
 
 
@@ -182,50 +183,16 @@ class VaccinePeptide(DataclassSerializable):
 
     def lexicographic_sort_key(self):
         """
-        Create tuple of scores so that candidates get sorted lexicographically
-        by multiple criteria. Make sure to make the wildtype epitope
-        score positive (since we want fewer wildtype epitopes) but the others
-        negative (since we want more of them).
+        Build the tuple used to sort vaccine peptides lexicographically.
+
+        Rules come from ``DEFAULT_RANKING_RULES`` (see ``vaxrank.ranking``)
+        and expand the ``"manufacturability"`` sentinel in place using this
+        peptide's own manufacturability rules + thresholds. The default
+        order is byte-identical to what this method produced before the
+        rules were extracted — the parity is pinned by
+        ``tests/test_ranking.py::test_default_rules_match_legacy_tuple``.
         """
-        # since we're sorting in decreasing order, numbers which we want
-        # to be larger must have their signs flipped
-        essential_score_tuple = (
-            # Sum of normalized MHC binding affinities of subsequences
-            # round to 5 digits to avoid floating point errors from
-            # serving as tie-breakers
-            -round(self.mutant_epitope_score, 6),
-
-            # Number of reads supporting the variant
-            -self.mutant_protein_fragment.n_alt_reads
-        )
-        manufacturability_score_tuple = self.peptide_synthesis_difficulty_score_tuple(
-            rules=self.manufacturability_rules,
-            **self.manufacturability_thresholds)
-        extra_score_tuple = (
-            # Number of reads supporting the particular protein sequence
-            # sequence we're using for this vaccine peptide. Currently
-            # all vaccine peptides are drawn from the same larger sequence
-            # so this score shouldn't change.
-            -self.mutant_protein_fragment.n_alt_reads_supporting_protein_sequence,
-
-            # Minimize the sum of non-mutant MHC binding scores,
-            # round to prevent floating point errors from serving as
-            # tie-breakers
-            round(self.wildtype_epitope_score, 6),
-
-            # All else being equal, we prefer to maximize the number of
-            # mutant amino acids
-            -self.mutant_protein_fragment.n_mutant_amino_acids,
-
-            # If nothing else can serve as a tie break then try to center
-            # the mutation in the vaccine peptide.
-            -self.mutant_protein_fragment.mutation_distance_from_edge
-        )
-        return (
-            essential_score_tuple +
-            manufacturability_score_tuple +
-            extra_score_tuple
-        )
+        return compute_ranking_tuple(self)
 
     def contains_mutant_epitopes(self):
         return len(self.mutant_epitope_predictions) > 0


### PR DESCRIPTION
Progress on #199.

## Summary
Pure refactor: pulls `essential_score_tuple + manufacturability + extra_score_tuple` out of `VaccinePeptide.lexicographic_sort_key` into a registry pattern that mirrors the manufacturability one shipped in 2.5.0. **Zero behavior change** — the default output is pinned byte-for-byte to the pre-refactor sort tuple.

This is **Phase 1 of B** from our triage:
- Phase 1 (this PR): pure refactor, no config surface change
- Phase 2 (follow-up): expose `vaccine_peptides.ranking_rules` through `VaccineConfig` and YAML

## Changes
- **New** `vaxrank/ranking.py`:
  - `RANKING_RULE_REGISTRY` with 6 named rules (mutant_epitope_score, n_alt_reads, n_alt_reads_supporting, wildtype_epitope_score, n_mutant_amino_acids, mutation_distance_from_edge) + a `"manufacturability"` sentinel.
  - `DEFAULT_RANKING_RULES` — 7-entry tuple pinned byte-for-byte to today's `lexicographic_sort_key` output.
  - `compute_ranking_tuple(peptide, rules=None)` — walks the rule list, expands the `"manufacturability"` sentinel inline using the peptide's own manufacturability rules + thresholds (keeping the two registries decoupled).
- `VaccinePeptide.lexicographic_sort_key` shrinks to a one-line delegation. The derived-attribute / `__post_init__` story is unchanged.
- **New** `tests/test_ranking.py`:
  - `test_default_rules_match_legacy_tuple` — parametrized across 6 peptide sequences × 3 epitope scores × 3 read counts = **54 parity cases**. An inline replica of the pre-refactor sort tuple lives in the test file so drift can't hide in either direction.
  - Unknown-rule error, reorder/subset, manufacturability-drop, and a test confirming the `"manufacturability"` sentinel respects per-peptide manufacturability rule overrides.

## Impact
Downstream code — `VaxrankResults`, `core_logic.py`, report templates — is untouched. `VaccinePeptide` instances sort identically.

## Test plan
- [x] `pytest tests/test_ranking.py` — 60 passed
- [x] Full `pytest` suite — **374 passed, 1 skipped**
- [ ] CI matrix green

## Follow-up (Phase 2)
Add `ranking_rules: Optional[tuple] = None` on `VaccineConfig` + `VaccinePeptide`, wire through `VaxrankConfigSchema` and the loader's `_VACCINE_CONFIG_MAPPING`. Small — ~1 hour.