### PR TITLE
mRNA: polyA tail + structured manifest + three FASTAs + CSV (closes #252)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,43 @@
 
 Vaxrank is the neoantigen ranking component of the
 [OpenVax](https://www.openvax.org/) pipeline for designing personalized
-cancer vaccines.  Given a patient's somatic mutations, tumor RNA sequencing
-data, and HLA type, Vaxrank selects and ranks the mutant antigens most
-likely to elicit a T-cell response and emits them in whichever vaccine
-modality the user wants — peptide pools, mRNA constructs, or analysis
-reports for review.
+cancer vaccines.  Given either (a) a patient's somatic mutations + tumor
+RNA-seq + HLA type, or (b) a pre-computed neoepitope report from
+[LENS](https://github.com/openvax/lens) or pVACseq, Vaxrank selects and
+ranks the mutant antigens most likely to elicit a T-cell response and
+emits them as the vaccine type(s) the user requests — peptide pools,
+mRNA constructs, or analysis reports for review.
+
+## Architecture
+
+```
+INPUT (one of)
+  ├── --vcf + --bam              full pipeline: variant calling → Isovar
+  │                              transcript assembly → MHC prediction → ranking
+  └── --input-lens / --input-pvacseq
+                                 use a pre-computed neoepitope report;
+                                 ranking happens against existing
+                                 (peptide, allele) predictions
+
+SHARED MIDDLE
+  ranked_variants_with_vaccine_peptides   (the canonical intermediate;
+                                           same shape from both inputs)
+
+VACCINE-TYPE DISPATCH (multi-valued; --vaccine-type)
+  ├── peptide   →  FASTA + JSON manifest + vendor order-form CSV
+  │                (sub-modes via --peptide-mode: slp / minimal_epitope /
+  │                multi_epitope)
+  ├── mrna      →  three FASTAs (cds / no_polyA / full) + JSON manifest +
+  │                long-format CSV
+  └── (future)  →  dna, etc. plug in as one entry in the dispatch table
+
+REPORTS (orthogonal to vaccine-type)
+  CSV / XLSX / ASCII / HTML / PDF / JSON / neoepitope-report
+```
+
+Vaxrank always ranks; whether each vaccine-type writer fires depends on
+both `--vaccine-type` and the corresponding `--output-<type>` path being
+set. The reports are independent and stack with any vaccine type.
 
 ## Overview
 
@@ -45,40 +77,96 @@ peptide synthesiser:
    filters out peptides that appear in the reference proteome, annotates
    known cancer hotspot mutations, and ranks candidates by a combined
    immunogenicity and manufacturability score.
-5. **Construct emission** — the ranked candidates are written out in the
-   modality the trial calls for: a peptide pool ready for synthesis, an
-   mRNA construct ready for IVT, or analysis reports for clinical review.
+5. **Vaccine-type dispatch** — the ranked candidates are written out as
+   one or more of the vaccine types selected via `--vaccine-type`: a
+   peptide pool ready for synthesis, an mRNA construct ready for IVT, or
+   both. Analysis reports are emitted independently. Steps 1-3 are
+   skipped when an external neoepitope report is supplied via
+   `--input-lens` or `--input-pvacseq`; the ranking and dispatch steps
+   are identical.
 
-## Output modes
+## Vaccine types and output modes
 
-Vaxrank emits the ranked candidates in any combination of the four
-modalities below; pass the corresponding `--output-*` flags to enable
-each.
+Vaccine-type selection is controlled by `--vaccine-type` (multi-valued,
+default `peptide`). Each type's writer fires only if its
+`--output-<type>` path is also set. Reports are orthogonal — they run
+regardless of vaccine type and can be combined with any of the
+construct outputs.
 
-| Modality | What you get | Flags |
+```sh
+# Peptide pool (default vaccine type)
+vaxrank --vcf v.vcf --bam r.bam --output-peptide pool.fasta
+
+# mRNA construct
+vaxrank --vcf v.vcf --bam r.bam --vaccine-type mrna --output-mrna mrna_out/
+
+# Both at once
+vaxrank --vcf v.vcf --bam r.bam --vaccine-type peptide mrna \
+        --output-peptide pool.fasta --output-mrna mrna_out/
+
+# Reports only (no vaccine constructs)
+vaxrank --vcf v.vcf --bam r.bam --output-pdf-report report.pdf
+
+# Drive vaccine design from a pre-computed LENS report
+vaxrank --input-lens patient.lens.tsv --vaccine-type mrna \
+        --output-mrna mrna_out/ --output-mrna-csv layers.csv
+```
+
+| Output | What you get | Flags |
 |---|---|---|
-| **Analysis reports** (default) | Per-variant tables of vaccine peptide candidates, predicted epitopes, and manufacturability scores in ASCII / HTML / PDF / XLSX / JSON | `--output-ascii-report`, `--output-html-report`, `--output-pdf-report`, `--output-xlsx-report`, `--output-csv`, `--output-json-file` |
-| **Peptide constructs** | FASTA + JSON manifest + vendor order-form CSV. Three sub-modes: `slp` (one synthetic long peptide per ranked vaccine peptide, default), `minimal_epitope` (top mutant MHC ligand only), `multi_epitope` (concatenate antigens with a linker). | `--output-peptide`, `--output-peptide-manifest`, `--output-peptide-order-form`, `--peptide-mode`, `--peptide-linker`, `--peptide-max-length-aa`, `--peptide-n-terminal-acetyl`, `--peptide-c-terminal-amide` |
-| **mRNA constructs** | FASTA + JSON manifest with full codon-optimized CDS, configurable 5' / 3' UTRs, signal peptide, optional MITC trafficking domain, and a shared linker library. Codon optimization uses [DnaChisel](https://github.com/Edinburgh-Genome-Foundry/DnaChisel); 2A self-cleaving peptides preserve their published codon usage automatically. | `--output-mrna`, `--output-mrna-manifest`, `--mrna-signal-peptide`, `--mrna-linker`, `--mrna-include-mitd`, `--mrna-5p-utr`, `--mrna-3p-utr`, `--mrna-codon-species`, `--mrna-max-length-nt` |
-| **Neoepitope CSV** | Compact per-epitope rows; can also be the *input* when running vaxrank on pre-computed pVACseq / LENS predictions | `--output-neoepitope-report`, `--input-pvacseq`, `--input-lens` |
+| **Analysis reports** | Per-variant tables of ranked vaccine peptide candidates, predicted epitopes, and manufacturability scores | `--output-ascii-report`, `--output-html-report`, `--output-pdf-report`, `--output-xlsx-report`, `--output-csv`, `--output-json-file` |
+| **Neoepitope report** | Per-(peptide, allele) report (XLSX/CSV). Default output of the LENS/pVACseq input path; also available on the full pipeline. | `--output-neoepitope-report` |
+| **Peptide constructs** | FASTA + JSON manifest + vendor order-form CSV. Sub-mode via `--peptide-mode`: `slp` (one SLP per ranked vaccine peptide, default), `minimal_epitope` (top mutant MHC ligand only), `multi_epitope` (concatenate antigens with a linker). | `--output-peptide`, `--output-peptide-manifest`, `--output-peptide-order-form`, `--peptide-mode`, `--peptide-linker`, `--peptide-max-length-aa`, `--peptide-n-terminal-acetyl`, `--peptide-c-terminal-amide` |
+| **mRNA constructs** | A *directory* containing three FASTAs (`cds.fasta`, `no_polyA.fasta`, `full.fasta`), plus an optional structured per-element JSON manifest and a long-format CSV exposing every layer with both AA and nt forms. Configurable 5'/3' UTRs (e.g. HBB / HBB_FI tandem), signal peptide (HLA-A / HLA-B / tPA / IgK / CD8A / CD28), optional MITD trafficking domain (HLA-A / HLA-B), polyA tail (default A120; optional segmented BNT162b2 pattern A30+linker+A70), and per-junction linker optimization that minimizes predicted MHC presentation of chimeric k-mers. Codon optimization uses [DnaChisel](https://github.com/Edinburgh-Genome-Foundry/DnaChisel); 2A self-cleaving peptides preserve their published codon usage automatically. | `--output-mrna` (directory), `--output-mrna-manifest`, `--output-mrna-csv`, `--output-mrna-csv-no-full-rows`, `--mrna-signal-peptide`, `--mrna-linker`, `--mrna-include-mitd` / `--mrna-no-mitd`, `--mrna-mitd`, `--mrna-5p-utr`, `--mrna-3p-utr`, `--mrna-poly-a-length`, `--mrna-poly-a-segmented`, `--mrna-poly-a-first-segment`, `--mrna-poly-a-segment-linker`, `--mrna-optimize-linkers` / `--mrna-no-optimize-linkers`, `--mrna-junction-candidates`, `--mrna-junction-rank-strong`, `--mrna-junction-rank-mild`, `--mrna-codon-species`, `--mrna-codon-method`, `--mrna-max-length-nt`, `--mrna-antigens-per-construct`, `--mrna-max-constructs` |
+| **External-input mode** | Drive vaccine design from a pre-computed neoepitope report instead of VCF + BAM. Same downstream dispatch — peptide and mRNA construct outputs work identically. | `--input-pvacseq`, `--input-lens` |
 
-The peptide and mRNA construct manifests share a schema (`modality`,
-`name`, `length`, `length_unit`, `antigen_names`, `components`,
-`manufacturability`) so downstream tooling can read either one
-uniformly.
+The peptide and mRNA construct JSON manifests share a back-compat
+schema (`modality`, `name`, `length`, `length_unit`, `antigen_names`,
+`components`, `manufacturability`). The mRNA manifest additionally
+exposes `cds`, `no_polya_nt`, `full_nt`, per-antigen `antigens` (each
+with AA + nt), and a structured `elements` dict with one entry per
+layer (5' UTR, signal peptide, antigens, linkers per junction, MITD,
+stop codon, 3' UTR, polyA) — every layer carrying both AA (where
+applicable) and nt forms for direct inspection.
 
-### Shared linker library
+### Shared linker library and grammar
 
-Both modalities consume the same set of linker names so a single
+Both vaccine types consume the same set of linker names so a single
 construct design can be ported between peptide and mRNA backbones.
-Available entries:
+
+**Static entries:**
 
 | Name | Type | Use |
 |---|---|---|
-| `GS`, `GS3` | flexible (Gly4Ser)n | Generic spacing between fused antigens (Huston *PNAS* 1988) |
-| `AAY` | proteasome-friendly | Between MHC-I CTL epitopes (Velders *J Immunol* 2001) |
+| `G2S`, `G3S`, `G4S`, `G5S` | flexible (Gly_n_Ser) | The (Gly4Ser)n family (Huston *PNAS* 1988); used clinically in BioNTech FixVac / iNeST as `(G4S)2` |
+| `EAAAK` | rigid α-helical | When fused antigens need separation rather than flex (Arai *Protein Eng* 2001) |
+| `RKRR`, `RVKR`, `RKRKR` | furin cleavage | R-X-(K/R)-R motif (Hosaka *J Biol Chem* 1991); preclinical in DNA vaccines, no clinical vaccine use as of 2025 |
+| `AAY` | proteasome-friendly | Empirical foundation: Livingston *Vaccine* 2001 (PMID 11535313); see citation in `vaxrank/vaccine_library.py` for the AAY-vs-GGGS empirical landscape (Yang 2015 vs Aguilar-Gurrieri 2023) |
+| `AAA` | alanine spacer | Aguilar-Gurrieri *Cancer Immunol Immunother* 2023 — strongest empirical alanine spacer for MHC-I presentation |
 | `GPGPG` | helper-T spacer | Between MHC-II epitopes (Livingston *J Immunol* 2002) |
 | `P2A`, `T2A`, `F2A`, `E2A` | self-cleaving 2A | Co-translational ribosomal skipping for mRNA constructs (Donnelly *J Gen Virol* 2001; Kim *PLoS ONE* 2011). In peptide mode these are functionally inert and the manifest annotates them as such. |
+
+**Compositional grammar** (parsed at lookup time):
+
+| Form | Meaning | Example |
+|---|---|---|
+| `(BASE)N` / `(BASE)xN` / `BASExN` | Repeat N times | `(G4S)2` → `GGGGSGGGGS`, `G4Sx2` → same |
+| `GnSm` | Literal n glycines + m serines (single unit, **not** a repeat) | `G6S` → `GGGGGGS`, `G4S2` → `GGGGSS` |
+| `AnY` | n alanines + tyrosine | `A3Y` → `AAAY` |
+| `An` | n alanines (no Y) | `A4` → `AAAA` |
+| `Gn` | n glycines (no S) | `G4` → `GGGG` |
+
+Repeat counts are capped at 100. 2A entries (codon-frozen, positional)
+are rejected in repeat forms — use the base linker once.
+
+Every name resolves through `vaccine_library.get_linker(name)` and
+returns a `Linker` with primary-source citations attached. The
+default mRNA inter-antigen linker is `(G4S)2` (BioNTech FixVac
+canonical, Sahin *Nature* 2017); the default peptide linker is
+`G4S3`. Per-junction MHC-aware linker swap (`--mrna-optimize-linkers`,
+on by default) considers `G3S`, `G4S`, `(G3S)2`, `(G4S)2`, `AAA` per
+junction and substitutes whichever minimizes predicted presentation
+of chimeric k-mers spanning the junction.
 
 All sequences carry primary-source citations in `vaxrank/vaccine_library.py`.
 
@@ -349,9 +437,12 @@ Use `--mhc-predictor <name>` to select one:
 
 ### Upstream inputs
 
-Vaxrank does not perform variant calling or read alignment itself.
-Those steps happen upstream, typically as part of a larger
-bioinformatics pipeline (e.g.
+Vaxrank accepts two distinct input shapes, both producing the same
+ranked-vaccine-peptides intermediate:
+
+**Full pipeline** (VCF + BAM): Vaxrank does not perform variant
+calling or read alignment itself.  Those steps happen upstream,
+typically as part of a larger bioinformatics pipeline (e.g.
 [neoantigen-vaccine-pipeline](https://github.com/openvax/neoantigen-vaccine-pipeline)):
 
 1. Tumor and matched-normal DNA are sequenced and aligned; a variant
@@ -361,7 +452,17 @@ bioinformatics pipeline (e.g.
    clinical records).
 
 Vaxrank takes these three inputs — the VCF, the tumor RNA BAM, and the
-HLA alleles — and produces a ranked list of vaccine peptide candidates.
+HLA alleles — runs Isovar transcript assembly + MHC binding prediction
++ ranking, and produces vaccine peptide candidates.
+
+**External-input mode** (`--input-lens` or `--input-pvacseq`): when an
+upstream tool (e.g. [LENS](https://github.com/openvax/lens) or pVACseq)
+has already produced a per-(peptide, allele) neoepitope report, Vaxrank
+skips Isovar + MHC prediction and consumes the report directly. The
+per-row `pep_context` (LENS) or `Best Peptide` (pVACseq aggregate) is
+used as the SLP-style antigen window. Downstream dispatch — reports +
+peptide constructs + mRNA constructs — is identical to the full
+pipeline.
 
 ### Mutant transcript assembly (Isovar)
 
@@ -405,16 +506,27 @@ then filtered and ranked by:
 
 ### Key modules
 
+**Shared upstream:**
+
 - `core_logic.py`: Main vaccine peptide selection algorithm
 - `epitope_logic.py`: Epitope scoring and filtering
+- `epitope_io.py`: LENS / pVACseq / vaxrank-native I/O for epitope predictions
+- `external_input.py`: Synthesize the canonical ranked-vaccine-peptides shape from a LENS / pVACseq report so external-input runs reach the same dispatch as VCF + BAM
 - `reference_proteome.py`: Set-based kmer index for reference proteome filtering (O(1) lookup, built once and cached)
 - `cancer_hotspots.py`: Cancer mutation hotspot annotation
 - `vaccine_peptide.py`: Vaccine peptide scoring and manufacturability
+- `vaccine_library.py`: Shared linker vocabulary + compositional grammar (`(BASE)N`, `GnSm`, `AnY`, `An`, `Gn`) with primary-source citations
+
+**Vaccine-type-specific (downstream):**
+
+- `peptide.py`: Peptide construct assembly + FASTA / JSON manifest / vendor order-form CSV writers; sub-modes `slp` / `minimal_epitope` / `multi_epitope`
+- `mrna.py`: mRNA construct assembly + three-FASTA / structured manifest / long-format CSV writers. DnaChisel codon optimization, 2A frozen-codon handling, configurable polyA tail (default A120, optional segmented BNT162b2 pattern), per-junction MHC-aware linker swap (issue #247)
+- `mrna_library.py`: mRNA-specific elements (5'/3' UTRs incl. tandem 2× HBB FI; signal peptides HLA-A / HLA-B / tPA / IgK / CD8A / CD28; MITD HLA-A / HLA-B)
+- `junction_swap.py`: Per-junction linker optimizer that minimizes predicted MHC presentation of chimeric k-mers spanning antigen junctions
+
+**Reports:**
+
 - `report.py`: Analysis-report generation (ASCII, HTML, PDF, XLSX, CSV, JSON)
-- `peptide.py`: Peptide construct assembly + FASTA / manifest / vendor order-form writers
-- `mrna.py`: mRNA construct assembly (DnaChisel codon optimization, 2A handling) + FASTA / manifest writers
-- `vaccine_library.py`: Shared linker vocabulary (GS-family, AAY, GPGPG, P2A/T2A/F2A/E2A) with citations
-- `mrna_library.py`: mRNA-specific elements (5'/3' UTRs, signal peptides, MITD)
 
 ## Papers & Citations
 

--- a/tests/data/epitope_fixtures/lens_multi_row_per_variant.tsv
+++ b/tests/data/epitope_fixtures/lens_multi_row_per_variant.tsv
@@ -1,0 +1,4 @@
+allele	peptide	netmhcpan_4.1b.score_el	netmhcpan_4.1b.perc_rank_el	netmhcpan_4.1b.score_ba	netmhcpan_4.1b.perc_rank_ba	netmhcpan_4.1b.aff_nm	mhcflurry_2.1.1.aff	mhcflurry_2.1.1.aff_perc	mhcflurry_2.1.1.pres_score	mhcflurry_2.1.1.pres_perc	antigen_source	mut_aa_pos	variant_coords	gene_name	tpm	netmhcpan_agretopicity	mhcflurry_agretopicity	pep_context
+HLA-A02:01	WEAKLLLLL	0.20	8.0	0.15	7.5	5000.00	4500.0	5.0	0.10	8.0	SNV	245	chr17:7675088:C:T	TP53	42.5	0.500	0.520	AAWEAKLLLLLGTR
+HLA-B07:02	STRNGLVLLL	0.95	0.1	0.92	0.2	22.50	18.0	0.05	0.95	0.05	SNV	245	chr17:7675088:C:T	TP53	42.5	0.005	0.004	AASTRNGLVLLLGTR
+HLA-A02:01	MIDDLEEEEE	0.60	2.5	0.55	2.8	500.00	450.0	1.5	0.40	2.5	SNV	245	chr17:7675088:C:T	TP53	42.5	0.050	0.060	AAMIDDLEEEEEGTR

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -1,0 +1,282 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end tests covering the LENS / pVACseq → vaccine-design path.
+
+Pre-PR-#253: external-input mode hard-short-circuited and the
+construct writers were never reached. These tests pin the new
+architecture: a single shared ``ranked_variants_with_vaccine_peptides``
+intermediate that *both* the VCF/BAM pipeline and the LENS / pVACseq
+loaders produce, then a shared dispatch (``_emit_outputs``) into
+modality-specific construct writers.
+"""
+
+import json
+import os
+
+from vaxrank.epitope_io import load_lens
+from vaxrank.external_input import (
+    _mut_offsets_in_context,
+    _parse_variant_coords,
+    ranked_from_lens_predictions,
+)
+
+DATA_DIR = os.path.join(
+    os.path.dirname(__file__), "data", "epitope_fixtures")
+
+
+def test_parse_variant_coords_typical_lens_form():
+    v = _parse_variant_coords("chr17:7675088:C:T")
+    assert v is not None
+    assert v.contig == "chr17"
+    assert v.start == 7675088
+    assert v.ref == "C"
+    assert v.alt == "T"
+
+
+def test_parse_variant_coords_malformed_returns_none():
+    assert _parse_variant_coords("garbage") is None
+    assert _parse_variant_coords("chr1:notapos:A:T") is None
+    assert _parse_variant_coords(None) is None
+
+
+def test_mut_offsets_in_context_finds_peptide():
+    # AASVVGSSSSSGTR contains SVVGSSSSS at offset 2, length 9
+    start, end = _mut_offsets_in_context("SVVGSSSSS", "AASVVGSSSSSGTR")
+    assert start == 2
+    assert end == 11
+
+
+def test_mut_offsets_in_context_falls_back_to_full_window():
+    # When the peptide isn't found in the context, the whole window is
+    # treated as the mutation span (so window-centering doesn't crop
+    # it out).
+    start, end = _mut_offsets_in_context("XYZXYZ", "AASVVGSSSSSGTR")
+    assert start == 0
+    assert end == len("AASVVGSSSSSGTR")
+
+
+def test_lens_to_ranked_vaccine_peptides_round_trip():
+    """Loading the LENS fixture and converting to ranked vaccine peptides
+    should produce one entry per unique variant, each carrying the
+    pep_context as the antigen fragment."""
+    path = os.path.join(DATA_DIR, "lens_example.tsv")
+    report_df, predictions = load_lens(path)
+    ranked = ranked_from_lens_predictions(predictions, path)
+    assert len(ranked) == 3, (
+        "LENS fixture has 3 unique variants; got %d" % len(ranked))
+    # Each ranked entry: (Variant, [VaccinePeptide])
+    for variant, peptides in ranked:
+        assert len(peptides) == 1
+        vp = peptides[0]
+        # Fragment AA = pep_context (the SLP-style window from LENS)
+        assert vp.mutant_protein_fragment.amino_acids
+        # All three fixture rows have pep_context longer than peptide
+        assert (len(vp.mutant_protein_fragment.amino_acids)
+                > len(vp.epitope_predictions[0].peptide_sequence))
+        # Mutation span is non-empty inside the fragment
+        assert (vp.mutant_protein_fragment.mutant_amino_acid_end_offset
+                > vp.mutant_protein_fragment.mutant_amino_acid_start_offset)
+
+
+def test_lens_drives_mrna_construct_assembly_end_to_end():
+    """LENS file → ranked vaccine peptides → assemble_mrna_constructs
+    must produce a non-empty construct. Pre-#253 the construct
+    writers were unreachable from external input — this test pins
+    that the path is now wired."""
+    from vaxrank.mrna import RNAConstructConfig, assemble_mrna_constructs
+
+    path = os.path.join(DATA_DIR, "lens_example.tsv")
+    report_df, predictions = load_lens(path)
+    ranked = ranked_from_lens_predictions(predictions, path)
+    assert ranked, "Expected non-empty ranked list from LENS fixture"
+
+    options = RNAConstructConfig(
+        signal_peptide=None, include_mitd=False,
+        utr_3p='HBB', poly_a_length=10,
+        antigens_per_construct=3, max_constructs=1,
+        max_antigen_length_aa=14,
+        optimize_linkers=False,
+    )
+    constructs = assemble_mrna_constructs(ranked, options=options)
+    assert len(constructs) == 1
+    c = constructs[0]
+    # Three antigens packed into one construct
+    assert len(c.antigen_names) == 3
+    # cds_aa contains all three antigen AA strings (or windowed
+    # subwindows centered on the mutation)
+    for vp_pair, name in zip(ranked, c.antigen_names):
+        # The antigen name carries the gene_name; LENS fixture genes
+        # are TP53, BRAF, KRAS.
+        assert any(g in name for g in ("TP53", "BRAF", "KRAS")), name
+    assert c.cds_nt.endswith("TAA")
+    assert c.full_nt.endswith("A" * 10)
+
+
+def test_lens_drives_peptide_construct_assembly_end_to_end():
+    """LENS file → peptide-vaccine constructs (SLP mode)."""
+    from vaxrank.peptide import (
+        PeptideConstructConfig, assemble_peptide_constructs)
+
+    path = os.path.join(DATA_DIR, "lens_example.tsv")
+    report_df, predictions = load_lens(path)
+    ranked = ranked_from_lens_predictions(predictions, path)
+
+    options = PeptideConstructConfig(mode='slp')
+    constructs = assemble_peptide_constructs(ranked, options=options)
+    assert len(constructs) == 3, (
+        "SLP mode: one construct per ranked vaccine peptide; "
+        "got %d" % len(constructs))
+
+
+def test_resolve_modality_from_args():
+    """--vaccine-modality and the auto inference rules."""
+    from types import SimpleNamespace
+    from vaxrank.cli.entry_point import _resolve_modality
+
+    # auto: derives from output flags
+    args = SimpleNamespace(
+        vaccine_modality='auto',
+        output_peptide='out.fasta', output_mrna='')
+    assert _resolve_modality(args) == (True, False)
+    args = SimpleNamespace(
+        vaccine_modality='auto',
+        output_peptide='', output_mrna='out_dir')
+    assert _resolve_modality(args) == (False, True)
+    args = SimpleNamespace(
+        vaccine_modality='auto',
+        output_peptide='p.fa', output_mrna='m_dir')
+    assert _resolve_modality(args) == (True, True)
+    args = SimpleNamespace(
+        vaccine_modality='auto',
+        output_peptide='', output_mrna='')
+    assert _resolve_modality(args) == (False, False)
+
+    # explicit overrides infer-from-flags
+    args = SimpleNamespace(
+        vaccine_modality='peptide', output_peptide='p.fa',
+        output_mrna='m_dir')
+    assert _resolve_modality(args) == (True, False)
+    args = SimpleNamespace(
+        vaccine_modality='mrna', output_peptide='p.fa',
+        output_mrna='m_dir')
+    assert _resolve_modality(args) == (False, True)
+    args = SimpleNamespace(
+        vaccine_modality='both', output_peptide='', output_mrna='')
+    assert _resolve_modality(args) == (True, True)
+    args = SimpleNamespace(
+        vaccine_modality='none', output_peptide='p.fa',
+        output_mrna='m_dir')
+    assert _resolve_modality(args) == (False, False)
+
+
+def test_lens_with_vaccine_modality_mrna_writes_three_fastas(tmp_path):
+    """End-to-end: --input-lens + --output-mrna writes three FASTAs.
+    Closes the pre-#253 short-circuit gap that made this fail."""
+    from types import SimpleNamespace
+
+    from vaxrank.cli.entry_point import _emit_outputs
+
+    path = os.path.join(DATA_DIR, "lens_example.tsv")
+    report_df, predictions = load_lens(path)
+    ranked = ranked_from_lens_predictions(predictions, path)
+
+    out_dir = str(tmp_path / "mrna_out")
+    args = SimpleNamespace(
+        # report flags off
+        output_csv='', output_xlsx_report='',
+        output_neoepitope_report='',
+        # peptide modality off
+        output_peptide='',
+        # mRNA modality on
+        output_mrna=out_dir,
+        output_mrna_manifest=str(tmp_path / "manifest.json"),
+        output_mrna_csv='',
+        output_mrna_csv_full_rows=True,
+        # mRNA defaults
+        mrna_signal_peptide=None,
+        mrna_linker='(G4S)2',
+        mrna_include_mitd=False,
+        mrna_mitd='HLA_A',
+        mrna_5p_utr='HBB', mrna_3p_utr='HBB',
+        mrna_codon_species='h_sapiens',
+        mrna_codon_method='use_best_codon',
+        mrna_min_antigen_length_aa=5,
+        mrna_max_antigen_length_aa=14,
+        mrna_antigens_per_construct=3,
+        mrna_max_constructs=1,
+        mrna_candidates_per_slot=1,
+        mrna_max_length_nt=4000,
+        mrna_optimize_linkers=False,
+        mrna_junction_candidates='',
+        mrna_junction_rank_strong=0.5,
+        mrna_junction_rank_mild=2.0,
+        mrna_poly_a_length=20,
+        mrna_poly_a_segmented=False,
+        mrna_poly_a_first_segment=30,
+        mrna_poly_a_segment_linker='GCATATGACT',
+        # modality switch
+        vaccine_modality='mrna',
+    )
+    _emit_outputs(args, ranked, source='external')
+    assert os.path.isfile(os.path.join(out_dir, "cds.fasta"))
+    assert os.path.isfile(os.path.join(out_dir, "no_polyA.fasta"))
+    assert os.path.isfile(os.path.join(out_dir, "full.fasta"))
+    with open(args.output_mrna_manifest) as f:
+        manifest = json.load(f)
+    assert len(manifest) == 1
+    assert manifest[0]['modality'] == 'mrna'
+    # full ends with polyA
+    full_body = ''.join(
+        line for line in open(
+            os.path.join(out_dir, "full.fasta")).read().split("\n")
+        if not line.startswith(">"))
+    assert full_body.endswith("A" * 20)
+
+
+def test_modality_none_skips_constructs_even_if_output_paths_set(tmp_path):
+    """--vaccine-modality=none suppresses construct writers even if
+    --output-peptide / --output-mrna are passed."""
+    from types import SimpleNamespace
+
+    from vaxrank.cli.entry_point import _emit_outputs
+
+    path = os.path.join(DATA_DIR, "lens_example.tsv")
+    report_df, predictions = load_lens(path)
+    ranked = ranked_from_lens_predictions(predictions, path)
+
+    out_dir = str(tmp_path / "mrna_out")
+    args = SimpleNamespace(
+        output_csv='', output_xlsx_report='',
+        output_neoepitope_report='',
+        output_peptide='',
+        output_mrna=out_dir,
+        output_mrna_manifest='', output_mrna_csv='',
+        output_mrna_csv_full_rows=True,
+        mrna_signal_peptide=None, mrna_linker='(G4S)2',
+        mrna_include_mitd=False, mrna_mitd='HLA_A',
+        mrna_5p_utr='HBB', mrna_3p_utr='HBB',
+        mrna_codon_species='h_sapiens',
+        mrna_codon_method='use_best_codon',
+        mrna_min_antigen_length_aa=5, mrna_max_antigen_length_aa=14,
+        mrna_antigens_per_construct=3, mrna_max_constructs=1,
+        mrna_candidates_per_slot=1, mrna_max_length_nt=4000,
+        mrna_optimize_linkers=False, mrna_junction_candidates='',
+        mrna_junction_rank_strong=0.5, mrna_junction_rank_mild=2.0,
+        mrna_poly_a_length=20, mrna_poly_a_segmented=False,
+        mrna_poly_a_first_segment=30,
+        mrna_poly_a_segment_linker='GCATATGACT',
+        vaccine_modality='none',
+    )
+    _emit_outputs(args, ranked, source='external')
+    assert not os.path.exists(out_dir), \
+        "modality=none should suppress mRNA writer; output dir was created"

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -162,6 +162,167 @@ def test_lens_drives_peptide_construct_assembly_end_to_end():
         "got %d" % len(constructs))
 
 
+# ---- pVACseq path coverage ----------------------------------------------
+
+def test_pvacseq_to_ranked_vaccine_peptides_round_trip():
+    """Smoke test for the pVACseq path: fixture has 3 unique variants
+    (TP53/BRAF/KRAS) with dashed-form IDs (chr-start-end-ref-alt).
+    The path was previously degenerate — _PVACSEQ_IC50_COLS was
+    untested and the ID parser only handled dotted form, producing
+    an empty ranked list end-to-end.
+    """
+    from vaxrank.epitope_io import load_pvacseq
+    from vaxrank.external_input import ranked_from_pvacseq_predictions
+
+    path = os.path.join(DATA_DIR, "pvacseq_example.tsv")
+    report_df, predictions = load_pvacseq(path)
+    ranked = ranked_from_pvacseq_predictions(predictions, path)
+    assert len(ranked) == 3, (
+        "pVACseq fixture has 3 unique variants; got %d" % len(ranked))
+    genes = sorted(
+        peps[0].mutant_protein_fragment.gene_name for _, peps in ranked)
+    assert genes == ['BRAF', 'KRAS', 'TP53']
+    # IDs are dashed-form (chr1-100000-100001-A-T), parsed correctly
+    contigs = sorted(v.contig for v, _ in ranked)
+    assert contigs == ['chr1', 'chr2', 'chr3']
+
+
+def test_pvacseq_id_parser_handles_dashed_and_dotted():
+    """The parser accepts both modern (chr1-100000-100001-A-T) and
+    legacy (1.123.A.T) ID forms, plus the 4-part dashed variant
+    (chr1-100000-A-T) without an explicit end position."""
+    from vaxrank.external_input import _parse_pvacseq_id
+
+    assert _parse_pvacseq_id("chr1-100000-100001-A-T") == ("chr1", 100000, "A", "T")
+    assert _parse_pvacseq_id("chr1-100000-A-T") == ("chr1", 100000, "A", "T")
+    assert _parse_pvacseq_id("1.123.A.T") == ("1", 123, "A", "T")
+    # Garbage / wrong shape returns None instead of raising
+    assert _parse_pvacseq_id("garbage") is None
+    assert _parse_pvacseq_id("chr1-notapos-A-T") is None
+    assert _parse_pvacseq_id(None) is None
+    assert _parse_pvacseq_id("") is None
+
+
+def test_pvacseq_drives_mrna_construct_assembly_end_to_end():
+    """End-to-end: pVACseq report → ranked → mRNA constructs (mirror
+    of the LENS end-to-end test). Pre-fix this produced zero
+    constructs because the ranked list was empty."""
+    from vaxrank.epitope_io import load_pvacseq
+    from vaxrank.external_input import ranked_from_pvacseq_predictions
+    from vaxrank.mrna import RNAConstructConfig, assemble_mrna_constructs
+
+    path = os.path.join(DATA_DIR, "pvacseq_example.tsv")
+    _, predictions = load_pvacseq(path)
+    ranked = ranked_from_pvacseq_predictions(predictions, path)
+    assert ranked
+
+    options = RNAConstructConfig(
+        signal_peptide=None, include_mitd=False,
+        utr_3p='HBB', poly_a_length=10,
+        antigens_per_construct=3, max_constructs=1,
+        max_antigen_length_aa=12, min_antigen_length_aa=5,
+        optimize_linkers=False)
+    constructs = assemble_mrna_constructs(ranked, options=options)
+    assert len(constructs) == 1
+    c = constructs[0]
+    assert len(c.antigen_names) == 3
+    assert c.cds_nt.endswith("TAA")
+
+
+# ---- LENS scoring-column edge cases --------------------------------------
+
+def test_lens_warns_when_no_affinity_columns_detected(tmp_path, caplog):
+    """When no pMHC_affinity predictor is detected, the
+    representative-peptide pick is degenerate (every row ties at
+    (2, 0.0); file-order first row "wins"). Pin that we warn
+    instead of silently picking arbitrarily.
+
+    Today this can be triggered by a stability-only LENS file
+    (netmhcstabpan present without mhcflurry/netmhcpan). It can also
+    fire if LENS ever adds tools whose ``kind`` is something other
+    than ``pMHC_affinity`` (presentation-only, cleavage,
+    immunogenicity, etc.) and the registry classifies them
+    accordingly. The warning is kind-agnostic — it reports the
+    detected kinds in its message.
+    """
+    import logging
+    from vaxrank.epitope_io import load_lens
+    from vaxrank.external_input import ranked_from_lens_predictions
+
+    # Stability-only fixture (the only "no affinity" case the
+    # current registry can produce). If new predictor kinds are added
+    # to _LENS_PREDICTOR_REGISTRY, add fixtures here covering them.
+    no_aff = tmp_path / "no_affinity.tsv"
+    no_aff.write_text(
+        "allele\tpeptide\tnetmhcstabpan_1.0.halflife_hours\t"
+        "netmhcstabpan_1.0.perc_rank_stab\tantigen_source\tmut_aa_pos\t"
+        "variant_coords\tgene_name\ttpm\tpep_context\n"
+        "HLA-A02:01\tSVVGSSSSS\t12.5\t0.5\tSNV\t245\t"
+        "chr17:7675088:C:T\tTP53\t42.5\tAASVVGSSSSSGTR\n")
+
+    _, predictions = load_lens(str(no_aff))
+    with caplog.at_level(logging.WARNING):
+        ranked = ranked_from_lens_predictions(predictions, str(no_aff))
+    # Still produces output (the file-order representative)
+    assert len(ranked) == 1
+    # Warning was emitted, mentions the detected non-affinity kinds
+    msg = next(
+        (r.message for r in caplog.records
+         if "no pMHC_affinity scoring columns" in r.message), None)
+    assert msg is not None, \
+        "Expected a warn-once for LENS input lacking affinity predictors"
+    assert "pMHC_stability" in msg, \
+        "Warning should report the detected non-affinity kinds; got %r" % msg
+
+
+# ---- _emit_outputs observability -----------------------------------------
+
+def test_emit_outputs_logs_active_and_fired_dispatch(caplog, tmp_path):
+    """The dispatch summary log line is part of the contract — pins
+    which vaccine types were considered active and which actually fired.
+    """
+    import logging
+    from types import SimpleNamespace
+    from vaxrank.cli.entry_point import _emit_outputs
+
+    path = os.path.join(DATA_DIR, "lens_example.tsv")
+    report_df, predictions = load_lens(path)
+    ranked = ranked_from_lens_predictions(predictions, path)
+
+    out_dir = str(tmp_path / "mrna_out")
+    args = SimpleNamespace(
+        output_csv='', output_xlsx_report='',
+        output_neoepitope_report='',
+        output_peptide='',
+        output_mrna=out_dir,
+        output_mrna_manifest='', output_mrna_csv='',
+        output_mrna_csv_full_rows=True,
+        mrna_signal_peptide=None, mrna_linker='(G4S)2',
+        mrna_include_mitd=False, mrna_mitd='HLA_A',
+        mrna_5p_utr='HBB', mrna_3p_utr='HBB',
+        mrna_codon_species='h_sapiens',
+        mrna_codon_method='use_best_codon',
+        mrna_min_antigen_length_aa=5, mrna_max_antigen_length_aa=14,
+        mrna_antigens_per_construct=3, mrna_max_constructs=1,
+        mrna_candidates_per_slot=1, mrna_max_length_nt=4000,
+        mrna_optimize_linkers=False, mrna_junction_candidates='',
+        mrna_junction_rank_strong=0.5, mrna_junction_rank_mild=2.0,
+        mrna_poly_a_length=20, mrna_poly_a_segmented=False,
+        mrna_poly_a_first_segment=30,
+        mrna_poly_a_segment_linker='GCATATGACT',
+        vaccine_type=['mrna'],
+    )
+    with caplog.at_level(logging.INFO):
+        _emit_outputs(args, ranked, source='external')
+    msgs = [r.message for r in caplog.records]
+    dispatch = [m for m in msgs if 'Vaccine-type dispatch' in m]
+    assert len(dispatch) == 1
+    line = dispatch[0]
+    assert "[external]" in line
+    assert "active=['mrna']" in line
+    assert "wrote=['mrna']" in line
+
+
 def test_resolve_vaccine_types_default_is_peptide():
     """Vaxrank is a vaccine-ranking library: there's always ranking
     to do. The default vaccine type is peptide; ``--vaccine-type`` is
@@ -246,7 +407,7 @@ def test_emit_outputs_warns_when_output_path_lacks_matching_type(
         "vaccine-type=['peptide']"
 
 
-def test_lens_with_vaccine_modality_mrna_writes_three_fastas(tmp_path):
+def test_lens_with_vaccine_type_mrna_writes_three_fastas(tmp_path):
     """End-to-end: --input-lens + --output-mrna writes three FASTAs.
     Closes the pre-#253 short-circuit gap that made this fail."""
     from types import SimpleNamespace

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -65,6 +65,30 @@ def test_mut_offsets_in_context_falls_back_to_full_window():
     assert end == len("AASVVGSSSSSGTR")
 
 
+def test_lens_picks_strongest_binder_when_multiple_rows_per_variant():
+    """Multi-row LENS fixture: one variant has three peptides at very
+    different IC50s. The representative pick must be the strongest
+    binder (lowest IC50), not the file-order first row.
+
+    Pre-fix: ``_pick_representative`` looked for non-existent columns
+    (``ic50``, ``percentile_rank``) and tied every row at (2, 0.0),
+    so it returned the alphabetically-first allele's row regardless
+    of binding strength. This test pins the fix.
+    """
+    path = os.path.join(DATA_DIR, "lens_multi_row_per_variant.tsv")
+    report_df, predictions = load_lens(path)
+    ranked = ranked_from_lens_predictions(predictions, path)
+    assert len(ranked) == 1, (
+        "Fixture has one variant with 3 peptides; got %d entries" % len(ranked))
+    _, peptides = ranked[0]
+    fragment = peptides[0].mutant_protein_fragment
+    # Strongest binder is STRNGLVLLL (mhcflurry IC50 = 18.0). Its
+    # pep_context is "AASTRNGLVLLLGTR".
+    assert "STRNGLVLLL" in fragment.amino_acids, (
+        "Expected pep_context to come from the strongest binder row "
+        "(STRNGLVLLL, IC50=18); got %r" % fragment.amino_acids)
+
+
 def test_lens_to_ranked_vaccine_peptides_round_trip():
     """Loading the LENS fixture and converting to ranked vaccine peptides
     should produce one entry per unique variant, each carrying the
@@ -138,101 +162,88 @@ def test_lens_drives_peptide_construct_assembly_end_to_end():
         "got %d" % len(constructs))
 
 
-def test_resolve_modality_auto_infers_from_output_flags():
-    """The 'auto' sentinel reads which output paths are populated."""
+def test_resolve_vaccine_types_default_is_peptide():
+    """Vaxrank is a vaccine-ranking library: there's always ranking
+    to do. The default vaccine type is peptide; ``--vaccine-type`` is
+    multi-valued so future types (DNA, etc.) plug in cleanly."""
     from types import SimpleNamespace
-    from vaxrank.cli.entry_point import _resolve_modality
+    from vaxrank.cli.entry_point import _resolve_vaccine_types
+
+    args = SimpleNamespace(vaccine_type=['peptide'])
+    assert _resolve_vaccine_types(args) == {'peptide'}
+
+    # Default applied when attr is missing or empty
+    args = SimpleNamespace()
+    assert _resolve_vaccine_types(args) == {'peptide'}
+    args = SimpleNamespace(vaccine_type=[])
+    assert _resolve_vaccine_types(args) == {'peptide'}
+
+
+def test_resolve_vaccine_types_explicit_lists():
+    """Multi-valued list returned as a set; order-free; duplicates
+    collapse."""
+    from types import SimpleNamespace
+    from vaxrank.cli.entry_point import _resolve_vaccine_types
 
     cases = [
-        (['auto'], 'out.fasta', '', {'peptide'}),
-        (['auto'], '', 'out_dir', {'mrna'}),
-        (['auto'], 'p.fa', 'm_dir', {'peptide', 'mrna'}),
-        (['auto'], '', '', set()),
+        (['peptide'], {'peptide'}),
+        (['mrna'], {'mrna'}),
+        (['peptide', 'mrna'], {'peptide', 'mrna'}),
+        (['mrna', 'peptide'], {'peptide', 'mrna'}),
+        (['mrna', 'mrna'], {'mrna'}),
     ]
-    for modality, op, om, expected in cases:
-        args = SimpleNamespace(
-            vaccine_modality=modality, output_peptide=op, output_mrna=om)
-        assert _resolve_modality(args) == expected, (
-            "modality=%r output_peptide=%r output_mrna=%r "
-            "expected %r got %r" % (
-                modality, op, om, expected, _resolve_modality(args)))
+    for vtypes, expected in cases:
+        args = SimpleNamespace(vaccine_type=vtypes)
+        assert _resolve_vaccine_types(args) == expected
 
 
-def test_resolve_modality_explicit_lists():
-    """Concrete modality lists override 'auto' inference. Listed
-    modalities are returned as a set; output flags are not consulted."""
-    from types import SimpleNamespace
-    from vaxrank.cli.entry_point import _resolve_modality
-
-    cases = [
-        (['peptide'], 'p.fa', 'm_dir', {'peptide'}),
-        (['mrna'], 'p.fa', 'm_dir', {'mrna'}),
-        (['peptide', 'mrna'], '', '', {'peptide', 'mrna'}),
-        (['mrna', 'peptide'], '', '', {'peptide', 'mrna'}),  # order-free
-        # duplicates collapse
-        (['mrna', 'mrna'], '', '', {'mrna'}),
-    ]
-    for modality, op, om, expected in cases:
-        args = SimpleNamespace(
-            vaccine_modality=modality, output_peptide=op, output_mrna=om)
-        assert _resolve_modality(args) == expected
-
-
-def test_resolve_modality_none_sentinel():
-    """'none' suppresses construct writers even if output paths set."""
-    from types import SimpleNamespace
-    from vaxrank.cli.entry_point import _resolve_modality
-
-    args = SimpleNamespace(
-        vaccine_modality=['none'],
-        output_peptide='p.fa', output_mrna='m_dir')
-    assert _resolve_modality(args) == set()
-
-
-def test_resolve_modality_rejects_sentinel_mixed_with_concrete():
-    """auto/none must be passed alone; mixing with mrna/peptide is a
-    user error."""
+def test_resolve_vaccine_types_rejects_unknown():
+    """'dna' or any unknown type must raise; users shouldn't get
+    silent no-ops while writing CLI scripts that pre-declare future
+    types."""
     import pytest as _pytest
     from types import SimpleNamespace
-    from vaxrank.cli.entry_point import _resolve_modality
+    from vaxrank.cli.entry_point import _resolve_vaccine_types
 
-    args = SimpleNamespace(
-        vaccine_modality=['auto', 'mrna'],
-        output_peptide='', output_mrna='m_dir')
-    with _pytest.raises(ValueError, match="sentinel"):
-        _resolve_modality(args)
-
-    args = SimpleNamespace(
-        vaccine_modality=['none', 'peptide'],
-        output_peptide='', output_mrna='')
-    with _pytest.raises(ValueError, match="sentinel"):
-        _resolve_modality(args)
+    args = SimpleNamespace(vaccine_type=['dna'])
+    with _pytest.raises(ValueError, match="Unknown vaccine type"):
+        _resolve_vaccine_types(args)
 
 
-def test_resolve_modality_rejects_unknown_modality():
-    """Adding 'dna' before its writer ships should fail clearly so
-    users don't get a silent no-op."""
-    import pytest as _pytest
-    from types import SimpleNamespace
-    from vaxrank.cli.entry_point import _resolve_modality
-
-    args = SimpleNamespace(
-        vaccine_modality=['dna'],
-        output_peptide='', output_mrna='')
-    with _pytest.raises(ValueError, match="Unknown vaccine modality"):
-        _resolve_modality(args)
-
-
-def test_resolve_modality_bare_string_tolerated():
+def test_resolve_vaccine_types_bare_string_tolerated():
     """argparse always yields a list, but a downstream caller might
     pass a bare string. Coerce instead of crashing."""
     from types import SimpleNamespace
-    from vaxrank.cli.entry_point import _resolve_modality
+    from vaxrank.cli.entry_point import _resolve_vaccine_types
+
+    args = SimpleNamespace(vaccine_type='mrna')
+    assert _resolve_vaccine_types(args) == {'mrna'}
+
+
+def test_emit_outputs_warns_when_output_path_lacks_matching_type(
+        caplog, tmp_path):
+    """If user passes --output-mrna but doesn't add 'mrna' to
+    --vaccine-type, we should warn loudly so they don't think mRNA
+    is being written."""
+    import logging
+    from types import SimpleNamespace
+    from vaxrank.cli.entry_point import _emit_outputs
 
     args = SimpleNamespace(
-        vaccine_modality='mrna',
-        output_peptide='', output_mrna='m_dir')
-    assert _resolve_modality(args) == {'mrna'}
+        vaccine_type=['peptide'],
+        output_peptide='',
+        output_mrna=str(tmp_path / "mrna_out"),
+        output_csv='', output_xlsx_report='',
+        output_neoepitope_report='',
+    )
+    with caplog.at_level(logging.WARNING):
+        _emit_outputs(args, ranked=[], source='external')
+    assert any(
+        "--output-mrna" in r.message
+        and "not in --vaccine-type" in r.message
+        for r in caplog.records), \
+        "Expected mismatch warning when --output-mrna is set but "\
+        "vaccine-type=['peptide']"
 
 
 def test_lens_with_vaccine_modality_mrna_writes_three_fastas(tmp_path):
@@ -280,8 +291,8 @@ def test_lens_with_vaccine_modality_mrna_writes_three_fastas(tmp_path):
         mrna_poly_a_segmented=False,
         mrna_poly_a_first_segment=30,
         mrna_poly_a_segment_linker='GCATATGACT',
-        # modality switch (multi-valued; pass a list)
-        vaccine_modality=['mrna'],
+        # vaccine-type switch (multi-valued; pass a list)
+        vaccine_type=['mrna'],
     )
     _emit_outputs(args, ranked, source='external')
     assert os.path.isfile(os.path.join(out_dir, "cds.fasta"))
@@ -299,9 +310,10 @@ def test_lens_with_vaccine_modality_mrna_writes_three_fastas(tmp_path):
     assert full_body.endswith("A" * 20)
 
 
-def test_modality_none_skips_constructs_even_if_output_paths_set(tmp_path):
-    """--vaccine-modality=none suppresses construct writers even if
-    --output-peptide / --output-mrna are passed."""
+def test_output_path_without_matching_type_does_not_write(tmp_path):
+    """Default vaccine-type=['peptide']. Passing --output-mrna without
+    'mrna' in vaccine-type should NOT write mRNA constructs (the
+    paired warning is covered separately)."""
     from types import SimpleNamespace
 
     from vaxrank.cli.entry_point import _emit_outputs
@@ -314,7 +326,7 @@ def test_modality_none_skips_constructs_even_if_output_paths_set(tmp_path):
     args = SimpleNamespace(
         output_csv='', output_xlsx_report='',
         output_neoepitope_report='',
-        output_peptide='',
+        output_peptide='',  # peptide writer also no-ops (no path)
         output_mrna=out_dir,
         output_mrna_manifest='', output_mrna_csv='',
         output_mrna_csv_full_rows=True,
@@ -331,8 +343,9 @@ def test_modality_none_skips_constructs_even_if_output_paths_set(tmp_path):
         mrna_poly_a_length=20, mrna_poly_a_segmented=False,
         mrna_poly_a_first_segment=30,
         mrna_poly_a_segment_linker='GCATATGACT',
-        vaccine_modality=['none'],
+        vaccine_type=['peptide'],
     )
     _emit_outputs(args, ranked, source='external')
     assert not os.path.exists(out_dir), \
-        "modality=none should suppress mRNA writer; output dir was created"
+        "vaccine-type didn't include 'mrna'; mRNA writer should "\
+        "not have run, but output dir was created"

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -138,45 +138,101 @@ def test_lens_drives_peptide_construct_assembly_end_to_end():
         "got %d" % len(constructs))
 
 
-def test_resolve_modality_from_args():
-    """--vaccine-modality and the auto inference rules."""
+def test_resolve_modality_auto_infers_from_output_flags():
+    """The 'auto' sentinel reads which output paths are populated."""
     from types import SimpleNamespace
     from vaxrank.cli.entry_point import _resolve_modality
 
-    # auto: derives from output flags
-    args = SimpleNamespace(
-        vaccine_modality='auto',
-        output_peptide='out.fasta', output_mrna='')
-    assert _resolve_modality(args) == (True, False)
-    args = SimpleNamespace(
-        vaccine_modality='auto',
-        output_peptide='', output_mrna='out_dir')
-    assert _resolve_modality(args) == (False, True)
-    args = SimpleNamespace(
-        vaccine_modality='auto',
-        output_peptide='p.fa', output_mrna='m_dir')
-    assert _resolve_modality(args) == (True, True)
-    args = SimpleNamespace(
-        vaccine_modality='auto',
-        output_peptide='', output_mrna='')
-    assert _resolve_modality(args) == (False, False)
+    cases = [
+        (['auto'], 'out.fasta', '', {'peptide'}),
+        (['auto'], '', 'out_dir', {'mrna'}),
+        (['auto'], 'p.fa', 'm_dir', {'peptide', 'mrna'}),
+        (['auto'], '', '', set()),
+    ]
+    for modality, op, om, expected in cases:
+        args = SimpleNamespace(
+            vaccine_modality=modality, output_peptide=op, output_mrna=om)
+        assert _resolve_modality(args) == expected, (
+            "modality=%r output_peptide=%r output_mrna=%r "
+            "expected %r got %r" % (
+                modality, op, om, expected, _resolve_modality(args)))
 
-    # explicit overrides infer-from-flags
+
+def test_resolve_modality_explicit_lists():
+    """Concrete modality lists override 'auto' inference. Listed
+    modalities are returned as a set; output flags are not consulted."""
+    from types import SimpleNamespace
+    from vaxrank.cli.entry_point import _resolve_modality
+
+    cases = [
+        (['peptide'], 'p.fa', 'm_dir', {'peptide'}),
+        (['mrna'], 'p.fa', 'm_dir', {'mrna'}),
+        (['peptide', 'mrna'], '', '', {'peptide', 'mrna'}),
+        (['mrna', 'peptide'], '', '', {'peptide', 'mrna'}),  # order-free
+        # duplicates collapse
+        (['mrna', 'mrna'], '', '', {'mrna'}),
+    ]
+    for modality, op, om, expected in cases:
+        args = SimpleNamespace(
+            vaccine_modality=modality, output_peptide=op, output_mrna=om)
+        assert _resolve_modality(args) == expected
+
+
+def test_resolve_modality_none_sentinel():
+    """'none' suppresses construct writers even if output paths set."""
+    from types import SimpleNamespace
+    from vaxrank.cli.entry_point import _resolve_modality
+
     args = SimpleNamespace(
-        vaccine_modality='peptide', output_peptide='p.fa',
-        output_mrna='m_dir')
-    assert _resolve_modality(args) == (True, False)
+        vaccine_modality=['none'],
+        output_peptide='p.fa', output_mrna='m_dir')
+    assert _resolve_modality(args) == set()
+
+
+def test_resolve_modality_rejects_sentinel_mixed_with_concrete():
+    """auto/none must be passed alone; mixing with mrna/peptide is a
+    user error."""
+    import pytest as _pytest
+    from types import SimpleNamespace
+    from vaxrank.cli.entry_point import _resolve_modality
+
     args = SimpleNamespace(
-        vaccine_modality='mrna', output_peptide='p.fa',
-        output_mrna='m_dir')
-    assert _resolve_modality(args) == (False, True)
+        vaccine_modality=['auto', 'mrna'],
+        output_peptide='', output_mrna='m_dir')
+    with _pytest.raises(ValueError, match="sentinel"):
+        _resolve_modality(args)
+
     args = SimpleNamespace(
-        vaccine_modality='both', output_peptide='', output_mrna='')
-    assert _resolve_modality(args) == (True, True)
+        vaccine_modality=['none', 'peptide'],
+        output_peptide='', output_mrna='')
+    with _pytest.raises(ValueError, match="sentinel"):
+        _resolve_modality(args)
+
+
+def test_resolve_modality_rejects_unknown_modality():
+    """Adding 'dna' before its writer ships should fail clearly so
+    users don't get a silent no-op."""
+    import pytest as _pytest
+    from types import SimpleNamespace
+    from vaxrank.cli.entry_point import _resolve_modality
+
     args = SimpleNamespace(
-        vaccine_modality='none', output_peptide='p.fa',
-        output_mrna='m_dir')
-    assert _resolve_modality(args) == (False, False)
+        vaccine_modality=['dna'],
+        output_peptide='', output_mrna='')
+    with _pytest.raises(ValueError, match="Unknown vaccine modality"):
+        _resolve_modality(args)
+
+
+def test_resolve_modality_bare_string_tolerated():
+    """argparse always yields a list, but a downstream caller might
+    pass a bare string. Coerce instead of crashing."""
+    from types import SimpleNamespace
+    from vaxrank.cli.entry_point import _resolve_modality
+
+    args = SimpleNamespace(
+        vaccine_modality='mrna',
+        output_peptide='', output_mrna='m_dir')
+    assert _resolve_modality(args) == {'mrna'}
 
 
 def test_lens_with_vaccine_modality_mrna_writes_three_fastas(tmp_path):
@@ -224,8 +280,8 @@ def test_lens_with_vaccine_modality_mrna_writes_three_fastas(tmp_path):
         mrna_poly_a_segmented=False,
         mrna_poly_a_first_segment=30,
         mrna_poly_a_segment_linker='GCATATGACT',
-        # modality switch
-        vaccine_modality='mrna',
+        # modality switch (multi-valued; pass a list)
+        vaccine_modality=['mrna'],
     )
     _emit_outputs(args, ranked, source='external')
     assert os.path.isfile(os.path.join(out_dir, "cds.fasta"))
@@ -275,7 +331,7 @@ def test_modality_none_skips_constructs_even_if_output_paths_set(tmp_path):
         mrna_poly_a_length=20, mrna_poly_a_segmented=False,
         mrna_poly_a_first_segment=30,
         mrna_poly_a_segment_linker='GCATATGACT',
-        vaccine_modality='none',
+        vaccine_modality=['none'],
     )
     _emit_outputs(args, ranked, source='external')
     assert not os.path.exists(out_dir), \

--- a/tests/test_mrna.py
+++ b/tests/test_mrna.py
@@ -479,3 +479,229 @@ def test_polya_segmented_appears_in_full_fasta_and_csv():
     assert len(poly_rows) == 1
     assert poly_rows[0]['nt'] == expected_tail
     assert poly_rows[0]['note'] == 'segmented'
+
+
+# ---- Review-fix coverage (PR #253 second-pass) ---------------------------
+
+def test_output_dir_rejects_existing_file(tmp_path):
+    """Old API took a FASTA file path; new API takes a directory.
+    Pointing --output-mrna at an existing file must raise loudly."""
+    pairs = [_variant_pair("KLQGHSAP")]
+    constructs = assemble_mrna_constructs(
+        pairs, options=RNAConstructConfig(
+            signal_peptide=None, include_mitd=False,
+            utr_3p='HBB', poly_a_length=0))
+    existing_file = tmp_path / "out.fasta"
+    existing_file.write_text("placeholder")
+    import pytest as _pytest
+    with _pytest.raises(ValueError, match="directory"):
+        write_mrna_outputs(constructs, str(existing_file))
+
+
+def test_output_dir_rejects_fasta_suffix(tmp_path):
+    """Even if the path doesn't exist, .fasta / .fa suffixes are blocked
+    so 'vaxrank --output-mrna out.fasta' fails clearly instead of
+    silently creating a directory called out.fasta/."""
+    pairs = [_variant_pair("KLQGHSAP")]
+    constructs = assemble_mrna_constructs(
+        pairs, options=RNAConstructConfig(
+            signal_peptide=None, include_mitd=False,
+            utr_3p='HBB', poly_a_length=0))
+    import pytest as _pytest
+    for bad in ("out.fasta", "out.fa", "OUT.FASTA"):
+        path = tmp_path / bad
+        with _pytest.raises(ValueError, match="directory"):
+            write_mrna_outputs(constructs, str(path))
+
+
+def test_output_dir_idempotent_makedirs(tmp_path):
+    """Writing twice into the same dir must succeed; second write
+    overwrites the FASTAs in-place (no error from existing dir)."""
+    pairs = [_variant_pair("KLQGHSAP")]
+    constructs = assemble_mrna_constructs(
+        pairs, options=RNAConstructConfig(
+            signal_peptide=None, include_mitd=False,
+            utr_3p='HBB', poly_a_length=0))
+    out_dir = str(tmp_path / "mrna")
+    write_mrna_outputs(constructs, out_dir)
+    write_mrna_outputs(constructs, out_dir)
+    assert os.path.isfile(os.path.join(out_dir, "cds.fasta"))
+
+
+def test_csv_pre_mitd_linker_uses_index_label_not_index(tmp_path):
+    """Pre-MITD linker rows put 'mitd' in index_label, not in the
+    integer-typed index column. Spreadsheet sorts on `index` stay
+    numeric."""
+    import csv as _csv
+    pairs = [_variant_pair("KLQGHSAPVL", gene_name='GENEA'),
+             _variant_pair("MNNVDEILGRWESPV", contig='2', start=200,
+                           gene_name='GENEB')]
+    options = RNAConstructConfig(
+        signal_peptide=None, linker='G4S',
+        optimize_linkers=False,
+        include_mitd=True, mitd='HLA_A',
+        utr_3p='HBB', poly_a_length=0,
+        antigens_per_construct=2,
+        max_antigen_length_aa=20)
+    constructs = assemble_mrna_constructs(pairs, options=options)
+    csv_path = tmp_path / "manifest.csv"
+    out_dir = tmp_path / "out"
+    write_mrna_outputs(constructs, str(out_dir), csv_path=str(csv_path))
+    with open(csv_path) as f:
+        rows = list(_csv.DictReader(f))
+    linker_rows = [r for r in rows if r['element_kind'] == 'linker']
+    assert linker_rows, "Expected linker rows in CSV"
+    pre_mitd = [r for r in linker_rows if r['index_label'] == 'mitd']
+    inter = [r for r in linker_rows if r['index_label'] != 'mitd']
+    assert len(pre_mitd) == 1, (
+        "Expected exactly one pre-MITD linker row, got %d" % len(pre_mitd))
+    assert pre_mitd[0]['index'] == '', (
+        "Pre-MITD linker must leave the integer index blank "
+        "(label-only); got %r" % pre_mitd[0]['index'])
+    assert pre_mitd[0]['note'] == 'pre_mitd'
+    # Inter-antigen linkers have integer indices, not labels.
+    for r in inter:
+        assert r['index'].isdigit(), (
+            "Inter-antigen linker index must be numeric, got %r"
+            % r['index'])
+        assert r['index_label'] == ''
+
+
+def test_csv_lean_mode_omits_full_rows(tmp_path):
+    """csv_include_full_rows=False suppresses the cds / no_polyA /
+    full summary rows so the CSV's widest cells are per-element."""
+    import csv as _csv
+    pairs = [_variant_pair("KLQGHSAP")]
+    constructs = assemble_mrna_constructs(
+        pairs, options=RNAConstructConfig(
+            signal_peptide=None, include_mitd=False,
+            utr_3p='HBB', poly_a_length=10))
+    csv_path = tmp_path / "manifest.csv"
+    out_dir = tmp_path / "out"
+    write_mrna_outputs(
+        constructs, str(out_dir),
+        csv_path=str(csv_path), csv_include_full_rows=False)
+    with open(csv_path) as f:
+        rows = list(_csv.DictReader(f))
+    kinds = {r['element_kind'] for r in rows}
+    # full-rows are suppressed
+    assert 'cds' not in kinds
+    assert 'no_polyA' not in kinds
+    assert 'full' not in kinds
+    # per-element rows remain
+    assert 'utr_5p' in kinds
+    assert 'utr_3p' in kinds
+    assert 'poly_a' in kinds
+
+
+def test_dropped_dead_linker_name_param():
+    """_build_protein_with_segments no longer takes a linker_name arg.
+    Pin the signature so a future regression that re-adds the dead
+    parameter is caught immediately."""
+    import inspect
+    from vaxrank.mrna import _build_protein_with_segments
+    sig = inspect.signature(_build_protein_with_segments)
+    assert 'linker_name' not in sig.parameters, (
+        "linker_name was a dead parameter and should remain removed; "
+        "got params %s" % list(sig.parameters))
+    # signal_peptide_name and mitd_name are *used* and must stay.
+    assert 'signal_peptide_name' in sig.parameters
+    assert 'mitd_name' in sig.parameters
+
+
+def test_start_codon_segment_has_named_kind():
+    """The pre-2.14 code emitted name=None for the prepended start
+    codon segment. Pin that we now use 'start_codon' as the name."""
+    from vaxrank.mrna import _build_protein_with_segments
+    from vaxrank.vaccine_library import get_linker
+    linker = get_linker("G4S")
+    # No signal peptide and antigen doesn't start with M → assembler
+    # prepends a start codon segment.
+    _, _, segments = _build_protein_with_segments(
+        antigen_aas=["KLQGH"], antigen_names=["A"],
+        signal_peptide_aa="", signal_peptide_name=None,
+        linker=linker, mitd_aa="", mitd_name=None)
+    start = next(s for s in segments if s['kind'] == 'start_codon')
+    assert start['name'] == 'start_codon', (
+        "start_codon segment name must not be None; got %r"
+        % start['name'])
+
+
+def test_mitd_nt_slice_is_bounded(tmp_path):
+    """MITD nt slice must use [start_aa*3:end_aa*3], not an open-ended
+    [start_aa*3:] slice. Pin by checking that nt length = aa length × 3
+    exactly (open-ended slice would equal the rest of coding_dna,
+    which today happens to match but is fragile)."""
+    pairs = [_variant_pair("KLQGHSAPVL")]
+    options = RNAConstructConfig(
+        signal_peptide=None, linker='G4S',
+        optimize_linkers=False,
+        include_mitd=True, mitd='HLA_A',
+        utr_3p='HBB', poly_a_length=0,
+        antigens_per_construct=1,
+        max_antigen_length_aa=15)
+    [c] = assemble_mrna_constructs(pairs, options=options)
+    m = c.elements['mitd']
+    assert m is not None
+    # Strict invariant: nt length matches AA length × 3 exactly.
+    assert m['length_nt'] == m['length_aa'] * 3
+    assert len(m['nt']) == m['length_aa'] * 3
+
+
+def test_junction_swap_meta_appears_in_elements_when_optimizer_runs():
+    """When the junction-aware optimizer runs (predictor + alleles
+    supplied), elements['junction_swap'] is populated. Without
+    predictor, elements['junction_swap'] reflects the fallback."""
+    from types import SimpleNamespace
+    from vaxrank.junction_swap import junction_kmers
+    from varcode import Variant
+
+    # Two antigens; predictor scores a strong hit on (G4S)2 only,
+    # so AAA should win.
+    a1, a2 = "KLQGHSAPVL", "DVIVNCDESLLAS"
+    g4s2_kmers = junction_kmers(a1, "GGGGSGGGGS", a2, k_lengths=(9,))
+    rank_table = {(g4s2_kmers[0], "HLA-A*02:01"): 0.05}
+
+    class StubPredictor:
+        def __init__(self, table): self.table = table
+        def predict_peptides(self, peptides):
+            out = []
+            for p in peptides:
+                out.append(SimpleNamespace(
+                    peptide=p, allele="HLA-A*02:01",
+                    percentile_rank=self.table.get(
+                        (p, "HLA-A*02:01"), 99.0)))
+            return out
+
+    fragment_a = SimpleNamespace(
+        amino_acids=a1, gene_name='GENEA',
+        mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=len(a1))
+    fragment_b = SimpleNamespace(
+        amino_acids=a2, gene_name='GENEB',
+        mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=len(a2))
+    pep_a = SimpleNamespace(
+        mutant_protein_fragment=fragment_a, mutant_epitope_predictions=[])
+    pep_b = SimpleNamespace(
+        mutant_protein_fragment=fragment_b, mutant_epitope_predictions=[])
+    pairs = [
+        (Variant('1', 100, 'A', 'T'), [pep_a]),
+        (Variant('2', 200, 'A', 'T'), [pep_b]),
+    ]
+
+    options = RNAConstructConfig(
+        signal_peptide=None, include_mitd=False,
+        optimize_linkers=True,
+        junction_swap_candidates=("(G4S)2", "AAA"),
+        junction_kmer_lengths=(9,),
+        antigens_per_construct=2, max_constructs=1,
+        max_antigen_length_aa=20,
+        utr_3p='HBB', poly_a_length=0,
+    )
+    [c] = assemble_mrna_constructs(
+        pairs, options=options,
+        mhc_predictor=StubPredictor(rank_table),
+        mhc_alleles=["HLA-A*02:01"])
+    # The structured elements dict must carry junction_swap
+    assert 'junction_swap' in c.elements
+    assert c.elements['junction_swap']['enabled'] is True
+    assert 'AAA' in c.elements['junction_swap']['chosen']

--- a/tests/test_mrna.py
+++ b/tests/test_mrna.py
@@ -108,10 +108,13 @@ def test_assembly_basic_construct():
     assert len(constructs) == 1
     c = constructs[0]
     assert c.antigen_names == ['GENEA_1_100_A_T', 'GENEB_2_200_A_T']
-    assert c.sequence.startswith(UTR_5P_HBB)
-    assert c.sequence.endswith(UTR_3P_HBB)
+    assert c.no_polya_nt.startswith(UTR_5P_HBB)
+    assert c.no_polya_nt.endswith(UTR_3P_HBB)
+    # full_nt has polyA tail beyond UTR_3P_HBB
+    assert c.full_nt.startswith(UTR_5P_HBB)
+    assert c.full_nt.endswith("A" * 120)
     # CDS sits between UTRs and ends with a stop codon and starts with ATG
-    cds = c.sequence[len(UTR_5P_HBB):-len(UTR_3P_HBB)]
+    cds = c.no_polya_nt[len(UTR_5P_HBB):-len(UTR_3P_HBB)]
     assert cds[:3] == 'ATG'
     assert cds[-3:] == 'TAA'
     protein = _translate(cds[:-3])
@@ -125,7 +128,7 @@ def test_assembly_prepends_atg_when_no_signal_peptide():
     pairs = [_variant_pair("KLQGHSAPVLDVIVN", gene_name='GENE')]
     options = RNAConstructConfig(signal_peptide=None, linker='GS3', include_mitd=False, utr_3p='HBB')
     [c] = assemble_mrna_constructs(pairs, options=options)
-    cds = c.sequence[len(UTR_5P_HBB):-len(UTR_3P_HBB)]
+    cds = c.no_polya_nt[len(UTR_5P_HBB):-len(UTR_3P_HBB)]
     assert cds[:3] == 'ATG'
     protein = _translate(cds[:-3])
     assert protein == "MKLQGHSAPVLDVIVN"
@@ -135,7 +138,7 @@ def test_assembly_does_not_double_prepend_when_antigen_starts_with_m():
     pairs = [_variant_pair("MNNVDEILGRWESPV", gene_name='GENE')]
     options = RNAConstructConfig(signal_peptide=None, linker='GS3', include_mitd=False, utr_3p='HBB')
     [c] = assemble_mrna_constructs(pairs, options=options)
-    cds = c.sequence[len(UTR_5P_HBB):-len(UTR_3P_HBB)]
+    cds = c.no_polya_nt[len(UTR_5P_HBB):-len(UTR_3P_HBB)]
     protein = _translate(cds[:-3])
     assert protein == "MNNVDEILGRWESPV"
 
@@ -145,7 +148,7 @@ def test_assembly_with_mitd_appends_trafficking_domain():
     options = RNAConstructConfig(signal_peptide=None, linker='GS3',
                           include_mitd=True, mitd='HLA_A', utr_3p='HBB')
     [c] = assemble_mrna_constructs(pairs, options=options)
-    cds = c.sequence[len(UTR_5P_HBB):-len(UTR_3P_HBB)]
+    cds = c.no_polya_nt[len(UTR_5P_HBB):-len(UTR_3P_HBB)]
     protein = _translate(cds[:-3])
     # No signal peptide selected and antigen doesn't start with M, so the
     # assembler prepends one to keep the CDS translatable.
@@ -208,7 +211,7 @@ def test_assembly_p2a_linker_preserves_blessed_dna():
     options = RNAConstructConfig(signal_peptide='tPA', linker='P2A',
                           include_mitd=False, utr_3p='HBB')
     [c] = assemble_mrna_constructs(pairs, options=options)
-    cds = c.sequence[len(UTR_5P_HBB):-len(UTR_3P_HBB)]
+    cds = c.no_polya_nt[len(UTR_5P_HBB):-len(UTR_3P_HBB)]
     assert LINKER_P2A.dna in cds
     # And translation matches the AA-level expectation (signal + a1 + P2A + a2)
     protein = _translate(cds[:-3])
@@ -224,12 +227,16 @@ def test_write_mrna_outputs_fasta_and_manifest():
     constructs = assemble_mrna_constructs(
         pairs,
         options=RNAConstructConfig(signal_peptide=None, include_mitd=False,
-                                  utr_3p='HBB'))
+                                  utr_3p='HBB', poly_a_length=0))
     with tempfile.TemporaryDirectory() as tmp:
