### PR TITLE
Ship default.yaml + --print-default-config; close last #199 item

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ if __name__ == "__main__":
         long_description=readme_markdown,
         long_description_content_type="text/markdown",
         packages=find_packages(exclude=["tests", "tests.*"]),
-        package_data={"vaxrank": ["templates/*", "data/*", "logging.conf"]},
+        package_data={"vaxrank": [
+            "templates/*", "data/*", "logging.conf", "config/*.yaml"]},
         entry_points={"console_scripts": ["vaxrank = vaxrank.cli.entry_point:main"]},
     )

--- a/tests/test_vaccine_peptide_config.py
+++ b/tests/test_vaccine_peptide_config.py
@@ -266,3 +266,149 @@ def test_vaccine_config_rejects_unknown_ranking_rule():
 
     with pytest.raises(ValueError, match="Unknown ranking rule"):
         VaccineConfig(ranking_rules=("not_a_real_rule",))
+
+
+# ── require_mutant_epitopes_in_variant ───────────────────────────────────────
+
+def test_vaccine_config_default_requires_mutant_epitopes():
+    """Legacy behavior preserved: default is to drop variants with no
+    mutant-overlapping epitopes."""
+    from vaxrank.vaccine_config import VaccineConfig
+    assert VaccineConfig().require_mutant_epitopes_in_variant is True
+
+
+def test_require_mutant_epitopes_yaml_override(tmp_path):
+    """vaccine_peptides.require_mutant_epitopes_in_variant: false in YAML
+    propagates into the config struct."""
+    import yaml
+    from vaxrank.config.loader import (
+        extract_vaccine_config_kwargs, load_vaxrank_config)
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump({
+        "vaccine_peptides": {"require_mutant_epitopes_in_variant": False}
+    }))
+    import argparse
+    args = argparse.Namespace(config=[str(cfg_path)],
+                              config_set_overrides=None,
+                              config_expr_overrides=None)
+    merged = load_vaxrank_config(args)
+    kwargs = extract_vaccine_config_kwargs(merged)
+    assert kwargs["require_mutant_epitopes_in_variant"] is False
+
+
+def test_create_vaccine_peptides_dict_respects_require_mutant_epitopes():
+    """When require_mutant_epitopes_in_variant=False, variants with no
+    mutant-overlapping vaccine peptides should still appear in the
+    output dict (instead of being silently dropped)."""
+    from unittest.mock import MagicMock, patch
+    from vaxrank.core_logic import create_vaccine_peptides_dict
+    from vaxrank.vaccine_config import VaccineConfig
+
+    # Fake a single isovar result + a non-mutant-covering vaccine peptide.
+    iso = MagicMock()
+    iso.variant = "v1"
+    no_epi_peptide = MagicMock()
+    no_epi_peptide.contains_mutant_epitopes.return_value = False
+
+    with patch("vaxrank.core_logic.vaccine_peptides_for_variant",
+               return_value=[no_epi_peptide]):
+        # Default (require=True): variant dropped.
+        out_strict = create_vaccine_peptides_dict(
+            isovar_results=[iso], mhc_predictor=MagicMock(),
+            vaccine_config=VaccineConfig())
+        assert out_strict == {}
+
+        # require=False: variant kept.
+        out_lax = create_vaccine_peptides_dict(
+            isovar_results=[iso], mhc_predictor=MagicMock(),
+            vaccine_config=VaccineConfig(
+                require_mutant_epitopes_in_variant=False))
+        assert "v1" in out_lax
+
+
+# ── Bundled default.yaml ─────────────────────────────────────────────────────
+
+def test_bundled_default_yaml_is_present_and_parses():
+    """The shipped vaxrank/config/default.yaml must be installed and
+    parse as valid YAML."""
+    from importlib.resources import files
+    import yaml
+    text = files("vaxrank.config").joinpath("default.yaml").read_text()
+    parsed = yaml.safe_load(text)
+    # Top-level sections present
+    assert set(parsed) >= {"epitopes", "vaccine_peptides", "manufacturability"}
+
+
+def test_bundled_default_yaml_round_trips_to_default_configs():
+    """Loading the shipped default.yaml produces configs whose effective
+    behavior matches plain EpitopeConfig() / VaccineConfig() defaults.
+
+    Equality isn't quite ``==`` because the YAML lists ranking_rules /
+    manufacturability_rules explicitly (so users can see the names) while
+    the dataclasses default these to ``None`` (which the rule executor
+    interprets as DEFAULT_RANKING_RULES / DEFAULT_MANUFACTURABILITY_RULES).
+    Compare resolved tuples instead of raw struct equality.
+    """
+    from importlib.resources import files
+    import argparse
+    import tempfile
+    from vaxrank.cli.epitope_config_args import epitope_config_from_args
+    from vaxrank.cli.vaccine_config_args import vaccine_config_from_args
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.manufacturability import DEFAULT_MANUFACTURABILITY_RULES
+    from vaxrank.ranking import DEFAULT_RANKING_RULES
+    from vaxrank.vaccine_config import VaccineConfig
+
+    src = files("vaxrank.config").joinpath("default.yaml").read_text()
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+        f.write(src)
+        path = f.name
+    try:
+        args = argparse.Namespace(
+            config=[path], config_set_overrides=None,
+            config_expr_overrides=None,
+            min_epitope_score=None, scoring_mode=None,
+            default_affinity_predictor=None,
+            default_stability_predictor=None,
+            default_presentation_predictor=None,
+            vaccine_peptide_length=None,
+            padding_around_mutation=None,
+            max_vaccine_peptides_per_mutation=None,
+            num_epitopes_per_vaccine_peptide=None,
+        )
+        ec = epitope_config_from_args(args)
+        vc = vaccine_config_from_args(args)
+        # Epitope side has no list-typed fields, so == works.
+        assert ec == EpitopeConfig()
+        # Vaccine side: effective rule tuples should match the defaults.
+        assert vc.ranking_rules == DEFAULT_RANKING_RULES
+        assert vc.manufacturability_rules == DEFAULT_MANUFACTURABILITY_RULES
+        # All scalar fields match defaults too.
+        defaults = VaccineConfig()
+        for field in (
+            "preferred_peptide_length", "min_peptide_length",
+            "max_peptide_length", "padding_around_mutation",
+            "max_vaccine_peptides_per_variant", "num_mutant_epitopes_to_keep",
+            "score_fraction_of_best", "combined_score_mode",
+            "max_c_terminal_hydropathy", "min_kmer_hydropathy",
+            "max_kmer_hydropathy_low_priority", "max_kmer_hydropathy_high_priority",
+            "require_mutant_epitopes_in_variant",
+        ):
+            assert getattr(vc, field) == getattr(defaults, field), (
+                f"default.yaml drift: {field}")
+    finally:
+        os.unlink(path)
+
+
+def test_print_default_config_cli_dumps_yaml(capsys):
+    """`vaxrank --print-default-config` should write the bundled YAML and
+    exit with code 0 before doing any real work."""
+    from vaxrank.cli.entry_point import main
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--print-default-config"])
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out.startswith("# Vaxrank default configuration")
+    assert "epitopes:" in captured.out
+    assert "vaccine_peptides:" in captured.out
+    assert "manufacturability:" in captured.out

