### PR TITLE
Surface DNA/RNA VAF in reports (closes #57)

### DIFF
--- a/tests/test_mutant_protein_sequence.py
+++ b/tests/test_mutant_protein_sequence.py
@@ -120,6 +120,35 @@ def test_keep_top_k_epitopes():
             p.logistic_epitope_score() for p in vaccine_peptide.mutant_epitope_predictions)
         almost_eq_(mutant_epitope_score, vaccine_peptide.mutant_epitope_score)
 
+def test_rna_vaf_property():
+    from varcode import Variant
+    fragment = MutantProteinFragment(
+        variant=Variant('X', '8125624', 'C', 'A'),
+        gene_name='Wdr13',
+        amino_acids='KLQGHSAPVLDVIVNCDESLLASSD',
+        mutant_amino_acid_start_offset=12,
+        mutant_amino_acid_end_offset=13,
+        n_overlapping_reads=80,
+        n_alt_reads=25,
+        n_ref_reads=75,
+        n_alt_reads_supporting_protein_sequence=2,
+        supporting_reference_transcripts=[])
+    eq_(0.25, fragment.rna_vaf)
+
+    zero_fragment = MutantProteinFragment(
+        variant=Variant('X', '8125624', 'C', 'A'),
+        gene_name='Wdr13',
+        amino_acids='KLQGHSAPVLDVIVNCDESLLASSD',
+        mutant_amino_acid_start_offset=12,
+        mutant_amino_acid_end_offset=13,
+        n_overlapping_reads=0,
+        n_alt_reads=0,
+        n_ref_reads=0,
+        n_alt_reads_supporting_protein_sequence=0,
+        supporting_reference_transcripts=[])
+    assert zero_fragment.rna_vaf is None
+
+
 def test_mutant_protein_fragment_serialization():
     arg_parser = make_vaxrank_arg_parser()
     keep_k_epitopes = 3

--- a/tests/test_vaf.py
+++ b/tests/test_vaf.py
@@ -83,6 +83,28 @@ def test_dna_vaf_handles_af_as_list():
     assert out[v] == 0.25
 
 
+def test_dna_vaf_af_uses_alt_allele_index():
+    # FORMAT/AF is one value per ALT allele on multiallelic records.
+    # A variant split from the second ALT must read the second entry,
+    # not always entry [0]. Regression for the bug where _parse_af
+    # always took value[0].
+    v = object()
+    sample = {'TUMOR': {'AF': [0.1, 0.4]}}
+    coll = _stub_collection({'a.vcf': {v: _entry(sample, alt_allele_index=1)}})
+    out = extract_dna_vaf_by_variant(coll, tumor_sample_name='TUMOR')
+    assert out[v] == 0.4
+
+
+def test_dna_vaf_af_index_out_of_range_falls_back_to_ad():
+    # If AF doesn't have an entry for this alt_allele_index but AD does,
+    # fall back to AD rather than mis-reporting the wrong allele's VAF.
+    v = object()
+    sample = {'TUMOR': {'AF': [0.1], 'AD': [60, 20, 20]}}
+    coll = _stub_collection({'a.vcf': {v: _entry(sample, alt_allele_index=1)}})
+    out = extract_dna_vaf_by_variant(coll, tumor_sample_name='TUMOR')
+    assert abs(out[v] - 0.20) < 1e-9
+
+
 def test_dna_vaf_empty_collection():
     coll = SimpleNamespace(source_to_metadata_dict={})
     assert extract_dna_vaf_by_variant(coll) == {}

--- a/tests/test_vaf.py
+++ b/tests/test_vaf.py
@@ -115,3 +115,29 @@ def test_dna_vaf_zero_depth_returns_none():
     coll = _stub_collection({'a.vcf': {v: _entry({'TUMOR': {'AD': [0, 0]}})}})
     out = extract_dna_vaf_by_variant(coll, tumor_sample_name='TUMOR')
     assert v not in out
