### PR TITLE
Expose vaccine_peptides.ranking_rules in YAML config (Phase 2 of #199)

### DIFF
--- a/tests/test_core_logic_config.py
+++ b/tests/test_core_logic_config.py
@@ -242,6 +242,7 @@ def test_vaccine_peptides_from_epitopes_score_fraction_of_best_from_config():
             manufacturability_thresholds=None,
             manufacturability_rules=None,
             combined_score_mode=None,
+            ranking_rules=None,
         ):
             self.mutant_protein_fragment = mutant_protein_fragment
             self.combined_score = 10.0 if mutant_protein_fragment.amino_acids == "AAAA" else 8.5

--- a/tests/test_vaccine_peptide_config.py
+++ b/tests/test_vaccine_peptide_config.py
@@ -193,3 +193,76 @@ def test_vaccine_peptide_roundtrip_omits_defaults():
     d = vp.to_dict()
     assert "manufacturability_rules" not in d
     assert "combined_score_mode" not in d
+    assert "ranking_rules" not in d
+
+
+def test_vaccine_peptide_ranking_rules_tuple_coercion():
+    """List of ranking rule names coerced to tuple (same contract as
+    manufacturability_rules)."""
+    vp = VaccinePeptide(
+        mutant_protein_fragment=_make_fragment(),
+        epitope_predictions=[_make_mutant_epitope()],
+        ranking_rules=["mutant_epitope_score", "n_alt_reads"],
+    )
+    assert vp.ranking_rules == ("mutant_epitope_score", "n_alt_reads")
+    assert isinstance(vp.ranking_rules, tuple)
+    # Sort tuple length reflects the custom 2-rule list.
+    assert len(vp.lexicographic_sort_key()) == 2
+
+
+def test_vaccine_peptide_custom_ranking_rules_in_to_dict():
+    vp = VaccinePeptide(
+        mutant_protein_fragment=_make_fragment(),
+        epitope_predictions=[_make_mutant_epitope()],
+        ranking_rules=["mutant_epitope_score"],
+    )
+    d = vp.to_dict()
+    assert d["ranking_rules"] == ["mutant_epitope_score"]
+
+
+def test_end_to_end_yaml_ranking_rules():
+    """YAML with vaccine_peptides.ranking_rules loads through the config
+    pipeline to a VaccineConfig tuple and threads into VaccinePeptide."""
+    yaml_content = """
+vaccine_peptides:
+  ranking_rules:
+    - mutant_epitope_score
+    - n_alt_reads
+    - manufacturability
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(yaml_content)
+        config_path = f.name
+    try:
+        args = argparse.Namespace(
+            config=config_path,
+            vaccine_peptide_length=None,
+            padding_around_mutation=None,
+            max_vaccine_peptides_per_variant=None,
+            num_epitopes_per_vaccine_peptide=None,
+            config_set_overrides=None,
+            config_expr_overrides=None,
+        )
+        vc = vaccine_config_from_args(args)
+        assert vc.ranking_rules == (
+            "mutant_epitope_score", "n_alt_reads", "manufacturability",
+        )
+        assert isinstance(vc.ranking_rules, tuple)
+        # Custom rules drop the extra_score_tuple tiers (n_alt_reads_supporting,
+        # wildtype_epitope_score, n_mutant_amino_acids, mutation_distance_from_edge).
+        vp = VaccinePeptide(
+            mutant_protein_fragment=_make_fragment(),
+            epitope_predictions=[_make_mutant_epitope()],
+            ranking_rules=vc.ranking_rules,
+        )
+        # 2 essential + 10 manufacturability defaults = 12 entries
+        assert len(vp.lexicographic_sort_key()) == 12
+    finally:
+        os.unlink(config_path)
+
+
+def test_vaccine_config_rejects_unknown_ranking_rule():
+    from vaxrank.vaccine_config import VaccineConfig
+
+    with pytest.raises(ValueError, match="Unknown ranking rule"):
+        VaccineConfig(ranking_rules=("not_a_real_rule",))

--- a/vaxrank/config/loader.py
+++ b/vaxrank/config/loader.py
@@ -221,6 +221,7 @@ _VACCINE_CONFIG_MAPPING: list[tuple[str, str]] = [
     ("vaccine_peptides.per_mutation", "max_vaccine_peptides_per_variant"),
     ("vaccine_peptides.score_fraction_of_best", "score_fraction_of_best"),
     ("vaccine_peptides.combined_score_mode", "combined_score_mode"),
+    ("vaccine_peptides.ranking_rules", "ranking_rules"),
     ("manufacturability.max_c_terminal_hydropathy", "max_c_terminal_hydropathy"),
     ("manufacturability.min_kmer_hydropathy", "min_kmer_hydropathy"),
     ("manufacturability.max_kmer_hydropathy_low_priority", "max_kmer_hydropathy_low_priority"),
@@ -260,10 +261,11 @@ def extract_epitope_config_kwargs(config: dict[str, Any]) -> dict[str, Any]:
 def extract_vaccine_config_kwargs(config: dict[str, Any]) -> dict[str, Any]:
     kwargs = _extract_via_mapping(config, _VACCINE_CONFIG_MAPPING)
 
-    # VaccineConfig declares manufacturability_rules as Optional[tuple[str, ...]];
-    # YAML gives us a list, so coerce.
-    if "manufacturability_rules" in kwargs and kwargs["manufacturability_rules"] is not None:
-        kwargs["manufacturability_rules"] = tuple(kwargs["manufacturability_rules"])
+    # VaccineConfig declares *_rules fields as Optional[tuple[str, ...]];
+    # YAML gives us lists, so coerce.
+    for rules_key in ("manufacturability_rules", "ranking_rules"):
+        if rules_key in kwargs and kwargs[rules_key] is not None:
+            kwargs[rules_key] = tuple(kwargs[rules_key])
 
     # When preferred_peptide_length is set but min/max are not,
     # default them to match preferred so the range is consistent.

--- a/vaxrank/config/schema.py
+++ b/vaxrank/config/schema.py
@@ -47,6 +47,7 @@ class VaccinePeptidesConfigSchema(
     max_epitopes_per_candidate: Optional[int] = None
     score_fraction_of_best: Optional[float] = None
     combined_score_mode: Optional[str] = None
+    ranking_rules: Optional[list[str]] = None
     manufacturability: Optional[ManufacturabilityConfigSchema] = None
 
 

--- a/vaxrank/core_logic.py
+++ b/vaxrank/core_logic.py
@@ -347,6 +347,7 @@ def vaccine_peptides_from_epitopes(
             },
             manufacturability_rules=vaccine_config.manufacturability_rules,
             combined_score_mode=vaccine_config.combined_score_mode,
+            ranking_rules=vaccine_config.ranking_rules,
         )
 
         logger.debug(

--- a/vaxrank/vaccine_config.py
+++ b/vaxrank/vaccine_config.py
@@ -43,6 +43,7 @@ from .config.defaults import (
     DEFAULT_VACCINE_PEPTIDE_SCORE_FRACTION_OF_BEST,
 )
 from .manufacturability import MANUFACTURABILITY_RULE_REGISTRY
+from .ranking import RANKING_RULE_REGISTRY
 
 
 COMBINED_SCORE_MODES = (
@@ -150,6 +151,7 @@ class VaccineConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     max_kmer_hydropathy_high_priority: float = DEFAULT_MANUFACTURABILITY_MAX_KMER_HYDROPATHY_HIGH_PRIORITY
     manufacturability_rules: Optional[tuple[str, ...]] = None
     combined_score_mode: str = DEFAULT_COMBINED_SCORE_MODE
+    ranking_rules: Optional[tuple[str, ...]] = None
 
     def __post_init__(self):
         if self.preferred_peptide_length < 1:
@@ -212,3 +214,10 @@ class VaccineConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
                 f"combined_score_mode must be one of {COMBINED_SCORE_MODES}, "
                 f"got '{self.combined_score_mode}'"
             )
+        if self.ranking_rules is not None:
+            for rule_name in self.ranking_rules:
+                if rule_name not in RANKING_RULE_REGISTRY:
+                    raise ValueError(
+                        f"Unknown ranking rule '{rule_name}'. "
+                        f"Available: {sorted(RANKING_RULE_REGISTRY)}"
+                    )

--- a/vaxrank/vaccine_peptide.py
+++ b/vaxrank/vaccine_peptide.py
@@ -70,6 +70,14 @@ class VaccinePeptide(DataclassSerializable):
         ``reads_times_epitope``, or ``epitope_only``. Does not affect
         the ``expression_score`` property, which always reports
         ``sqrt(n_alt_reads)``.
+
+    ranking_rules : sequence of str or None
+        Ordered list of ranking rule names driving the lexicographic
+        sort tuple on ``lexicographic_sort_key``. Names must appear in
+        ``RANKING_RULE_REGISTRY``; the special sentinel
+        ``"manufacturability"`` expands to the peptide's manufacturability
+        sort tuple. When None the 7-entry default order is used
+        (byte-identical with prior releases).
     """
 
     mutant_protein_fragment: Any