--- a/tests/test_vaccine_peptide_config.py
+++ b/tests/test_vaccine_peptide_config.py
@@ -339,7 +339,7 @@ def test_bundled_default_yaml_is_present_and_parses():
     assert set(parsed) >= {"epitopes", "vaccine_peptides", "manufacturability"}
 
 
-def test_bundled_default_yaml_round_trips_to_default_configs():
+def test_bundled_default_yaml_round_trips_to_default_configs(tmp_path):
     """Loading the shipped default.yaml produces configs whose effective
     behavior matches plain EpitopeConfig() / VaccineConfig() defaults.
 
@@ -351,7 +351,6 @@ def test_bundled_default_yaml_round_trips_to_default_configs():
     """
     from importlib.resources import files
     import argparse
-    import tempfile
     from vaxrank.cli.epitope_config_args import epitope_config_from_args
     from vaxrank.cli.vaccine_config_args import vaccine_config_from_args
     from vaxrank.epitope_config import EpitopeConfig
@@ -360,44 +359,140 @@ def test_bundled_default_yaml_round_trips_to_default_configs():
     from vaxrank.vaccine_config import VaccineConfig
 
     src = files("vaxrank.config").joinpath("default.yaml").read_text()
-    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
-        f.write(src)
-        path = f.name
-    try:
-        args = argparse.Namespace(
-            config=[path], config_set_overrides=None,
-            config_expr_overrides=None,
-            min_epitope_score=None, scoring_mode=None,
-            default_affinity_predictor=None,
-            default_stability_predictor=None,
-            default_presentation_predictor=None,
-            vaccine_peptide_length=None,
-            padding_around_mutation=None,
-            max_vaccine_peptides_per_mutation=None,
-            num_epitopes_per_vaccine_peptide=None,
+    path = tmp_path / "default.yaml"
+    path.write_text(src)
+
+    args = argparse.Namespace(
+        config=[str(path)], config_set_overrides=None,
+        config_expr_overrides=None,
+        min_epitope_score=None, scoring_mode=None,
+        default_affinity_predictor=None,
+        default_stability_predictor=None,
+        default_presentation_predictor=None,
+        vaccine_peptide_length=None,
+        padding_around_mutation=None,
+        max_vaccine_peptides_per_mutation=None,
+        num_epitopes_per_vaccine_peptide=None,
+    )
+    ec = epitope_config_from_args(args)
+    vc = vaccine_config_from_args(args)
+    # Epitope side has no list-typed fields, so == works.
+    assert ec == EpitopeConfig()
+    # Vaccine side: effective rule tuples should match the defaults.
+    assert vc.ranking_rules == DEFAULT_RANKING_RULES
+    assert vc.manufacturability_rules == DEFAULT_MANUFACTURABILITY_RULES
+    # All scalar fields match defaults too.
+    defaults = VaccineConfig()
+    for field in (
+        "preferred_peptide_length", "min_peptide_length",
+        "max_peptide_length", "padding_around_mutation",
+        "max_vaccine_peptides_per_variant", "num_mutant_epitopes_to_keep",
+        "score_fraction_of_best", "combined_score_mode",
+        "max_c_terminal_hydropathy", "min_kmer_hydropathy",
+        "max_kmer_hydropathy_low_priority", "max_kmer_hydropathy_high_priority",
+        "require_mutant_epitopes_in_variant",
+    ):
+        assert getattr(vc, field) == getattr(defaults, field), (
+            f"default.yaml drift: {field}")
+
+
+def test_default_yaml_uncommented_keys_match_schema():
+    """Every uncommented key under each top-level section in default.yaml
+    must be a recognized schema field. Catches drift like keys placed in
+    the wrong section or renamed without updating the YAML."""
+    from importlib.resources import files
+    import yaml
+    from vaxrank.config.schema import (
+        EpitopesConfigSchema,
+        ManufacturabilityConfigSchema,
+        VaccinePeptidesConfigSchema,
+    )
+
+    text = files("vaxrank.config").joinpath("default.yaml").read_text()
+    parsed = yaml.safe_load(text)
+
+    schema_for_section = {
+        "epitopes": EpitopesConfigSchema,
+        "vaccine_peptides": VaccinePeptidesConfigSchema,
+        "manufacturability": ManufacturabilityConfigSchema,
+    }
+    for section, schema_cls in schema_for_section.items():
+        assert section in parsed, f"Missing section in default.yaml: {section}"
+        section_dict = parsed[section] or {}
+        # Drop the nested manufacturability sub-object inside vaccine_peptides
+        # (handled separately above) so it doesn't trigger forbid_unknown_fields
+        # when it's actually a different schema.
+        if section == "vaccine_peptides":
+            section_dict = {k: v for k, v in section_dict.items()
+                            if k != "manufacturability"}
+        # forbid_unknown_fields=True on each schema means msgspec will raise
+        # if any key in section_dict is not a declared schema field.
+        import msgspec
+        msgspec.convert(section_dict, schema_cls)
+
+
+def test_default_yaml_commented_examples_are_valid():
+    """Commented-out example lines in default.yaml are advertised as 'just
+    uncomment to enable' starters. Walk every commented YAML key in the
+    shipped file and verify it's a recognized schema field in its
+    section. Catches the kind of bug where a future edit puts an
+    `epitopes`-only key under `vaccine_peptides`.
+    """
+    from importlib.resources import files
+    import re
+    from vaxrank.config.schema import (
+        EpitopesConfigSchema,
+        ManufacturabilityConfigSchema,
+        VaccinePeptidesConfigSchema,
+    )
+
+    text = files("vaxrank.config").joinpath("default.yaml").read_text()
+
+    schema_for_section = {
+        "epitopes": EpitopesConfigSchema,
+        "vaccine_peptides": VaccinePeptidesConfigSchema,
+        "manufacturability": ManufacturabilityConfigSchema,
+    }
+    section_fields = {
+        s: set(c.__struct_fields__) for s, c in schema_for_section.items()
+    }
+
+    section = None
+    # `# - foo` rule-list comments, `# foo: ...` field comments — capture
+    # both. Skip lines under a nested `manufacturability:` block inside
+    # vaccine_peptides (handled separately under its own section).
+    inside_nested_manuf = False
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        # Top-level section header
+        m = re.match(r"^([a-z_]+):\s*$", line)
+        if m and m.group(1) in schema_for_section:
+            section = m.group(1)
+            inside_nested_manuf = False
+            continue
+        if section is None:
+            continue
+        # Nested manufacturability inside vaccine_peptides
+        if section == "vaccine_peptides" and re.match(
+                r"^\s+manufacturability:\s*$", line):
+            inside_nested_manuf = True
+            continue
+        if inside_nested_manuf:
+            continue
+        # Match commented field lines: `  # field: value`
+        m = re.match(r"^\s*#\s*([a-z_]+):\s", line)
+        if not m:
+            continue
+        key = m.group(1)
+        # Skip rule-list entries (those are values, not field names).
+        # Heuristic: rule-list lines start with `# - ` not `# key:`.
+        # Field comments always have a colon AFTER the name and at least
+        # one char before the # (the indent).
+        assert key in section_fields[section], (
+            f"Commented example `{key}:` in section `{section}` is not a "
+            f"valid field (allowed: {sorted(section_fields[section])}). "
+            f"Either move the line to the right section or fix the key name."
         )
-        ec = epitope_config_from_args(args)
-        vc = vaccine_config_from_args(args)
-        # Epitope side has no list-typed fields, so == works.
-        assert ec == EpitopeConfig()
-        # Vaccine side: effective rule tuples should match the defaults.
-        assert vc.ranking_rules == DEFAULT_RANKING_RULES
-        assert vc.manufacturability_rules == DEFAULT_MANUFACTURABILITY_RULES
-        # All scalar fields match defaults too.
-        defaults = VaccineConfig()
-        for field in (
-            "preferred_peptide_length", "min_peptide_length",
-            "max_peptide_length", "padding_around_mutation",
-            "max_vaccine_peptides_per_variant", "num_mutant_epitopes_to_keep",
-            "score_fraction_of_best", "combined_score_mode",
-            "max_c_terminal_hydropathy", "min_kmer_hydropathy",
-            "max_kmer_hydropathy_low_priority", "max_kmer_hydropathy_high_priority",
-            "require_mutant_epitopes_in_variant",
-        ):
-            assert getattr(vc, field) == getattr(defaults, field), (
-                f"default.yaml drift: {field}")
-    finally:
-        os.unlink(path)
 
 
 def test_print_default_config_cli_dumps_yaml(capsys):

--- a/tests/test_vaccine_peptide_config.py
+++ b/tests/test_vaccine_peptide_config.py
@@ -479,8 +479,13 @@ def test_default_yaml_commented_examples_are_valid():
             continue
         if inside_nested_manuf:
             continue
-        # Match commented field lines: `  # field: value`
-        m = re.match(r"^\s*#\s*([a-z_]+):\s", line)
+        # Match top-level commented field lines: `  # field: value`.
+        # Require exactly one space between `#` and the field name so that
+        # deeper-nested commented values (`#   pMHC_affinity: mhcflurry`
+        # under a parent `# default_methods:`) are skipped — they're values
+        # of the parent dict, not section-level fields, and shouldn't be
+        # checked against the section's schema.
+        m = re.match(r"^\s*# ([a-z_]+):\s", line)
         if not m:
             continue
         key = m.group(1)
@@ -493,6 +498,34 @@ def test_default_yaml_commented_examples_are_valid():
             f"valid field (allowed: {sorted(section_fields[section])}). "
             f"Either move the line to the right section or fix the key name."
         )