+
+
+def test_dna_vaf_warns_when_tumor_sample_name_unmatched(caplog):
+    # User typo: VCF FORMAT has 'TUMOUR' but --tumor-sample-name was
+    # 'TUMOR'. Before the guard, dict.get() returned None silently and
+    # every variant dropped out without a hint.
+    import logging
+    v = object()
+    coll = _stub_collection({'a.vcf': {v: _entry({'TUMOUR': {'AF': 0.4}})}})
+    with caplog.at_level(logging.WARNING):
+        out = extract_dna_vaf_by_variant(coll, tumor_sample_name='TUMOR')
+    assert v not in out
+    assert any('TUMOR' in rec.message and 'TUMOUR' in rec.message
+               for rec in caplog.records), \
+        "Expected a warning that 'TUMOR' didn't match and listed 'TUMOUR'"
+
+
+def test_dna_vaf_ad_with_none_entry_returns_none():
+    # AD=[ref, None, alt2] would, with the prior `[x for x in v if x is
+    # not None]` filter, shift indices and silently report the wrong
+    # allele's VAF. The entry must be rejected instead.
+    v = object()
+    sample = {'TUMOR': {'AD': [50, None, 30]}}
+    coll = _stub_collection({'a.vcf': {v: _entry(sample, alt_allele_index=1)}})
+    out = extract_dna_vaf_by_variant(coll, tumor_sample_name='TUMOR')
+    assert v not in out