@@ -80,6 +88,7 @@ class VaccinePeptide(DataclassSerializable):
     manufacturability_thresholds: Optional[dict] = None
     manufacturability_rules: Optional[tuple] = None
     combined_score_mode: Optional[str] = None
+    ranking_rules: Optional[tuple] = None
 
     # Derived attributes computed in __post_init__ — not part of the
     # serialized form. `init=False` keeps them out of the generated
@@ -97,6 +106,8 @@ class VaccinePeptide(DataclassSerializable):
         self.manufacturability_thresholds = self.manufacturability_thresholds or {}
         if self.manufacturability_rules is not None:
             self.manufacturability_rules = tuple(self.manufacturability_rules)
+        if self.ranking_rules is not None:
+            self.ranking_rules = tuple(self.ranking_rules)
 
         # Validate combined_score_mode; resolve None to the legacy default.
         resolved_mode = self.combined_score_mode or DEFAULT_COMBINED_SCORE_MODE
@@ -185,14 +196,15 @@ class VaccinePeptide(DataclassSerializable):
         """
         Build the tuple used to sort vaccine peptides lexicographically.
 
-        Rules come from ``DEFAULT_RANKING_RULES`` (see ``vaxrank.ranking``)
-        and expand the ``"manufacturability"`` sentinel in place using this
+        Rules come from ``self.ranking_rules`` if supplied, otherwise
+        ``DEFAULT_RANKING_RULES`` (see ``vaxrank.ranking``). The special
+        ``"manufacturability"`` sentinel expands in place using this
         peptide's own manufacturability rules + thresholds. The default
         order is byte-identical to what this method produced before the
         rules were extracted — the parity is pinned by
         ``tests/test_ranking.py::test_default_rules_match_legacy_tuple``.
         """