+
+
+def test_default_yaml_default_methods_block_uncomments_cleanly():
+    """``epitopes.default_methods`` is the only nested-dict example in
+    default.yaml that ships commented out. Strip the leading ``# `` from
+    that block and confirm the result parses + validates against the
+    schema, so the documented "uncomment to enable" pattern actually
+    works for that block."""
+    from importlib.resources import files
+    import re
+    import yaml
+    import msgspec
+    from vaxrank.config.schema import VaxrankConfigSchema
+
+    text = files("vaxrank.config").joinpath("default.yaml").read_text()
+    activated = re.sub(
+        r"^(\s*)# (default_methods:|  pMHC_\w+:.*)$",
+        r"\1\2",
+        text, flags=re.MULTILINE,
+    )
+    parsed = yaml.safe_load(activated)
+    msgspec.convert(parsed, VaxrankConfigSchema)
+    assert (parsed["epitopes"]["default_methods"]["pMHC_affinity"]
+            == "mhcflurry")
+    assert (parsed["epitopes"]["default_methods"]["pMHC_stability"]
+            == "netmhcstabpan")
+    assert (parsed["epitopes"]["default_methods"]["pMHC_presentation"]
+            == "mhcflurry")
 
 
 def test_print_default_config_cli_dumps_yaml(capsys):

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -12,7 +12,7 @@
 
 
 