--- a/tests/test_vaf.py
+++ b/tests/test_vaf.py
@@ -1,0 +1,95 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for DNA VAF extraction from varcode VCF metadata."""
+
+from types import SimpleNamespace
+
+from vaxrank.vaf import extract_dna_vaf_by_variant
+
+
+def _stub_collection(metadata_by_source):
+    return SimpleNamespace(source_to_metadata_dict=metadata_by_source)
+
+
+def _entry(sample_info, alt_allele_index=0):
+    return {
+        'id': '.',
+        'qual': None,
+        'filter': 'PASS',
+        'info': {},
+        'sample_info': sample_info,
+        'alt_allele_index': alt_allele_index,
+    }
+
+
+def test_dna_vaf_prefers_af_field():
+    v = object()
+    coll = _stub_collection({'a.vcf': {v: _entry({'TUMOR': {'AF': 0.42, 'AD': [10, 5]}})}})
+    out = extract_dna_vaf_by_variant(coll, tumor_sample_name='TUMOR')
+    assert out[v] == 0.42
+
+
+def test_dna_vaf_falls_back_to_ad():
+    v = object()
+    coll = _stub_collection({'a.vcf': {v: _entry({'TUMOR': {'AD': [70, 30]}})}})
+    out = extract_dna_vaf_by_variant(coll, tumor_sample_name='TUMOR')
+    assert abs(out[v] - 0.30) < 1e-9
+
+
+def test_dna_vaf_uses_alt_allele_index():
+    v = object()
+    sample = {'TUMOR': {'AD': [60, 20, 20]}}
+    coll = _stub_collection({'a.vcf': {v: _entry(sample, alt_allele_index=1)}})
+    out = extract_dna_vaf_by_variant(coll, tumor_sample_name='TUMOR')
+    assert abs(out[v] - 0.20) < 1e-9
+
+
+def test_dna_vaf_auto_picks_single_sample():
+    v = object()
+    coll = _stub_collection({'a.vcf': {v: _entry({'ONLY': {'AF': 0.1}})}})
+    out = extract_dna_vaf_by_variant(coll)
+    assert out[v] == 0.1
+
+
+def test_dna_vaf_skips_multi_sample_without_name():
+    v = object()
+    sample = {'TUMOR': {'AF': 0.4}, 'NORMAL': {'AF': 0.0}}
+    coll = _stub_collection({'a.vcf': {v: _entry(sample)}})
+    out = extract_dna_vaf_by_variant(coll)
+    assert v not in out
+
+
+def test_dna_vaf_skips_when_neither_af_nor_ad():
+    v = object()
+    coll = _stub_collection({'a.vcf': {v: _entry({'TUMOR': {'GT': '0/1'}})}})
+    out = extract_dna_vaf_by_variant(coll, tumor_sample_name='TUMOR')
+    assert v not in out
+
+
+def test_dna_vaf_handles_af_as_list():
+    v = object()
+    coll = _stub_collection({'a.vcf': {v: _entry({'TUMOR': {'AF': [0.25]}})}})
+    out = extract_dna_vaf_by_variant(coll, tumor_sample_name='TUMOR')
+    assert out[v] == 0.25
+
+
+def test_dna_vaf_empty_collection():
+    coll = SimpleNamespace(source_to_metadata_dict={})
+    assert extract_dna_vaf_by_variant(coll) == {}
+
+
+def test_dna_vaf_zero_depth_returns_none():
+    v = object()
+    coll = _stub_collection({'a.vcf': {v: _entry({'TUMOR': {'AD': [0, 0]}})}})
+    out = extract_dna_vaf_by_variant(coll, tumor_sample_name='TUMOR')
+    assert v not in out

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -182,6 +182,12 @@ def add_advanced_args(arg_parser):
         help="Path to pre-computed MHC binding predictions (topiary TSV/Parquet "
              "or CSV). Used as a lookup cache; peptides not in the cache fall "
              "through to the live MHC predictor.")
+    advanced_group.add_argument(
+        "--tumor-sample-name",
+        default=None,
+        help="Name of the tumor sample column in the VCF FORMAT fields, used "
+             "to read DNA VAF (FORMAT/AF, falling back to AD). Required for "
+             "multi-sample VCFs; auto-picked when only one sample is present.")
 
 
 def add_output_args(arg_parser):

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -60,6 +60,7 @@ from ..report import (
 )
 from ..patient_info import PatientInfo
 from ..mrna import MRNAOptions, assemble_mrna_constructs, write_mrna_outputs
+from ..vaf import extract_dna_vaf_by_variant
 
 logger = logging.getLogger(__name__)
 
@@ -255,7 +256,8 @@ def main(args_list=None):
         reviewers=args.output_reviewed_by,
         args_for_report=args_for_report,
         input_json_file=input_json_file,
-        cosmic_vcf_filename=args.cosmic_vcf_filename)
+        cosmic_vcf_filename=args.cosmic_vcf_filename,
+        dna_vaf_by_variant=data.get('dna_vaf_by_variant') or {})
 
     template_data = template_data_creator.compute_template_data()
 
@@ -379,6 +381,9 @@ def ranked_vaccine_peptides_with_metadata_from_parsed_args(args):
     logger.info("Variants: %d loaded, %d after filtering invalid contigs",
                 len(all_variants), len(variants))
 
+    dna_vaf_by_variant = extract_dna_vaf_by_variant(
+        all_variants, tumor_sample_name=getattr(args, 'tumor_sample_name', None))
+
     vaxrank_results = run_vaxrank_from_parsed_args(args)
 
     variants_count_dict = vaxrank_results.variant_counts()
@@ -388,7 +393,8 @@ def ranked_vaccine_peptides_with_metadata_from_parsed_args(args):
 
     if args.output_passing_variants_csv:
         variant_metadata_dicts = vaxrank_results.variant_properties(
-            gene_pathway_check=GenePathwayCheck())
+            gene_pathway_check=GenePathwayCheck(),
+            dna_vaf_by_variant=dna_vaf_by_variant)
         df = pd.DataFrame(variant_metadata_dicts)
         df.to_csv(args.output_passing_variants_csv, index=False)
 
@@ -413,6 +419,7 @@ def ranked_vaccine_peptides_with_metadata_from_parsed_args(args):
         'variants': ranked_variants_with_vaccine_peptides_for_report,
         'patient_info': patient_info,
         'args': vars(args),
+        'dna_vaf_by_variant': dna_vaf_by_variant,
     }
     logger.info('About to save args: %s', data['args'])
 

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -245,6 +245,17 @@ class MutantProteinFragment(DataclassSerializable):
         """
         return self.n_overlapping_reads - (self.n_ref_reads + self.n_alt_reads)
 