-        fasta_path = os.path.join(tmp, "out.fasta")
+        out_dir = os.path.join(tmp, "out")
         manifest_path = os.path.join(tmp, "out.json")
-        write_mrna_outputs(constructs, fasta_path, manifest_path)
-        with open(fasta_path) as f:
+        write_mrna_outputs(constructs, out_dir, manifest_path)
+        # Three FASTAs land in the directory.
+        assert os.path.isfile(os.path.join(out_dir, "cds.fasta"))
+        assert os.path.isfile(os.path.join(out_dir, "no_polyA.fasta"))
+        assert os.path.isfile(os.path.join(out_dir, "full.fasta"))
+        with open(os.path.join(out_dir, "no_polyA.fasta")) as f:
             text = f.read()
         assert text.startswith(">seq_001")
         assert UTR_5P_HBB in text.replace('\n', '')
@@ -240,7 +247,14 @@ def test_write_mrna_outputs_fasta_and_manifest():
         assert entry['length_unit'] == 'nt'
         assert entry['name'] == 'seq_001'
         assert entry['antigen_names'] == ['GENE_1_1000_A_T']
-        assert entry['length'] == len(constructs[0].sequence)
+        # New structured fields
+        assert 'lengths' in entry
+        assert 'cds' in entry
+        assert 'no_polya_nt' in entry
+        assert 'full_nt' in entry
+        assert 'antigens' in entry
+        assert 'elements' in entry
+        # Back-compat 2.12 schema preserved
         assert 'components' in entry
         assert 'manufacturability' in entry
 