-from argparse import Action, ArgumentParser
+from argparse import SUPPRESS, Action, ArgumentParser
 
 from isovar.cli import make_isovar_arg_parser
 from mhctools.cli import add_mhc_args
@@ -24,10 +24,37 @@ from ..version import __version__
 
 
 
+class _PrintDefaultConfigAction(Action):
+    """Dump the bundled default YAML config and exit.
+
+    Useful as a starting point: ``vaxrank --print-default-config > my-config.yaml``
+    produces a fully-commented config file the user can edit and then pass
+    via ``--config my-config.yaml``.
+    """
+    def __init__(self, option_strings, dest=SUPPRESS, default=SUPPRESS,
+                 help=None):
+        super().__init__(
+            option_strings=option_strings, dest=dest, default=default,
+            nargs=0, help=help)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        import sys
+        from importlib.resources import files
+        text = files("vaxrank.config").joinpath("default.yaml").read_text()
+        sys.stdout.write(text)
+        parser.exit()
+
+
 def make_vaxrank_arg_parser():
     # create common parser with the --version flag
     parent_parser = ArgumentParser('parent', add_help=False)
     parent_parser.add_argument('--version', action='version', version='Vaxrank %s' % (__version__,))
+    parent_parser.add_argument(
+        '--print-default-config',
+        action=_PrintDefaultConfigAction,
+        help="Print the bundled default YAML config to stdout and exit. "
+             "Pipe to a file (`> my-config.yaml`) to start from a fully "
+             "documented config you can edit, then run with --config.")
 
     # inherit commandline options from Isovar
     arg_parser = make_isovar_arg_parser(

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -12,7 +12,9 @@
 
 
 
+import sys
 from argparse import SUPPRESS, Action, ArgumentParser
+from importlib.resources import files
 
 from isovar.cli import make_isovar_arg_parser
 from mhctools.cli import add_mhc_args
@@ -38,8 +40,6 @@ class _PrintDefaultConfigAction(Action):
             nargs=0, help=help)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        import sys