+    @property
+    def rna_vaf(self):
+        """
+        RNA variant allele frequency: alt / (alt + ref). Returns None when
+        no ref+alt reads were observed.
+        """
+        denom = self.n_alt_reads + self.n_ref_reads
+        if denom == 0:
+            return None
+        return self.n_alt_reads / denom
+
     def interval_overlaps_mutation(self, start_offset, end_offset):
         """
         Does the given start_offset:end_offset interval overlap the mutated

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -248,8 +248,18 @@ class MutantProteinFragment(DataclassSerializable):
     @property
     def rna_vaf(self):
         """
-        RNA variant allele frequency: alt / (alt + ref). Returns None when
-        no ref+alt reads were observed.
+        RNA variant allele frequency.
+
+        Computed as ``n_alt_reads / (n_alt_reads + n_ref_reads)`` —
+        ``n_other_reads`` (reads matching neither ref nor alt) is
+        excluded from the denominator so the value reports an
+        alt-vs-ref ratio rather than alt-out-of-total-overlapping.
+        Matches the convention used by
+        ``vaxrank_results.variant_properties`` for JSON/CSV output.
+        Differs from ``isovar.IsovarResult.fraction_alt_fragments``,
+        which divides by the total fragment count including "other".
+
+        Returns None when no ref+alt reads were observed.
         """
         denom = self.n_alt_reads + self.n_ref_reads
         if denom == 0:

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -47,12 +47,14 @@ class TemplateDataCreator(object):
             reviewers,
             args_for_report,
             input_json_file,
-            cosmic_vcf_filename=None):
+            cosmic_vcf_filename=None,
+            dna_vaf_by_variant=None):
         """
         Construct a TemplateDataCreator object, from the output of the vaxrank pipeline.
         """
         self.ranked_variants_with_vaccine_peptides = ranked_variants_with_vaccine_peptides
         self.patient_info = patient_info
+        self.dna_vaf_by_variant = dna_vaf_by_variant or {}
 
         # filter output-related command-line args: we want to display everything else
         args_to_display_in_report = {
@@ -105,10 +107,14 @@ class TemplateDataCreator(object):
         mutant_protein_fragment = top_vaccine_peptide.mutant_protein_fragment
         top_score = _sanitize(top_vaccine_peptide.combined_score)
         igv_locus = "chr%s:%d" % (variant.contig, variant.start)
+        rna_vaf = mutant_protein_fragment.rna_vaf
+        dna_vaf = self.dna_vaf_by_variant.get(variant)
         variant_data = OrderedDict([
             ('IGV locus', igv_locus),
             ('Gene name', mutant_protein_fragment.gene_name),
             ('Top score', top_score),
+            ('DNA VAF', '%.3f' % dna_vaf if dna_vaf is not None else 'n/a'),
+            ('RNA VAF', '%.3f' % rna_vaf if rna_vaf is not None else 'n/a'),
             ('RNA reads supporting variant allele', mutant_protein_fragment.n_alt_reads),
             ('RNA reads supporting reference allele', mutant_protein_fragment.n_ref_reads),
             ('RNA reads supporting other alleles', mutant_protein_fragment.n_other_reads),

--- a/vaxrank/vaf.py
+++ b/vaxrank/vaf.py
@@ -22,14 +22,20 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def _parse_af(value):
-    """Parse a FORMAT 'AF' value, which may be a float, list, or string."""
+def _parse_af(value, alt_allele_index=0):
+    """Parse a FORMAT 'AF' value, which may be a float, list, or string.
+
+    For multiallelic records, AF is conventionally one value per ALT
+    allele; ``alt_allele_index`` (0-based into the alt-only list) selects
+    the right entry. Scalar values are returned as-is regardless of
+    ``alt_allele_index``.
+    """
     if value is None:
         return None
     if isinstance(value, (list, tuple)):
-        if not value:
+        if alt_allele_index < 0 or alt_allele_index >= len(value):
             return None
-        value = value[0]
+        value = value[alt_allele_index]
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -104,7 +110,7 @@ def extract_dna_vaf_by_variant(variant_collection, tumor_sample_name=None):
                     skipped_ambiguous += 1
                 continue
             alt_idx = info.get('alt_allele_index', 0)
-            vaf = _parse_af(sample.get('AF'))
+            vaf = _parse_af(sample.get('AF'), alt_idx)
             if vaf is None:
                 vaf = _vaf_from_ad(sample.get('AD'), alt_idx)
             if vaf is None:

--- a/vaxrank/vaf.py
+++ b/vaxrank/vaf.py
@@ -48,13 +48,20 @@ def _vaf_from_ad(value, alt_allele_index):
 
     AD is conventionally [ref_depth, alt1_depth, alt2_depth, ...].
     ``alt_allele_index`` is the 0-based index into the alt-only list (so
-    AD index = alt_allele_index + 1). Returns None if depths are missing
-    or sum to zero.
+    AD index = alt_allele_index + 1). VAF is reported as
+    ``alt_K / sum(AD)`` (matches GATK's convention for FORMAT/AF —
+    fraction of total reads supporting this specific alt).
+
+    Returns None if AD is absent, contains a None entry (filtering
+    those out would shift indices and silently change the meaning of
+    ``alt_allele_index``), or sums to zero.
     """
     if not isinstance(value, (list, tuple)):
         return None