@@ -269,3 +283,199 @@ def test_select_antigen_window_used_by_both_modalities():
     from vaxrank.vaccine_library import select_antigen_window
     assert mrna.select_antigen_window is select_antigen_window
     assert peptide.select_antigen_window is select_antigen_window
+
+
+# ---- polyA + structured manifest + CSV (issue #252) -----------------------
+
+def test_build_poly_a_default_120():
+    from vaxrank.mrna import build_poly_a
+    options = RNAConstructConfig()
+    tail = build_poly_a(options)
+    assert tail == "A" * 120
+
+
+def test_build_poly_a_zero_length():
+    from vaxrank.mrna import build_poly_a
+    options = RNAConstructConfig(poly_a_length=0)
+    assert build_poly_a(options) == ""
+
+
+def test_build_poly_a_segmented_bnt162b2_pattern():
+    """BNT162b2 architecture: A30 + GCATATGACT + A70 = 100 A's split
+    by a 10-nt linker (Xia 2021, PMC8310186)."""
+    from vaxrank.mrna import build_poly_a
+    options = RNAConstructConfig(
+        poly_a_length=100, poly_a_segmented=True,
+        poly_a_first_segment=30,
+        poly_a_segment_linker="GCATATGACT")
+    tail = build_poly_a(options)
+    assert tail == "A" * 30 + "GCATATGACT" + "A" * 70
+
+
+def test_build_poly_a_negative_raises():
+    from vaxrank.mrna import build_poly_a
+    options = RNAConstructConfig(poly_a_length=-1)
+    with pytest.raises(ValueError):
+        build_poly_a(options)
+
+
+def test_assemble_full_includes_polya_no_polya_does_not():
+    """``c.full_nt`` must end with the polyA tail; ``c.no_polya_nt``
+    must end with the 3' UTR (no polyA). This is the contract for
+    the three-FASTA output."""
+    pairs = [_variant_pair("KLQGHSAPVL")]
+    options = RNAConstructConfig(
+        signal_peptide=None, include_mitd=False,
+        utr_3p='HBB', poly_a_length=120)
+    [c] = assemble_mrna_constructs(pairs, options=options)
+    assert c.no_polya_nt.endswith(UTR_3P_HBB)
+    assert not c.no_polya_nt.endswith("A" * 120)
+    assert c.full_nt.endswith("A" * 120)
+    # full = no_polya + polyA (exact concatenation, nothing else)
+    assert c.full_nt == c.no_polya_nt + ("A" * 120)
+    # cds_nt is no-UTR no-polyA, ends with stop codon
+    assert c.cds_nt.endswith("TAA")
+    assert UTR_5P_HBB not in c.cds_nt
+
+
+def test_assemble_structured_elements_carry_aa_and_nt():
+    """Each element in c.elements must carry both AA (where applicable)
+    and nt, with lengths matching."""
+    pairs = [_variant_pair("KLQGHSAPVL", gene_name='GENEA'),
+             _variant_pair("MNNVDEILGRWESPV", contig='2', start=200,
+                           gene_name='GENEB')]
+    options = RNAConstructConfig(
+        signal_peptide='HLA_A', linker='G4S',  # short linker for clear math
+        optimize_linkers=False,
+        include_mitd=True, mitd='HLA_A',
+        utr_3p='HBB', poly_a_length=10,
+        antigens_per_construct=2,
+        max_antigen_length_aa=20)
+    [c] = assemble_mrna_constructs(pairs, options=options)
+
+    el = c.elements
+    # 5' UTR + 3' UTR are nt-only (no AA)
+    assert el['utr_5p']['nt'] == UTR_5P_HBB
+    assert el['utr_5p']['length_nt'] == len(UTR_5P_HBB)
+    assert el['utr_3p']['nt'] == UTR_3P_HBB
+    # Signal peptide has aa + nt; nt length = aa length × 3
+    sp = el['signal_peptide']
+    assert sp['aa'].startswith("M")
+    assert sp['length_nt'] == sp['length_aa'] * 3
+    assert len(sp['nt']) == sp['length_nt']
+    # MITD has aa + nt
+    m = el['mitd']
+    assert m is not None
+    assert m['length_nt'] == m['length_aa'] * 3
+    # PolyA element
+    assert el['poly_a']['nt'] == "A" * 10
+    assert el['poly_a']['length_nt'] == 10
+    assert el['poly_a']['segmented'] is False
+    # Antigens have AA + nt with length math
+    assert len(c.antigens) == 2
+    for a in c.antigens:
+        assert a['length_nt'] == a['length_aa'] * 3
+        assert len(a['nt']) == a['length_nt']
+    # The CDS view stitches signal + antigens + linkers + MITD
+    assert c.cds_aa.startswith(sp['aa'])
+    # Stop codon present at end of cds_nt
+    assert c.cds_nt.endswith("TAA")
+
+
+def test_write_mrna_three_fastas_have_matching_records():
+    """Each of the three FASTAs has the same number of records (one
+    per construct), with matching names, but different sequences."""
+    pairs = [_variant_pair("KLQGHSAPVL", gene_name='GENEA'),
+             _variant_pair("MNNVDEILGR", contig='2', start=200,
+                           gene_name='GENEB')]
+    options = RNAConstructConfig(
+        signal_peptide=None, include_mitd=False,
+        utr_3p='HBB', poly_a_length=50,
+        antigens_per_construct=2)
+    constructs = assemble_mrna_constructs(pairs, options=options)
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = os.path.join(tmp, "out")
+        write_mrna_outputs(constructs, out_dir)
+        cds = open(os.path.join(out_dir, "cds.fasta")).read()
+        no_polya = open(os.path.join(out_dir, "no_polyA.fasta")).read()
+        full = open(os.path.join(out_dir, "full.fasta")).read()
+    # All three have the seq_001 header
+    for txt in (cds, no_polya, full):
+        assert ">seq_001" in txt
+    # full > no_polyA > cds in body length
+    cds_body = "".join(line for line in cds.split("\n") if not line.startswith(">"))
+    no_pa_body = "".join(line for line in no_polya.split("\n") if not line.startswith(">"))
+    full_body = "".join(line for line in full.split("\n") if not line.startswith(">"))
+    assert len(cds_body) < len(no_pa_body) < len(full_body)
+    # full = no_polyA + 50 A's
+    assert full_body == no_pa_body + ("A" * 50)
+
+
+def test_write_mrna_csv_one_row_per_element():
+    """CSV is long-format: one row per (construct, element). All key
+    element kinds appear; nt strings are non-empty for nt-bearing rows."""
+    import csv as _csv
+
+    pairs = [_variant_pair("KLQGHSAPVL", gene_name='GENEA')]
+    options = RNAConstructConfig(
+        signal_peptide='HLA_A', linker='G4S',
+        optimize_linkers=False,
+        include_mitd=True, mitd='HLA_A',
+        utr_3p='HBB', poly_a_length=20,
+        antigens_per_construct=1,
+        max_antigen_length_aa=20)
+    constructs = assemble_mrna_constructs(pairs, options=options)
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = os.path.join(tmp, "out")
+        csv_path = os.path.join(tmp, "manifest.csv")
+        write_mrna_outputs(constructs, out_dir, csv_path=csv_path)
+        with open(csv_path) as f:
+            rows = list(_csv.DictReader(f))
+    kinds = {r['element_kind'] for r in rows}
+    expected = {
+        'utr_5p', 'signal_peptide', 'antigen', 'mitd',
+        'stop_codon', 'utr_3p', 'poly_a',
+        'cds', 'no_polyA', 'full',
+    }
+    assert expected <= kinds, "missing element kinds: %s" % (expected - kinds)
+    # Per-construct: each row's nt column is non-empty for nt-bearing kinds.
+    for r in rows:
+        if r['element_kind'] in {'utr_5p', 'utr_3p', 'poly_a',
+                                  'stop_codon', 'no_polyA', 'full',
+                                  'antigen', 'signal_peptide', 'mitd', 'cds'}:
+            # poly_a_length=20 + 0-length linkers shouldn't have empty
+            # nt rows for these element kinds.
+            assert r['nt'], (
+                "Expected nt for %s row, got empty: %r"
+                % (r['element_kind'], r))
+
+
+def test_polya_segmented_appears_in_full_fasta_and_csv():
+    """End-to-end: --mrna-poly-a-segmented round-trips through the
+    construct, FASTA, and CSV."""
+    import csv as _csv
+
+    pairs = [_variant_pair("KLQGHSAPVL", gene_name='G')]
+    options = RNAConstructConfig(
+        signal_peptide=None, include_mitd=False,
+        utr_3p='HBB',
+        poly_a_length=100, poly_a_segmented=True,
+        poly_a_first_segment=30,
+        poly_a_segment_linker="GCATATGACT",
+        antigens_per_construct=1)
+    constructs = assemble_mrna_constructs(pairs, options=options)
+    [c] = constructs
+    expected_tail = "A" * 30 + "GCATATGACT" + "A" * 70
+    assert c.poly_a_nt == expected_tail
+    assert c.full_nt.endswith(expected_tail)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = os.path.join(tmp, "out")
+        csv_path = os.path.join(tmp, "manifest.csv")
+        write_mrna_outputs(constructs, out_dir, csv_path=csv_path)
+        with open(csv_path) as f:
+            rows = list(_csv.DictReader(f))
+    poly_rows = [r for r in rows if r['element_kind'] == 'poly_a']
+    assert len(poly_rows) == 1
+    assert poly_rows[0]['nt'] == expected_tail
+    assert poly_rows[0]['note'] == 'segmented'