-        from importlib.resources import files
         text = files("vaxrank.config").joinpath("default.yaml").read_text()
         sys.stdout.write(text)
         parser.exit()

--- a/vaxrank/config/default.yaml
+++ b/vaxrank/config/default.yaml
@@ -58,6 +58,12 @@ epitopes:
   #   pMHC_stability: netmhcstabpan
   #   pMHC_presentation: mhcflurry
 
+  # Cap on epitope predictions retained per variant during processing
+  # (set 0 to keep everything; higher values cost more time). The same
+  # setting is also accepted as ``vaccine_peptides.max_epitopes_per_candidate``
+  # — pick one section, never both (vaxrank errors if both are set).
+  # top_epitopes_per_candidate: 1000
+
 
 vaccine_peptides:
   # ---- Length / position ----
@@ -68,9 +74,6 @@ vaccine_peptides:
 
   # ---- How many to keep per variant ----
   per_mutation: 1
-  # Cap on epitope predictions retained per variant during processing
-  # (set 0 to keep everything; higher values cost more time).
-  # top_epitopes_per_candidate: 1000
 
   # ---- Score / ranking ----
   # 'sqrt_reads_times_epitope' (default) | 'reads_times_epitope' | 'epitope_only'.
@@ -110,10 +113,9 @@ manufacturability:
 
   # Ordered list of synthesis-difficulty rules applied when the
   # 'manufacturability' sentinel is reached in vaccine_peptides.ranking_rules.
-  # Available rules: cysteine_count, cterm_hydropathy, max_hydropathy_high,
-  # difficult_n_terminal, c_terminal_cysteine, c_terminal_proline,
-  # n_terminal_asparagine, n_terminal_methionine, aspartate_proline,
-  # max_hydropathy_low, min_hydropathy.
+  # The order below matches the legacy hard-coded tie-break order
+  # (preserved byte-for-byte). 'n_terminal_methionine' is registered but
+  # not in the legacy default — uncomment to enable.
   rules:
     - cysteine_count
     - cterm_hydropathy