+    if any(x is None for x in value):
+        return None
     try:
-        depths = [int(x) for x in value if x is not None]
+        depths = [int(x) for x in value]
     except (TypeError, ValueError):
         return None
     if not depths or sum(depths) == 0:
@@ -65,12 +72,26 @@ def _vaf_from_ad(value, alt_allele_index):
     return depths[alt_idx] / sum(depths)
 
 
+# Sentinel returned when a tumor_sample_name was supplied but doesn't appear in
+# the VCF's FORMAT samples — distinct from "no usable sample" so the caller can
+# warn about typos rather than silently dropping every variant.
+_SAMPLE_NAME_NOT_FOUND = object()
+
+
 def _pick_tumor_sample(sample_info, tumor_sample_name):
-    """Pick the sample dict to read AF/AD from. ``None`` if ambiguous."""
+    """Pick the sample dict to read AF/AD from.
+
+    Returns ``None`` when no usable sample is found (no FORMAT data, or
+    a multi-sample VCF without ``--tumor-sample-name``). Returns
+    ``_SAMPLE_NAME_NOT_FOUND`` when a name was supplied but doesn't
+    appear in the FORMAT dict.
+    """
     if not sample_info:
         return None
     if tumor_sample_name:
-        return sample_info.get(tumor_sample_name)
+        if tumor_sample_name not in sample_info:
+            return _SAMPLE_NAME_NOT_FOUND
+        return sample_info[tumor_sample_name]
     if len(sample_info) == 1:
         return next(iter(sample_info.values()))
     return None
@@ -102,11 +123,18 @@ def extract_dna_vaf_by_variant(variant_collection, tumor_sample_name=None):
     dna_vaf = {}
     skipped_missing = 0
     skipped_ambiguous = 0
+    skipped_unmatched_name = 0
+    available_sample_names = set()
     for _source, per_variant in metadata.items():
         for variant, info in per_variant.items():
-            sample = _pick_tumor_sample(info.get('sample_info'), tumor_sample_name)
+            sample_info = info.get('sample_info') or {}
+            available_sample_names.update(sample_info)
+            sample = _pick_tumor_sample(sample_info, tumor_sample_name)
+            if sample is _SAMPLE_NAME_NOT_FOUND:
+                skipped_unmatched_name += 1
+                continue
             if sample is None:
-                if info.get('sample_info') and len(info['sample_info']) > 1:
+                if sample_info and len(sample_info) > 1:
                     skipped_ambiguous += 1
                 continue
             alt_idx = info.get('alt_allele_index', 0)
@@ -118,6 +146,14 @@ def extract_dna_vaf_by_variant(variant_collection, tumor_sample_name=None):
                 continue
             dna_vaf[variant] = vaf
 