--- a/tests/test_vaccine_library.py
+++ b/tests/test_vaccine_library.py
@@ -338,12 +338,12 @@ def test_both_modalities_emit_compatible_manifests(tmp_path):
 
     p_fasta = tmp_path / "peptide.fasta"
     p_manifest = tmp_path / "peptide.json"
-    m_fasta = tmp_path / "mrna.fasta"
+    m_dir = tmp_path / "mrna"
     m_manifest = tmp_path / "mrna.json"
     write_peptide_outputs(
         p_constructs, str(p_fasta), str(p_manifest))
     write_mrna_outputs(
-        m_constructs, str(m_fasta), str(m_manifest))
+        m_constructs, str(m_dir), str(m_manifest))
 
     p_entry = json.loads(p_manifest.read_text())[0]
     m_entry = json.loads(m_manifest.read_text())[0]

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -212,20 +212,15 @@ def add_output_args(arg_parser):
     output_args_group = arg_parser.add_argument_group("Output options")
 
     output_args_group.add_argument(
-        "--vaccine-modality",
+        "--vaccine-type",
         nargs='+',
-        default=["auto"],
-        choices=["auto", "none", "peptide", "mrna"],
-        metavar="MODALITY",
-        help="Which vaccine-design modalities to run. Multi-valued so future "
-             "modalities (DNA, mRNA-LNP variants, etc.) plug in as additional "
-             "choices without an API change. Examples: "
-             "'--vaccine-modality auto' (default; infer from output flags), "
-             "'--vaccine-modality mrna', "
-             "'--vaccine-modality peptide mrna' (both), "
-             "'--vaccine-modality none' (report-only run, suppresses "
-             "construct writers even if --output-peptide / --output-mrna "
-             "are set). 'auto' / 'none' are sentinels — must be passed alone. "
+        default=["peptide"],
+        choices=["peptide", "mrna"],
+        metavar="TYPE",
+        help="Which vaccine type(s) to design. Multi-valued so future "
+             "types (DNA, etc.) plug in as additional choices. "
+             "Default: peptide. Examples: '--vaccine-type peptide', "
+             "'--vaccine-type mrna', '--vaccine-type peptide mrna' (both). "
              "'peptide' is an umbrella; the SLP / minimal-epitope / "
              "multi-epitope sub-mode lives in --peptide-mode.")
 

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -212,6 +212,19 @@ def add_output_args(arg_parser):
     output_args_group = arg_parser.add_argument_group("Output options")
 
     output_args_group.add_argument(
+        "--vaccine-modality",
+        default="auto",
+        choices=["auto", "peptide", "mrna", "both", "none"],
+        help="Which vaccine-design modalities to run. The shared upstream "
+             "epitope-prediction + window-selection logic is identical for "
+             "all modalities; this is the *sharp switch* for downstream "
+             "design output. 'auto' (default) infers from --output-peptide "
+             "and --output-mrna: pass either, both, or neither. 'peptide' / "
+             "'mrna' / 'both' explicitly select; 'none' suppresses both "
+             "even if --output-peptide / --output-mrna are set (useful for "
+             "report-only runs).")
+
+    output_args_group.add_argument(
         "--output-patient-id",
         default="",
         help="Patient ID to use in report")
@@ -326,8 +339,17 @@ def add_mrna_output_args(group):
         default="",
         help="Optional path to a long-format CSV. One row per "
              "(construct, element); columns: construct, element_kind, "
-             "index, name, aa, nt, length_aa, length_nt, note. Lets you "
-             "open a vaccine in a spreadsheet and inspect every layer.")
+             "index, index_label, name, aa, nt, length_aa, length_nt, "
+             "note. Lets you open a vaccine in a spreadsheet and inspect "
+             "every layer.")
+    group.add_argument(
+        "--output-mrna-csv-no-full-rows",
+        dest="output_mrna_csv_full_rows",
+        action="store_false",
+        default=True,
+        help="Suppress the per-construct cds / no_polyA / full summary "
+             "rows in the CSV (the rows with the longest nt cells). "
+             "Per-element rows are unaffected.")
     group.add_argument(
         "--mrna-signal-peptide",
         default="HLA_B",

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -310,14 +310,24 @@ def add_mrna_output_args(group):
     group.add_argument(
         "--output-mrna",
         default="",
-        help="Path to FASTA file of assembled mRNA vaccine constructs. "
-             "When set, vaxrank emits one or more mRNA constructs containing "
-             "the top vaccine peptides as concatenated antigens.")
+        help="Output *directory* for assembled mRNA vaccine constructs. "
+             "When set, vaxrank writes three FASTA files into the directory: "
+             "cds.fasta (start codon → stop codon), no_polyA.fasta "
+             "(5' UTR + CDS + 3' UTR), and full.fasta (no_polyA + polyA tail). "
+             "Each FASTA has one record per construct.")
     group.add_argument(
         "--output-mrna-manifest",
         default="",
-        help="Optional path to a JSON manifest describing each mRNA construct "
-             "(component names, length, contained antigens).")
+        help="Optional path to a JSON manifest with the structured "
+             "per-element view of each mRNA construct (every layer with "
+             "AA + nt where applicable, all sequence variants, lengths).")
+    group.add_argument(
+        "--output-mrna-csv",
+        default="",
+        help="Optional path to a long-format CSV. One row per "
+             "(construct, element); columns: construct, element_kind, "
+             "index, name, aa, nt, length_aa, length_nt, note. Lets you "
+             "open a vaccine in a spreadsheet and inspect every layer.")
     group.add_argument(
         "--mrna-signal-peptide",
         default="HLA_B",
@@ -363,6 +373,33 @@ def add_mrna_output_args(group):
         help="3' UTR name (one of: %s). Default: HBB_FI (tandem 2× HBB / "
              "FI element, BioNTech FixVac canonical)."
              % ", ".join(sorted(UTRS_3P)))
+    group.add_argument(
+        "--mrna-poly-a-length",
+        default=120,
+        type=int,
+        help="PolyA tail length in nt. Default: 120 (BioNTech FixVac / "
+             "BNT122 per Sahin 2017). Set 0 to omit the polyA tail "
+             "(full.fasta will then equal no_polyA.fasta).")
+    group.add_argument(
+        "--mrna-poly-a-segmented",
+        action="store_true",
+        default=False,
+        help="Split the polyA into two segments separated by a 10-nt "
+             "linker (BNT162b2 architecture: A30 + GCATATGACT + A70 per "
+             "Xia 2021, PMC8310186). Increases mRNA stability by "
+             "reducing template recombination during in vitro "
+             "transcription.")
+    group.add_argument(
+        "--mrna-poly-a-first-segment",
+        default=30,
+        type=int,
+        help="Length (nt) of the first polyA segment when "
+             "--mrna-poly-a-segmented is set. Default: 30.")
+    group.add_argument(
+        "--mrna-poly-a-segment-linker",
+        default="GCATATGACT",
+        help="Linker sequence between segmented polyA segments. "
+             "Default: GCATATGACT (BNT162b2 canonical).")
     group.add_argument(
         "--mrna-codon-species",
         default="h_sapiens",

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -213,16 +213,21 @@ def add_output_args(arg_parser):
 
     output_args_group.add_argument(
         "--vaccine-modality",
-        default="auto",
-        choices=["auto", "peptide", "mrna", "both", "none"],
-        help="Which vaccine-design modalities to run. The shared upstream "
-             "epitope-prediction + window-selection logic is identical for "
-             "all modalities; this is the *sharp switch* for downstream "
-             "design output. 'auto' (default) infers from --output-peptide "
-             "and --output-mrna: pass either, both, or neither. 'peptide' / "
-             "'mrna' / 'both' explicitly select; 'none' suppresses both "
-             "even if --output-peptide / --output-mrna are set (useful for "
-             "report-only runs).")
+        nargs='+',
+        default=["auto"],
+        choices=["auto", "none", "peptide", "mrna"],
+        metavar="MODALITY",
+        help="Which vaccine-design modalities to run. Multi-valued so future "
+             "modalities (DNA, mRNA-LNP variants, etc.) plug in as additional "
+             "choices without an API change. Examples: "
+             "'--vaccine-modality auto' (default; infer from output flags), "
+             "'--vaccine-modality mrna', "
+             "'--vaccine-modality peptide mrna' (both), "
+             "'--vaccine-modality none' (report-only run, suppresses "
+             "construct writers even if --output-peptide / --output-mrna "
+             "are set). 'auto' / 'none' are sentinels — must be passed alone. "
+             "'peptide' is an umbrella; the SLP / minimal-epitope / "
+             "multi-epitope sub-mode lives in --peptide-mode.")
 
     output_args_group.add_argument(
         "--output-patient-id",

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -124,63 +124,32 @@ def _epitope_config_from_args_safe(args):
         return EpitopeConfig()
 
 
-_KNOWN_MODALITIES = {'peptide', 'mrna'}
-# Future modalities plug in here as their writers land:
-# _KNOWN_MODALITIES |= {'dna', ...}
-_MODALITY_SENTINELS = {'auto', 'none'}
+_KNOWN_VACCINE_TYPES = {'peptide', 'mrna'}
+# Future vaccine types plug in here as their writers land:
+# _KNOWN_VACCINE_TYPES |= {'dna', ...}
 
 
-def _resolve_modality(args):
-    """Decide which vaccine-design modalities to run.
+def _resolve_vaccine_types(args):
+    """Return the set of vaccine types to design.
 
-    The ``--vaccine-modality`` flag is multi-valued. Returns the
-    set of active modality names — e.g. ``{'mrna'}``,
-    ``{'peptide', 'mrna'}``, or ``set()`` for a report-only run.
-
-    Sentinels:
-      - ``auto`` (default) infers from ``--output-peptide`` /
-        ``--output-mrna``. Must be passed alone.
-      - ``none`` suppresses construct writers even if output paths
-        are set. Must be passed alone.
-
-    Mixing a sentinel with a concrete modality raises ``ValueError``
-    with a clear message.
+    ``--vaccine-type`` is multi-valued; default ``['peptide']``.
+    Vaxrank always ranks (no "ranking-off" sentinel); whether each
+    type's writer fires also depends on its output path being set.
+    Unknown types raise ``ValueError`` so adding 'dna' before its
+    writer ships fails clearly.
     """
-    raw = getattr(args, 'vaccine_modality', ['auto']) or ['auto']
+    raw = getattr(args, 'vaccine_type', ['peptide']) or ['peptide']
     # argparse with nargs='+' always yields a list; tolerate a bare
     # string in case a downstream caller bypassed the parser.
     if isinstance(raw, str):
         raw = [raw]
-    selected = list(raw)
-    sentinels = [m for m in selected if m in _MODALITY_SENTINELS]
-    concrete = [m for m in selected if m in _KNOWN_MODALITIES]
-    unknown = [m for m in selected
-               if m not in _MODALITY_SENTINELS and m not in _KNOWN_MODALITIES]
+    types = set(raw)
+    unknown = types - _KNOWN_VACCINE_TYPES
     if unknown:
         raise ValueError(
-            "Unknown vaccine modality %r. Known: %s; sentinels: %s." % (
-                unknown,
-                sorted(_KNOWN_MODALITIES),
-                sorted(_MODALITY_SENTINELS)))
-    if sentinels and concrete:
-        raise ValueError(
-            "--vaccine-modality sentinel %r cannot be combined with "
-            "concrete modalities %r — pass the sentinel alone or list "
-            "concrete modalities." % (sentinels, concrete))
-    if sentinels and len(sentinels) > 1:
-        raise ValueError(
-            "--vaccine-modality accepts at most one sentinel "
-            "(auto/none); got %r." % sentinels)
-    if 'none' in sentinels:
-        return set()
-    if 'auto' in sentinels or not selected:
-        out = set()
-        if getattr(args, 'output_peptide', ''):
-            out.add('peptide')
-        if getattr(args, 'output_mrna', ''):
-            out.add('mrna')
-        return out
-    return set(concrete)
+            "Unknown vaccine type %r. Known: %s." % (
+                sorted(unknown), sorted(_KNOWN_VACCINE_TYPES)))
+    return types
 
 
 def _emit_neoepitope_report_external(args, report_df, predictions):
@@ -295,11 +264,11 @@ def _emit_mrna_constructs(args, ranked):
         len(constructs), args.output_mrna)
 
 
-# Per-modality dispatcher table. Each entry: modality name → (
+# Per-type dispatch table. Each entry: vaccine-type name → (
 #   output-flag attribute on args, writer callable taking (args, ranked)
-# ). Adding a new modality (e.g. 'dna') is a one-line registration here
-# plus the writer module — no changes to _emit_outputs needed.
-_MODALITY_DISPATCH = {
+# ). Adding a new vaccine type (e.g. 'dna') is a one-line registration
+# here plus the writer module — no changes to _emit_outputs needed.
+_VACCINE_TYPE_DISPATCH = {
     'peptide': ('output_peptide', _emit_peptide_constructs),
     'mrna': ('output_mrna', _emit_mrna_constructs),
 }
@@ -310,34 +279,29 @@ def _emit_outputs(args, ranked, source):
 
     ``ranked`` is the shared ``[(Variant, [VaccinePeptide])]``
     intermediate; ``source`` is 'pipeline' (VCF/BAM) or 'external'
-    (LENS/pVACseq) — used only for messaging today, but keeps the
-    branch point explicit for future modality-specific gating.
+    (LENS/pVACseq).
 
-    The set of active modalities comes from ``_resolve_modality`` and
-    drives the per-modality dispatch table at the top of this module.
-    Modality-specific code lives only inside the per-writer helpers.
+    Active vaccine types come from ``_resolve_vaccine_types``. A type
+    fires only if both: (a) it's in the active set, and (b) its
+    ``--output-<type>`` path is set. Vaxrank-without-an-output-path is
+    a valid (ranking-only) run.
     """
-    active = _resolve_modality(args)
+    active = _resolve_vaccine_types(args)
 
-    # Reports run for both sources; CSV / XLSX rank reports are not
-    # modality-specific. On the external-input path, the LENS-native
-    # per-(peptide, allele) report (already written by
-    # _emit_neoepitope_report_external) and this rank-report would
-    # collide on --output-csv — so skip make_csv_report there.
+    # Rank reports run for both sources; on the external-input path
+    # the LENS-native per-(peptide, allele) report already consumed
+    # ``--output-csv`` (via _emit_neoepitope_report_external) so the
+    # rank-report writer would collide — skip it there.
     if (args.output_csv or args.output_xlsx_report) and source != 'external':
         make_csv_report(
             ranked,
             excel_report_path=args.output_xlsx_report,
             csv_report_path=args.output_csv)
-    elif (args.output_csv or args.output_xlsx_report) and source == 'external':
-        # On external input, --output-csv was consumed by the
-        # neoepitope-report writer; --output-xlsx-report is currently
-        # unused. Document and skip.
-        if args.output_xlsx_report:
-            logger.info(
-                "--output-xlsx-report ignored on external-input path "
-                "(use --output-neoepitope-report for the LENS / pVACseq "
-                "XLSX format).")
+    elif args.output_xlsx_report and source == 'external':
+        logger.info(
+            "--output-xlsx-report ignored on external-input path "
+            "(use --output-neoepitope-report for the LENS / pVACseq "
+            "XLSX format).")
 
     if args.output_neoepitope_report and source == 'pipeline':
         num_epitopes = getattr(args, 'num_epitopes_per_vaccine_peptide', None)
@@ -346,24 +310,35 @@ def _emit_outputs(args, ranked, source):
             num_epitopes_per_peptide=num_epitopes,
             excel_report_path=args.output_neoepitope_report)
 
