### PR TITLE
Lift base_name + alt-suffix loop into iter_named_antigens (closes #248)

### DIFF
--- a/tests/test_vaccine_library.py
+++ b/tests/test_vaccine_library.py
@@ -335,3 +335,102 @@ def test_both_modalities_emit_compatible_manifests(tmp_path):
     assert p_entry['length_unit'] == 'aa'
     assert m_entry['modality'] == 'mrna'
     assert m_entry['length_unit'] == 'nt'
+
+
+# ---- iter_named_antigens shared helper (#248) -----------------------------
+
+def test_iter_named_antigens_naming_format():
+    from types import SimpleNamespace
+    from varcode import Variant
+    from vaxrank.vaccine_library import iter_named_antigens
+
+    fragment = SimpleNamespace(
+        amino_acids="KLQGH", gene_name='GENE',
+        mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=5)
+    peptide = SimpleNamespace(
+        mutant_protein_fragment=fragment, mutant_epitope_predictions=[])
+    pairs = [(Variant('1', 1000, 'A', 'T'), [peptide])]
+    [(name, frag, pep)] = list(iter_named_antigens(pairs))
+    assert name == "GENE_1_1000_A_T"
+    assert frag is fragment
+    assert pep is peptide
+
+
+def test_iter_named_antigens_alt_suffix():
+    from types import SimpleNamespace
+    from varcode import Variant
+    from vaxrank.vaccine_library import iter_named_antigens
+
+    def _peptide(aa):
+        f = SimpleNamespace(
+            amino_acids=aa, gene_name='G',
+            mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=len(aa))
+        return SimpleNamespace(mutant_protein_fragment=f)
+
+    pairs = [(Variant('1', 100, 'A', 'T'), [_peptide("ABC"), _peptide("DEF"), _peptide("GHI")])]
+    names = [n for n, _, _ in iter_named_antigens(pairs, candidates_per_slot=3)]
+    assert names == ["G_1_100_A_T", "G_1_100_A_T_alt1", "G_1_100_A_T_alt2"]
+
+
+def test_iter_named_antigens_skips_empty_peptide_lists():
+    from varcode import Variant
+    from vaxrank.vaccine_library import iter_named_antigens
+    pairs = [(Variant('1', 100, 'A', 'T'), [])]
+    assert list(iter_named_antigens(pairs)) == []
+
+
+def test_iter_named_antigens_handles_missing_gene_name():
+    from types import SimpleNamespace
+    from varcode import Variant
+    from vaxrank.vaccine_library import iter_named_antigens
+    fragment = SimpleNamespace(
+        amino_acids="KLQ", gene_name=None,
+        mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=3)
+    peptide = SimpleNamespace(mutant_protein_fragment=fragment)
+    pairs = [(Variant('1', 100, 'A', 'T'), [peptide])]
+    [(name, _, _)] = list(iter_named_antigens(pairs))
+    assert name == "unknown_1_100_A_T"
+
+
+def test_iter_named_antigens_caps_at_candidates_per_slot():
+    from types import SimpleNamespace
+    from varcode import Variant
+    from vaxrank.vaccine_library import iter_named_antigens
+
+    def _peptide(aa):
+        f = SimpleNamespace(
+            amino_acids=aa, gene_name='G',
+            mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=len(aa))
+        return SimpleNamespace(mutant_protein_fragment=f)
+
+    pairs = [(Variant('1', 100, 'A', 'T'),
+              [_peptide("ABC"), _peptide("DEF"), _peptide("GHI")])]
+    # candidates_per_slot=2 → only top 2 walked
+    out = list(iter_named_antigens(pairs, candidates_per_slot=2))
+    assert len(out) == 2
+
+
+def test_peptide_and_mrna_names_match_for_same_input():
+    """mRNA and peptide modes use the shared iter_named_antigens helper,
+    so the antigen names in their respective manifests are identical
+    for any given ranked input. Catches a regression where one modality
+    forks its own naming convention.
+    """
+    from types import SimpleNamespace
+    from varcode import Variant
+    from vaxrank.peptide import (
+        PeptideConstructConfig, assemble_peptide_constructs)
+    from vaxrank.mrna import (
+        RNAConstructConfig, assemble_mrna_constructs)
+
+    fragment = SimpleNamespace(
+        amino_acids="KLQGHSAPVLDVIVN", gene_name='GENE',
+        mutant_amino_acid_start_offset=5, mutant_amino_acid_end_offset=10)
+    peptide = SimpleNamespace(
+        mutant_protein_fragment=fragment, mutant_epitope_predictions=[],
+        manufacturability_scores=None)
+    pairs = [(Variant('1', 1000, 'A', 'T'), [peptide])]
+
+    [p] = assemble_peptide_constructs(pairs, options=PeptideConstructConfig())
+    [m] = assemble_mrna_constructs(pairs, options=RNAConstructConfig())
+    assert p.antigen_names == m.antigen_names

--- a/vaxrank/mrna.py
+++ b/vaxrank/mrna.py
@@ -51,7 +51,11 @@ from .mrna_library import (
     UTRS_3P,
     UTRS_5P,
 )
-from .vaccine_library import get_linker, select_antigen_window
+from .vaccine_library import (
+    get_linker,
+    iter_named_antigens,
+    select_antigen_window,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -254,32 +258,18 @@ def _antigen_aa_sequences(ranked_vaccine_peptides, max_antigen_length_aa,
     user's configured floor (e.g. a stop-loss extension that produced
     only a few mutant residues).
 
-    ``candidates_per_slot`` walks through additional ranked candidates
-    per variant; alternates get a ``_alt<k>`` suffix on their name so
-    different constructs can be traced back.
+    Naming + alt-suffix logic comes from ``iter_named_antigens`` so the
+    antigen names match the peptide-modality output.
     """
-    for variant, peptides in ranked_vaccine_peptides:
-        if not peptides:
-            continue
-        for idx, peptide in enumerate(peptides[:max(1, candidates_per_slot)]):
-            fragment = peptide.mutant_protein_fragment
-            name = "%s_%s_%s_%s_%s" % (
-                fragment.gene_name or 'unknown',
-                variant.contig,
-                variant.start,
-                variant.ref or '.',
-                variant.alt or '.',
-            )
-            if idx > 0:
-                name = "%s_alt%d" % (name, idx)
-            window = select_antigen_window(
-                fragment, name, max_antigen_length_aa)
-            if len(window) < min_antigen_length_aa:
-                logger.warning(
-                    "Antigen %s emitted at %d aa, below "
-                    "--mrna-min-antigen-length-aa (%d).",
-                    name, len(window), min_antigen_length_aa)
-            yield name, window
+    for name, fragment, _peptide in iter_named_antigens(
+            ranked_vaccine_peptides, candidates_per_slot=candidates_per_slot):
+        window = select_antigen_window(fragment, name, max_antigen_length_aa)
+        if len(window) < min_antigen_length_aa:
+            logger.warning(
+                "Antigen %s emitted at %d aa, below "
+                "--mrna-min-antigen-length-aa (%d).",
+                name, len(window), min_antigen_length_aa)
+        yield name, window
 
 
 def _build_protein_with_segments(antigen_aas, signal_peptide_aa, linker,

--- a/vaxrank/peptide.py
+++ b/vaxrank/peptide.py
@@ -35,7 +35,11 @@ import logging
 from dataclasses import dataclass, field
 
 from .manufacturability import ManufacturabilityScores
-from .vaccine_library import get_linker, select_antigen_window
+from .vaccine_library import (
+    get_linker,
+    iter_named_antigens,
+    select_antigen_window,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,38 +86,24 @@ def _antigen_records(ranked_vaccine_peptides, mode, max_antigen_length_aa,
                      candidates_per_slot=1):
     """Yield ``(name, amino_acids)`` per antigen.
 
-    ``candidates_per_slot`` controls how many alternate windows are
-    emitted per variant: 1 picks just the top-ranked vaccine peptide,
-    higher values walk through additional candidates the ranking
-    pipeline produced. Each alternate gets a ``_alt<k>`` suffix on its
-    base name for traceability.
+    Mode dispatch only — naming + alt-suffix logic comes from
+    ``iter_named_antigens``, shared with mRNA assembly so the antigen
+    names match across modalities.
     """
-    for variant, peptides in ranked_vaccine_peptides:
-        if not peptides:
-            continue
-        for idx, peptide in enumerate(peptides[:max(1, candidates_per_slot)]):
-            fragment = peptide.mutant_protein_fragment
-            base_name = "%s_%s_%s_%s_%s" % (
-                getattr(fragment, 'gene_name', None) or 'unknown',
-                variant.contig,
-                variant.start,
-                variant.ref or '.',
-                variant.alt or '.',
-            )
-            if idx > 0:
-                base_name = "%s_alt%d" % (base_name, idx)
-            if mode == "minimal_epitope":
-                top = _top_mutant_epitope(peptide)
-                if top is None:
-                    logger.info(
-                        "Skipping %s in minimal_epitope mode: no mutant "
-                        "epitope predictions available.", base_name)
-                    continue
-                yield base_name + "_epitope", top.peptide_sequence
-            else:
-                # slp + multi_epitope: pick a mutation-centered window
-                yield base_name, select_antigen_window(
-                    fragment, base_name, max_antigen_length_aa)
+    for base_name, fragment, peptide in iter_named_antigens(
+            ranked_vaccine_peptides, candidates_per_slot=candidates_per_slot):
+        if mode == "minimal_epitope":
+            top = _top_mutant_epitope(peptide)
+            if top is None:
+                logger.info(
+                    "Skipping %s in minimal_epitope mode: no mutant "
+                    "epitope predictions available.", base_name)
+                continue
+            yield base_name + "_epitope", top.peptide_sequence
+        else:
+            # slp + multi_epitope: pick a mutation-centered window
+            yield base_name, select_antigen_window(
+                fragment, base_name, max_antigen_length_aa)
 
 
 def _top_mutant_epitope(vaccine_peptide):

--- a/vaxrank/vaccine_library.py
+++ b/vaxrank/vaccine_library.py
@@ -265,6 +265,39 @@ def get_linker(name):
     return LINKERS[canonical]
 
 
+def iter_named_antigens(ranked_vaccine_peptides, candidates_per_slot=1):
+    """Yield ``(name, fragment, vaccine_peptide)`` per ranked candidate.
+
+    Both peptide and mRNA assembly walk the same ranked list and need
+    the same per-candidate name (``gene_chr_pos_ref_alt`` with an
+    ``_alt<k>`` suffix on alternates). Centralizing the loop here keeps
+    that naming consistent across modalities.
+
+    Parameters
+    ----------
+    ranked_vaccine_peptides : list[(varcode.Variant, list[VaccinePeptide])]
+    candidates_per_slot : int
+        How many ranked alternates to walk per variant. The first
+        candidate gets the bare name; subsequent candidates get
+        ``_alt1``, ``_alt2``, etc.
+    """
+    for variant, peptides in ranked_vaccine_peptides:
+        if not peptides:
+            continue
+        for idx, peptide in enumerate(peptides[:max(1, candidates_per_slot)]):
+            fragment = peptide.mutant_protein_fragment
+            base_name = "%s_%s_%s_%s_%s" % (
+                getattr(fragment, 'gene_name', None) or 'unknown',
+                variant.contig,
+                variant.start,
+                variant.ref or '.',
+                variant.alt or '.',
+            )
+            if idx > 0:
+                base_name = "%s_alt%d" % (base_name, idx)
+            yield base_name, fragment, peptide
+
+
 def select_antigen_window(fragment, base_name, max_length_aa):
     """Return a sub-window of the vaccine peptide that preserves the mutation.
 

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.12.0"
+__version__ = "2.12.1"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Final cleanup from #248: the per-candidate naming loop (\`gene_chr_pos_ref_alt\` + \`_alt<k>\` suffix) was duplicated between \`vaxrank/peptide.py\` and \`vaxrank/mrna.py\`. PR #246 lifted \`select_antigen_window\` into \`vaccine_library\`; this PR finishes the job by lifting the iteration loop too.

## What changes

- New helper \`vaxrank.vaccine_library.iter_named_antigens(ranked, candidates_per_slot=1)\` yields \`(name, fragment, vaccine_peptide)\` per candidate.
- \`peptide._antigen_records\` and \`mrna._antigen_aa_sequences\` now consume it instead of duplicating the loop.
- Behavior is identical — pure refactor. New side effect: peptide and mRNA manifests are guaranteed to share their \`antigen_names\` character-for-character for the same ranked input.

## Tests

+6 in \`tests/test_vaccine_library.py\`:
- naming format
- \`_alt<k>\` suffix
- empty-peptide-list skipping
- missing-gene-name fallback
- \`candidates_per_slot\` cap
- end-to-end: peptide and mRNA modes produce identical \`antigen_names\` for the same input

550 passing, lint clean.

Closes #248.