+    if skipped_unmatched_name:
+        logger.warning(
+            "DNA VAF: --tumor-sample-name '%s' did not match any FORMAT "
+            "sample in the VCF; %d variant(s) skipped. Available samples: %s.",
+            tumor_sample_name,
+            skipped_unmatched_name,
+            ", ".join(sorted(available_sample_names)) or "(none)",
+        )
     if skipped_ambiguous:
         logger.warning(
             "DNA VAF: %d variant(s) skipped because the VCF has multiple "

--- a/vaxrank/vaf.py
+++ b/vaxrank/vaf.py
@@ -1,0 +1,126 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DNA VAF extraction from VCF FORMAT/sample data.
+
+varcode's ``load_vcf`` keeps per-variant INFO and per-sample FORMAT fields
+on ``VariantCollection.source_to_metadata_dict``. This module reads that
+metadata and returns a ``{Variant: float}`` mapping of DNA VAF values.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_af(value):
+    """Parse a FORMAT 'AF' value, which may be a float, list, or string."""
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        value = value[0]
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _vaf_from_ad(value, alt_allele_index):
+    """
+    Compute VAF from a FORMAT 'AD' (allelic depth) array.
+
+    AD is conventionally [ref_depth, alt1_depth, alt2_depth, ...].
+    ``alt_allele_index`` is the 0-based index into the alt-only list (so
+    AD index = alt_allele_index + 1). Returns None if depths are missing
+    or sum to zero.
+    """
+    if not isinstance(value, (list, tuple)):
+        return None
+    try:
+        depths = [int(x) for x in value if x is not None]
+    except (TypeError, ValueError):
+        return None
+    if not depths or sum(depths) == 0:
+        return None
+    alt_idx = alt_allele_index + 1
+    if alt_idx >= len(depths):
+        return None
+    return depths[alt_idx] / sum(depths)
+
+
+def _pick_tumor_sample(sample_info, tumor_sample_name):
+    """Pick the sample dict to read AF/AD from. ``None`` if ambiguous."""
+    if not sample_info:
+        return None
+    if tumor_sample_name:
+        return sample_info.get(tumor_sample_name)
+    if len(sample_info) == 1:
+        return next(iter(sample_info.values()))
+    return None
+
+
+def extract_dna_vaf_by_variant(variant_collection, tumor_sample_name=None):
+    """
+    Build a ``{Variant: dna_vaf}`` mapping by reading per-sample FORMAT
+    data attached to ``variant_collection.source_to_metadata_dict``.
+
+    Prefers the FORMAT/AF field; falls back to AD when AF is absent.
+    Variants without usable depth/frequency data are omitted.
+
+    Parameters
+    ----------
+    variant_collection : varcode.VariantCollection
+    tumor_sample_name : str, optional
+        Name of the FORMAT-column sample to read. Required for multi-sample
+        VCFs; auto-picked when only one sample is present.
+
+    Returns
+    -------
+    dict[varcode.Variant, float]
+    """
+    metadata = getattr(variant_collection, 'source_to_metadata_dict', None) or {}
+    if not metadata:
+        return {}
+
+    dna_vaf = {}
+    skipped_missing = 0
+    skipped_ambiguous = 0
+    for _source, per_variant in metadata.items():
+        for variant, info in per_variant.items():
+            sample = _pick_tumor_sample(info.get('sample_info'), tumor_sample_name)
+            if sample is None:
+                if info.get('sample_info') and len(info['sample_info']) > 1:
+                    skipped_ambiguous += 1
+                continue
+            alt_idx = info.get('alt_allele_index', 0)
+            vaf = _parse_af(sample.get('AF'))
+            if vaf is None:
+                vaf = _vaf_from_ad(sample.get('AD'), alt_idx)
+            if vaf is None:
+                skipped_missing += 1
+                continue
+            dna_vaf[variant] = vaf
+
+    if skipped_ambiguous:
+        logger.warning(
+            "DNA VAF: %d variant(s) skipped because the VCF has multiple "
+            "samples but --tumor-sample-name was not provided.",
+            skipped_ambiguous,
+        )
+    if skipped_missing:
+        logger.info(
+            "DNA VAF: %d variant(s) lacked a usable AF/AD field.",
+            skipped_missing,
+        )
+    return dna_vaf

--- a/vaxrank/vaxrank_results.py
+++ b/vaxrank/vaxrank_results.py
@@ -75,13 +75,16 @@ class VaxrankResults(DataclassSerializable):
             for v in variant_properties)
         return counts_dict
 