-    for modality in sorted(active):
-        if modality not in _MODALITY_DISPATCH:
+    fired = []
+    for vtype in sorted(active):
+        if vtype not in _VACCINE_TYPE_DISPATCH:
             logger.warning(
-                "vaccine modality %r recognized but has no writer "
-                "registered (future-modality stub); skipping.", modality)
+                "vaccine type %r recognized but has no writer "
+                "registered (future-type stub); skipping.", vtype)
             continue
-        attr, writer = _MODALITY_DISPATCH[modality]
+        attr, writer = _VACCINE_TYPE_DISPATCH[vtype]
         if getattr(args, attr, ''):
             writer(args, ranked)
-        else:
+            fired.append(vtype)
+        # No output path → ranking-only for that type. Silent (vs.
+        # warning) because peptide is the default vaccine type and
+        # we don't want to spam users who only want a report run.
+
+    # Warn if user provided an output path for a type they didn't ask
+    # for — usually a typo / forgotten --vaccine-type flag.
+    for vtype, (attr, _) in _VACCINE_TYPE_DISPATCH.items():
+        if vtype not in active and getattr(args, attr, ''):
             logger.warning(
-                "--vaccine-modality requested %s but --%s is empty; "
-                "skipping %s constructs.",
-                modality, attr.replace('_', '-'), modality)
+                "--%s is set but '%s' is not in --vaccine-type %s; "
+                "no %s constructs will be written. Add '%s' to "
+                "--vaccine-type to enable.",
+                attr.replace('_', '-'), vtype, sorted(active),
+                vtype, vtype)
 
     logger.info(
-        "Vaccine modality dispatch [%s]: active=%s",
-        source, sorted(active) or ['(none)'])
+        "Vaccine-type dispatch [%s]: active=%s wrote=%s",
+        source, sorted(active), fired or ['(none)'])
 
 
 def configure_logging(args):
@@ -390,12 +365,22 @@ def _resolve_ensembl_release(args):
 
 def main(args_list=None):
     """
-    Rank personalized cancer neoantigens from somatic variants, tumor
-    RNA, and patient HLA type. The ranked candidates can be emitted as
-    analysis reports, peptide vaccine constructs, or mRNA vaccine
-    constructs (or any combination).
+    Rank personalized cancer neoantigens from somatic variants + tumor
+    RNA (or a pre-computed LENS / pVACseq report) and emit the ranked
+    candidates as one or more vaccine types plus optional analysis
+    reports.
 
-    Example (analysis report + peptide pool + mRNA construct):
+    Inputs (one of):
+      - --vcf + --bam: full pipeline (variant calling → Isovar
+        transcript assembly → MHC prediction → ranking)
+      - --input-lens / --input-pvacseq: external neoepitope report,
+        skipping the predict-from-genome stages
+
+    Vaccine-type dispatch is driven by ``--vaccine-type`` (multi-valued;
+    default 'peptide'). Each type's writer fires only if its
+    ``--output-<type>`` path is also set.
+
+    Example (full pipeline; reports + peptide pool + mRNA constructs):
 
         vaxrank \\
             --vcf somatic.vcf \\
@@ -403,9 +388,18 @@ def main(args_list=None):
             --mhc-predictor netmhc \\
             --mhc-alleles HLA-A*02:01 \\
             --vaccine-peptide-length 25 \\
+            --vaccine-type peptide mrna \\
             --output-pdf-report report.pdf \\
             --output-peptide vaccine-peptides.fasta \\
-            --output-mrna vaccine-mrna.fasta
+            --output-mrna vaccine-mrna_dir/
+
+    Example (LENS-driven mRNA design):
+
+        vaxrank \\
+            --input-lens patient.lens.tsv \\
+            --vaccine-type mrna \\
+            --output-mrna mrna_dir/ \\
+            --output-mrna-csv layers.csv
     """
     if args_list is None:
         args_list = sys.argv[1:]

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -124,30 +124,63 @@ def _epitope_config_from_args_safe(args):
         return EpitopeConfig()
 
 
+_KNOWN_MODALITIES = {'peptide', 'mrna'}
+# Future modalities plug in here as their writers land:
+# _KNOWN_MODALITIES |= {'dna', ...}
+_MODALITY_SENTINELS = {'auto', 'none'}
+
+
 def _resolve_modality(args):
     """Decide which vaccine-design modalities to run.
 
-    Resolution: explicit ``--vaccine-modality {peptide,mrna,both,none,
-    auto}`` wins. ``auto`` (default) derives from which output flags
-    were set: ``--output-peptide`` enables peptide, ``--output-mrna``
-    enables mRNA. Independent — both can be on at once.
+    The ``--vaccine-modality`` flag is multi-valued. Returns the
+    set of active modality names — e.g. ``{'mrna'}``,
+    ``{'peptide', 'mrna'}``, or ``set()`` for a report-only run.
 
-    Returns a (run_peptide, run_mrna) bool pair.
+    Sentinels:
+      - ``auto`` (default) infers from ``--output-peptide`` /
+        ``--output-mrna``. Must be passed alone.
+      - ``none`` suppresses construct writers even if output paths
+        are set. Must be passed alone.
+
+    Mixing a sentinel with a concrete modality raises ``ValueError``
+    with a clear message.
     """
-    explicit = getattr(args, 'vaccine_modality', 'auto')
-    if explicit == 'peptide':
-        return True, False
-    if explicit == 'mrna':
-        return False, True
-    if explicit == 'both':
-        return True, True
-    if explicit == 'none':
-        return False, False
-    # 'auto' — derive from output flags.
-    return (
-        bool(getattr(args, 'output_peptide', '')),
-        bool(getattr(args, 'output_mrna', '')),
-    )
+    raw = getattr(args, 'vaccine_modality', ['auto']) or ['auto']
+    # argparse with nargs='+' always yields a list; tolerate a bare
+    # string in case a downstream caller bypassed the parser.
+    if isinstance(raw, str):
+        raw = [raw]
+    selected = list(raw)
+    sentinels = [m for m in selected if m in _MODALITY_SENTINELS]
+    concrete = [m for m in selected if m in _KNOWN_MODALITIES]
+    unknown = [m for m in selected
+               if m not in _MODALITY_SENTINELS and m not in _KNOWN_MODALITIES]
+    if unknown:
+        raise ValueError(
+            "Unknown vaccine modality %r. Known: %s; sentinels: %s." % (
+                unknown,
+                sorted(_KNOWN_MODALITIES),
+                sorted(_MODALITY_SENTINELS)))
+    if sentinels and concrete:
+        raise ValueError(
+            "--vaccine-modality sentinel %r cannot be combined with "
+            "concrete modalities %r — pass the sentinel alone or list "
+            "concrete modalities." % (sentinels, concrete))
+    if sentinels and len(sentinels) > 1:
+        raise ValueError(
+            "--vaccine-modality accepts at most one sentinel "
+            "(auto/none); got %r." % sentinels)
+    if 'none' in sentinels:
+        return set()
+    if 'auto' in sentinels or not selected:
+        out = set()
+        if getattr(args, 'output_peptide', ''):
+            out.add('peptide')
+        if getattr(args, 'output_mrna', ''):
+            out.add('mrna')
+        return out
+    return set(concrete)
 
 
 def _emit_neoepitope_report_external(args, report_df, predictions):
@@ -262,6 +295,16 @@ def _emit_mrna_constructs(args, ranked):
         len(constructs), args.output_mrna)
 
 
+# Per-modality dispatcher table. Each entry: modality name → (
+#   output-flag attribute on args, writer callable taking (args, ranked)
+# ). Adding a new modality (e.g. 'dna') is a one-line registration here
+# plus the writer module — no changes to _emit_outputs needed.
+_MODALITY_DISPATCH = {
+    'peptide': ('output_peptide', _emit_peptide_constructs),
+    'mrna': ('output_mrna', _emit_mrna_constructs),
+}
+
+
 def _emit_outputs(args, ranked, source):
     """Single fan-out point for everything downstream of ranking.
 
@@ -269,41 +312,58 @@ def _emit_outputs(args, ranked, source):
     intermediate; ``source`` is 'pipeline' (VCF/BAM) or 'external'
     (LENS/pVACseq) — used only for messaging today, but keeps the
     branch point explicit for future modality-specific gating.
+
+    The set of active modalities comes from ``_resolve_modality`` and
+    drives the per-modality dispatch table at the top of this module.
+    Modality-specific code lives only inside the per-writer helpers.
     """
-    run_peptide, run_mrna = _resolve_modality(args)
+    active = _resolve_modality(args)
 
     # Reports run for both sources; CSV / XLSX rank reports are not
-    # modality-specific.
-    if args.output_csv or args.output_xlsx_report:
+    # modality-specific. On the external-input path, the LENS-native
+    # per-(peptide, allele) report (already written by
+    # _emit_neoepitope_report_external) and this rank-report would
+    # collide on --output-csv — so skip make_csv_report there.
+    if (args.output_csv or args.output_xlsx_report) and source != 'external':
         make_csv_report(
             ranked,
             excel_report_path=args.output_xlsx_report,
             csv_report_path=args.output_csv)
+    elif (args.output_csv or args.output_xlsx_report) and source == 'external':
+        # On external input, --output-csv was consumed by the
+        # neoepitope-report writer; --output-xlsx-report is currently
+        # unused. Document and skip.
+        if args.output_xlsx_report:
+            logger.info(
+                "--output-xlsx-report ignored on external-input path "
+                "(use --output-neoepitope-report for the LENS / pVACseq "
+                "XLSX format).")
 
-    if args.output_neoepitope_report:
+    if args.output_neoepitope_report and source == 'pipeline':
         num_epitopes = getattr(args, 'num_epitopes_per_vaccine_peptide', None)
         make_minimal_neoepitope_report(
             ranked,
             num_epitopes_per_peptide=num_epitopes,
             excel_report_path=args.output_neoepitope_report)
 
-    if run_peptide and getattr(args, 'output_peptide', ''):
-        _emit_peptide_constructs(args, ranked)
-    elif run_peptide and not getattr(args, 'output_peptide', ''):
-        logger.warning(
-            "--vaccine-modality requested peptide output but "
-            "--output-peptide is empty; skipping peptide constructs.")
-
-    if run_mrna and getattr(args, 'output_mrna', ''):
-        _emit_mrna_constructs(args, ranked)
-    elif run_mrna and not getattr(args, 'output_mrna', ''):
-        logger.warning(
-            "--vaccine-modality requested mRNA output but --output-mrna "
-            "is empty; skipping mRNA constructs.")
+    for modality in sorted(active):
+        if modality not in _MODALITY_DISPATCH:
+            logger.warning(
+                "vaccine modality %r recognized but has no writer "
+                "registered (future-modality stub); skipping.", modality)
+            continue
+        attr, writer = _MODALITY_DISPATCH[modality]
+        if getattr(args, attr, ''):
+            writer(args, ranked)
+        else:
+            logger.warning(
+                "--vaccine-modality requested %s but --%s is empty; "
+                "skipping %s constructs.",
+                modality, attr.replace('_', '-'), modality)
 
     logger.info(
-        "Vaccine modality dispatch [%s]: peptide=%s mrna=%s",
-        source, run_peptide, run_mrna)
+        "Vaccine modality dispatch [%s]: active=%s",
+        source, sorted(active) or ['(none)'])
 
 
 def configure_logging(args):

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -281,6 +281,10 @@ def main(args_list=None):
             junction_swap_candidates=junction_candidates,
             junction_rank_strong=args.mrna_junction_rank_strong,
             junction_rank_mild=args.mrna_junction_rank_mild,
+            poly_a_length=args.mrna_poly_a_length,
+            poly_a_segmented=args.mrna_poly_a_segmented,
+            poly_a_first_segment=args.mrna_poly_a_first_segment,
+            poly_a_segment_linker=args.mrna_poly_a_segment_linker,
         )
         if options.optimize_linkers:
             try:
@@ -310,11 +314,12 @@ def main(args_list=None):
             mhc_predictor=mhc_predictor, mhc_alleles=mhc_alleles)
         write_mrna_outputs(
             constructs,
-            fasta_path=args.output_mrna,
+            output_dir=args.output_mrna,
             manifest_path=getattr(args, 'output_mrna_manifest', '') or None,
+            csv_path=getattr(args, 'output_mrna_csv', '') or None,
         )
         logger.info(
-            "Wrote %d mRNA construct(s) to %s",
+            "Wrote %d mRNA construct(s) to %s/{cds,no_polyA,full}.fasta",
             len(constructs), args.output_mrna)
 
     ########################

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -44,8 +44,6 @@ from ..config import load_vaxrank_config
 
 from ..core_logic import run_vaxrank
 from ..epitope_io import (
-    load_pvacseq,
-    load_lens,
     save_predictions,
     write_neoepitope_report,
 )
@@ -112,42 +110,200 @@ def _filter_unannotatable_variants(variants):
     return variants
 
 
-def _run_external_input_mode(args):
-    """
-    Load epitope predictions from pVACseq or LENS, score them, and
-    write the requested output reports (CSV, XLSX neoepitope report).
-    """
+def _has_external_input(args):
+    return bool(
+        getattr(args, 'input_pvacseq', None)
+        or getattr(args, 'input_lens', None))
+
+
+def _epitope_config_from_args_safe(args):
     from ..epitope_config import EpitopeConfig
-    from .epitope_config_args import epitope_config_from_args
-
     try:
-        epitope_config = epitope_config_from_args(args)
+        return epitope_config_from_args(args)
     except Exception:
-        epitope_config = EpitopeConfig()
+        return EpitopeConfig()
 
-    if getattr(args, 'input_pvacseq', None):
-        report_df, predictions = load_pvacseq(args.input_pvacseq)
-    elif getattr(args, 'input_lens', None):
-        report_df, predictions = load_lens(args.input_lens)
-    else:
-        return False  # no external input
 
-    if report_df.empty:
-        logger.warning("No epitope predictions loaded")
-        return True
+def _resolve_modality(args):
+    """Decide which vaccine-design modalities to run.
 
+    Resolution: explicit ``--vaccine-modality {peptide,mrna,both,none,
+    auto}`` wins. ``auto`` (default) derives from which output flags
+    were set: ``--output-peptide`` enables peptide, ``--output-mrna``
+    enables mRNA. Independent — both can be on at once.
+
+    Returns a (run_peptide, run_mrna) bool pair.
+    """
+    explicit = getattr(args, 'vaccine_modality', 'auto')
+    if explicit == 'peptide':
+        return True, False
+    if explicit == 'mrna':
+        return False, True
+    if explicit == 'both':
+        return True, True
+    if explicit == 'none':
+        return False, False
+    # 'auto' — derive from output flags.
+    return (
+        bool(getattr(args, 'output_peptide', '')),
+        bool(getattr(args, 'output_mrna', '')),
+    )
+
+
+def _emit_neoepitope_report_external(args, report_df, predictions):
+    """LENS / pVACseq specific report path: writes the per-(peptide,
+    allele) neoepitope CSV / XLSX. Independent from the modality
+    dispatch — these are *report* outputs, not vaccine-design outputs.
+    """
+    if report_df is None or report_df.empty:
+        return
+    epitope_config = _epitope_config_from_args_safe(args)
     write_neoepitope_report(
         report_df=report_df,
         predictions=predictions,
-        excel_report_path=getattr(args, 'output_neoepitope_report', '') or None,
+        excel_report_path=(
+            getattr(args, 'output_neoepitope_report', '') or None),
         csv_report_path=getattr(args, 'output_csv', '') or None,
         epitope_config=epitope_config,
     )
-
     if getattr(args, 'output_epitopes', ''):
         save_predictions(predictions, args.output_epitopes)
 
-    return True
+
+def _emit_peptide_constructs(args, ranked):
+    """Build + write peptide-vaccine constructs. Modality-specific."""
+    peptide_options = PeptideConstructConfig(
+        mode=args.peptide_mode,
+        linker=args.peptide_linker,
+        min_antigen_length_aa=args.peptide_min_antigen_length_aa,
+        max_antigen_length_aa=args.peptide_max_antigen_length_aa,
+        antigens_per_construct=args.peptide_antigens_per_construct,
+        max_constructs=args.peptide_max_constructs,
+        candidates_per_slot=args.peptide_candidates_per_slot,
+        n_terminal_acetylation=args.peptide_n_terminal_acetyl,
+        c_terminal_amidation=args.peptide_c_terminal_amide,
+        scale_mg=args.peptide_scale_mg,
+        purity_percent=args.peptide_purity_percent,
+        counterion=args.peptide_counterion,
+    )
+    constructs = assemble_peptide_constructs(ranked, options=peptide_options)
+    write_peptide_outputs(
+        constructs,
+        fasta_path=args.output_peptide,
+        manifest_path=getattr(args, 'output_peptide_manifest', '') or None,
+        order_form_path=getattr(args, 'output_peptide_order_form', '') or None,
+        options=peptide_options,
+    )
+    logger.info(
+        "Wrote %d peptide construct(s) to %s",
+        len(constructs), args.output_peptide)
+
+
+def _emit_mrna_constructs(args, ranked):
+    """Build + write mRNA-vaccine constructs. Modality-specific."""
+    junction_candidates = tuple(
+        s.strip() for s in (args.mrna_junction_candidates or "").split(",")
+        if s.strip()
+    )
+    options = RNAConstructConfig(
+        signal_peptide=(args.mrna_signal_peptide or None),
+        linker=args.mrna_linker,
+        include_mitd=args.mrna_include_mitd,
+        mitd=args.mrna_mitd,
+        utr_5p=args.mrna_5p_utr,
+        utr_3p=args.mrna_3p_utr,
+        codon_species=args.mrna_codon_species,
+        codon_method=args.mrna_codon_method,
+        min_antigen_length_aa=args.mrna_min_antigen_length_aa,
+        max_antigen_length_aa=args.mrna_max_antigen_length_aa,
+        antigens_per_construct=args.mrna_antigens_per_construct,
+        max_constructs=args.mrna_max_constructs,
+        candidates_per_slot=args.mrna_candidates_per_slot,
+        max_length_nt=args.mrna_max_length_nt,
+        optimize_linkers=args.mrna_optimize_linkers,
+        junction_swap_candidates=junction_candidates,
+        junction_rank_strong=args.mrna_junction_rank_strong,
+        junction_rank_mild=args.mrna_junction_rank_mild,
+        poly_a_length=args.mrna_poly_a_length,
+        poly_a_segmented=args.mrna_poly_a_segmented,
+        poly_a_first_segment=args.mrna_poly_a_first_segment,
+        poly_a_segment_linker=args.mrna_poly_a_segment_linker,
+    )
+    if options.optimize_linkers:
+        try:
+            mhc_predictor = mhc_binding_predictor_from_args(args)
+            mhc_alleles = mhc_alleles_from_args(args)
+        except Exception as e:
+            logger.warning(
+                "Could not load MHC predictor / alleles for "
+                "per-junction linker optimization (%s). The optimizer "
+                "will fall back to the shared linker at every junction. "
+                "Set --mhc-predictor + --mhc-alleles to enable it.", e)
+            logger.debug(
+                "Predictor / alleles load traceback:", exc_info=True)
+            mhc_predictor = None
+            mhc_alleles = None
+    else:
+        mhc_predictor = None
+        mhc_alleles = None
+    constructs = assemble_mrna_constructs(
+        ranked, options=options,
+        mhc_predictor=mhc_predictor, mhc_alleles=mhc_alleles)
+    write_mrna_outputs(
+        constructs,
+        output_dir=args.output_mrna,
+        manifest_path=getattr(args, 'output_mrna_manifest', '') or None,
+        csv_path=getattr(args, 'output_mrna_csv', '') or None,
+        csv_include_full_rows=getattr(
+            args, 'output_mrna_csv_full_rows', True),
+    )
+    logger.info(
+        "Wrote %d mRNA construct(s) to %s/{cds,no_polyA,full}.fasta",
+        len(constructs), args.output_mrna)
+
+
+def _emit_outputs(args, ranked, source):
+    """Single fan-out point for everything downstream of ranking.
+
+    ``ranked`` is the shared ``[(Variant, [VaccinePeptide])]``
+    intermediate; ``source`` is 'pipeline' (VCF/BAM) or 'external'
+    (LENS/pVACseq) — used only for messaging today, but keeps the
+    branch point explicit for future modality-specific gating.
+    """
+    run_peptide, run_mrna = _resolve_modality(args)
+
+    # Reports run for both sources; CSV / XLSX rank reports are not
+    # modality-specific.
+    if args.output_csv or args.output_xlsx_report:
+        make_csv_report(
+            ranked,
+            excel_report_path=args.output_xlsx_report,
+            csv_report_path=args.output_csv)
+
+    if args.output_neoepitope_report:
+        num_epitopes = getattr(args, 'num_epitopes_per_vaccine_peptide', None)
+        make_minimal_neoepitope_report(
+            ranked,
+            num_epitopes_per_peptide=num_epitopes,
+            excel_report_path=args.output_neoepitope_report)
+
+    if run_peptide and getattr(args, 'output_peptide', ''):
+        _emit_peptide_constructs(args, ranked)
+    elif run_peptide and not getattr(args, 'output_peptide', ''):
+        logger.warning(
+            "--vaccine-modality requested peptide output but "
+            "--output-peptide is empty; skipping peptide constructs.")
+
+    if run_mrna and getattr(args, 'output_mrna', ''):
+        _emit_mrna_constructs(args, ranked)
+    elif run_mrna and not getattr(args, 'output_mrna', ''):
+        logger.warning(
+            "--vaccine-modality requested mRNA output but --output-mrna "
+            "is empty; skipping mRNA constructs.")
+
+    logger.info(
+        "Vaccine modality dispatch [%s]: peptide=%s mrna=%s",
+        source, run_peptide, run_mrna)
 
 
 def configure_logging(args):
@@ -199,132 +355,58 @@ def main(args_list=None):
     _resolve_ensembl_release(args)
     logger.info(args)
 
-    # When --input-pvacseq or --input-lens is provided, load external
-    # predictions, score, and write reports — skip the full pipeline.
-    if _run_external_input_mode(args):
-        return
+    # Architecture (post-#252):
+    #
+    #   INPUT
+    #     ├── --vcf + --bam  →  ranked_vaccine_peptides_with_metadata_from_parsed_args
+    #     └── --input-lens / --input-pvacseq  →  external_input.load_external_ranked
+    #                                            └── synthesize ranked from the report
+    #
+    #   SHARED:  ranked_variants_with_vaccine_peptides
+    #
+    #   DOWNSTREAM (modality-agnostic reports + peptide / mRNA construct dispatch)
+    #     _emit_outputs(args, ranked, source)
+    #
+    # The external-input path no longer hard-short-circuits — it
+    # produces the same shape as the VCF/BAM path so peptide and mRNA
+    # vaccine designs work end-to-end from LENS / pVACseq files.
+    from ..external_input import load_external_ranked
 