@@ -122,6 +124,7 @@ manufacturability:
     - c_terminal_cysteine
     - c_terminal_proline
     - n_terminal_asparagine
+    # - n_terminal_methionine
     - aspartate_proline
     - max_hydropathy_low
     - min_hydropathy

--- a/vaxrank/config/default.yaml
+++ b/vaxrank/config/default.yaml
@@ -1,0 +1,127 @@
+# Vaxrank default configuration.
+#
+# Every value below mirrors the in-code default, so an empty config plus this
+# file produces identical behavior to running vaxrank with no --config at all.
+# Copy this file, change what you want, and pass it via:
+#
+#     vaxrank --config my-config.yaml ...
+#
+# You can also dump it any time via:
+#
+#     vaxrank --print-default-config > my-config.yaml
+#
+# The three sections below correspond to the three frozen-config dataclasses
+# vaxrank uses internally:
+#   epitopes        -> vaxrank.epitope_config.EpitopeConfig
+#   vaccine_peptides -> vaxrank.vaccine_config.VaccineConfig (peptide assembly)
+#   manufacturability -> vaxrank.vaccine_config.VaccineConfig (synthesis rules)
+
+
+epitopes:
+  # ---- Scalar scoring knobs ----
+  # IC50 (nM) at which the logistic epitope score equals 0.5.
+  logistic_midpoint: 350.0
+  # Width parameter controlling the steepness of the logistic curve.
+  logistic_width: 150.0
+  # Drop epitopes whose normalized score falls below this threshold.
+  min_score: 0.00001
+  # Maximum IC50 (nM) considered. Above this, default scoring drives to 0.
+  affinity_cutoff: 5000.0
+  # Percentile-rank cutoff (used in scoring_mode: percentile_rank).
+  percentile_rank_cutoff: 10.0
+  # 'affinity' (default) | 'percentile_rank'.
+  scoring_mode: affinity
+
+  # ---- Topiary DSL (optional, overrides scalar knobs above when set) ----
+  # filter_expr is a boolean DSL string evaluated against the topiary
+  # DataFrame: it drops rows wholesale before scoring. Examples:
+  #   "affinity <= 500"
+  #   "affinity <= 500 & percentile_rank <= 2"
+  #   "affinity['mhcflurry'] <= 500 | affinity['netmhcpan'] <= 500"
+  # filter_expr: null
+
+  # score_expr is a numeric DSL string producing one score per
+  # (peptide, allele) group. When unset, vaxrank synthesizes the default
+  # logistic node from the scalar knobs above. Examples:
+  #   "affinity.logistic_normalized(350, 150)"
+  #   "affinity['mhcflurry'].logistic(350, 150) * 0.5
+  #     + affinity['netmhcpan'].logistic(350, 150) * 0.5"
+  # score_expr: null
+
+  # ---- Default predictor methods (only matters with multi-model inputs) ----
+  # When an input source (e.g. LENS) emits multiple predictor models for the
+  # same topiary Kind, unqualified DSL refs (``affinity.value``) need a
+  # default method. Set per Kind below; otherwise vaxrank auto-picks
+  # (mhcflurry > netmhcpan > netmhcstabpan > alphabetical).
+  # default_methods:
+  #   pMHC_affinity: mhcflurry
+  #   pMHC_stability: netmhcstabpan
+  #   pMHC_presentation: mhcflurry
+
+
+vaccine_peptides:
+  # ---- Length / position ----
+  preferred_length: 25
+  min_length: 25
+  max_length: 25
+  padding_around_mutation: 5
+
+  # ---- How many to keep per variant ----
+  per_mutation: 1
+  # Cap on epitope predictions retained per variant during processing
+  # (set 0 to keep everything; higher values cost more time).
+  # top_epitopes_per_candidate: 1000
+
+  # ---- Score / ranking ----
+  # 'sqrt_reads_times_epitope' (default) | 'reads_times_epitope' | 'epitope_only'.
+  combined_score_mode: sqrt_reads_times_epitope
+  # Keep candidates whose score is at least this fraction of the best
+  # before lexicographic tie-breaking.
+  score_fraction_of_best: 0.99
+
+  # Ordered list of tie-break rules (legacy default below). The
+  # 'manufacturability' sentinel expands inline using the manufacturability
+  # rules + thresholds in the section below. Available rules:
+  # mutant_epitope_score, n_alt_reads, n_alt_reads_supporting,
+  # wildtype_epitope_score, n_mutant_amino_acids, mutation_distance_from_edge,
+  # manufacturability.
+  ranking_rules:
+    - mutant_epitope_score
+    - n_alt_reads
+    - manufacturability
+    - n_alt_reads_supporting
+    - wildtype_epitope_score
+    - n_mutant_amino_acids
+    - mutation_distance_from_edge
+
+  # When true (legacy default), drop variants whose vaccine peptides cover
+  # zero mutant epitopes from the report. Set false to keep every variant
+  # for which any vaccine peptide could be assembled — useful when the
+  # report itself is downstream input to an independent predictor.
+  require_mutant_epitopes_in_variant: true
+
+
+manufacturability:
+  # ---- Numeric thresholds (passed to the rule functions) ----
+  max_c_terminal_hydropathy: 1.5
+  min_kmer_hydropathy: 0.0
+  max_kmer_hydropathy_low_priority: 1.5
+  max_kmer_hydropathy_high_priority: 2.5
+
+  # Ordered list of synthesis-difficulty rules applied when the
+  # 'manufacturability' sentinel is reached in vaccine_peptides.ranking_rules.
+  # Available rules: cysteine_count, cterm_hydropathy, max_hydropathy_high,
+  # difficult_n_terminal, c_terminal_cysteine, c_terminal_proline,
+  # n_terminal_asparagine, n_terminal_methionine, aspartate_proline,
+  # max_hydropathy_low, min_hydropathy.
+  rules:
+    - cysteine_count
+    - cterm_hydropathy
+    - max_hydropathy_high
+    - difficult_n_terminal
+    - c_terminal_cysteine
+    - c_terminal_proline
+    - n_terminal_asparagine
+    - aspartate_proline
+    - max_hydropathy_low
+    - min_hydropathy

