### PR TITLE
Orthogonal antigen-design axes shared across peptide + mRNA (subsumes #255)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,72 @@ peptide synthesiser:
    `--input-lens` or `--input-pvacseq`; the ranking and dispatch steps
    are identical.
 
+## Vaccine designs
+
+Vaxrank's vaccine design space is two **orthogonal axes** (shared
+across vaccine types) plus the type itself:
+
+| Axis | Values | What it controls |
+|---|---|---|
+| `--vaccine-type` | `peptide` / `mrna` (multi-valued) | The platform |
+| `--antigen-content` | `mutation_spanning` / `minimal_epitope` | What each antigen *is* |
+| `--antigens-per-construct` | `1` / `N` | How many antigens to concatenate per construct |
+
+Combined, the matrix yields 8 distinct designs — 4 per vaccine type:
+
+| Type | Content | Per-construct | Design name | Reference |
+|---|---|---|---|---|
+| peptide | mutation_spanning | 1 | **SLP** (default) | PGV-001 (Bortman 2025) |
+| peptide | mutation_spanning | N | Multi-SLP / multi-epitope long peptide | |
+| peptide | minimal_epitope | 1 | Minimal-ligand peptide | |
+| peptide | minimal_epitope | N | Concatenated minimal-ligand peptide | |
+| mrna | mutation_spanning | N | **BioNTech FixVac / iNeST** (default for mRNA) | Sahin 2017 / Rojas 2023 |
+| mrna | mutation_spanning | 1 | Single-antigen mRNA | |
+| mrna | minimal_epitope | N | "String of beads" mRNA | Velten 2018 |
+| mrna | minimal_epitope | 1 | Single-ligand mRNA | |
+
+A third knob, `--epitopes-per-antigen`, controls how many top MHC
+ligands to take *per ranked vaccine peptide* when content is
+`minimal_epitope`. The default `1` is the legacy "single top ligand"
+semantics; >1 packs multiple top ligands from the same variant as
+separate antigens.
+
+```sh
+# Default: SLP peptide pool
+vaxrank --vcf v.vcf --bam r.bam --output-peptide pool.fasta
+
+# Multi-epitope concatenated peptide
+vaxrank --vcf v.vcf --bam r.bam \
+        --output-peptide pool.fasta \
+        --peptide-antigens-per-construct 5 --peptide-linker AAY
+
+# Minimal-epitope peptide (single ligand per construct)
+vaxrank --vcf v.vcf --bam r.bam \
+        --output-peptide pool.fasta \
+        --antigen-content minimal_epitope
+
+# BioNTech FixVac canonical mRNA (default for --vaccine-type mrna)
+vaxrank --vcf v.vcf --bam r.bam --vaccine-type mrna --output-mrna out/
+
+# String-of-beads mRNA (concatenated minimal epitopes)
+vaxrank --vcf v.vcf --bam r.bam --vaccine-type mrna --output-mrna out/ \
+        --mrna-antigen-content minimal_epitope --mrna-antigens-per-construct 8 \
+        --mrna-linker AAY
+
+# Top-2 ligands per variant in a string-of-beads mRNA
+vaxrank --vcf v.vcf --bam r.bam --vaccine-type mrna --output-mrna out/ \
+        --mrna-antigen-content minimal_epitope \
+        --mrna-epitopes-per-antigen 2 --mrna-antigens-per-construct 16
+
+# Both modalities at once
+vaxrank --vcf v.vcf --bam r.bam --vaccine-type peptide mrna \
+        --output-peptide pool.fasta --output-mrna mrna_out/
+```
+
+The legacy `--peptide-mode {slp, minimal_epitope, multi_epitope}`
+flag still works as a shorthand (slp ≡ mutation_spanning + 1, etc.)
+but the orthogonal axes are preferred for new designs.
+
 ## Vaccine types and output modes
 
 Vaccine-type selection is controlled by `--vaccine-type` (multi-valued,

--- a/tests/test_design_matrix.py
+++ b/tests/test_design_matrix.py
@@ -1,0 +1,373 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Vaccine-design matrix: every combination of (vaccine_type,
+antigen_content, antigens_per_construct).
+
+The two design axes are orthogonal and shared across vaccine types:
+- ``antigen_content`` ∈ {mutation_spanning, minimal_epitope}
+- ``antigens_per_construct`` ∈ {1, N}
+
+Combined with vaccine_type ∈ {peptide, mrna}, there are 8 design
+points. This module pins each one end-to-end so a future refactor of
+the dispatch / config plumbing can't silently drop a combination.
+
+Eight distinct designs:
+
+    +----------+-------------------+-----------------+-------------------------+
+    | type     | antigen_content   | per_construct   | name                    |
+    +----------+-------------------+-----------------+-------------------------+
+    | peptide  | mutation_spanning | 1               | SLP (PGV-001 canonical) |
+    | peptide  | mutation_spanning | N               | multi-SLP concatenated  |
+    | peptide  | minimal_epitope   | 1               | minimal-ligand peptide  |
+    | peptide  | minimal_epitope   | N               | concat-minimal-ligand   |
+    | mrna     | mutation_spanning | N               | BioNTech FixVac / iNeST |
+    | mrna     | mutation_spanning | 1               | single-antigen mRNA     |
+    | mrna     | minimal_epitope   | N               | string-of-beads mRNA    |
+    | mrna     | minimal_epitope   | 1               | single-ligand mRNA      |
+    +----------+-------------------+-----------------+-------------------------+
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from varcode import Variant
+
+from vaxrank.epitope_prediction import EpitopePrediction
+from vaxrank.mrna import RNAConstructConfig, assemble_mrna_constructs
+from vaxrank.peptide import PeptideConstructConfig, assemble_peptide_constructs
+
+
+def _make_vaccine_peptide(
+        amino_acids, gene_name, mut_start, mut_end, n_alt_reads,
+        epitope_seqs_with_ic50):
+    """Build a stub VaccinePeptide-shaped object that the assemblers
+    can consume without going through the full ranking pipeline.
+
+    ``epitope_seqs_with_ic50`` is a list of ``(peptide_sequence,
+    ic50_nM)``. The first entry becomes the top mutant epitope.
+    """
+    fragment = SimpleNamespace(
+        amino_acids=amino_acids,
+        gene_name=gene_name,
+        mutant_amino_acid_start_offset=mut_start,
+        mutant_amino_acid_end_offset=mut_end,
+        n_alt_reads=n_alt_reads,
+    )
+    epitope_predictions = [
+        EpitopePrediction(
+            allele="HLA-A*02:01",
+            peptide_sequence=seq,
+            wt_peptide_sequence="",
+            ic50=ic50,
+            wt_ic50=10000.0,
+            percentile_rank=ic50 / 100.0,
+            prediction_method_name="stub",
+            overlaps_mutation=True,
+            source_sequence=amino_acids,
+            offset=0,
+            occurs_in_reference=False,
+        )
+        for seq, ic50 in epitope_seqs_with_ic50
+    ]
+    return SimpleNamespace(
+        mutant_protein_fragment=fragment,
+        mutant_epitope_predictions=epitope_predictions,
+        wildtype_epitope_predictions=[],
+        epitope_predictions=epitope_predictions,
+    )
+
+
+def _ranked_three_variants():
+    """Three variants × multiple ligand candidates each, suitable for
+    every cell of the design matrix."""
+    a1 = _make_vaccine_peptide(
+        "AAKLQGHSAPVLDVIVNCD", gene_name="GENEA",
+        mut_start=2, mut_end=12, n_alt_reads=10,
+        epitope_seqs_with_ic50=[
+            ("KLQGHSAPV", 30.0),    # top
+            ("LQGHSAPVL", 80.0),    # second
+            ("QGHSAPVLD", 220.0),   # third
+        ])
+    a2 = _make_vaccine_peptide(
+        "MNNVDEILGRWESPVKLPK", gene_name="GENEB",
+        mut_start=2, mut_end=12, n_alt_reads=8,
+        epitope_seqs_with_ic50=[
+            ("NVDEILGRW", 45.0),
+            ("VDEILGRWE", 110.0),
+        ])
+    a3 = _make_vaccine_peptide(
+        "AAVVVGADGVGKSALTIIQ", gene_name="GENEC",
+        mut_start=4, mut_end=14, n_alt_reads=6,
+        epitope_seqs_with_ic50=[
+            ("VVVGADGVG", 65.0),
+        ])
+    return [
+        (Variant("1", 100, "A", "T"), [a1]),
+        (Variant("2", 200, "G", "C"), [a2]),
+        (Variant("3", 300, "C", "T"), [a3]),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Peptide design matrix (4 cells)
+# ---------------------------------------------------------------------------
+
+def test_peptide_slp():
+    """SLP: mutation_spanning content, 1 antigen per construct.
+    Canonical PGV-001 design — one synthetic long peptide per ranked
+    variant."""
+    options = PeptideConstructConfig(
+        antigen_content="mutation_spanning",
+        antigens_per_construct=1,
+        max_antigen_length_aa=15,
+        min_antigen_length_aa=5,
+        max_constructs=10)
+    constructs = assemble_peptide_constructs(_ranked_three_variants(), options)
+    assert len(constructs) == 3, "SLP: one construct per variant"
+    for c in constructs:
+        assert len(c.antigen_names) == 1
+        # Peptide is mutation-spanning (≤ 15 aa here)
+        assert 5 <= len(c.sequence) <= 15
+        assert c.components['antigen_content'] == "mutation_spanning"
+        assert c.components['antigens_per_construct'] == 1
+
+
+def test_peptide_multi_slp():
+    """Multi-SLP: mutation_spanning, N per construct. Several SLPs
+    concatenated with a linker into one longer peptide."""
+    options = PeptideConstructConfig(
+        mode="multi_epitope",  # legacy shorthand still works
+        antigens_per_construct=3,
+        linker="G4S3",
+        max_antigen_length_aa=15,
+        min_antigen_length_aa=5,
+        max_constructs=10)
+    constructs = assemble_peptide_constructs(_ranked_three_variants(), options)
+    assert len(constructs) == 1
+    [c] = constructs
+    assert len(c.antigen_names) == 3
+    # All three antigens linked
+    assert c.sequence.count("GGGGS") >= 2  # at least 2 linkers between 3 antigens
+    assert c.components['antigen_content'] == "mutation_spanning"
+    assert c.components['antigens_per_construct'] == 3
+
+
+def test_peptide_minimal_epitope():
+    """Minimal-epitope peptide: single short MHC ligand per variant.
+    Each construct is just the top mutant ligand (~9 aa)."""
+    options = PeptideConstructConfig(
+        antigen_content="minimal_epitope",
+        antigens_per_construct=1,
+        epitopes_per_antigen=1,
+        min_antigen_length_aa=5,
+        max_constructs=10)
+    constructs = assemble_peptide_constructs(_ranked_three_variants(), options)
+    assert len(constructs) == 3
+    # Each construct's sequence is the top ligand from its variant
+    seqs = sorted(c.sequence for c in constructs)
+    assert seqs == sorted(["KLQGHSAPV", "NVDEILGRW", "VVVGADGVG"])
+    for c in constructs:
+        assert c.components['antigen_content'] == "minimal_epitope"
+        # Antigen name disambiguator carries the _epitope suffix
+        assert c.antigen_names[0].endswith("_epitope")
+
+
+def test_peptide_concat_minimal_ligands():
+    """Multi-epitope minimal: concatenated short MHC ligands. New
+    combo unlocked by the orthogonal axes (was not expressible
+    pre-PR)."""
+    options = PeptideConstructConfig(
+        antigen_content="minimal_epitope",
+        antigens_per_construct=3,
+        epitopes_per_antigen=1,
+        linker="AAY",  # canonical CTL-spacer for concatenated minimal epitopes
+        max_constructs=10,
+        min_antigen_length_aa=5)
+    constructs = assemble_peptide_constructs(_ranked_three_variants(), options)
+    [c] = constructs
+    assert len(c.antigen_names) == 3
+    # Three 9-mers with AAY linkers: 9 + 3 + 9 + 3 + 9 = 33 aa
+    assert len(c.sequence) == 33
+    assert c.sequence.count("AAY") == 2  # 2 linkers between 3 antigens
+    assert c.components['antigen_content'] == "minimal_epitope"
+
+
+def test_peptide_minimal_with_multiple_top_ligands():
+    """epitopes_per_antigen > 1: multiple top ligands from the same
+    variant, each as its own antigen. Pins that we don't hardcode
+    'just one top ligand matters'."""
+    options = PeptideConstructConfig(
+        antigen_content="minimal_epitope",
+        antigens_per_construct=1,  # 1 construct per ligand
+        epitopes_per_antigen=2,    # take top-2 from each VP
+        min_antigen_length_aa=5,
+        max_constructs=20)
+    constructs = assemble_peptide_constructs(_ranked_three_variants(), options)
+    # GENEA has 3 ligands → take 2; GENEB has 2 → take 2; GENEC has 1 → take 1
+    # Total: 5 single-ligand constructs.
+    assert len(constructs) == 5
+    seqs = sorted(c.sequence for c in constructs)
+    assert seqs == sorted([
+        "KLQGHSAPV", "LQGHSAPVL",      # GENEA top-2
+        "NVDEILGRW", "VDEILGRWE",      # GENEB top-2
+        "VVVGADGVG",                    # GENEC only has 1
+    ])
+    # Names include the disambiguating suffix when >1 ligand from same VP
+    suffixes = sorted(c.antigen_names[0].split("_")[-1] for c in constructs)
+    assert "epitope1" in suffixes
+    assert "epitope2" in suffixes
+
+
+# ---------------------------------------------------------------------------
+# mRNA design matrix (4 cells)
+# ---------------------------------------------------------------------------
+
+def test_mrna_biontech_canonical():
+    """BioNTech FixVac / iNeST: mutation_spanning, N per construct,
+    HLA-B signal peptide + MITD + tandem HBB UTRs. The default
+    RNAConstructConfig — pinned here as a regression test."""
+    options = RNAConstructConfig(
+        signal_peptide=None, include_mitd=False,  # simplify slice math
+        antigens_per_construct=3,
+        max_antigen_length_aa=15,
+        min_antigen_length_aa=5,
+        utr_3p='HBB',  # not HBB_FI for slice simplicity
+        poly_a_length=20,
+        optimize_linkers=False,
+        max_constructs=1)
+    constructs = assemble_mrna_constructs(_ranked_three_variants(), options)
+    assert len(constructs) == 1
+    [c] = constructs
+    assert len(c.antigens) == 3
+    # Each antigen is a mutation-centered window (≤ 15 aa)
+    for ant in c.antigens:
+        assert ant['length_aa'] <= 15
+
+
+def test_mrna_single_antigen():
+    """Single-antigen mRNA: mutation_spanning, 1 per construct. One
+    SLP per construct, multiple constructs spilling. Less common
+    clinically but a valid design."""
+    options = RNAConstructConfig(
+        signal_peptide=None, include_mitd=False,
+        antigens_per_construct=1,
+        max_constructs=10,
+        max_antigen_length_aa=15,
+        min_antigen_length_aa=5,
+        utr_3p='HBB',
+        poly_a_length=20,
+        optimize_linkers=False)
+    constructs = assemble_mrna_constructs(_ranked_three_variants(), options)
+    assert len(constructs) == 3
+    for c in constructs:
+        assert len(c.antigens) == 1
+
+
+def test_mrna_string_of_beads():
+    """String-of-beads mRNA: minimal_epitope, N per construct.
+    Concatenated short MHC ligands in an mRNA backbone — analogous
+    to Velten et al. 2018's polyepitope mRNA design."""
+    options = RNAConstructConfig(
+        signal_peptide=None, include_mitd=False,
+        antigen_content="minimal_epitope",
+        epitopes_per_antigen=1,
+        antigens_per_construct=3,
+        max_constructs=1,
+        max_antigen_length_aa=15,
+        min_antigen_length_aa=5,
+        linker="AAY",  # CTL spacer for minimal-epitope mRNA
+        utr_3p='HBB',
+        poly_a_length=20,
+        optimize_linkers=False)
+    constructs = assemble_mrna_constructs(_ranked_three_variants(), options)
+    [c] = constructs
+    assert len(c.antigens) == 3
+    # Each antigen is a 9-aa minimal ligand
+    for ant in c.antigens:
+        assert ant['length_aa'] == 9
+        # The CDS contains the 9-aa ligand sequences
+    # AA names carry the _epitope suffix from minimal_epitope mode
+    for name in c.antigen_names:
+        assert name.endswith("_epitope")
+
+
+def test_mrna_single_ligand():
+    """Single-ligand mRNA: minimal_epitope, 1 per construct. Unusual
+    (mRNA payload usually wants more density) but a valid corner of
+    the design matrix."""
+    options = RNAConstructConfig(
+        signal_peptide=None, include_mitd=False,
+        antigen_content="minimal_epitope",
+        epitopes_per_antigen=1,
+        antigens_per_construct=1,
+        max_constructs=10,
+        max_antigen_length_aa=15,
+        min_antigen_length_aa=5,
+        utr_3p='HBB',
+        poly_a_length=20,
+        optimize_linkers=False)
+    constructs = assemble_mrna_constructs(_ranked_three_variants(), options)
+    assert len(constructs) == 3
+    for c in constructs:
+        assert len(c.antigens) == 1
+        assert c.antigens[0]['length_aa'] == 9
+
+
+def test_mrna_string_of_beads_multiple_top_ligands():
+    """epitopes_per_antigen > 1 in mRNA: multiple top ligands from
+    the same variant become separate antigens. Pins the
+    "don't-assume-just-one-matters" semantics for the mRNA path too."""
+    options = RNAConstructConfig(
+        signal_peptide=None, include_mitd=False,
+        antigen_content="minimal_epitope",
+        epitopes_per_antigen=3,  # all GENEA ligands; GENEB top-2; GENEC top-1
+        antigens_per_construct=10,  # generous cap
+        max_constructs=1,
+        max_antigen_length_aa=15,
+        min_antigen_length_aa=5,
+        linker="AAY",
+        utr_3p='HBB',
+        poly_a_length=20,
+        max_length_nt=4000,
+        optimize_linkers=False)
+    constructs = assemble_mrna_constructs(_ranked_three_variants(), options)
+    [c] = constructs
+    # 3 (GENEA) + 2 (GENEB) + 1 (GENEC) = 6 minimal-ligand antigens
+    assert len(c.antigens) == 6
+    # Each is a 9-aa ligand
+    for ant in c.antigens:
+        assert ant['length_aa'] == 9
+
+
+# ---------------------------------------------------------------------------
+# Validation: invalid axis values raise
+# ---------------------------------------------------------------------------
+
+def test_peptide_invalid_antigen_content_raises():
+    with pytest.raises(ValueError, match="antigen_content"):
+        PeptideConstructConfig(antigen_content="garbage")
+
+
+def test_peptide_invalid_mode_raises():
+    with pytest.raises(ValueError, match="mode must be one of"):
+        PeptideConstructConfig(mode="not_a_mode")
+
+
+def test_mrna_invalid_antigen_content_raises():
+    """mRNA dispatches at antigen-extraction time; invalid content
+    surfaces there with a clear message."""
+    options = RNAConstructConfig(
+        antigen_content="garbage", utr_3p='HBB', poly_a_length=0,
+        optimize_linkers=False)
+    with pytest.raises(ValueError, match="antigen_content"):
+        assemble_mrna_constructs(_ranked_three_variants(), options)

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -220,9 +220,32 @@ def add_output_args(arg_parser):
         help="Which vaccine type(s) to design. Multi-valued so future "
              "types (DNA, etc.) plug in as additional choices. "
              "Default: peptide. Examples: '--vaccine-type peptide', "
-             "'--vaccine-type mrna', '--vaccine-type peptide mrna' (both). "
-             "'peptide' is an umbrella; the SLP / minimal-epitope / "
-             "multi-epitope sub-mode lives in --peptide-mode.")
+             "'--vaccine-type mrna', '--vaccine-type peptide mrna' (both).")
+
+    # Shared antigen-design axes — apply to BOTH peptide and mRNA
+    # unless overridden by the per-type flag (--peptide-* / --mrna-*).
+    # The two orthogonal axes:
+    #   antigen_content: what each antigen *is*
+    #   antigens_per_construct: how many to concatenate per construct
+    output_args_group.add_argument(
+        "--antigen-content",
+        default=None,
+        choices=["mutation_spanning", "minimal_epitope"],
+        help="Default antigen content for both peptide and mRNA "
+             "vaccines: 'mutation_spanning' (centered SLP-style window "
+             "of --max-antigen-length-aa, default) or 'minimal_epitope' "
+             "(top mutant MHC ligand(s), ~9 aa each). Per-type flags "
+             "(--peptide-antigen-content / --mrna-antigen-content) "
+             "override.")
+    output_args_group.add_argument(
+        "--epitopes-per-antigen",
+        default=None,
+        type=int,
+        help="When --antigen-content=minimal_epitope, take this many "
+             "top score-sorted ligands per ranked vaccine peptide as "
+             "separate antigens. Default: 1 (the legacy single-top "
+             "ligand semantics). Set >1 to pack multiple top ligands "
+             "from the same variant.")
 
     output_args_group.add_argument(
         "--output-patient-id",
@@ -487,6 +510,21 @@ def add_mrna_output_args(group):
         help="Antigens packed into a single mRNA construct. Default: 5. "
              "Antigens beyond the cap spill into additional constructs.")
     group.add_argument(
+        "--mrna-antigen-content",
+        default=None,
+        choices=["mutation_spanning", "minimal_epitope"],
+        help="Override --antigen-content for mRNA. 'mutation_spanning' "
+             "(default if --antigen-content unset) emits 25-aa SLP-style "
+             "windows; 'minimal_epitope' emits top MHC ligands as "
+             "antigens — concatenated minimal-epitope mRNA "
+             "(\"string of beads\") is a first-class design.")
+    group.add_argument(
+        "--mrna-epitopes-per-antigen",
+        default=None,
+        type=int,
+        help="Override --epitopes-per-antigen for mRNA. Only used when "
+             "antigen content is 'minimal_epitope'.")
+    group.add_argument(
         "--mrna-max-constructs",
         default=1,
         type=int,
@@ -529,9 +567,24 @@ def add_peptide_output_args(group):
         "--peptide-mode",
         default="slp",
         choices=["slp", "minimal_epitope", "multi_epitope"],
-        help="slp (default): one synthetic long peptide per ranked variant. "
-             "minimal_epitope: just the top mutant MHC ligand per variant. "
-             "multi_epitope: concatenate antigens with --peptide-linker.")
+        help="Back-compat shorthand for the orthogonal axes "
+             "(--antigen-content + --peptide-antigens-per-construct). "
+             "slp (default): mutation_spanning, 1 per construct. "
+             "minimal_epitope: minimal_epitope, 1 per construct. "
+             "multi_epitope: mutation_spanning, N per construct (set N "
+             "via --peptide-antigens-per-construct). Prefer the new "
+             "axis flags for new designs.")
+    group.add_argument(
+        "--peptide-antigen-content",
+        default=None,
+        choices=["mutation_spanning", "minimal_epitope"],
+        help="Override --antigen-content for peptide vaccines. When "
+             "set, overrides whatever --peptide-mode would derive.")
+    group.add_argument(
+        "--peptide-epitopes-per-antigen",
+        default=None,
+        type=int,
+        help="Override --epitopes-per-antigen for peptide vaccines.")
     group.add_argument(
         "--peptide-linker",
         default="G4S3",

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -172,9 +172,32 @@ def _emit_neoepitope_report_external(args, report_df, predictions):
         save_predictions(predictions, args.output_epitopes)
 
 
+def _resolve_axis(args, per_type_attr, shared_attr, fallback):
+    """Resolve a shared antigen-design axis with per-type override.
+
+    Resolution: per-type explicit > shared > fallback. Per-type and
+    shared values of None mean "unset" (defer to the next layer).
+    """
+    per = getattr(args, per_type_attr, None)
+    if per is not None:
+        return per
+    shared = getattr(args, shared_attr, None)
+    if shared is not None:
+        return shared
+    return fallback
+
+
 def _emit_peptide_constructs(args, ranked):
     """Build + write peptide-vaccine constructs. Modality-specific."""
-    peptide_options = PeptideConstructConfig(
+    # Resolve the orthogonal antigen-design axes:
+    # per-type override > shared default > config default. The legacy
+    # --peptide-mode is consumed by PeptideConstructConfig.__post_init__
+    # when no explicit axis flag is set.
+    antigen_content = _resolve_axis(
+        args, 'peptide_antigen_content', 'antigen_content', None)
+    epitopes_per_antigen = _resolve_axis(
+        args, 'peptide_epitopes_per_antigen', 'epitopes_per_antigen', 1)
+    config_kwargs = dict(
         mode=args.peptide_mode,
         linker=args.peptide_linker,
         min_antigen_length_aa=args.peptide_min_antigen_length_aa,
@@ -187,7 +210,11 @@ def _emit_peptide_constructs(args, ranked):
         scale_mg=args.peptide_scale_mg,
         purity_percent=args.peptide_purity_percent,
         counterion=args.peptide_counterion,
+        epitopes_per_antigen=epitopes_per_antigen,
     )
+    if antigen_content is not None:
+        config_kwargs['antigen_content'] = antigen_content
+    peptide_options = PeptideConstructConfig(**config_kwargs)
     constructs = assemble_peptide_constructs(ranked, options=peptide_options)
     write_peptide_outputs(
         constructs,
@@ -207,6 +234,10 @@ def _emit_mrna_constructs(args, ranked):
         s.strip() for s in (args.mrna_junction_candidates or "").split(",")
         if s.strip()
     )
+    antigen_content = _resolve_axis(
+        args, 'mrna_antigen_content', 'antigen_content', 'mutation_spanning')
+    epitopes_per_antigen = _resolve_axis(
+        args, 'mrna_epitopes_per_antigen', 'epitopes_per_antigen', 1)
     options = RNAConstructConfig(
         signal_peptide=(args.mrna_signal_peptide or None),
         linker=args.mrna_linker,
@@ -216,6 +247,8 @@ def _emit_mrna_constructs(args, ranked):
         utr_3p=args.mrna_3p_utr,
         codon_species=args.mrna_codon_species,
         codon_method=args.mrna_codon_method,
+        antigen_content=antigen_content,
+        epitopes_per_antigen=epitopes_per_antigen,
         min_antigen_length_aa=args.mrna_min_antigen_length_aa,
         max_antigen_length_aa=args.mrna_max_antigen_length_aa,
         antigens_per_construct=args.mrna_antigens_per_construct,

--- a/vaxrank/mrna.py
+++ b/vaxrank/mrna.py
@@ -57,6 +57,7 @@ from .vaccine_library import (
     get_linker,
     iter_named_antigens,
     select_antigen_window,
+    top_mutant_epitopes,
 )
 
 logger = logging.getLogger(__name__)
@@ -159,6 +160,14 @@ class RNAConstructConfig:
     utr_3p: str = "HBB_FI"  # tandem 2× HBB
     codon_species: str = "h_sapiens"
     codon_method: str = "use_best_codon"
+    # Antigen-design axes — shared semantics with PeptideConstructConfig.
+    # ``antigen_content`` ∈ {'mutation_spanning', 'minimal_epitope'};
+    # the latter packs top MHC ligands as antigens instead of
+    # mutation-centered windows. ``epitopes_per_antigen`` only matters
+    # for ``minimal_epitope`` content (legacy 1-per-VP semantics by
+    # default; >1 packs multiple top ligands from the same variant).
+    antigen_content: str = "mutation_spanning"
+    epitopes_per_antigen: int = 1
     min_antigen_length_aa: int = 15
     max_antigen_length_aa: int = 25  # Sahin 2017 used 27mers; 25 is typical
     antigens_per_construct: int = 5
@@ -295,27 +304,55 @@ def codon_optimize(amino_acids, species="h_sapiens", method="use_best_codon",
 
 
 def _antigen_aa_sequences(ranked_vaccine_peptides, max_antigen_length_aa,
-                          min_antigen_length_aa=0, candidates_per_slot=1):
-    """Yield ``(name, amino_acid_string)`` per antigen, mutation-centered
-    and clipped to ``max_antigen_length_aa``.
+                          min_antigen_length_aa=0, candidates_per_slot=1,
+                          antigen_content="mutation_spanning",
+                          epitopes_per_antigen=1):
+    """Yield ``(name, amino_acid_string)`` per antigen.
 
-    Warns when the emitted window falls below ``min_antigen_length_aa`` —
-    typically a sign that the underlying fragment is shorter than the
-    user's configured floor (e.g. a stop-loss extension that produced
-    only a few mutant residues).
+    Dispatches on ``antigen_content`` (shared semantics with
+    ``peptide._antigen_records``):
 
-    Naming + alt-suffix logic comes from ``iter_named_antigens`` so the
-    antigen names match the peptide-modality output.
+    - ``'mutation_spanning'``: emit a mutation-centered window of up
+      to ``max_antigen_length_aa`` per VaccinePeptide (canonical mRNA
+      antigen — BioNTech FixVac-style 25mer).
+    - ``'minimal_epitope'``: emit the top ``epitopes_per_antigen``
+      MHC ligands per VaccinePeptide as separate (short) antigens.
+      Concatenated minimal-epitope mRNA constructs (≈ Velten 2021's
+      "string-of-beads" design) become first-class.
+
+    Warns when a mutation_spanning window falls below
+    ``min_antigen_length_aa`` (typically a stop-loss / frameshift
+    fragment shorter than the floor); for minimal_epitope content,
+    skip-with-info when no epitope predictions are available.
+
+    Naming + alt-suffix logic comes from ``iter_named_antigens`` so
+    the antigen names match the peptide-modality output.
     """
-    for name, fragment, _peptide in iter_named_antigens(
+    if antigen_content not in ('mutation_spanning', 'minimal_epitope'):
+        raise ValueError(
+            "antigen_content must be 'mutation_spanning' or "
+            "'minimal_epitope'; got %r" % antigen_content)
+    for name, fragment, peptide in iter_named_antigens(
             ranked_vaccine_peptides, candidates_per_slot=candidates_per_slot):
-        window = select_antigen_window(fragment, name, max_antigen_length_aa)
-        if len(window) < min_antigen_length_aa:
-            logger.warning(
-                "Antigen %s emitted at %d aa, below "
-                "--mrna-min-antigen-length-aa (%d).",
-                name, len(window), min_antigen_length_aa)
-        yield name, window
+        if antigen_content == "minimal_epitope":
+            tops = top_mutant_epitopes(peptide, n=epitopes_per_antigen)
+            if not tops:
+                logger.info(
+                    "Skipping %s in minimal_epitope mode: no mutant "
+                    "epitope predictions available.", name)
+                continue
+            for k, ep in enumerate(tops):
+                suffix = "_epitope" if len(tops) == 1 else "_epitope%d" % (k + 1)
+                yield name + suffix, ep.peptide_sequence
+        else:
+            window = select_antigen_window(
+                fragment, name, max_antigen_length_aa)
+            if len(window) < min_antigen_length_aa:
+                logger.warning(
+                    "Antigen %s emitted at %d aa, below "
+                    "--mrna-min-antigen-length-aa (%d).",
+                    name, len(window), min_antigen_length_aa)
+            yield name, window
 
 
 def _build_protein_with_segments(antigen_aas, antigen_names, signal_peptide_aa,
@@ -563,7 +600,9 @@ def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
         ranked_vaccine_peptides,
         max_antigen_length_aa=options.max_antigen_length_aa,
         min_antigen_length_aa=options.min_antigen_length_aa,
-        candidates_per_slot=options.candidates_per_slot))
+        candidates_per_slot=options.candidates_per_slot,
+        antigen_content=options.antigen_content,
+        epitopes_per_antigen=options.epitopes_per_antigen))
     if not antigens:
         return []
 

--- a/vaxrank/peptide.py
+++ b/vaxrank/peptide.py
@@ -39,6 +39,7 @@ from .vaccine_library import (
     get_linker,
     iter_named_antigens,
     select_antigen_window,
+    top_mutant_epitopes,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,18 +49,52 @@ logger = logging.getLogger(__name__)
 class PeptideConstructConfig:
     """User-configurable peptide construct parameters.
 
+    Two orthogonal axes drive the vaccine design (shared with
+    ``RNAConstructConfig``):
+
+    - ``antigen_content`` ∈ ``{'mutation_spanning', 'minimal_epitope'}``
+      — what each antigen *is*. ``mutation_spanning`` extracts a
+      mutation-centered window of up to ``max_antigen_length_aa``
+      (the SLP/long-peptide content). ``minimal_epitope`` extracts
+      the top ``epitopes_per_antigen`` MHC ligands per VaccinePeptide
+      and emits each as its own short antigen.
+    - ``antigens_per_construct`` — how many antigens to *concatenate*
+      into one construct (with the configured ``linker``).
+
+    The four corners of the matrix:
+
+      content=mutation_spanning, per_construct=1   → SLP (one peptide
+                                                     per ranked vaccine
+                                                     peptide; PGV-001
+                                                     canonical)
+      content=mutation_spanning, per_construct=N   → Multi-SLP /
+                                                     "multi-epitope long"
+                                                     concatenation
+      content=minimal_epitope,  per_construct=1   → Minimal-epitope
+                                                     peptide (one short
+                                                     ligand per variant)
+      content=minimal_epitope,  per_construct=N   → Concatenated
+                                                     minimal-ligand
+                                                     pool
+
     Defaults match the canonical PGV-001 personalized peptide vaccine
     layout: ~20 synthetic long peptides per pool, one antigen per
     peptide, 15-25 aa per peptide.
 
-    The ``scale_mg`` / ``purity_percent`` / ``counterion`` fields drive
-    the vendor order form's per-construct columns. They're per-vaccine
-    constants in current practice (one purity target across the pool),
-    but are kept here so the writer can render them without a separate
+    Legacy ``mode`` field (``slp`` / ``minimal_epitope`` /
+    ``multi_epitope``) is preserved as a back-compat shorthand; when
+    set non-default it derives ``antigen_content`` and
+    ``antigens_per_construct`` in ``__post_init__``.
+
+    ``scale_mg`` / ``purity_percent`` / ``counterion`` drive the
+    vendor order form's per-construct columns; per-vaccine constants
+    today, kept here so the writer can render them without a separate
     config object.
     """
-    mode: str = "slp"            # 'slp' | 'minimal_epitope' | 'multi_epitope'
-    linker: str = "G4S3"         # only used in multi_epitope mode
+    mode: str = "slp"            # legacy alias; see __post_init__
+    antigen_content: str = "mutation_spanning"  # 'mutation_spanning' | 'minimal_epitope'
+    epitopes_per_antigen: int = 1               # for minimal_epitope content
+    linker: str = "G4S3"         # only used when antigens_per_construct > 1
     min_antigen_length_aa: int = 15
     max_antigen_length_aa: int = 25
     antigens_per_construct: int = 1
@@ -70,6 +105,34 @@ class PeptideConstructConfig:
     scale_mg: float = 5.0           # synthesis scale per peptide
     purity_percent: float = 95.0    # HPLC purity target
     counterion: str = "TFA"         # default salt form (TFA / acetate / HCl / free)
+
+    def __post_init__(self):
+        # Derive the orthogonal axes from the legacy ``mode`` shorthand
+        # when the user passed it (or the default 'slp' was kept). The
+        # rule: if the user already set ``antigen_content`` /
+        # ``antigens_per_construct`` non-default, those win — mode is
+        # only consulted when it would change the dataclass default.
+        if self.mode == "slp":
+            # default; nothing to derive (mutation_spanning + per_construct=1)
+            pass
+        elif self.mode == "minimal_epitope":
+            self.antigen_content = "minimal_epitope"
+            # antigens_per_construct stays at user-set value (default 1)
+        elif self.mode == "multi_epitope":
+            # mutation_spanning content (legacy semantics);
+            # antigens_per_construct must already be > 1 for this to
+            # do anything different from slp — left to the user.
+            self.antigen_content = "mutation_spanning"
+        else:
+            raise ValueError(
+                "PeptideConstructConfig.mode must be one of "
+                "{'slp', 'minimal_epitope', 'multi_epitope'}; got %r" %
+                self.mode)
+        if self.antigen_content not in (
+                'mutation_spanning', 'minimal_epitope'):
+            raise ValueError(
+                "antigen_content must be 'mutation_spanning' or "
+                "'minimal_epitope'; got %r" % self.antigen_content)
 
 
 @dataclass
@@ -82,37 +145,41 @@ class PeptideConstruct:
     manufacturability: dict = field(default_factory=dict)
 
 
-def _antigen_records(ranked_vaccine_peptides, mode, max_antigen_length_aa,
+def _antigen_records(ranked_vaccine_peptides, antigen_content,
+                     max_antigen_length_aa, epitopes_per_antigen=1,
                      candidates_per_slot=1):
     """Yield ``(name, amino_acids)`` per antigen.
 
-    Mode dispatch only — naming + alt-suffix logic comes from
-    ``iter_named_antigens``, shared with mRNA assembly so the antigen
-    names match across modalities.
+    Dispatch on ``antigen_content``:
+      - ``'mutation_spanning'``: emit one mutation-centered window per
+        VaccinePeptide (or per ``candidates_per_slot`` alternates).
+      - ``'minimal_epitope'``: emit the top
+        ``epitopes_per_antigen`` MHC ligands per VaccinePeptide as
+        independent antigens. ``epitopes_per_antigen=1`` (default) is
+        the legacy "single top ligand" semantics; >1 packs multiple
+        ligands from the same variant.
+
+    Naming + alt-suffix logic comes from ``iter_named_antigens``,
+    shared with mRNA assembly so antigen names match across types.
     """
     for base_name, fragment, peptide in iter_named_antigens(
             ranked_vaccine_peptides, candidates_per_slot=candidates_per_slot):
-        if mode == "minimal_epitope":
-            top = _top_mutant_epitope(peptide)
-            if top is None:
+        if antigen_content == "minimal_epitope":
+            tops = top_mutant_epitopes(peptide, n=epitopes_per_antigen)
+            if not tops:
                 logger.info(
                     "Skipping %s in minimal_epitope mode: no mutant "
                     "epitope predictions available.", base_name)
                 continue
-            yield base_name + "_epitope", top.peptide_sequence
+            for k, ep in enumerate(tops):
+                # When epitopes_per_antigen=1 keep the legacy
+                # ``<name>_epitope`` suffix; for >1 disambiguate.
+                suffix = "_epitope" if len(tops) == 1 else "_epitope%d" % (k + 1)
+                yield base_name + suffix, ep.peptide_sequence
         else:
-            # slp + multi_epitope: pick a mutation-centered window
+            # mutation_spanning: pick a mutation-centered window
             yield base_name, select_antigen_window(
                 fragment, base_name, max_antigen_length_aa)
-
-
-def _top_mutant_epitope(vaccine_peptide):
-    """Pick the highest-scoring mutant epitope; None if none available."""
-    predictions = getattr(vaccine_peptide, 'mutant_epitope_predictions', None) or []
-    if not predictions:
-        return None
-    # mutant_epitope_predictions is already sorted by score in the pipeline
-    return predictions[0]
 
 
 def _manufacturability_for(sequence):
@@ -190,27 +257,31 @@ def assemble_peptide_constructs(ranked_vaccine_peptides, options=None):
     list[PeptideConstruct]
     """
     options = options or PeptideConstructConfig()
-    if options.mode not in ("slp", "minimal_epitope", "multi_epitope"):
-        raise ValueError(
-            "Unknown peptide mode '%s'; expected one of slp, "
-            "minimal_epitope, multi_epitope." % (options.mode,))
 
     records = list(_antigen_records(
-        ranked_vaccine_peptides, options.mode,
+        ranked_vaccine_peptides, options.antigen_content,
         options.max_antigen_length_aa,
+        epitopes_per_antigen=options.epitopes_per_antigen,
         candidates_per_slot=options.candidates_per_slot))
     if not records:
         return []
 
+    # ``mode`` retained in the manifest for back-compat; ``antigen_content``
+    # + ``antigens_per_construct`` are the orthogonal axes that actually
+    # drive dispatch.
     base_components = {
         'mode': options.mode,
+        'antigen_content': options.antigen_content,
+        'antigens_per_construct': options.antigens_per_construct,
         'n_terminal_acetylation': options.n_terminal_acetylation,
         'c_terminal_amidation': options.c_terminal_amidation,
     }
 
     constructs = []
-    if options.mode in ("slp", "minimal_epitope"):
-        # One construct per (variant, candidate) record. Cap at max_constructs.
+    if options.antigens_per_construct <= 1:
+        # One construct per (variant, candidate) record. Covers both
+        # SLP (mutation_spanning, 1 per construct) and minimal-epitope
+        # (one short ligand per variant) designs.
         for i, (name, sequence) in enumerate(records):
             if len(constructs) >= options.max_constructs:
                 logger.info(
@@ -232,7 +303,10 @@ def assemble_peptide_constructs(ranked_vaccine_peptides, options=None):
             ))
         return constructs
 
-    # multi_epitope
+    # antigens_per_construct > 1: bin-pack into multi-antigen
+    # constructs. Works for both content types — concatenated SLPs
+    # (the legacy ``multi_epitope`` design) and concatenated minimal
+    # ligands (a new combination unlocked by the orthogonal axes).
     linker = get_linker(options.linker)
     if linker.inert_in_peptide_mode:
         logger.warning(

--- a/vaxrank/vaccine_library.py
+++ b/vaxrank/vaccine_library.py
@@ -601,3 +601,34 @@ def select_antigen_window(fragment, base_name, max_length_aa):
     end = min(len(aa), start + max_length_aa)
     start = max(0, end - max_length_aa)
     return aa[start:end]
+
+
+def mutant_epitopes_sorted(vaccine_peptide):
+    """All mutant epitopes on a VaccinePeptide, score-sorted (best first).
+
+    Returns the full list (possibly empty). The pipeline already sorts
+    ``mutant_epitope_predictions`` by score, so this is a thin wrapper
+    that exposes the slice point to callers.
+
+    Used by both peptide and mRNA vaccine assembly when
+    ``antigen_content='minimal_epitope'`` — the antigen is one or more
+    short MHC ligands instead of a mutation-spanning long window. The
+    caller chooses how many to take (typically via
+    ``epitopes_per_antigen``); designs that pack multiple top ligands
+    from the same variant are first-class, not an afterthought.
+    """
+    return list(
+        getattr(vaccine_peptide, 'mutant_epitope_predictions', None) or [])
+
+
+def top_mutant_epitopes(vaccine_peptide, n=1):
+    """Top ``n`` score-sorted mutant epitopes on a VaccinePeptide.
+
+    Returns a list of length ``min(n, len(predictions))`` — possibly
+    empty when no predictions exist. ``n=1`` (the default) gives the
+    legacy "single top ligand" semantics; pass a larger ``n`` to get
+    multiple top ligands from the same variant.
+    """
+    if n <= 0:
+        return []
+    return mutant_epitopes_sorted(vaccine_peptide)[:n]

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.14.0"
+__version__ = "2.15.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Folds #255's intent (split peptide modes into leaf modalities) into a better factoring: the vaccine-design space is two **orthogonal axes shared across vaccine types**, not a peptide-only umbrella with a sub-mode enum.

## The matrix

| Type | Content | N | Design name | Reference |
|---|---|---|---|---|
| peptide | mutation_spanning | 1 | **SLP** (default) | PGV-001 (Bortman 2025) |
| peptide | mutation_spanning | N | Multi-SLP concatenated | |
| peptide | minimal_epitope | 1 | Minimal-ligand peptide | |
| peptide | minimal_epitope | N | Concatenated minimal-ligand pool | |
| mrna | mutation_spanning | N | **BioNTech FixVac / iNeST** | Sahin 2017 / Rojas 2023 |
| mrna | mutation_spanning | 1 | Single-antigen mRNA | |
| mrna | minimal_epitope | N | "String of beads" mRNA | Velten 2018 |
| mrna | minimal_epitope | 1 | Single-ligand mRNA | |

3 of these designs (concatenated minimal-ligand peptide, string-of-beads mRNA, single-ligand mRNA) were not expressible pre-PR.

## Don't-assume-one-matters

Replaced `_top_mutant_epitope(vp) → single` with `top_mutant_epitopes(vp, n=1) → list` + a config `epitopes_per_antigen` that takes top-N ligands per variant. Default 1 (legacy semantics); >1 is first-class — both peptide and mRNA paths handle it.

## CLI

Shared flags + per-type overrides:

```
--antigen-content {mutation_spanning, minimal_epitope}      # shared default
--epitopes-per-antigen N                                    # shared default
--peptide-antigen-content / --peptide-epitopes-per-antigen  # peptide override
--mrna-antigen-content    / --mrna-epitopes-per-antigen     # mRNA override
```

Legacy `--peptide-mode {slp, minimal_epitope, multi_epitope}` continues as a back-compat shorthand.

## Test plan

- [x] `./lint.sh` clean
- [x] `./test.sh` 643 tests pass (+13 new design-matrix tests), 93% coverage
- [x] Every cell of the 8-cell matrix has an end-to-end test
- [x] `epitopes_per_antigen=2` for peptide and mRNA both pinned
- [x] Invalid axis values raise clearly
- [ ] CI green on all matrix entries

Bumps 2.14.0 → 2.15.0. Subsumes #255.