-    check_args(args)
+    patient_info = None
+    args_for_report = args
+    report_df = None
+    predictions = None
 
-    data = ranked_vaccine_peptides_with_metadata_from_parsed_args(args)
-
-    ranked_variants_with_vaccine_peptides = data['variants']
-    patient_info = data['patient_info']
-    args_for_report = data['args']
-
-    ###################
-    # CSV-based reports
-    ###################
-    if args.output_csv or args.output_xlsx_report:
-        make_csv_report(
-            ranked_variants_with_vaccine_peptides,
-            excel_report_path=args.output_xlsx_report,
-            csv_report_path=args.output_csv)
-
-    if args.output_neoepitope_report:
-        # num_epitopes_per_vaccine_peptide may not be set in cached mode
-        num_epitopes = getattr(args, 'num_epitopes_per_vaccine_peptide', None)
-        make_minimal_neoepitope_report(
-            ranked_variants_with_vaccine_peptides,
-            num_epitopes_per_peptide=num_epitopes,
-            excel_report_path=args.output_neoepitope_report)
-
-    if getattr(args, 'output_peptide', ''):
-        peptide_options = PeptideConstructConfig(
-            mode=args.peptide_mode,
-            linker=args.peptide_linker,
-            min_antigen_length_aa=args.peptide_min_antigen_length_aa,
-            max_antigen_length_aa=args.peptide_max_antigen_length_aa,
-            antigens_per_construct=args.peptide_antigens_per_construct,
-            max_constructs=args.peptide_max_constructs,
-            candidates_per_slot=args.peptide_candidates_per_slot,
-            n_terminal_acetylation=args.peptide_n_terminal_acetyl,
-            c_terminal_amidation=args.peptide_c_terminal_amide,
-            scale_mg=args.peptide_scale_mg,
-            purity_percent=args.peptide_purity_percent,
-            counterion=args.peptide_counterion,
-        )
-        peptide_constructs = assemble_peptide_constructs(
-            ranked_variants_with_vaccine_peptides, options=peptide_options)
-        write_peptide_outputs(
-            peptide_constructs,
-            fasta_path=args.output_peptide,
-            manifest_path=getattr(args, 'output_peptide_manifest', '') or None,
-            order_form_path=getattr(args, 'output_peptide_order_form', '') or None,
-            options=peptide_options,
-        )
-        logger.info(
-            "Wrote %d peptide construct(s) to %s",
-            len(peptide_constructs), args.output_peptide)
-
-    if getattr(args, 'output_mrna', ''):
-        junction_candidates = tuple(
-            s.strip() for s in (args.mrna_junction_candidates or "").split(",")
-            if s.strip()
-        )
-        options = RNAConstructConfig(
-            signal_peptide=(args.mrna_signal_peptide or None),
-            linker=args.mrna_linker,
-            include_mitd=args.mrna_include_mitd,
-            mitd=args.mrna_mitd,
-            utr_5p=args.mrna_5p_utr,
-            utr_3p=args.mrna_3p_utr,
-            codon_species=args.mrna_codon_species,
-            codon_method=args.mrna_codon_method,
-            min_antigen_length_aa=args.mrna_min_antigen_length_aa,
-            max_antigen_length_aa=args.mrna_max_antigen_length_aa,
-            antigens_per_construct=args.mrna_antigens_per_construct,
-            max_constructs=args.mrna_max_constructs,
-            candidates_per_slot=args.mrna_candidates_per_slot,
-            max_length_nt=args.mrna_max_length_nt,
-            optimize_linkers=args.mrna_optimize_linkers,
-            junction_swap_candidates=junction_candidates,
-            junction_rank_strong=args.mrna_junction_rank_strong,
-            junction_rank_mild=args.mrna_junction_rank_mild,
-            poly_a_length=args.mrna_poly_a_length,
-            poly_a_segmented=args.mrna_poly_a_segmented,
-            poly_a_first_segment=args.mrna_poly_a_first_segment,
-            poly_a_segment_linker=args.mrna_poly_a_segment_linker,
-        )
-        if options.optimize_linkers:
-            try:
-                mhc_predictor = mhc_binding_predictor_from_args(args)
-                mhc_alleles = mhc_alleles_from_args(args)
-            except Exception as e:
-                # Predictor / alleles aren't configured (or instantiation
-                # failed in mhctools / mhcflurry). The optimizer will warn
-                # and fall back; don't fail the whole vaxrank run. Log
-                # with traceback so genuine bugs in predictor loading are
-                # still visible (visible at DEBUG level).
-                logger.warning(
-                    "Could not load MHC predictor / alleles for "
-                    "per-junction linker optimization (%s). The optimizer "
-                    "will fall back to the shared linker at every junction. "
-                    "Set --mhc-predictor + --mhc-alleles to enable it.",
-                    e)
-                logger.debug(
-                    "Predictor / alleles load traceback:", exc_info=True)
-                mhc_predictor = None
-                mhc_alleles = None
+    if _has_external_input(args):
+        loaded = load_external_ranked(args)
+        if loaded is None:
+            ranked_variants_with_vaccine_peptides = []
         else:
-            mhc_predictor = None
-            mhc_alleles = None
-        constructs = assemble_mrna_constructs(
-            ranked_variants_with_vaccine_peptides, options=options,
-            mhc_predictor=mhc_predictor, mhc_alleles=mhc_alleles)
-        write_mrna_outputs(
-            constructs,
-            output_dir=args.output_mrna,
-            manifest_path=getattr(args, 'output_mrna_manifest', '') or None,
-            csv_path=getattr(args, 'output_mrna_csv', '') or None,
-        )
-        logger.info(
-            "Wrote %d mRNA construct(s) to %s/{cds,no_polyA,full}.fasta",
-            len(constructs), args.output_mrna)
+            ranked_variants_with_vaccine_peptides, report_df, predictions = loaded
+        if not ranked_variants_with_vaccine_peptides:
+            logger.warning(
+                "External input produced no ranked vaccine peptides; "
+                "writing only the per-(peptide, allele) neoepitope "
+                "report (if requested).")
+        # Per-(peptide, allele) CSV / XLSX report is unique to the
+        # external-input path; emit it before the shared dispatch.
+        _emit_neoepitope_report_external(args, report_df, predictions)
+        source = 'external'
+    else:
+        check_args(args)
+        data = ranked_vaccine_peptides_with_metadata_from_parsed_args(args)
+        ranked_variants_with_vaccine_peptides = data['variants']
+        patient_info = data['patient_info']
+        args_for_report = data['args']
+        source = 'pipeline'
+
+    _emit_outputs(args, ranked_variants_with_vaccine_peptides, source)
 
     ########################
-    # Template-based reports
+    # Template-based reports (PDF / HTML / ASCII) — pipeline path only
     ########################
+    if source != 'pipeline':
+        return
 
     if not (args.output_ascii_report or args.output_html_report or args.output_pdf_report):
         return

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -327,7 +327,7 @@ class DetectedPredictor:
     agretopicity_col: str | None = None
 
 
-def _detect_lens_predictors(columns):
+def detect_lens_predictors(columns):
     """Return a list of :class:`DetectedPredictor` for every known tool present.
 
     Unknown tools (not in ``_LENS_PREDICTOR_REGISTRY``) are ignored; we'd have
@@ -392,7 +392,7 @@ def _pick_canonical_predictor(affinity_preds):
     return sorted(affinity_preds, key=lambda d: d.tool)[0]
 
 
-def _normalize_hla_allele(allele):
+def normalize_hla_allele(allele):
     """LENS emits alleles as 'HLA-A01:01'; vaxrank output uses 'HLA-A*01:01'."""
     if not allele:
         return allele
@@ -434,7 +434,7 @@ def load_lens(path):
         raise ValueError(
             f"LENS file {path} missing required columns: {missing}")
 
-    detected = _detect_lens_predictors(df.columns)
+    detected = detect_lens_predictors(df.columns)
     if not detected:
         raise ValueError(
             f"LENS file {path} has no recognized predictor columns "
@@ -465,7 +465,7 @@ def load_lens(path):
         allele_raw = row.get("allele", "")
         if pd.isna(allele_raw) or not allele_raw:
             continue
-        allele = _normalize_hla_allele(str(allele_raw))
+        allele = normalize_hla_allele(str(allele_raw))
 
         # Build one EpitopePrediction per chosen predictor for this row.
         # Predictions with no usable value for this row are skipped.

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -41,8 +41,14 @@ import logging
 
 import pandas as pd
 
+from .epitope_io import _detect_lens_predictors, _normalize_hla_allele
 from .mutant_protein_fragment import MutantProteinFragment
 from .vaccine_peptide import VaccinePeptide
+
+# pVACseq aggregate-report scoring column priority. Sniffed against
+# the row dict; the first column present + non-NaN wins.
+_PVACSEQ_IC50_COLS = ('IC50 MT', 'Best IC50 Score MT')
+_PVACSEQ_RANK_COLS = ('%ile MT', 'Best Percentile MT')
 
 logger = logging.getLogger(__name__)
 
@@ -81,23 +87,42 @@ def _mut_offsets_in_context(peptide, pep_context):
     return idx, idx + len(peptide)
 
 
-def _pick_representative(group_rows):
+def _row_score(row, ic50_cols, rank_cols):
+    """Numeric score for a row: smallest IC50 (strongest binder) wins,
+    falling back to smallest percentile rank when IC50 is missing.
+
+    ``ic50_cols`` / ``rank_cols`` are tuples of column names tried in
+    priority order; the first non-NaN match is used. Returns a sortable
+    ``(tier, value)`` tuple where tier 0 = real IC50, tier 1 = rank,
+    tier 2 = no signal (rows tie at 0.0).
+    """
+    for col in ic50_cols:
+        v = row.get(col)
+        if v is not None and pd.notna(v):
+            try:
+                return (0, float(v))
+            except (TypeError, ValueError):
+                continue
+    for col in rank_cols:
+        v = row.get(col)
+        if v is not None and pd.notna(v):
+            try:
+                return (1, float(v))
+            except (TypeError, ValueError):
+                continue
+    return (2, 0.0)
+
+
+def _pick_representative(group_rows, ic50_cols, rank_cols):
     """Pick the row whose peptide will represent this variant in the
     construct pipeline.
 
-    Strategy: smallest IC50 (= strongest predicted binder). If the
-    LENS file doesn't carry IC50 (mhcflurry-presentation only), fall
-    back to lowest percentile rank.
+    Strategy: smallest IC50 (= strongest predicted binder). If no
+    IC50 column is present, fall back to smallest percentile rank.
+
+    Returns the strongest-binder row from ``group_rows``.
     """
-    def _key(r):
-        ic50 = r.get('ic50')
-        if ic50 is not None and pd.notna(ic50):
-            return (0, float(ic50))
-        rank = r.get('percentile_rank')
-        if rank is not None and pd.notna(rank):
-            return (1, float(rank))
-        return (2, 0.0)
-    return sorted(group_rows, key=_key)[0]
+    return min(group_rows, key=lambda r: _row_score(r, ic50_cols, rank_cols))
 
 
 def _coerce_n_alt_reads(tpm):
@@ -145,6 +170,18 @@ def ranked_from_lens_predictions(predictions, lens_tsv_path, genome=None,
     if df.empty:
         return []
 
+    # Auto-detect which LENS predictor columns are present so the
+    # representative-row pick reads real values. Without this, every
+    # row scored 0.0 and stable-sort returned the file-order first
+    # row (typically the alphabetically-first allele) instead of the
+    # strongest binder.
+    detected = _detect_lens_predictors(df.columns)
+    affinity_cols = tuple(
+        d.value_col for d in detected if d.kind == 'pMHC_affinity')
+    rank_cols = tuple(
+        d.percentile_col for d in detected
+        if d.percentile_col and d.kind == 'pMHC_affinity')
+
     # Index predictions by (peptide, allele) so we can attach all
     # per-predictor predictions to each candidate vaccine peptide.
     by_key = {}
@@ -167,7 +204,7 @@ def ranked_from_lens_predictions(predictions, lens_tsv_path, genome=None,
             logger.warning(
                 "Could not parse LENS variant_coords %r; skipping.", coords)
             continue
-        rep = _pick_representative(group_rows)
+        rep = _pick_representative(group_rows, affinity_cols, rank_cols)
         peptide = rep.get('peptide') or ""
         pep_context = rep.get('pep_context') or ""
         if not pep_context:
@@ -201,12 +238,10 @@ def ranked_from_lens_predictions(predictions, lens_tsv_path, genome=None,
         seen_keys = set()
         for r in group_rows:
             pep = r.get('peptide') or ""
-            allele_raw = r.get('allele') or ""
             # load_lens normalizes 'HLA-A02:01' → 'HLA-A*02:01';
             # match the same form here so the (peptide, allele)
             # lookup hits.
-            from .epitope_io import _normalize_hla_allele
-            allele = _normalize_hla_allele(str(allele_raw))
+            allele = _normalize_hla_allele(str(r.get('allele') or ""))
             key = (pep, allele)
             if key in seen_keys:
                 continue
@@ -271,7 +306,8 @@ def ranked_from_pvacseq_predictions(predictions, report_df, genome=None,
     ranked = []
     from varcode import Variant
     for vid, group_rows in groups.items():
-        rep = _pick_representative(group_rows)
+        rep = _pick_representative(
+            group_rows, _PVACSEQ_IC50_COLS, _PVACSEQ_RANK_COLS)
         best_pep = rep.get('Best Peptide') or rep.get('peptide') or ""
         gene = rep.get('Gene') or 'unknown'
         # pVACseq IDs look like "1.123.A.T" or similar; try to parse

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -41,7 +41,7 @@ import logging
 
 import pandas as pd
 
-from .epitope_io import _detect_lens_predictors, _normalize_hla_allele
+from .epitope_io import detect_lens_predictors, normalize_hla_allele
 from .mutant_protein_fragment import MutantProteinFragment
 from .vaccine_peptide import VaccinePeptide
 
@@ -175,12 +175,24 @@ def ranked_from_lens_predictions(predictions, lens_tsv_path, genome=None,
     # row scored 0.0 and stable-sort returned the file-order first
     # row (typically the alphabetically-first allele) instead of the
     # strongest binder.
-    detected = _detect_lens_predictors(df.columns)
+    detected = detect_lens_predictors(df.columns)
     affinity_cols = tuple(
         d.value_col for d in detected if d.kind == 'pMHC_affinity')
     rank_cols = tuple(
         d.percentile_col for d in detected
         if d.percentile_col and d.kind == 'pMHC_affinity')
+    if not affinity_cols and not rank_cols:
+        # No pMHC_affinity predictor detected — typically a
+        # presentation-only LENS file. _row_score will tie every row
+        # at (2, 0.0) and the file-order first row "wins". Warn so
+        # the user knows the representative pick is arbitrary.
+        kinds = sorted({d.kind for d in detected}) or ['(none)']
+        logger.warning(
+            "LENS file has no pMHC_affinity scoring columns "
+            "(detected kinds: %s); per-variant representative-peptide "
+            "pick will fall back to file order. Consider running with "
+            "a predictor that emits pMHC affinity (e.g. mhcflurry, "
+            "netmhcpan-ba).", kinds)
 
     # Index predictions by (peptide, allele) so we can attach all
     # per-predictor predictions to each candidate vaccine peptide.
@@ -241,7 +253,7 @@ def ranked_from_lens_predictions(predictions, lens_tsv_path, genome=None,
             # load_lens normalizes 'HLA-A02:01' → 'HLA-A*02:01';
             # match the same form here so the (peptide, allele)
             # lookup hits.
-            allele = _normalize_hla_allele(str(r.get('allele') or ""))
+            allele = normalize_hla_allele(str(r.get('allele') or ""))
             key = (pep, allele)
             if key in seen_keys:
                 continue
@@ -276,57 +288,101 @@ def ranked_from_lens_predictions(predictions, lens_tsv_path, genome=None,
     return ranked
 
 
-def ranked_from_pvacseq_predictions(predictions, report_df, genome=None,
+def _parse_pvacseq_id(vid):
+    """Parse a pVACseq aggregate ``ID`` field into a varcode.Variant.
+
+    Common forms in the wild:
+      - ``chr1-100000-100001-A-T`` (5-part dashed: contig-start-end-ref-alt)
+      - ``chr1-100000-A-T`` (4-part dashed)
+      - ``1.123.A.T`` (4-part dotted, legacy)
+
+    Returns ``(contig, start, ref, alt)`` tuple or ``None`` if the
+    string doesn't match any recognized form.
+    """
+    if not vid:
+        return None
+    s = str(vid)
+    # Try dashed first (modern pVACseq aggregate output).
+    if '-' in s:
+        parts = s.split('-')
+        if len(parts) == 5:  # contig-start-end-ref-alt
+            try:
+                return parts[0], int(parts[1]), parts[3], parts[4]
+            except ValueError:
+                return None
+        if len(parts) == 4:  # contig-start-ref-alt
+            try:
+                return parts[0], int(parts[1]), parts[2], parts[3]
+            except ValueError:
+                return None
+    # Dotted (legacy)
+    parts = s.split('.')
+    if len(parts) == 4:
+        try:
+            return parts[0], int(parts[1]), parts[2], parts[3]
+        except ValueError:
+            return None
+    return None
+
+
+def ranked_from_pvacseq_predictions(predictions, pvacseq_tsv_path,
+                                    genome=None,
                                     num_mutant_epitopes_to_keep=None):
     """pVACseq variant of :func:`ranked_from_lens_predictions`.
 