-    def variant_properties(self, gene_pathway_check=None):
+    def variant_properties(self, gene_pathway_check=None, dna_vaf_by_variant=None):
         """
         Parameters
         ----------
         gene_pathway_check : GenePathwayCheck (optional)
             Used to look up whether a mutation or its affected gene are in some
             biologically important pathway.
+        dna_vaf_by_variant : dict[varcode.Variant, float] (optional)
+            DNA VAF values extracted from the source VCF's FORMAT/AF (or AD)
+            fields. Variants without a DNA VAF entry get ``None``.
 
         Returns
         -------
@@ -89,9 +92,16 @@ class VaxrankResults(DataclassSerializable):
         e.g. whether this variant is part of a pathway of interest,
         is a strong MHC binder, etc.
         """
+        dna_vaf_by_variant = dna_vaf_by_variant or {}
         variant_properties_list = []
         for isovar_result in self.isovar_results:
             variant = isovar_result.variant
+
+            rna_vaf = None
+            num_alt = getattr(isovar_result, 'num_alt_fragments', None)
+            num_ref = getattr(isovar_result, 'num_ref_fragments', None)
+            if num_alt is not None and num_ref is not None and (num_alt + num_ref) > 0:
+                rna_vaf = num_alt / (num_alt + num_ref)
 
             variant_dict = OrderedDict((
                 ('gene_name', isovar_result.top_gene_name),
@@ -103,6 +113,8 @@ class VaxrankResults(DataclassSerializable):
                     isovar_result.predicted_effect_modifies_protein_sequence),
                 ('rna_support',
                     isovar_result.has_mutant_protein_sequence_from_rna),
+                ('dna_vaf', dna_vaf_by_variant.get(variant)),
+                ('rna_vaf', rna_vaf),
             ))
 
             # TODO:

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.10.1"
+__version__ = "2.11.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Unifies variant allele frequency reporting across the three vaxrank input modes and surfaces it in the JSON, passing-variants CSV, and HTML/PDF/ASCII variant header sections.

| Source | DNA VAF | RNA VAF |
|---|---|---|
| \`--vcf\` (varcode) | \`source_to_metadata_dict[vcf][variant]['sample_info'][tumor_sample]['AF']\`, falls back to \`AD\` | n/a |
| isovar (\`--bam\`) | n/a | \`num_alt_fragments / (num_alt + num_ref)\` |
| LENS / pVACseq | already in \`epitope_io.py:248\` | already in \`epitope_io.py:249\` |

## Changes

- **\`vaxrank/vaf.py\`** (new): \`extract_dna_vaf_by_variant(variant_collection, tumor_sample_name=None)\` reads varcode's per-source metadata and returns \`{Variant: float}\`. Prefers FORMAT/AF, falls back to AD, skips variants whose VCF has multiple samples but no \`--tumor-sample-name\`.
- **\`MutantProteinFragment.rna_vaf\`**: derived property = \`n_alt / (n_alt + n_ref)\`, \`None\` when both are 0.
- **\`vaxrank_results.variant_properties()\`**: accepts optional \`dna_vaf_by_variant\`, adds \`dna_vaf\` and \`rna_vaf\` columns.
- **\`TemplateDataCreator\` / \`_variant_data\`**: \`DNA VAF\` and \`RNA VAF\` rows in the per-variant header.
- **\`--tumor-sample-name\`**: new CLI flag for multi-sample VCFs.

## Test plan

- [x] \`./lint.sh\` passes
- [x] \`./test.sh\` passes (448 tests, +10 new)
- [x] New unit tests for \`vaf.extract_dna_vaf_by_variant\` (AF preferred, AD fallback, alt-allele indexing, single-sample auto-pick, multi-sample skip, list-form AF, zero-depth handling)
- [x] New unit test for \`MutantProteinFragment.rna_vaf\`
- [ ] CI green on all matrix entries

Closes #57.