-        return compute_ranking_tuple(self)
+        return compute_ranking_tuple(self, rules=self.ranking_rules)
 
     def contains_mutant_epitopes(self):
         return len(self.mutant_epitope_predictions) > 0
@@ -235,4 +247,6 @@ class VaccinePeptide(DataclassSerializable):
             d["manufacturability_rules"] = list(self.manufacturability_rules)
         if self.combined_score_mode != DEFAULT_COMBINED_SCORE_MODE:
             d["combined_score_mode"] = self.combined_score_mode
+        if self.ranking_rules is not None:
+            d["ranking_rules"] = list(self.ranking_rules)
         return d


### PR DESCRIPTION
Builds on **#235** (Phase 1 refactor — the rule registry). **Merge #235 first**, then this PR will re-target `main` automatically; or merge both via the queue.

Progress on #199 — closes the last config-surface item from the **still hard-coded** list.

## Summary
Adds `vaccine_peptides.ranking_rules` as a YAML key that flows through the whole config pipeline (schema → loader → `VaccineConfig` → `VaccinePeptide.lexicographic_sort_key`). Zero default-behavior change: when `ranking_rules` is unset, `DEFAULT_RANKING_RULES` still runs and Phase 1's parity test keeps holding.

Example:
```yaml
vaccine_peptides:
  ranking_rules:
    - mutant_epitope_score    # primary
    - n_alt_reads
    - manufacturability       # sentinel — expands to peptide's manufacturability sort tuple
    - wildtype_epitope_score  # moved earlier than default
    # n_alt_reads_supporting, n_mutant_amino_acids, mutation_distance_from_edge deliberately dropped
```

## Changes
- `VaxrankConfigSchema.vaccine_peptides.ranking_rules: Optional[list[str]]`.
- `VaccineConfig.ranking_rules: Optional[tuple[str, ...]]` with `__post_init__` validation against `RANKING_RULE_REGISTRY` — unknown rule names raise `ValueError`.
- `extract_vaccine_config_kwargs` coerces both `manufacturability_rules` and `ranking_rules` list→tuple via a small shared loop.
- `VaccinePeptide.ranking_rules: Optional[tuple]` field; threaded into `compute_ranking_tuple`; `to_dict` emits only when non-default.
- `core_logic.vaccine_peptides_from_epitopes` passes `vaccine_config.ranking_rules` into each VaccinePeptide it constructs.
- Test-mock in `test_core_logic_config.py` updated for the new kwarg.

## Tests
- `test_end_to_end_yaml_ranking_rules` — full YAML→VaccineConfig→VaccinePeptide pipeline including the `manufacturability` sentinel.
- `test_vaccine_peptide_ranking_rules_tuple_coercion` — list input → tuple field invariant.
- `test_vaccine_config_rejects_unknown_ranking_rule` — validation path.
- `test_vaccine_peptide_custom_ranking_rules_in_to_dict` / `test_vaccine_peptide_roundtrip_omits_defaults` — roundtrip coverage.

Full suite: **378 passed, 1 skipped** locally.

## Test plan
- [x] `pytest tests/test_vaccine_peptide_config.py tests/test_core_logic_config.py tests/test_ranking.py`
- [x] Full `pytest` suite
- [ ] CI matrix green (requires #235 to land first, or stacked merge)