-    pVACseq aggregate reports (the format ``load_pvacseq`` parses)
-    don't carry an SLP-context column in the same shape; we use
-    ``Best Peptide`` as the antigen sequence and treat the peptide
-    itself as the mutation span. mRNA construct generation from
-    pVACseq input therefore produces shorter antigen windows than
-    the LENS path.
+    Re-reads the raw aggregate TSV (the per-(peptide, allele)
+    ``report_df`` returned by ``load_pvacseq`` carries display columns
+    rather than the original ``ID`` / ``Best Peptide`` / ``IC50 MT``).
+
+    Uses ``Best Peptide`` as the antigen sequence and treats the
+    peptide itself as the mutation span (no SLP-context column).
+    mRNA construct generation from pVACseq input therefore produces
+    shorter antigen windows than the LENS path.
     """
-    if report_df is None or report_df.empty:
+    if not pvacseq_tsv_path:
+        return []
+    df = pd.read_csv(pvacseq_tsv_path, sep="\t", low_memory=False)
+    if df.empty:
         return []
 
     by_key = {}
     for p in predictions:
         by_key.setdefault((p.peptide_sequence, p.allele), []).append(p)
 
-    rows = report_df.to_dict('records')
+    rows = df.to_dict('records')
     groups = {}
     for r in rows:
-        # pVACseq aggregate uses 'ID' as a stable per-variant key.
         key = r.get('ID') or r.get('Index')
-        if key is None:
+        if key is None or pd.isna(key):
             continue
         groups.setdefault(key, []).append(r)
 
     ranked = []
     from varcode import Variant
+    n_skipped = 0
     for vid, group_rows in groups.items():
         rep = _pick_representative(
             group_rows, _PVACSEQ_IC50_COLS, _PVACSEQ_RANK_COLS)
         best_pep = rep.get('Best Peptide') or rep.get('peptide') or ""
         gene = rep.get('Gene') or 'unknown'
-        # pVACseq IDs look like "1.123.A.T" or similar; try to parse
-        # for variant location, else fall back to a placeholder.
-        contig, pos, ref, alt = '?', 0, 'N', 'N'
-        try:
-            parts = str(vid).split('.')
-            if len(parts) == 4:
-                contig, pos_s, ref, alt = parts
-                pos = int(pos_s)
-        except (TypeError, ValueError):
-            pass
+
+        parsed = _parse_pvacseq_id(vid)
+        if parsed is None:
+            n_skipped += 1
+            logger.debug(
+                "Could not parse pVACseq ID %r as a Variant; skipping.",
+                vid)
+            continue
+        contig, pos, ref, alt = parsed
         try:
             variant = Variant(
                 contig=contig, start=pos, ref=ref, alt=alt,
                 genome=genome, normalize_contig_names=False)
         except Exception:
-            logger.warning("Could not parse pVACseq ID %r as a Variant; "
-                           "skipping.", vid)
+            n_skipped += 1
+            logger.debug(
+                "Variant construction failed for pVACseq ID %r; skipping.",
+                vid, exc_info=True)
             continue
 
         fragment = MutantProteinFragment(
@@ -342,7 +398,8 @@ def ranked_from_pvacseq_predictions(predictions, report_df, genome=None,
         seen_keys = set()
         for r in group_rows:
             pep = r.get('Best Peptide') or r.get('peptide') or ""
-            allele = r.get('Allele') or r.get('allele') or ""
+            allele_raw = r.get('Allele') or r.get('allele') or ""
+            allele = normalize_hla_allele(str(allele_raw))
             key = (pep, allele)
             if key in seen_keys:
                 continue
@@ -358,6 +415,11 @@ def ranked_from_pvacseq_predictions(predictions, report_df, genome=None,
             epitope_predictions=epitope_preds,
             num_mutant_epitopes_to_keep=num_mutant_epitopes_to_keep,
         )]))
+
+    if n_skipped:
+        logger.warning(
+            "Skipped %d pVACseq row group(s) with unparseable IDs; "
+            "see DEBUG log for details.", n_skipped)
 
     ranked.sort(
         key=lambda pair: (
@@ -382,7 +444,7 @@ def load_external_ranked(args):
     if getattr(args, 'input_pvacseq', None):
         report_df, predictions = load_pvacseq(args.input_pvacseq)
         ranked = ranked_from_pvacseq_predictions(
-            predictions, report_df,
+            predictions, args.input_pvacseq,
             genome=getattr(args, 'genome', None))
         return ranked, report_df, predictions
     return None

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -1,0 +1,352 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Synthesize ranked-vaccine-peptide structures from external predictions.
+
+LENS and pVACseq files carry pre-computed (peptide, allele) MHC
+predictions plus a peptide-context column (the SLP-style window
+surrounding each neoepitope). Vaxrank's downstream code (reports,
+peptide constructs, mRNA constructs) consumes a list of
+``(varcode.Variant, list[VaccinePeptide])`` tuples — the same shape
+the VCF/BAM pipeline emits.
+
+This module bridges the two: it groups external predictions by
+variant, picks one representative peptide per variant, and wraps the
+context window in a ``MutantProteinFragment`` + ``VaccinePeptide`` so
+**the same output dispatch** runs whether the input was a VCF or a
+LENS report. Without this bridge the CLI hard-short-circuits external
+inputs into a one-line CSV and never reaches the construct writers
+(which is precisely the gap PR #253 closes).
+
+Limitations:
+- LENS / pVACseq don't carry RNA-supporting-fragment counts in a
+  uniform way, so ``n_alt_reads`` is set from ``tpm`` (LENS) or
+  defaults to 1. Combined-score ranking that depends on read counts
+  collapses to epitope-only effectively.
+- The "fragment" recovered from ``pep_context`` is just the SLP
+  window; transcript context isn't preserved. Stop-loss / frameshift
+  extensions aren't recoverable from external inputs.
+"""
+
+import logging
+
+import pandas as pd
+
+from .mutant_protein_fragment import MutantProteinFragment
+from .vaccine_peptide import VaccinePeptide
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_variant_coords(coords, genome=None):
+    """Parse ``chr:pos:ref:alt`` (LENS) into a ``varcode.Variant``.
+
+    Returns None if the string is malformed.
+    """
+    from varcode import Variant
+    if not isinstance(coords, str) or coords.count(":") < 3:
+        return None
+    parts = coords.split(":")
+    contig, pos, ref, alt = parts[0], parts[1], parts[2], parts[3]
+    try:
+        start = int(pos)
+    except ValueError:
+        return None
+    return Variant(contig=contig, start=start, ref=ref, alt=alt,
+                   genome=genome, normalize_contig_names=False)
+
+
+def _mut_offsets_in_context(peptide, pep_context):
+    """Locate the neoepitope inside its surrounding context.
+
+    Returns ``(start, end)`` AA offsets of the peptide within
+    ``pep_context``. If the peptide can't be located, the whole
+    context is treated as the mutation span (conservative — keeps the
+    centering helper from cropping out the mutation).
+    """
+    if not pep_context or not peptide:
+        return 0, len(pep_context or "")
+    idx = pep_context.find(peptide)
+    if idx < 0:
+        return 0, len(pep_context)
+    return idx, idx + len(peptide)
+
+
+def _pick_representative(group_rows):
+    """Pick the row whose peptide will represent this variant in the
+    construct pipeline.
+
+    Strategy: smallest IC50 (= strongest predicted binder). If the
+    LENS file doesn't carry IC50 (mhcflurry-presentation only), fall
+    back to lowest percentile rank.
+    """
+    def _key(r):
+        ic50 = r.get('ic50')
+        if ic50 is not None and pd.notna(ic50):
+            return (0, float(ic50))
+        rank = r.get('percentile_rank')
+        if rank is not None and pd.notna(rank):
+            return (1, float(rank))
+        return (2, 0.0)
+    return sorted(group_rows, key=_key)[0]
+
+
+def _coerce_n_alt_reads(tpm):
+    """LENS doesn't carry alt-read count directly. Use ``ceil(tpm)`` as
+    a stand-in so combined-score ranking has a non-degenerate
+    expression term. Falls back to 1 when tpm is missing/NaN."""
+    if tpm is None or pd.isna(tpm):
+        return 1
+    try:
+        return max(1, int(round(float(tpm))))
+    except (TypeError, ValueError):
+        return 1
+
+
+def ranked_from_lens_predictions(predictions, lens_tsv_path, genome=None,
+                                 num_mutant_epitopes_to_keep=None):
+    """Group LENS predictions by variant; emit ranked vaccine peptides.
+
+    Parameters
+    ----------
+    predictions : list of EpitopePrediction
+        Output of ``load_lens(path)``. Already one prediction per
+        (peptide, allele, predictor).
+    lens_tsv_path : str
+        Path to the original LENS TSV. We re-read the raw rows here
+        because the per-(peptide, allele) ``report_df`` returned by
+        ``load_lens`` doesn't carry ``pep_context`` / ``variant_coords``
+        in their original lower-snake form — they get rendered into
+        display columns. The raw TSV preserves them.
+    genome : varcode-compatible genome reference, optional
+        Passed through to ``Variant`` construction. When None,
+        Variants are constructed without genome resolution and
+        downstream code that needs gene annotation may degrade.
+    num_mutant_epitopes_to_keep : int, optional
+        Forwarded to ``VaccinePeptide``. When None, all overlapping
+        epitopes are kept.
+
+    Returns
+    -------
+    list[(varcode.Variant, list[VaccinePeptide])]
+    """
+    if not lens_tsv_path:
+        return []
+    df = pd.read_csv(lens_tsv_path, sep="\t", low_memory=False)
+    if df.empty:
+        return []
+
+    # Index predictions by (peptide, allele) so we can attach all
+    # per-predictor predictions to each candidate vaccine peptide.
+    by_key = {}
+    for p in predictions:
+        by_key.setdefault((p.peptide_sequence, p.allele), []).append(p)
+
+    # Group rows by variant. LENS uses lowercase snake_case columns.
+    rows = df.to_dict('records')
+    groups = {}
+    for r in rows:
+        coords = r.get('variant_coords')
+        if not coords:
+            continue
+        groups.setdefault(coords, []).append(r)
+
+    ranked = []
+    for coords, group_rows in groups.items():
+        variant = _parse_variant_coords(coords, genome=genome)
+        if variant is None:
+            logger.warning(
+                "Could not parse LENS variant_coords %r; skipping.", coords)
+            continue
+        rep = _pick_representative(group_rows)
+        peptide = rep.get('peptide') or ""
+        pep_context = rep.get('pep_context') or ""
+        if not pep_context:
+            # No SLP window available — fall back to using the
+            # neoepitope itself as the antigen. The construct will be
+            # short but valid.
+            pep_context = peptide
+        gene_name = rep.get('gene_name') or 'unknown'
+        tpm = rep.get('tpm')
+
+        start_off, end_off = _mut_offsets_in_context(peptide, pep_context)
+        n_alt = _coerce_n_alt_reads(tpm)
+
+        fragment = MutantProteinFragment(
+            variant=variant,
+            gene_name=str(gene_name),
+            amino_acids=str(pep_context),
+            mutant_amino_acid_start_offset=start_off,
+            mutant_amino_acid_end_offset=end_off,
+            supporting_reference_transcripts=[],
+            n_overlapping_reads=n_alt,
+            n_alt_reads=n_alt,
+            n_ref_reads=0,
+            n_alt_reads_supporting_protein_sequence=n_alt,
+        )
+
+        # Collect all predictions for any peptide associated with this
+        # variant (not just the representative) so reports / scoring
+        # see the full landscape.
+        epitope_preds = []
+        seen_keys = set()
+        for r in group_rows:
+            pep = r.get('peptide') or ""
+            allele_raw = r.get('allele') or ""
+            # load_lens normalizes 'HLA-A02:01' → 'HLA-A*02:01';
+            # match the same form here so the (peptide, allele)
+            # lookup hits.
+            from .epitope_io import _normalize_hla_allele
+            allele = _normalize_hla_allele(str(allele_raw))
+            key = (pep, allele)
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            epitope_preds.extend(by_key.get(key, []))
+
+        # Make sure at least one prediction overlaps the mutation so
+        # the VaccinePeptide isn't pruned to zero mutant epitopes.
+        # LENS predictions are mutant-derived — flag them all.
+        for p in epitope_preds:
+            if not p.overlaps_mutation:
+                p.overlaps_mutation = True
+
+        if not epitope_preds:
+            continue
+
+        vp = VaccinePeptide(
+            mutant_protein_fragment=fragment,
+            epitope_predictions=epitope_preds,
+            num_mutant_epitopes_to_keep=num_mutant_epitopes_to_keep,
+        )
+        ranked.append((variant, [vp]))
+
+    # Order by mutant_epitope_score descending so the top candidates
+    # win greedy bin-packing in the construct assemblers. Ties broken
+    # alphabetically by variant coordinates for determinism.
+    ranked.sort(
+        key=lambda pair: (
+            -pair[1][0].mutant_epitope_score if pair[1] else 0.0,
+            str(pair[0]),
+        ))
+    return ranked
+
+
+def ranked_from_pvacseq_predictions(predictions, report_df, genome=None,
+                                    num_mutant_epitopes_to_keep=None):
+    """pVACseq variant of :func:`ranked_from_lens_predictions`.
+
+    pVACseq aggregate reports (the format ``load_pvacseq`` parses)
+    don't carry an SLP-context column in the same shape; we use
+    ``Best Peptide`` as the antigen sequence and treat the peptide
+    itself as the mutation span. mRNA construct generation from
+    pVACseq input therefore produces shorter antigen windows than
+    the LENS path.
+    """
+    if report_df is None or report_df.empty:
+        return []
+
+    by_key = {}
+    for p in predictions:
+        by_key.setdefault((p.peptide_sequence, p.allele), []).append(p)
+
+    rows = report_df.to_dict('records')
+    groups = {}
+    for r in rows:
+        # pVACseq aggregate uses 'ID' as a stable per-variant key.
+        key = r.get('ID') or r.get('Index')
+        if key is None:
+            continue
+        groups.setdefault(key, []).append(r)
+
+    ranked = []
+    from varcode import Variant
+    for vid, group_rows in groups.items():
+        rep = _pick_representative(group_rows)
+        best_pep = rep.get('Best Peptide') or rep.get('peptide') or ""
+        gene = rep.get('Gene') or 'unknown'
+        # pVACseq IDs look like "1.123.A.T" or similar; try to parse
+        # for variant location, else fall back to a placeholder.
+        contig, pos, ref, alt = '?', 0, 'N', 'N'
+        try:
+            parts = str(vid).split('.')
+            if len(parts) == 4:
+                contig, pos_s, ref, alt = parts
+                pos = int(pos_s)
+        except (TypeError, ValueError):
+            pass
+        try:
+            variant = Variant(
+                contig=contig, start=pos, ref=ref, alt=alt,
+                genome=genome, normalize_contig_names=False)
+        except Exception:
+            logger.warning("Could not parse pVACseq ID %r as a Variant; "
+                           "skipping.", vid)
+            continue
+
+        fragment = MutantProteinFragment(
+            variant=variant, gene_name=str(gene),
+            amino_acids=str(best_pep),
+            mutant_amino_acid_start_offset=0,
+            mutant_amino_acid_end_offset=len(best_pep),
+            supporting_reference_transcripts=[],
+            n_overlapping_reads=1, n_alt_reads=1,
+            n_ref_reads=0, n_alt_reads_supporting_protein_sequence=1,
+        )
+        epitope_preds = []
+        seen_keys = set()
+        for r in group_rows:
+            pep = r.get('Best Peptide') or r.get('peptide') or ""
+            allele = r.get('Allele') or r.get('allele') or ""
+            key = (pep, allele)
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            epitope_preds.extend(by_key.get(key, []))
+        for p in epitope_preds:
+            if not p.overlaps_mutation:
+                p.overlaps_mutation = True
+        if not epitope_preds:
+            continue
+        ranked.append((variant, [VaccinePeptide(
+            mutant_protein_fragment=fragment,
+            epitope_predictions=epitope_preds,
+            num_mutant_epitopes_to_keep=num_mutant_epitopes_to_keep,
+        )]))
+
+    ranked.sort(
+        key=lambda pair: (
+            -pair[1][0].mutant_epitope_score if pair[1] else 0.0,
+            str(pair[0]),
+        ))
+    return ranked
+
+
+def load_external_ranked(args):
+    """Dispatch helper: load LENS / pVACseq based on args, return
+    ``(ranked, report_df, predictions)`` or ``None`` if neither flag
+    is set.
+    """
+    from .epitope_io import load_lens, load_pvacseq
+    if getattr(args, 'input_lens', None):
+        report_df, predictions = load_lens(args.input_lens)
+        ranked = ranked_from_lens_predictions(
+            predictions, args.input_lens,
+            genome=getattr(args, 'genome', None))
+        return ranked, report_df, predictions
+    if getattr(args, 'input_pvacseq', None):
+        report_df, predictions = load_pvacseq(args.input_pvacseq)
+        ranked = ranked_from_pvacseq_predictions(
+            predictions, report_df,
+            genome=getattr(args, 'genome', None))
+        return ranked, report_df, predictions
+    return None

--- a/vaxrank/mrna.py
+++ b/vaxrank/mrna.py
@@ -177,15 +177,37 @@ class RNAConstructConfig:
     junction_kmer_lengths: tuple = (8, 9, 10, 11)
     junction_rank_strong: float = 0.5
     junction_rank_mild: float = 2.0
+    # PolyA tail (issue #252). Default A120 matches BioNTech IVAC
+    # MUTANOME / FixVac (Sahin 2017). When ``poly_a_segmented`` is
+    # True, the tail is split as A_first + linker + A_rest, mirroring
+    # BNT162b2 (A30 + GCATATGACT + A70 per Xia 2021, PMC8310186).
+    poly_a_length: int = 120
+    poly_a_segmented: bool = False
+    poly_a_first_segment: int = 30
+    poly_a_segment_linker: str = "GCATATGACT"
 
 
 @dataclass
 class RNAConstruct:
-    """A single assembled mRNA construct."""
+    """A single assembled mRNA construct.
+
+    ``sequence`` is the full nt sequence including polyA tail (kept as
+    the canonical "the construct" string for back-compat callers).
+    The structured per-element manifest is exposed via ``elements``,
+    ``antigens``, and the explicit ``cds_nt`` / ``no_polya_nt`` /
+    ``full_nt`` views.
+    """
     name: str
     antigen_names: list
     sequence: str
     components: dict = field(default_factory=dict)
+    cds_aa: str = ""
+    cds_nt: str = ""        # protein-coding DNA *including* stop codon
+    no_polya_nt: str = ""   # 5' UTR + cds_nt + 3' UTR
+    full_nt: str = ""       # no_polya_nt + polyA tail
+    poly_a_nt: str = ""
+    elements: dict = field(default_factory=dict)
+    antigens: list = field(default_factory=list)
 
 
 def _resolve_named(table, name, kind):
