### PR TITLE
Drop pysam source-build CI step and direct pin (closes #220)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,15 +54,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-cov ruff
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Install pysam from source (Python 3.13 fix)
-        if: matrix.python-version == '3.13'
-        run: |
-          # pysam 0.23.x has Cython profiling enabled which breaks
-          # coverage on 3.13 (sys.monitoring bug). Fixed on master
-          # (commit 54f3d41) but not yet released. Remove this step
-          # once pysam >=0.24 is out.
-          pip install --no-binary pysam --force-reinstall \
-            git+https://github.com/pysam-developers/pysam.git
       - name: Install wkhtmltopdf
         run: |
           sudo apt-get install -y xfonts-base xfonts-75dpi

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ openpyxl
 xvfbwrapper  # legacy: only needed with --pdf-backend=pdfkit on headless Linux
 astropy>=6.1
 platformdirs
-pysam>=0.23.0
 msgspec>=0.18.6,<1.0.0
 dnachisel>=3.2.0,<4.0.0
 serializable>=1.1.0,<2.0.0

--- a/tests/test_no_direct_pysam_import.py
+++ b/tests/test_no_direct_pysam_import.py
@@ -1,0 +1,58 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guard the invariant that vaxrank never imports pysam directly.
+
+Issue #220 dropped the standalone ``pysam>=0.23.0`` line from
+requirements.txt: vaxrank reads BAMs only through isovar, which owns
+its own pysam pin. If a future change adds ``import pysam`` to a
+vaxrank module, the package will still work in dev (pysam is
+transitively installed) but requirements.txt no longer documents the
+dependency. This test fails before that drift can ship.
+"""
+
+import ast
+import pathlib
+
+
+VAXRANK_ROOT = pathlib.Path(__file__).resolve().parent.parent / "vaxrank"
+
+
+def _python_files(root):
+    for path in root.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        yield path
+
+
+def _imports_pysam(source):
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "pysam" or alias.name.startswith("pysam."):
+                    return True
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "pysam" or (
+                    node.module and node.module.startswith("pysam.")):
+                return True
+    return False
+
+
+def test_no_direct_pysam_import():
+    offenders = []
+    for path in _python_files(VAXRANK_ROOT):
+        if _imports_pysam(path.read_text()):
+            offenders.append(str(path.relative_to(VAXRANK_ROOT.parent)))
+    assert not offenders, (
+        "vaxrank must not import pysam directly (see #220 — isovar owns the "
+        "pysam dep). Offending files:\n  " + "\n  ".join(offenders))

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.10.0"
+__version__ = "2.10.1"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

- **CI**: pysam 0.24.0 ships Linux/macOS cp313 wheels and includes the Cython-profile / `sys.monitoring` fix, so the Python 3.13 source-build workaround in `tests.yml` is no longer needed.
- **requirements.txt**: vaxrank doesn't import pysam directly — isovar owns the dependency (`pysam>=0.15.2`). The standalone `pysam>=0.23.0` line was dead weight; drop it and let isovar set the floor.
- **version**: 2.8.0 → 2.8.1.

Closes #220.

## Test plan

- [x] `./lint.sh` passes
- [x] `./test.sh` passes locally with pysam 0.24.0 (438 passed)
- [ ] CI green on all matrix entries (3.10–3.13)