--- a/vaxrank/config/loader.py
+++ b/vaxrank/config/loader.py
@@ -223,6 +223,8 @@ _VACCINE_CONFIG_MAPPING: list[tuple[str, str]] = [
     ("vaccine_peptides.score_fraction_of_best", "score_fraction_of_best"),
     ("vaccine_peptides.combined_score_mode", "combined_score_mode"),
     ("vaccine_peptides.ranking_rules", "ranking_rules"),
+    ("vaccine_peptides.require_mutant_epitopes_in_variant",
+     "require_mutant_epitopes_in_variant"),
     ("manufacturability.max_c_terminal_hydropathy", "max_c_terminal_hydropathy"),
     ("manufacturability.min_kmer_hydropathy", "min_kmer_hydropathy"),
     ("manufacturability.max_kmer_hydropathy_low_priority", "max_kmer_hydropathy_low_priority"),

--- a/vaxrank/config/schema.py
+++ b/vaxrank/config/schema.py
@@ -18,6 +18,7 @@ class EpitopesConfigSchema(
     top_epitopes_per_candidate: Optional[int] = None
     filter_expr: Optional[str] = None
     score_expr: Optional[str] = None
+    default_methods: Optional[dict[str, str]] = None
 
 
 class ManufacturabilityConfigSchema(
@@ -48,6 +49,7 @@ class VaccinePeptidesConfigSchema(
     score_fraction_of_best: Optional[float] = None
     combined_score_mode: Optional[str] = None
     ranking_rules: Optional[list[str]] = None
+    require_mutant_epitopes_in_variant: Optional[bool] = None
     manufacturability: Optional[ManufacturabilityConfigSchema] = None
 
 

--- a/vaxrank/core_logic.py
+++ b/vaxrank/core_logic.py
@@ -133,6 +133,10 @@ def create_vaccine_peptides_dict(
     Returns a dictionary of varcode.Variant objects to a list of
     VaccinePeptides.
     """
+    require_mutant_epitopes = (
+        vaccine_config.require_mutant_epitopes_in_variant
+        if vaccine_config is not None else True
+    )
     vaccine_peptides_dict = {}
     for isovar_result in isovar_results:
         variant = isovar_result.variant
@@ -147,8 +151,12 @@ def create_vaccine_peptides_dict(
             allow_dna_only_fallback=allow_dna_only_fallback,
         )
 
-        if any(x.contains_mutant_epitopes() for x in vaccine_peptides):
-            vaccine_peptides_dict[variant] = vaccine_peptides
+        if not vaccine_peptides:
+            continue
+        if require_mutant_epitopes and not any(
+                x.contains_mutant_epitopes() for x in vaccine_peptides):
+            continue
+        vaccine_peptides_dict[variant] = vaccine_peptides
 
     return vaccine_peptides_dict
 

--- a/vaxrank/vaccine_config.py
+++ b/vaxrank/vaccine_config.py
@@ -152,6 +152,13 @@ class VaccineConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     manufacturability_rules: Optional[tuple[str, ...]] = None
     combined_score_mode: str = DEFAULT_COMBINED_SCORE_MODE
     ranking_rules: Optional[tuple[str, ...]] = None
+    # When True (default, legacy behavior), variants whose vaccine peptides
+    # contain no mutant-overlapping epitopes are dropped from the report
+    # entirely. Set False to keep every variant for which any vaccine
+    # peptide could be assembled, regardless of epitope coverage —
+    # useful when the report itself is downstream input for an
+    # independent epitope predictor.
+    require_mutant_epitopes_in_variant: bool = True
 
     def __post_init__(self):
         if self.preferred_peptide_length < 1:


### PR DESCRIPTION
## Summary

Two related improvements:

1. **Make the last hardcoded scoring item from #199 configurable.** The variant filter at `core_logic.py:150` (silently drop variants with zero mutant-overlapping epitopes) becomes `vaccine_peptides.require_mutant_epitopes_in_variant: bool` (default `true`, preserves legacy behavior). Set `false` to keep every variant a vaccine peptide could be assembled for — useful when the vaxrank report is downstream input for another predictor.

2. **Ship `vaxrank/config/default.yaml`** that documents every YAML knob with its default value. Add `vaxrank --print-default-config` to dump it. Lets users bootstrap a complete starter config:

   ```bash
   vaxrank --print-default-config > my-config.yaml
   # edit what you want
   vaxrank --config my-config.yaml ...
   ```

The default.yaml is grouped by section (`epitopes` / `vaccine_peptides` / `manufacturability`), with comments pointing at DSL syntax for the non-trivial knobs (`filter_expr`, `score_expr`, `default_methods`).

## Status of #199 after this PR

Per the audit, all the items listed in the 2026-04-20 status comment have shipped:
- combined_score formula → `vaccine_peptides.combined_score_mode` (3 modes)
- ranking tuple → `vaccine_peptides.ranking_rules` + `RANKING_RULE_REGISTRY`
- manufacturability rules → `manufacturability.rules` + registry
- manufacturability thresholds → 4 fields in `manufacturability:`
- variant "drop if zero epitopes" filter → **this PR**

I'd recommend closing #199 once this lands.

## Status of #227

Pin bump to varcode 4.x done (in v2.7.0). `apply_variant_to_transcript` from varcode 2.x's MutantTranscript model is used by `mutant_protein_fragment.py`. Zygosity attributes from varcode 2.x are not used anywhere in vaxrank — and don't need to be unless we add a feature that needs them. I'd recommend closing #227 with that note (or splitting zygosity off to its own ticket if there's a use case).

## Schema additions caught along the way

- `epitopes.default_methods` was added in 2.7.0 but hadn't been added to the `EpitopesConfigSchema` struct, so YAML use was rejected by `forbid_unknown_fields`. Fixed in this PR.
- `vaccine_peptides.require_mutant_epitopes_in_variant` is the new field for this PR.

## Test plan

- [x] `VaccineConfig().require_mutant_epitopes_in_variant` defaults to `True` (legacy).
- [x] YAML override propagates: `vaccine_peptides.require_mutant_epitopes_in_variant: false` → kwargs reflect it.
- [x] `create_vaccine_peptides_dict` respects the flag (variant kept under false; dropped under true).
- [x] Bundled `default.yaml` parses and round-trips to default config behavior (rule-tuple resolution compared, since `None` ≠ `(...)` literally but is equivalent semantically).
- [x] `vaxrank --print-default-config` exits 0 and dumps the YAML to stdout.
- [x] Full suite: 434 passed, 1 skipped.

## Notes for reviewers

- `default.yaml` lists `ranking_rules` and `manufacturability.rules` explicitly so users can see the names. The dataclasses default to `None` (which the rule executors interpret as the registry's default tuple). Test compares effective behavior, not literal field equality.
- `package_data` in `setup.py` extended to include `config/*.yaml` so the file ships in the wheel. Verified the import-resources path works with `vaxrank --print-default-config`.