@@ -294,15 +316,22 @@ def _antigen_aa_sequences(ranked_vaccine_peptides, max_antigen_length_aa,
         yield name, window
 
 
-def _build_protein_with_segments(antigen_aas, signal_peptide_aa, linker,
-                                 mitd_aa, per_junction_linkers=None,
+def _build_protein_with_segments(antigen_aas, antigen_names, signal_peptide_aa,
+                                 signal_peptide_name, linker, linker_name,
+                                 mitd_aa, mitd_name,
+                                 per_junction_linkers=None,
                                  pre_mitd_linker=None):
     """Concatenate signal peptide + antigens + linker/MITD into one protein.
 
-    Returns ``(protein_str, frozen_segments)`` where ``frozen_segments``
-    is a list of ``(start_aa, end_aa, blessed_dna)`` tuples for linker
-    occurrences that should be codon-frozen during mRNA optimization
-    (i.e. ``Linker.freeze_in_mrna`` and ``Linker.dna`` set).
+    Returns ``(protein_str, frozen_segments, aa_segments)`` where:
+      - ``frozen_segments`` is a list of ``(start_aa, end_aa, blessed_dna)``
+        for linkers that should be codon-frozen during mRNA optimization
+        (``Linker.freeze_in_mrna`` and ``Linker.dna`` set).
+      - ``aa_segments`` is a list of ``dict``s, one per CDS element, with
+        keys ``kind`` ('signal_peptide' / 'antigen' / 'linker' / 'mitd' /
+        'start_codon'), ``name``, ``start_aa``, ``end_aa``, ``aa``. The
+        caller slices the back-translated DNA at ``[start*3:end*3]`` to
+        recover per-element nt.
 
     Ensures the result begins with M so the back-translated CDS has a
     start codon. When a signal peptide is supplied, its N-terminal M
@@ -321,16 +350,33 @@ def _build_protein_with_segments(antigen_aas, signal_peptide_aa, linker,
             raise ValueError(
                 "per_junction_linkers length %d != antigens-1 (%d)" % (
                     len(per_junction_linkers), expected))
+    if antigen_names is None:
+        antigen_names = ["antigen_%d" % i for i in range(len(antigen_aas))]
 
     parts = []
     frozen = []
+    segments = []
     aa_offset = 0
+
+    def _emit(kind, name, aa, junction_index=None):
+        nonlocal aa_offset
+        seg = {
+            'kind': kind,
+            'name': name,
+            'aa': aa,
+            'start_aa': aa_offset,
+            'end_aa': aa_offset + len(aa),
+        }
+        if junction_index is not None:
+            seg['junction_index'] = junction_index
+        segments.append(seg)
+        parts.append(aa)
+        aa_offset += len(aa)
+
     if signal_peptide_aa:
-        parts.append(signal_peptide_aa)
-        aa_offset += len(signal_peptide_aa)
+        _emit('signal_peptide', signal_peptide_name, signal_peptide_aa)
     if not signal_peptide_aa and antigen_aas and not antigen_aas[0].startswith("M"):
-        parts.append("M")
-        aa_offset += 1
+        _emit('start_codon', None, "M")
     for i, aa in enumerate(antigen_aas):
         if i > 0:
             if per_junction_linkers is not None:
@@ -339,23 +385,44 @@ def _build_protein_with_segments(antigen_aas, signal_peptide_aa, linker,
                 this_linker = linker
             this_aa = this_linker.amino_acids
             if this_linker.freeze_in_mrna and this_linker.dna:
-                frozen.append((aa_offset, aa_offset + len(this_aa), this_linker.dna))
-            parts.append(this_aa)
-            aa_offset += len(this_aa)
-        parts.append(aa)
-        aa_offset += len(aa)
+                frozen.append(
+                    (aa_offset, aa_offset + len(this_aa), this_linker.dna))
+            _emit('linker', this_linker.name, this_aa, junction_index=i - 1)
+        _emit('antigen', antigen_names[i], aa)
     if mitd_aa:
         # Pre-MITD linker: use override if supplied (per-junction
         # optimizer path), else fall back to the shared `linker`.
         mitd_link = pre_mitd_linker if pre_mitd_linker is not None else linker
         linker_aa = mitd_link.amino_acids
         if mitd_link.freeze_in_mrna and mitd_link.dna:
-            frozen.append((aa_offset, aa_offset + len(linker_aa), mitd_link.dna))
-        parts.append(linker_aa)
-        aa_offset += len(linker_aa)
-        parts.append(mitd_aa)
-        aa_offset += len(mitd_aa)
-    return "".join(parts), frozen
+            frozen.append(
+                (aa_offset, aa_offset + len(linker_aa), mitd_link.dna))
+        # Tag the pre-MITD linker with junction_index = "mitd" sentinel so
+        # the manifest can distinguish it from inter-antigen junctions.
+        _emit('linker', mitd_link.name, linker_aa, junction_index='mitd')
+        _emit('mitd', mitd_name, mitd_aa)
+    return "".join(parts), frozen, segments
+
+
+def build_poly_a(options):
+    """Build the polyA tail nt string from RNAConstructConfig.
+
+    Non-segmented: ``A`` * poly_a_length (matches Sahin 2017 BNT122).
+    Segmented: ``A`` * first_segment + segment_linker + ``A`` * rest,
+    where rest = max(0, poly_a_length - poly_a_first_segment). The
+    segment linker's bases are NOT counted toward poly_a_length —
+    the configured length is the total adenosine count, mirroring
+    Xia 2021's description of BNT162b2 (A30 + GCAUAUGACU + A70 =
+    100 A's split by 10-nt linker).
+    """
+    if options.poly_a_length < 0:
+        raise ValueError(
+            "poly_a_length must be >= 0 (got %d)" % options.poly_a_length)
+    if not options.poly_a_segmented:
+        return "A" * options.poly_a_length
+    first = max(0, min(options.poly_a_first_segment, options.poly_a_length))
+    rest = options.poly_a_length - first
+    return "A" * first + options.poly_a_segment_linker + "A" * rest
 
 
 def _packing_linker_aa(options, linker):
@@ -588,8 +655,10 @@ def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
                         'note': "default linker beat or tied all candidates",
                     }
 
-        protein, frozen_segments = _build_protein_with_segments(
-            antigen_aas, signal_peptide_aa, linker, mitd_aa,
+        protein, frozen_segments, aa_segments = _build_protein_with_segments(
+            antigen_aas, names, signal_peptide_aa, options.signal_peptide,
+            linker, options.linker, mitd_aa,
+            options.mitd if options.include_mitd else None,
             per_junction_linkers=per_junction_linkers,
             pre_mitd_linker=pre_mitd_linker)
         coding_dna = codon_optimize(
@@ -599,7 +668,92 @@ def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
             avoid_patterns=options.avoid_patterns,
             frozen_segments=frozen_segments,
         )
-        sequence = utr_5p_dna + coding_dna + STOP_CODON + utr_3p_dna
+        # Three sequence views: cds_nt = back-translated protein + STOP;
+        # no_polya_nt = 5' UTR + cds_nt + 3' UTR; full_nt = no_polya_nt
+        # + polyA tail. ``sequence`` keeps full_nt for back-compat with
+        # callers that read it as the canonical "the construct" string.
+        cds_nt = coding_dna + STOP_CODON
+        no_polya_nt = utr_5p_dna + cds_nt + utr_3p_dna
+        poly_a_nt = build_poly_a(options)
+        full_nt = no_polya_nt + poly_a_nt
+
+        # Per-element manifest with both AA and nt forms. Antigens are
+        # listed separately (one entry per packed antigen). Linkers per
+        # junction are also listed separately so the manifest preserves
+        # per-junction-swap information.
+        antigens_meta = []
+        linker_segments = []
+        for seg in aa_segments:
+            nt_slice = coding_dna[seg['start_aa'] * 3:seg['end_aa'] * 3]
+            seg_record = {
+                'name': seg['name'],
+                'aa': seg['aa'],
+                'nt': nt_slice,
+                'length_aa': len(seg['aa']),
+                'length_nt': len(nt_slice),
+                'start_aa': seg['start_aa'],
+                'end_aa': seg['end_aa'],
+            }
+            if seg['kind'] == 'antigen':
+                antigens_meta.append(seg_record)
+            elif seg['kind'] == 'linker':
+                ls = dict(seg_record)
+                ls['junction_index'] = seg.get('junction_index')
+                linker_segments.append(ls)
+
+        elements = {}
+        if signal_peptide_aa:
+            sp_seg = next(
+                s for s in aa_segments if s['kind'] == 'signal_peptide')
+            elements['signal_peptide'] = {
+                'name': options.signal_peptide,
+                'aa': signal_peptide_aa,
+                'nt': coding_dna[sp_seg['start_aa'] * 3:sp_seg['end_aa'] * 3],
+                'length_aa': len(signal_peptide_aa),
+                'length_nt': len(signal_peptide_aa) * 3,
+            }
+        else:
+            elements['signal_peptide'] = None
+        elements['utr_5p'] = {
+            'name': options.utr_5p, 'nt': utr_5p_dna,
+            'length_nt': len(utr_5p_dna),
+        }
+        elements['linkers_per_junction'] = linker_segments
+        elements['mitd'] = (
+            {
+                'name': options.mitd, 'aa': mitd_aa,
+                'nt': coding_dna[
+                    next(s for s in aa_segments
+                         if s['kind'] == 'mitd')['start_aa'] * 3:],
+                'length_aa': len(mitd_aa),
+                'length_nt': len(mitd_aa) * 3,
+            }
+            if mitd_aa else None
+        )
+        elements['stop_codon'] = STOP_CODON
+        elements['utr_3p'] = {
+            'name': options.utr_3p, 'nt': utr_3p_dna,
+            'length_nt': len(utr_3p_dna),
+        }
+        elements['poly_a'] = {
+            'length_nt': options.poly_a_length,
+            'segmented': options.poly_a_segmented,
+            'segment_linker': (
+                options.poly_a_segment_linker
+                if options.poly_a_segmented else None),
+            'first_segment_nt': (
+                options.poly_a_first_segment
+                if options.poly_a_segmented else None),
+            'nt': poly_a_nt,
+        }
+        elements['codon_species'] = options.codon_species
+        elements['codon_method'] = options.codon_method
+        if junction_swap_meta is not None:
+            elements['junction_swap'] = junction_swap_meta
+
+        # Back-compat ``components`` dict: same fields the 2.12.x
+        # manifest carried, so existing readers don't break. The
+        # richer per-element view lives on RNAConstruct.elements.
         components = {
             'utr_5p': options.utr_5p,
             'signal_peptide': options.signal_peptide,
@@ -612,42 +766,154 @@ def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
         }
         if junction_swap_meta is not None:
             components['junction_swap'] = junction_swap_meta
+
         constructs.append(RNAConstruct(
             name="seq_%03d" % (i + 1),
             antigen_names=names,
-            sequence=sequence,
+            sequence=full_nt,
             components=components,
+            cds_aa=protein,
+            cds_nt=cds_nt,
+            no_polya_nt=no_polya_nt,
+            full_nt=full_nt,
+            poly_a_nt=poly_a_nt,
+            elements=elements,
+            antigens=antigens_meta,
         ))
     return constructs
 
 
-def write_mrna_outputs(constructs, fasta_path, manifest_path=None):
-    """Write FASTA + optional JSON manifest describing each construct.
+def _wrap_fasta(seq, line_width=80):
+    return "\n".join(seq[i:i + line_width] for i in range(0, len(seq), line_width))
 
-    Manifest entries follow a shared schema (``modality``, ``name``,
-    ``length``, ``length_unit``, ``antigen_names``, ``components``,
-    ``manufacturability``) so the peptide-mode writer can produce a
-    structurally compatible manifest.
+
+def write_mrna_outputs(constructs, output_dir, manifest_path=None,
+                       csv_path=None):
+    """Write three FASTAs (cds / full / no_polyA) + optional manifest + CSV.
+
+    Output layout (issue #252):
+      <output_dir>/cds.fasta        — coding DNA (start codon → stop codon)
+      <output_dir>/no_polyA.fasta   — 5' UTR + CDS + 3' UTR
+      <output_dir>/full.fasta       — no_polyA + polyA tail
+
+    All three contain one record per construct, matched by ``name``.
+
+    ``manifest_path`` (optional): JSON manifest with the structured
+    per-element view (``elements``, ``antigens``, all sequence variants).
+    ``csv_path`` (optional): long-format CSV — one row per (construct,
+    element) — exposing AA + nt for every layer for spreadsheet
+    inspection.
     """
-    with open(fasta_path, 'w') as f:
-        for c in constructs:
-            f.write(">%s antigens=%s length=%d\n" % (
-                c.name, ','.join(c.antigen_names), len(c.sequence)))
-            for i in range(0, len(c.sequence), 80):
-                f.write(c.sequence[i:i + 80] + "\n")
+    import csv as _csv
+    import os
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    fasta_specs = [
+        ('cds.fasta', 'cds_nt'),
+        ('no_polyA.fasta', 'no_polya_nt'),
+        ('full.fasta', 'full_nt'),
+    ]
+    for filename, attr in fasta_specs:
+        path = os.path.join(output_dir, filename)
+        with open(path, 'w') as f:
+            for c in constructs:
+                seq = getattr(c, attr)
+                f.write(">%s antigens=%s length=%d\n" % (
+                    c.name, ','.join(c.antigen_names), len(seq)))
+                f.write(_wrap_fasta(seq))
+                f.write("\n")
 
     if manifest_path:
         manifest = [
             {
                 'modality': 'mrna',
                 'name': c.name,
-                'length': len(c.sequence),
+                'length': len(c.full_nt),  # canonical "the construct" length
                 'length_unit': 'nt',
                 'antigen_names': c.antigen_names,
-                'components': c.components,
-                'manufacturability': {},  # nt-level metrics: see openvax/vaxrank#245
+                'lengths': {
+                    'cds_aa': len(c.cds_aa),
+                    'cds_nt': len(c.cds_nt),
+                    'no_polya_nt': len(c.no_polya_nt),
+                    'full_nt': len(c.full_nt),
+                    'poly_a_nt': len(c.poly_a_nt),
+                },
+                'cds': {'aa': c.cds_aa, 'nt': c.cds_nt},
+                'no_polya_nt': c.no_polya_nt,
+                'full_nt': c.full_nt,
+                'antigens': c.antigens,
+                'elements': c.elements,
+                'components': c.components,  # legacy 2.12 schema for back-compat
+                'manufacturability': {},
             }
             for c in constructs
         ]
         with open(manifest_path, 'w') as f:
             json.dump(manifest, f, indent=2)
+
+    if csv_path:
+        # Long format: one row per (construct, element). AA + nt are
+        # both populated when applicable; missing fields stay empty.
+        with open(csv_path, 'w', newline='') as f:
+            w = _csv.writer(f)
+            w.writerow([
+                'construct', 'element_kind', 'index', 'name',
+                'aa', 'nt', 'length_aa', 'length_nt', 'note',
+            ])
+            for c in constructs:
+                el = c.elements
+                # 5' UTR
+                u5 = el.get('utr_5p') or {}
+                w.writerow([c.name, 'utr_5p', '', u5.get('name', ''),
+                            '', u5.get('nt', ''), '', u5.get('length_nt', ''),
+                            ''])
+                # signal peptide
+                sp = el.get('signal_peptide')
+                if sp:
+                    w.writerow([c.name, 'signal_peptide', '', sp['name'],
+                                sp['aa'], sp['nt'],
+                                sp['length_aa'], sp['length_nt'], ''])
+                # antigens (interleaved with linkers below for visual
+                # in-order inspection — write antigens first then
+                # linkers separately, since the index column qualifies)
+                for j, a in enumerate(c.antigens):
+                    w.writerow([c.name, 'antigen', j, a['name'],
+                                a['aa'], a['nt'],
+                                a['length_aa'], a['length_nt'], ''])
+                # linkers (per junction; junction_index disambiguates
+                # inter-antigen vs pre-MITD)
+                for ls in el.get('linkers_per_junction', []):
+                    note = ('pre_mitd' if ls.get('junction_index') == 'mitd'
+                            else '')
+                    w.writerow([c.name, 'linker', ls.get('junction_index', ''),
+                                ls['name'], ls['aa'], ls['nt'],
+                                ls['length_aa'], ls['length_nt'], note])
+                # MITD
+                m = el.get('mitd')
+                if m:
+                    w.writerow([c.name, 'mitd', '', m['name'],
+                                m['aa'], m['nt'],
+                                m['length_aa'], m['length_nt'], ''])
+                # stop codon
+                w.writerow([c.name, 'stop_codon', '', '', '',
+                            el.get('stop_codon', ''), '', 3, ''])
+                # 3' UTR
+                u3 = el.get('utr_3p') or {}
+                w.writerow([c.name, 'utr_3p', '', u3.get('name', ''),
+                            '', u3.get('nt', ''), '', u3.get('length_nt', ''),
+                            ''])
+                # polyA
+                pa = el.get('poly_a') or {}
+                pa_note = ('segmented' if pa.get('segmented') else 'unsegmented')
+                w.writerow([c.name, 'poly_a', '', '', '',
+                            pa.get('nt', ''), '', pa.get('length_nt', ''),
+                            pa_note])
+                # full assembled views — no element name, just whole-seq
+                # length references for convenience.
+                w.writerow([c.name, 'cds', '', '', c.cds_aa, c.cds_nt,
+                            len(c.cds_aa), len(c.cds_nt), ''])
+                w.writerow([c.name, 'no_polyA', '', '', '', c.no_polya_nt,
+                            '', len(c.no_polya_nt), ''])
+                w.writerow([c.name, 'full', '', '', '', c.full_nt,
+                            '', len(c.full_nt), ''])

--- a/vaxrank/mrna.py
+++ b/vaxrank/mrna.py
@@ -30,8 +30,10 @@ combined antigen string would exceed ``max_length_nt`` or
 constructs returned in the same order.
 """
 
+import csv
 import json
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -317,9 +319,8 @@ def _antigen_aa_sequences(ranked_vaccine_peptides, max_antigen_length_aa,
 
 
 def _build_protein_with_segments(antigen_aas, antigen_names, signal_peptide_aa,
-                                 signal_peptide_name, linker, linker_name,
-                                 mitd_aa, mitd_name,
-                                 per_junction_linkers=None,
+                                 signal_peptide_name, linker, mitd_aa,
+                                 mitd_name, per_junction_linkers=None,
                                  pre_mitd_linker=None):
     """Concatenate signal peptide + antigens + linker/MITD into one protein.
 
@@ -376,7 +377,7 @@ def _build_protein_with_segments(antigen_aas, antigen_names, signal_peptide_aa,
     if signal_peptide_aa:
         _emit('signal_peptide', signal_peptide_name, signal_peptide_aa)
     if not signal_peptide_aa and antigen_aas and not antigen_aas[0].startswith("M"):
-        _emit('start_codon', None, "M")
+        _emit('start_codon', 'start_codon', "M")
     for i, aa in enumerate(antigen_aas):
         if i > 0:
             if per_junction_linkers is not None:
@@ -657,7 +658,7 @@ def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
 
         protein, frozen_segments, aa_segments = _build_protein_with_segments(
             antigen_aas, names, signal_peptide_aa, options.signal_peptide,
-            linker, options.linker, mitd_aa,
+            linker, mitd_aa,
             options.mitd if options.include_mitd else None,
             per_junction_linkers=per_junction_linkers,
             pre_mitd_linker=pre_mitd_linker)
@@ -701,34 +702,32 @@ def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
                 ls['junction_index'] = seg.get('junction_index')
                 linker_segments.append(ls)
 
-        elements = {}
-        if signal_peptide_aa:
-            sp_seg = next(
-                s for s in aa_segments if s['kind'] == 'signal_peptide')
-            elements['signal_peptide'] = {
-                'name': options.signal_peptide,
-                'aa': signal_peptide_aa,
-                'nt': coding_dna[sp_seg['start_aa'] * 3:sp_seg['end_aa'] * 3],
-                'length_aa': len(signal_peptide_aa),
-                'length_nt': len(signal_peptide_aa) * 3,
+        # Helper: build the per-element record for a given segment kind.
+        def _seg_record(kind, declared_name):
+            seg = next((s for s in aa_segments if s['kind'] == kind), None)
+            if seg is None:
+                return None
+            nt = coding_dna[seg['start_aa'] * 3:seg['end_aa'] * 3]
+            return {
+                'name': declared_name,
+                'aa': seg['aa'],
+                'nt': nt,
+                'length_aa': len(seg['aa']),
+                'length_nt': len(nt),
             }
-        else:
-            elements['signal_peptide'] = None
+
+        elements = {}
         elements['utr_5p'] = {
             'name': options.utr_5p, 'nt': utr_5p_dna,
             'length_nt': len(utr_5p_dna),
         }
+        elements['signal_peptide'] = (
+            _seg_record('signal_peptide', options.signal_peptide)
+            if signal_peptide_aa else None
+        )
         elements['linkers_per_junction'] = linker_segments
         elements['mitd'] = (
-            {
-                'name': options.mitd, 'aa': mitd_aa,
-                'nt': coding_dna[
-                    next(s for s in aa_segments
-                         if s['kind'] == 'mitd')['start_aa'] * 3:],
-                'length_aa': len(mitd_aa),
-                'length_nt': len(mitd_aa) * 3,
-            }
-            if mitd_aa else None
+            _seg_record('mitd', options.mitd) if mitd_aa else None
         )
         elements['stop_codon'] = STOP_CODON
         elements['utr_3p'] = {
@@ -787,8 +786,31 @@ def _wrap_fasta(seq, line_width=80):
     return "\n".join(seq[i:i + line_width] for i in range(0, len(seq), line_width))
 
 
+_FASTA_LIKE_SUFFIXES = (".fasta", ".fa", ".fna", ".ffn", ".fas")
+
+
+def _validate_output_dir(output_dir):
+    """Reject paths that look like the pre-2.14 single-FASTA target.
+
+    The old API took a FASTA file path here; the new API takes a
+    directory. Silently creating ``out.fasta/`` when the user meant a
+    file is a sharp footgun, so block it loudly.
+    """
+    if os.path.isfile(output_dir):
+        raise ValueError(
+            "--output-mrna is now a *directory* (writes cds.fasta / "
+            "no_polyA.fasta / full.fasta into it); got an existing file "
+            "%r. Pass a directory path instead." % output_dir)
+    if any(output_dir.lower().endswith(s) for s in _FASTA_LIKE_SUFFIXES):
+        raise ValueError(
+            "--output-mrna is now a *directory* (writes cds.fasta / "
+            "no_polyA.fasta / full.fasta into it); got %r which looks "
+            "like a FASTA file path. Pass a directory path instead "
+            "(e.g. drop the .fasta suffix)." % output_dir)
+
+
 def write_mrna_outputs(constructs, output_dir, manifest_path=None,
-                       csv_path=None):
+                       csv_path=None, csv_include_full_rows=True):
     """Write three FASTAs (cds / full / no_polyA) + optional manifest + CSV.
 
     Output layout (issue #252):
@@ -797,16 +819,28 @@ def write_mrna_outputs(constructs, output_dir, manifest_path=None,
       <output_dir>/full.fasta       — no_polyA + polyA tail
 
     All three contain one record per construct, matched by ``name``.
+    When ``poly_a_length=0``, full.fasta and no_polyA.fasta are
+    identical by construction; an info-level log line notes this.
 
     ``manifest_path`` (optional): JSON manifest with the structured
     per-element view (``elements``, ``antigens``, all sequence variants).
     ``csv_path`` (optional): long-format CSV — one row per (construct,
     element) — exposing AA + nt for every layer for spreadsheet
     inspection.
-    """
-    import csv as _csv
-    import os
+    ``csv_include_full_rows``: emit summary rows for cds / no_polyA /
+    full (each carrying the full-length nt). Default True. Set False
+    when the per-element rows are all you want — keeps cells narrow
+    enough for spreadsheet column views.
 
+    Manifest schema notes
+    ---------------------
+    Some ``elements`` keys are **None when the corresponding component
+    is disabled**: ``signal_peptide`` is None when no signal peptide is
+    selected, ``mitd`` is None when ``include_mitd=False``. Downstream
+    readers must null-check both. ``elements['linkers_per_junction']``
+    is always a list (possibly empty for a single-antigen construct).
+    """
+    _validate_output_dir(output_dir)
     os.makedirs(output_dir, exist_ok=True)
 
     fasta_specs = [
@@ -823,6 +857,11 @@ def write_mrna_outputs(constructs, output_dir, manifest_path=None,
                     c.name, ','.join(c.antigen_names), len(seq)))
                 f.write(_wrap_fasta(seq))
                 f.write("\n")
+
+    if constructs and constructs[0].full_nt == constructs[0].no_polya_nt:
+        logger.info(
+            "poly_a_length=0: full.fasta and no_polyA.fasta are identical "
+            "(no polyA tail appended).")
 
     if manifest_path:
         manifest = [
@@ -853,67 +892,78 @@ def write_mrna_outputs(constructs, output_dir, manifest_path=None,
             json.dump(manifest, f, indent=2)
 
     if csv_path:
-        # Long format: one row per (construct, element). AA + nt are
-        # both populated when applicable; missing fields stay empty.
+        # Long format: one row per (construct, element). The `index`
+        # column is integer-only (junction position for linkers,
+        # antigen position for antigens, blank otherwise). Free-form
+        # qualifiers (e.g. 'mitd', 'pre_mitd', 'segmented') go in the
+        # `index_label` / `note` columns so spreadsheet sorts on
+        # `index` stay numeric.
         with open(csv_path, 'w', newline='') as f:
-            w = _csv.writer(f)
+            w = csv.writer(f)
             w.writerow([
-                'construct', 'element_kind', 'index', 'name',
+                'construct', 'element_kind', 'index', 'index_label', 'name',
                 'aa', 'nt', 'length_aa', 'length_nt', 'note',
             ])
             for c in constructs:
                 el = c.elements
                 # 5' UTR
                 u5 = el.get('utr_5p') or {}
-                w.writerow([c.name, 'utr_5p', '', u5.get('name', ''),
+                w.writerow([c.name, 'utr_5p', '', '', u5.get('name', ''),
                             '', u5.get('nt', ''), '', u5.get('length_nt', ''),
                             ''])
                 # signal peptide
                 sp = el.get('signal_peptide')
                 if sp:
-                    w.writerow([c.name, 'signal_peptide', '', sp['name'],
+                    w.writerow([c.name, 'signal_peptide', '', '', sp['name'],
                                 sp['aa'], sp['nt'],
                                 sp['length_aa'], sp['length_nt'], ''])
-                # antigens (interleaved with linkers below for visual
-                # in-order inspection — write antigens first then
-                # linkers separately, since the index column qualifies)
+                # antigens
                 for j, a in enumerate(c.antigens):
-                    w.writerow([c.name, 'antigen', j, a['name'],
+                    w.writerow([c.name, 'antigen', j, '', a['name'],
                                 a['aa'], a['nt'],
                                 a['length_aa'], a['length_nt'], ''])
-                # linkers (per junction; junction_index disambiguates
-                # inter-antigen vs pre-MITD)
+                # linkers per junction; the pre-MITD linker uses an
+                # empty integer index + 'mitd' label so spreadsheet
+                # sorts on 'index' stay numeric.
                 for ls in el.get('linkers_per_junction', []):
-                    note = ('pre_mitd' if ls.get('junction_index') == 'mitd'
-                            else '')
-                    w.writerow([c.name, 'linker', ls.get('junction_index', ''),
+                    ji = ls.get('junction_index')
+                    if ji == 'mitd':
+                        idx_int = ''
+                        idx_label = 'mitd'
+                        note = 'pre_mitd'
+                    else:
+                        idx_int = ji if isinstance(ji, int) else ''
+                        idx_label = ''
+                        note = ''
+                    w.writerow([c.name, 'linker', idx_int, idx_label,
                                 ls['name'], ls['aa'], ls['nt'],
                                 ls['length_aa'], ls['length_nt'], note])
                 # MITD
                 m = el.get('mitd')
                 if m:
-                    w.writerow([c.name, 'mitd', '', m['name'],
+                    w.writerow([c.name, 'mitd', '', '', m['name'],
                                 m['aa'], m['nt'],
                                 m['length_aa'], m['length_nt'], ''])
                 # stop codon
-                w.writerow([c.name, 'stop_codon', '', '', '',
+                w.writerow([c.name, 'stop_codon', '', '', '', '',
                             el.get('stop_codon', ''), '', 3, ''])
                 # 3' UTR
                 u3 = el.get('utr_3p') or {}
-                w.writerow([c.name, 'utr_3p', '', u3.get('name', ''),
+                w.writerow([c.name, 'utr_3p', '', '', u3.get('name', ''),
                             '', u3.get('nt', ''), '', u3.get('length_nt', ''),
                             ''])
                 # polyA
                 pa = el.get('poly_a') or {}
                 pa_note = ('segmented' if pa.get('segmented') else 'unsegmented')
-                w.writerow([c.name, 'poly_a', '', '', '',
+                w.writerow([c.name, 'poly_a', '', '', '', '',
                             pa.get('nt', ''), '', pa.get('length_nt', ''),
                             pa_note])
-                # full assembled views — no element name, just whole-seq
-                # length references for convenience.
-                w.writerow([c.name, 'cds', '', '', c.cds_aa, c.cds_nt,
-                            len(c.cds_aa), len(c.cds_nt), ''])
-                w.writerow([c.name, 'no_polyA', '', '', '', c.no_polya_nt,
-                            '', len(c.no_polya_nt), ''])
-                w.writerow([c.name, 'full', '', '', '', c.full_nt,
-                            '', len(c.full_nt), ''])
+                # full assembled views — opt-out via csv_include_full_rows.
+                if csv_include_full_rows:
+                    w.writerow([c.name, 'cds', '', '', '', c.cds_aa, c.cds_nt,
+                                len(c.cds_aa), len(c.cds_nt), ''])
+                    w.writerow([c.name, 'no_polyA', '', '', '', '',
+                                c.no_polya_nt,
+                                '', len(c.no_polya_nt), ''])
+                    w.writerow([c.name, 'full', '', '', '', '', c.full_nt,
+                                '', len(c.full_nt), ''])

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.13.0"
+__version__ = "2.14.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

What started as #252 (mRNA polyA + structured manifest) grew to encompass an output-mode redesign, the LENS/pVACseq → vaccine-design pipe, the `--vaccine-modality` → `--vaccine-type` flag rename, and a chain of review-driven fixes. Closes #252.

## Architecture

```
INPUT (one of)
  ├── --vcf + --bam              full pipeline (Isovar → MHC predict → rank)
  └── --input-lens / --input-pvacseq
                                 use a pre-computed neoepitope report
                                 (no longer hard-short-circuits!)

SHARED MIDDLE
  ranked_variants_with_vaccine_peptides   (canonical intermediate;
                                           same shape from both inputs)

VACCINE-TYPE DISPATCH (multi-valued; --vaccine-type, default 'peptide')
  ├── peptide   →  FASTA + JSON manifest + vendor order-form CSV
  ├── mrna      →  three FASTAs (cds / no_polyA / full) + structured
  │                JSON manifest + long-format CSV
  └── (future)  →  dna, etc. plug in as one entry in _VACCINE_TYPE_DISPATCH

REPORTS (orthogonal — stack with any vaccine type)
  CSV / XLSX / ASCII / HTML / PDF / JSON / neoepitope-report
```

## What's in this PR

### mRNA outputs (#252)

- **PolyA tail** in `RNAConstructConfig`: `poly_a_length=120` (BioNTech FixVac / BNT122 per Sahin 2017); optional segmented mode (BNT162b2 architecture A30+GCATATGACT+A70 per Xia 2021).
- **Three FASTA outputs** in a directory: `cds.fasta`, `no_polyA.fasta`, `full.fasta`.
- **Structured manifest** with per-element AA + nt; long-format CSV via `--output-mrna-csv` (lean variant via `--output-mrna-csv-no-full-rows`).

### LENS / pVACseq → vaccine design

Pre-PR `--input-lens` / `--input-pvacseq` short-circuited and the construct writers were unreachable. New `vaxrank/external_input.py` synthesizes the canonical ranked intermediate from a LENS or pVACseq report.

- LENS path: groups by `variant_coords`; uses `pep_context` as the SLP-style fragment; representative peptide picked by the canonical `pMHC_affinity` predictor's value column.
- pVACseq path: re-reads the raw aggregate TSV; ID parser handles dashed `chr1-100000-100001-A-T`, short-dashed `chr1-100000-A-T`, and legacy dotted `1.123.A.T` forms.

### `--vaccine-type` switch

Vaxrank always ranks; `--vaccine-type` is a clean multi-valued enum:

```
--vaccine-type peptide               # default
--vaccine-type mrna
--vaccine-type peptide mrna          # both
```

A type fires only if both: (a) it's in `--vaccine-type`, and (b) its `--output-<type>` path is set. Output paths provided for unselected types warn. Future types (DNA, etc.) plug in as one entry in `_VACCINE_TYPE_DISPATCH`. (#255 tracks splitting `peptide` into leaf modalities.)

### Per-junction MHC-aware linker swap (#247, on by default)

Per-junction optimizer picks linkers (`G3S` / `G4S` / `(G3S)2` / `(G4S)2` / `AAA`) to minimize predicted MHC presentation of chimeric k-mers. Falls back to the shared linker when the predictor isn't available.

### Review fixes

Two rounds of review surfaced and fixed:

1. Dead `linker_name` parameter; bounded MITD nt slice; named `start_codon` segment; `--output-mrna` rejects file paths / `.fasta` suffixes loudly.
2. CSV `index` split into integer-only + string `index_label` (numeric sort stays numeric); module-level imports; documented `None|dict` schema for optional elements; log line when `full == no_polyA`.
3. Multi-valued `--vaccine-type` shape; sentinel mixing rejected.
4. Fixed `_pick_representative` reading nonexistent columns; multi-row LENS fixture pinning strongest-binder selection.
5. `--output-csv` collision in external-input mode handled (skip rank-report writer when LENS already consumed the path).
6. Promoted `detect_lens_predictors` / `normalize_hla_allele` from private cross-module imports to public API.
7. Warn-once when LENS has no pMHC_affinity scoring columns.
8. Fixed broken pVACseq path (was returning empty ranked list); pVACseq smoke test added.

### README refresh

- Architecture diagram showing input → shared ranking → vaccine-type dispatch.
- Output-modes table refreshed against current flags (was missing every flag added in #251 and #253; had a `MITC` typo).
- Linker library expanded with full static set + compositional grammar.
- "Upstream inputs" documents both VCF+BAM and external-input paths.
- Key modules grouped Shared / Vaccine-type-specific / Reports.

## CLI surface (new / changed)

```
--vaccine-type peptide [mrna]           # multi-valued; replaces --vaccine-modality
--output-mrna OUT_DIR                   # was a single FASTA path; now a directory
--output-mrna-csv FILE.csv              # new
--output-mrna-csv-no-full-rows          # new (lean CSV)
--mrna-poly-a-length 120                # new
--mrna-poly-a-segmented                 # new (BNT162b2 architecture)
--mrna-poly-a-first-segment 30          # new
--mrna-poly-a-segment-linker GCATATGACT # new
--mrna-optimize-linkers                 # on by default (#247)
--mrna-no-optimize-linkers              # opt-out
--mrna-junction-candidates G3S,G4S,...  # override candidate set
--mrna-junction-rank-strong 0.5
--mrna-junction-rank-mild 2.0
```

## Breaking changes

- `--vaccine-modality` removed; use `--vaccine-type`.
- `--output-mrna` semantic shift: directory path (was single FASTA). The new file-suffix guard raises with a clear migration hint when users pass `out.fasta`.
- `--input-lens` / `--input-pvacseq` no longer short-circuits (the previous behavior was a bug — they couldn't reach the construct writers).

Bumped 2.13.0 → 2.14.0.

## Test plan

- [x] `./lint.sh` clean
- [x] `./test.sh` 630 tests pass; 93% coverage
- [x] LENS → mRNA + peptide construct end-to-end
- [x] pVACseq → mRNA construct end-to-end (was broken pre-PR)
- [x] `--vaccine-type` resolution: defaults / explicit lists / unknown / orphan-output warnings
- [x] PolyA: default / zero / segmented BNT162b2 / negative-raises
- [x] CSV `index_label` for pre-MITD linker; lean CSV mode
- [x] `_emit_outputs` dispatch summary log line content
- [x] Multi-row LENS regression: strongest-binder representative pick
- [x] LENS no-affinity warn-once
- [ ] CI green on all matrix entries (3.10 / 3.11 / 3.12 / 3.13)

Refs #252, #247, #255.
