### PR TITLE
mRNA output ergonomics: naming, separators, ranking-report (#270)

### DIFF
--- a/tests/test_entry_point_helpers.py
+++ b/tests/test_entry_point_helpers.py
@@ -1,0 +1,324 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for the small helpers that live in
+:mod:`vaxrank.cli.entry_point` — the per-junction MHC resolver, the
+grouped args summary printer, and the LENS provenance-marker
+plumbing.
+
+Note: importing :mod:`vaxrank.cli.entry_point` transitively triggers
+isovar's ``logging.config.fileConfig`` which wipes pytest's caplog
+handlers from the root logger. So these tests attach a local
+``logging.Handler`` to the entry_point logger directly rather than
+relying on the ``caplog`` fixture. The behavior we're pinning is
+identical; only the capture mechanism differs.
+"""
+
+import logging
+from types import SimpleNamespace
+from contextlib import contextmanager
+
+import pytest
+
+
+@contextmanager
+def _capture_logger(logger_name, level=logging.DEBUG):
+    """Yield a list that fills with LogRecord objects emitted by
+    ``logger_name`` (and its children, by propagation) at or above
+    ``level``. Cleans up the handler on exit."""
+    target = logging.getLogger(logger_name)
+    records = []
+
+    class _Capture(logging.Handler):
+        def emit(self, r):
+            records.append(r)
+
+    handler = _Capture()
+    handler.setLevel(level)
+    prev_level = target.level
+    target.setLevel(level)
+    target.addHandler(handler)
+    try:
+        yield records
+    finally:
+        target.removeHandler(handler)
+        target.setLevel(prev_level)
+
+
+# -- _resolve_mhc_for_linker_optimizer --------------------------------
+
+
+def _args_with_inferred_alleles(alleles=None):
+    """Minimal Namespace shape that the LENS path actually produces.
+
+    Real LENS-mode args don't have ``--mhc-predictor`` /
+    ``--mhc-alleles`` (the external arg parser doesn't add them), so
+    the mhctools helpers raise ``AttributeError`` when called against
+    such a Namespace. The optimizer's job is to fall back to the
+    inferred-alleles path.
+    """
+    return SimpleNamespace(
+        _inferred_mhc_alleles_from_lens=list(alleles or []))
+
+
+def test_resolve_mhc_logs_inferred_alleles_then_predictor_missing():
+    """LENS-path: args lacks ``--mhc-alleles`` but the loader stashed
+    inferred alleles. The function still returns ``(None, None)``
+    because the optimizer needs *both* predictor and alleles — but
+    the ``inferred from report`` INFO surfaces, and the targeted
+    "predictor missing, alleles inferred" hint fires."""
+    from vaxrank.cli.entry_point import _resolve_mhc_for_linker_optimizer
+    args = _args_with_inferred_alleles(['HLA-A*02:01', 'HLA-B*07:02'])
+    with _capture_logger('vaxrank.cli.entry_point') as records:
+        predictor, alleles = _resolve_mhc_for_linker_optimizer(args)
+    assert predictor is None
+    # Function returns (None, None) because predictor is unset; alleles
+    # alone can't drive chimeric-k-mer scoring.
+    assert alleles is None
+    msgs = [r.getMessage() for r in records]
+    assert any('inferred from the LENS / pVACseq report' in m for m in msgs), \
+        "Expected the 'alleles inferred' INFO line; got %r" % msgs
+    pred_missing = [
+        r for r in records
+        if r.levelno == logging.WARNING
+        and 'alleles are available' in r.getMessage()
+    ]
+    assert pred_missing, \
+        "Expected the 'predictor missing, alleles available' hint"
+
+
+def test_resolve_mhc_no_inputs_at_all():
+    """Pipeline path with neither flag set: both come back None and
+    the warning explicitly mentions both flags."""
+    from vaxrank.cli.entry_point import _resolve_mhc_for_linker_optimizer
+    args = SimpleNamespace()  # no inferred alleles either
+    with _capture_logger('vaxrank.cli.entry_point') as records:
+        predictor, alleles = _resolve_mhc_for_linker_optimizer(args)
+    assert predictor is None
+    assert alleles is None
+    msg = ' '.join(r.getMessage() for r in records)
+    assert '--mhc-alleles' in msg
+    assert '--mhc-predictor' in msg
+
+
+def test_resolve_mhc_propagates_real_predictor_load_failure(monkeypatch):
+    """A genuine model-load error inside mhctools (e.g. a missing
+    weights file — surfaces as ``RuntimeError`` / ``OSError``) must
+    propagate, not be swallowed into "optimizer disabled". Pin the
+    narrowed exception scope so a future broadening of the catch
+    falls red here."""
+    from vaxrank.cli import entry_point as ep
+
+    class _BadDay(RuntimeError):
+        pass
+
+    def _kaboom(_args):
+        raise _BadDay("predictor went sideways")
+
+    monkeypatch.setattr(ep, 'mhc_binding_predictor_from_args', _kaboom)
+    args = SimpleNamespace(_inferred_mhc_alleles_from_lens=['HLA-A*02:01'])
+    with pytest.raises(_BadDay):
+        ep._resolve_mhc_for_linker_optimizer(args)
+
+
+# -- _log_args_summary -------------------------------------------------
+
+
+def _basic_args(**overrides):
+    """Minimal args shape with a parser_defaults snapshot. The
+    summary printer reads ``args._parser_defaults`` to decide what
+    counts as default — so ``parser_defaults`` is captured *before*
+    overrides are applied (mirroring how the real arg-parser
+    snapshot works in :func:`vaxrank.cli.arg_parser.parse_vaxrank_args`).
+    """
+    base = dict(
+        vcf=None, bam=None, input_lens=None, input_pvacseq=None,
+        ensembl_release=None, genome=None, tumor_sample_name=None,
+        input_json_file=None,
+        mhc_predictor=None, mhc_alleles=None, mhc_alleles_file=None,
+        mhc_epitope_lengths=None,
+        vaccine_type=['peptide', 'mrna'],
+        vaccine_peptide_length=25, padding_around_mutation=5,
+        antigen_content=None, epitopes_per_antigen=None,
+        peptide_mode='slp', peptide_linker='G4Sx3',
+        mrna_signal_peptide='HLA_B', mrna_linker='G4Sx2',
+        mrna_max_constructs=2, mrna_antigens_per_construct=5,
+        output_dir='', output_csv='', output_xlsx_report='',
+        output_ascii_report='', output_html_report='',
+        output_pdf_report='', output_neoepitope_report='',
+        output_json_file='', output_passing_variants_csv='',
+        output_isovar_csv='', output_epitopes='',
+        output_patient_id='', output_reviewed_by='',
+        output_final_review='', pdf_backend='pdfkit',
+        log_path='python.log',
+        manufacturability=None, wt_epitopes=True,
+        cosmic_vcf_filename='', max_mutations_in_report=None,
+        config=None, config_set_overrides=None,
+        config_expr_overrides=None,
+        verbose=False,
+        processing_aware_annotation=True,
+        pepsickle_human_only=False, pepsickle_threshold=0.5,
+    )
+    parser_defaults = dict(base)  # snapshot before overrides
+    base.update(overrides)
+    args = SimpleNamespace(**base)
+    args._parser_defaults = parser_defaults
+    return args
+
+
+def test_log_args_summary_smoke_no_user_overrides():
+    """No CLI overrides → every value matches its default. Without
+    ``--verbose`` we should still emit the header but nothing else
+    that names a value."""
+    from vaxrank.cli.entry_point import _log_args_summary
+    args = _basic_args()
+    with _capture_logger('vaxrank.cli.entry_point', logging.INFO) as records:
+        _log_args_summary(args)
+    msgs = [r.getMessage() for r in records
+            if 'Vaxrank run configuration' in r.getMessage()]
+    assert len(msgs) == 1, "Expected exactly one summary log call"
+    msg = msgs[0]
+    assert 'Vaxrank run configuration' in msg
+    # No value lines should leak through when everything matches
+    # defaults and verbose is off.
+    assert 'mrna_linker' not in msg
+
+
+def test_log_args_summary_surfaces_user_overrides():
+    """A user-set value differs from parser default → it gets a
+    line. Values that match defaults stay hidden."""
+    from vaxrank.cli.entry_point import _log_args_summary
+    args = _basic_args(input_lens='/path/to/file.tsv', vaccine_type=['mrna'])
+    with _capture_logger('vaxrank.cli.entry_point', logging.INFO) as records:
+        _log_args_summary(args)
+    msg = [r.getMessage() for r in records
+           if 'Vaxrank run configuration' in r.getMessage()][0]
+    assert 'input_lens' in msg
+    assert "/path/to/file.tsv" in msg
+    assert 'vaccine_type' in msg
+    assert "['mrna']" in msg
+    # A value that didn't change stays hidden (peptide_mode default).
+    assert 'peptide_mode' not in msg
+
+
+def test_log_args_summary_shows_auto_inferred_block():
+    """LENS-path inferred state lives on underscore-prefixed attrs
+    on args. ``_log_args_summary`` lifts them into a separate
+    ``[auto-inferred]`` section."""
+    from vaxrank.cli.entry_point import _log_args_summary
+    args = _basic_args()
+    args._inferred_mhc_alleles_from_lens = ['HLA-A*02:01']
+    with _capture_logger('vaxrank.cli.entry_point', logging.INFO) as records:
+        _log_args_summary(args)
+    msg = [r.getMessage() for r in records
+           if 'Vaxrank run configuration' in r.getMessage()][0]
+    assert 'auto-inferred' in msg
+    assert '_inferred_mhc_alleles_from_lens' in msg
+    assert 'HLA-A*02:01' in msg
+
+
+def test_log_args_summary_verbose_shows_defaults():
+    """``--verbose`` flips every key into the visible set, including
+    those equal to the parser default. The marker ``(default)``
+    annotates them."""
+    from vaxrank.cli.entry_point import _log_args_summary
+    args = _basic_args(verbose=True)
+    with _capture_logger('vaxrank.cli.entry_point', logging.INFO) as records:
+        _log_args_summary(args)
+    msg = [r.getMessage() for r in records
+           if 'Vaxrank run configuration' in r.getMessage()][0]
+    # Defaults visible with ``(default)`` annotation.
+    assert 'peptide_mode' in msg
+    assert '(default)' in msg
+
+
+# -- LENS antigen-source breakdown ordering ---------------------------
+
+
+def test_lens_antigen_source_breakdown_logs_before_filters():
+    """The up-front ``LENS report contains N row(s); antigen_source
+    breakdown:`` log line must fire BEFORE the per-filter "skipped X
+    rows" lines so the operator sees the input composition before
+    the drop counts."""
+    import os
+    from vaxrank.epitope_io import load_lens
+    from vaxrank.external_input import ranked_from_lens_predictions
+    from .testing_helpers import data_path
+
+    lens_path = data_path("epitope_fixtures/lens_example.tsv")
+    if not os.path.exists(lens_path):
+        pytest.skip("lens_example.tsv fixture not found")
+
+    _df, predictions = load_lens(lens_path)
+    with _capture_logger('vaxrank.external_input', logging.INFO) as records:
+        ranked_from_lens_predictions(predictions, lens_path)
+
+    breakdown_idx = [
+        i for i, r in enumerate(records)
+        if 'antigen_source breakdown' in r.getMessage()
+        and 'LENS report contains' in r.getMessage()
+    ]
+    skip_idx = [
+        i for i, r in enumerate(records)
+        if 'Skipped' in r.getMessage()
+        and 'variant_coords' in r.getMessage()
+    ]
+    if not breakdown_idx:
+        pytest.skip("Test fixture didn't trigger up-front breakdown line")
+    if skip_idx:
+        assert breakdown_idx[0] < skip_idx[0], (
+            "Up-front breakdown must log BEFORE filter messages; got "
+            "breakdown@%d, skipped@%d"
+            % (breakdown_idx[0], skip_idx[0]))
+
+
+def test_lens_antigen_source_breakdown_orders_snv_indel_first():
+    """The breakdown's stable order: SNV / INDEL up-front, then
+    other kinds by descending count, ``(missing)`` last. Pin the
+    ordering so a future maintainer can't accidentally swap to
+    pure-alphabetical."""
+    import os
+    import re
+    from vaxrank.epitope_io import load_lens
+    from vaxrank.external_input import ranked_from_lens_predictions
+    from .testing_helpers import data_path
+
+    lens_path = data_path("epitope_fixtures/lens_example.tsv")
+    if not os.path.exists(lens_path):
+        pytest.skip("lens_example.tsv fixture not found")
+
+    _df, predictions = load_lens(lens_path)
+    with _capture_logger('vaxrank.external_input', logging.INFO) as records:
+        ranked_from_lens_predictions(predictions, lens_path)
+
+    msgs = [
+        r.getMessage() for r in records
+        if 'LENS report contains' in r.getMessage()
+        and 'antigen_source breakdown' in r.getMessage()
+    ]
+    if not msgs:
+        pytest.skip("Test fixture didn't trigger up-front breakdown line")
+    line = msgs[0]
+    m = re.search(r'breakdown:\s*([^.]+)', line)
+    assert m, "Couldn't parse breakdown segment from: %r" % line
+    segments = [s.strip() for s in m.group(1).split(',')]
+    kinds_in_order = [s.split('=')[0].strip() for s in segments]
+    snv_idx = kinds_in_order.index('SNV') if 'SNV' in kinds_in_order else -1
+    indel_idx = (
+        kinds_in_order.index('INDEL') if 'INDEL' in kinds_in_order else -1)
+    missing_idx = (
+        kinds_in_order.index('(missing)')
+        if '(missing)' in kinds_in_order else -1)
+    if snv_idx >= 0:
+        for i, k in enumerate(kinds_in_order):
+            if k in ('SNV', 'INDEL'):
+                continue
+            assert snv_idx < i, "SNV must precede %r" % k
+    if missing_idx >= 0:
+        assert missing_idx == len(kinds_in_order) - 1, \
+            "'(missing)' must land last; got order %r" % kinds_in_order
+    if snv_idx >= 0 and indel_idx >= 0:
+        assert snv_idx < indel_idx

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -832,7 +832,7 @@ def test_vaccine_target_dir_layout(tmp_path):
 
 def test_lens_with_vaccine_type_mrna_writes_three_fastas(tmp_path):
     """End-to-end: --input-lens + --vaccine-type=mrna +
-    --output-dir=DIR writes three FASTAs + manifest + layers.csv
+    --output-dir=DIR writes three FASTAs + manifest + mrna-sequence-parts.csv
     directly into DIR (single-mode flat layout)."""
     from vaxrank.cli.entry_point import _emit_outputs
 

--- a/tests/test_mrna.py
+++ b/tests/test_mrna.py
@@ -312,36 +312,42 @@ def test_mrna_fasta_uses_semicolon_antigen_separator():
     assert "GENEA_1_100_A_T,GENEB_2_200_A_T" not in header
 
 
-def test_mrna_max_constructs_warning_reports_dropped_count(caplog):
+def test_mrna_max_constructs_logs_topk_selection_at_info(caplog):
     """When ``--mrna-max-constructs`` caps off the input list, the
-    warning needs to name how many antigens were dropped — naming
-    only the first one (``including X``) leaves the operator unable
-    to tell whether they lost 1 or 379. Pin the dropped-count
-    format so the user-facing diagnostic is useful."""
+    log line must (a) be INFO not WARNING (top-k selection is the
+    whole point of vaxrank, not an error), and (b) name the kept
+    count + total-ranked count so the operator can tell what fraction
+    landed in the vaccine."""
     import logging
     # Build 6 antigens against a cap of 1 construct × 2 antigens =
-    # 2 placed, 4 dropped.
+    # 2 selected, 4 not selected.
     pairs = [
         _variant_pair("KLQGHSAPVLDVIVN", contig=str(i + 1),
                       start=1000 + i, gene_name="GENE%d" % i)
         for i in range(6)
     ]
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         assemble_mrna_constructs(
             pairs,
             options=RNAConstructConfig(
                 signal_peptide=None, include_mitd=False,
                 utr_3p='HBB', poly_a_length=0,
                 antigens_per_construct=2, max_constructs=1))
-    cap_msgs = [
-        r.getMessage() for r in caplog.records
-        if "max-constructs" in r.getMessage()
+    # The cap event surfaces at INFO, never WARNING.
+    cap_records = [
+        r for r in caplog.records
+        if 'mRNA assembly' in r.getMessage()
+        and '--mrna-max-constructs' in r.getMessage()
     ]
-    assert cap_msgs, "Expected a --mrna-max-constructs cap warning"
-    msg = cap_msgs[0]
-    # 4 / 6 dropped; first dropped name appears too.
-    assert "4" in msg
+    assert cap_records, \
+        "Expected an mRNA assembly top-k log line at the cap"
+    assert all(r.levelno == logging.INFO for r in cap_records), \
+        "Cap event must be INFO, not WARNING (top-k selection is the goal)"
+    msg = cap_records[0].getMessage()
+    # Selected 2 of 6 ranked antigens.
+    assert "2" in msg
     assert "6" in msg
+    # The next-best (not-selected) antigen is named for traceability.
     assert "GENE2" in msg
 
 

--- a/tests/test_mrna.py
+++ b/tests/test_mrna.py
@@ -263,14 +263,14 @@ def test_write_mrna_outputs_fasta_and_manifest():
         assert os.path.isfile(os.path.join(out_dir, "full.fasta"))
         with open(os.path.join(out_dir, "no_polyA.fasta")) as f:
             text = f.read()
-        assert text.startswith(">seq_001")
+        assert text.startswith(">mrna_001")
         assert UTR_5P_HBB in text.replace('\n', '')
         with open(manifest_path) as f:
             manifest = json.load(f)
         entry = manifest[0]
         assert entry['modality'] == 'mrna'
         assert entry['length_unit'] == 'nt'
-        assert entry['name'] == 'seq_001'
+        assert entry['name'] == 'mrna_001'
         assert entry['antigen_names'] == ['GENE_1_1000_A_T']
         # New structured fields
         assert 'lengths' in entry
@@ -282,6 +282,67 @@ def test_write_mrna_outputs_fasta_and_manifest():
         # Back-compat 2.12 schema preserved
         assert 'components' in entry
         assert 'manufacturability' in entry
+
+
+def test_mrna_fasta_uses_semicolon_antigen_separator():
+    """The FASTA description's ``antigens=`` field must use ``;`` as
+    the separator — comma collides with FASTA-parsing tools that
+    treat ``,`` as a token boundary in description fields. Pin the
+    contract so a future maintainer can't accidentally regress to
+    comma-joined.
+    """
+    pairs = [
+        _variant_pair("KLQGHSAPVLDVIVN", contig='1', start=100, gene_name='GENEA'),
+        _variant_pair("MNNVDEILGRWESPV", contig='2', start=200, gene_name='GENEB'),
+    ]
+    constructs = assemble_mrna_constructs(
+        pairs,
+        options=RNAConstructConfig(
+            signal_peptide=None, include_mitd=False,
+            utr_3p='HBB', poly_a_length=0))
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = os.path.join(tmp, "out")
+        write_mrna_outputs(constructs, out_dir)
+        with open(os.path.join(out_dir, "cds.fasta")) as f:
+            header = f.readline().rstrip()
+    assert "antigens=" in header
+    # Both antigens land in one description, separated by ';'.
+    assert "GENEA_1_100_A_T;GENEB_2_200_A_T" in header
+    # And the legacy comma-joined form must not survive.
+    assert "GENEA_1_100_A_T,GENEB_2_200_A_T" not in header
+
+
+def test_mrna_max_constructs_warning_reports_dropped_count(caplog):
+    """When ``--mrna-max-constructs`` caps off the input list, the
+    warning needs to name how many antigens were dropped — naming
+    only the first one (``including X``) leaves the operator unable
+    to tell whether they lost 1 or 379. Pin the dropped-count
+    format so the user-facing diagnostic is useful."""
+    import logging
+    # Build 6 antigens against a cap of 1 construct × 2 antigens =
+    # 2 placed, 4 dropped.
+    pairs = [
+        _variant_pair("KLQGHSAPVLDVIVN", contig=str(i + 1),
+                      start=1000 + i, gene_name="GENE%d" % i)
+        for i in range(6)
+    ]
+    with caplog.at_level(logging.WARNING):
+        assemble_mrna_constructs(
+            pairs,
+            options=RNAConstructConfig(
+                signal_peptide=None, include_mitd=False,
+                utr_3p='HBB', poly_a_length=0,
+                antigens_per_construct=2, max_constructs=1))
+    cap_msgs = [
+        r.getMessage() for r in caplog.records
+        if "max-constructs" in r.getMessage()
+    ]
+    assert cap_msgs, "Expected a --mrna-max-constructs cap warning"
+    msg = cap_msgs[0]
+    # 4 / 6 dropped; first dropped name appears too.
+    assert "4" in msg
+    assert "6" in msg
+    assert "GENE2" in msg
 
 
 def test_mrna_min_antigen_length_warning(caplog):
@@ -424,9 +485,9 @@ def test_write_mrna_three_fastas_have_matching_records():
         cds = open(os.path.join(out_dir, "cds.fasta")).read()
         no_polya = open(os.path.join(out_dir, "no_polyA.fasta")).read()
         full = open(os.path.join(out_dir, "full.fasta")).read()
-    # All three have the seq_001 header
+    # All three have the mrna_001 header
     for txt in (cds, no_polya, full):
-        assert ">seq_001" in txt
+        assert ">mrna_001" in txt
     # full > no_polyA > cds in body length
     cds_body = "".join(line for line in cds.split("\n") if not line.startswith(">"))
     no_pa_body = "".join(line for line in no_polya.split("\n") if not line.startswith(">"))

--- a/tests/test_vaccine_library.py
+++ b/tests/test_vaccine_library.py
@@ -118,8 +118,10 @@ def test_get_linker_is_case_insensitive():
 
 
 def test_construct_name_format_consistent_across_modalities():
-    """mRNA constructs use 'seq_NNN'; peptide constructs use 'peptide_NNN'.
-    Same width and zero-padding so consumers can sort/parse uniformly.
+    """mRNA constructs use 'mrna_NNN'; peptide constructs use 'peptide_NNN'.
+    Same width and zero-padding so consumers can sort/parse uniformly,
+    and both names announce their modality so mixed-output downstream
+    pipelines don't collide on bare ``seq_NNN``.
     """
     import re
     from types import SimpleNamespace
@@ -139,7 +141,7 @@ def test_construct_name_format_consistent_across_modalities():
     [p] = assemble_peptide_constructs(pairs, options=PeptideConstructConfig())
 
     # Both should match <prefix>_NNN with the same numeric width.
-    pattern = re.compile(r"^(seq|peptide)_\d{3}$")
+    pattern = re.compile(r"^(mrna|peptide)_\d{3}$")
     assert pattern.match(m.name), \
         "mRNA construct name '%s' must match <prefix>_NNN" % m.name
     assert pattern.match(p.name), \

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -619,11 +619,12 @@ def add_mrna_output_args(group):
              "antigen content is 'minimal_epitope'.")
     group.add_argument(
         "--mrna-max-constructs",
-        default=1,
+        default=2,
         type=int,
-        help="Maximum number of mRNA constructs in the vaccine. Default: 1 "
-             "(one construct carrying all antigens). Higher values let "
-             "additional constructs absorb spillover.")
+        help="Maximum number of mRNA constructs in the vaccine. "
+             "Default: 2 (BioNTech FixVac canonical: 2× pentatope, "
+             "10 antigens at 5/construct, Sahin 2017). Set to 1 for "
+             "a single construct; raise for broader coverage.")
     group.add_argument(
         "--mrna-candidates-per-slot",
         default=1,

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -249,7 +249,7 @@ def add_output_args(arg_parser):
     # Canonical filenames per type:
     #   peptide/  vaccine.fasta, manifest.json, order_form.csv
     #   mrna/     cds.fasta, no_polyA.fasta, full.fasta,
-    #             manifest.json, layers.csv
+    #             manifest.json, mrna-sequence-parts.csv
     #
     # No file-extension-based mode switching: ``--output-dir`` is
     # never a file path. Tradeoff: single-file output ergonomics
@@ -266,14 +266,14 @@ def add_output_args(arg_parser):
              "Required when designing a vaccine; omit for "
              "ranking-only / report-only runs. Vaxrank picks "
              "canonical filenames inside (vaccine.fasta / cds.fasta / "
-             "manifest.json / order_form.csv / layers.csv).")
+             "manifest.json / order_form.csv / mrna-sequence-parts.csv).")
     output_args_group.add_argument(
         "--mrna-csv-no-full-rows",
         dest="mrna_csv_full_rows",
         action="store_false",
         default=True,
         help="mRNA-only. Suppress the per-construct cds / no_polyA / "
-             "full summary rows in the mRNA layers.csv (the rows "
+             "full summary rows in the mRNA mrna-sequence-parts.csv (the rows "
              "with the longest nt cells). Per-element rows are "
              "unaffected.")
 
@@ -458,7 +458,7 @@ def add_mrna_output_args(group):
     Output destinations are unified under ``--output-dir`` (see
     ``add_output_args``); the mRNA writer picks canonical filenames
     inside it (cds.fasta / no_polyA.fasta / full.fasta /
-    manifest.json / layers.csv). Only mrna-specific design
+    manifest.json / mrna-sequence-parts.csv). Only mrna-specific design
     parameters live here.
     """
     from ..mrna_library import MITDS, SIGNAL_PEPTIDES, UTRS_3P, UTRS_5P

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -389,6 +389,225 @@ def _emit_peptide_constructs(args, ranked, target_dir):
         len(constructs), target_dir)
 
 
+_ARG_GROUPS = (
+    ("Inputs", (
+        'vcf', 'bam', 'input_lens', 'input_pvacseq',
+        'ensembl_release', 'genome', 'tumor_sample_name',
+        'input_json_file',
+    )),
+    ("MHC", (
+        'mhc_predictor', 'mhc_alleles', 'mhc_alleles_file',
+        'mhc_epitope_lengths',
+    )),
+    ("Vaccine design", (
+        'vaccine_type', 'vaccine_peptide_length',
+        'padding_around_mutation', 'antigen_content',
+        'epitopes_per_antigen',
+    )),
+    ("Peptide", (
+        'peptide_mode', 'peptide_linker',
+        'peptide_min_antigen_length_aa', 'peptide_max_antigen_length_aa',
+        'peptide_antigens_per_construct', 'peptide_max_constructs',
+        'peptide_candidates_per_slot', 'peptide_n_terminal_acetyl',
+        'peptide_c_terminal_amide', 'peptide_scale_mg',
+        'peptide_purity_percent', 'peptide_counterion',
+        'peptide_antigen_content', 'peptide_epitopes_per_antigen',
+    )),
+    ("mRNA", (
+        'mrna_signal_peptide', 'mrna_linker', 'mrna_include_mitd',
+        'mrna_mitd', 'mrna_5p_utr', 'mrna_3p_utr',
+        'mrna_min_antigen_length_aa', 'mrna_max_antigen_length_aa',
+        'mrna_antigens_per_construct', 'mrna_max_constructs',
+        'mrna_candidates_per_slot', 'mrna_max_length_nt',
+        'mrna_codon_species', 'mrna_codon_method',
+        'mrna_optimize_linkers', 'mrna_junction_candidates',
+        'mrna_junction_rank_strong', 'mrna_junction_rank_mild',
+        'mrna_poly_a_length', 'mrna_poly_a_segmented',
+        'mrna_poly_a_first_segment', 'mrna_poly_a_segment_linker',
+        'mrna_csv_full_rows', 'mrna_antigen_content',
+        'mrna_epitopes_per_antigen',
+    )),
+    ("Processing-aware annotation", (
+        'processing_aware_annotation', 'pepsickle_human_only',
+        'pepsickle_threshold',
+    )),
+    ("Outputs", (
+        'output_dir', 'output_csv', 'output_xlsx_report',
+        'output_ascii_report', 'output_html_report',
+        'output_pdf_report', 'output_neoepitope_report',
+        'output_json_file', 'output_passing_variants_csv',
+        'output_isovar_csv', 'output_epitopes',
+        'output_patient_id', 'output_reviewed_by',
+        'output_final_review', 'pdf_backend', 'log_path',
+    )),
+    ("Reports", (
+        'manufacturability', 'wt_epitopes', 'cosmic_vcf_filename',
+        'max_mutations_in_report',
+    )),
+    ("Config", (
+        'config', 'config_set_overrides', 'config_expr_overrides',
+    )),
+)
+
+
+def _log_args_summary(args):
+    """Pretty-print the resolved args. Replaces ``logger.info(args)``
+    which was a single flat ``Namespace(...)`` dump that scrolled past
+    100 keys without grouping. We log:
+
+    * Section header per :data:`_ARG_GROUPS` group (only sections
+      with at least one set value).
+    * Within each section: ``key = value`` rows for keys whose value
+      *differs* from the parser default OR is a non-empty string —
+      the parser-defaults snapshot in ``args._parser_defaults``
+      lets us hide everything boring.
+    * A single ``(N defaults hidden — pass --verbose to see all)``
+      footer per section so the user knows the noise is suppressed,
+      not lost.
+
+    With ``--verbose`` (or DEBUG), every key prints (including
+    defaults). On the LENS path, args carries auto-inferred state
+    (``_inferred_mhc_alleles_from_lens``); those underscore-prefixed
+    keys are surfaced separately so the operator can see what was
+    auto-wired.
+    """
+    parser_defaults = getattr(args, '_parser_defaults', None) or {}
+    namespace = vars(args).copy()
+    namespace.pop('_parser_defaults', None)
+
+    verbose = bool(getattr(args, 'verbose', False))
+
+    grouped: dict[str, list[tuple[str, object]]] = {}
+    consumed: set[str] = set()
+    for section_name, keys in _ARG_GROUPS:
+        rows = []
+        for k in keys:
+            if k not in namespace:
+                continue
+            consumed.add(k)
+            v = namespace[k]
+            default = parser_defaults.get(k, _MISSING_SENTINEL)
+            is_default = (default is not _MISSING_SENTINEL and v == default)
+            if is_default and not verbose:
+                continue
+            rows.append((k, v, is_default))
+        if rows:
+            grouped[section_name] = rows
+    # Anything not claimed by a known section goes under "Other".
+    other_rows = []
+    for k, v in sorted(namespace.items()):
+        if k in consumed or k.startswith('_'):
+            continue
+        default = parser_defaults.get(k, _MISSING_SENTINEL)
+        is_default = (default is not _MISSING_SENTINEL and v == default)
+        if is_default and not verbose:
+            continue
+        other_rows.append((k, v, is_default))
+    if other_rows:
+        grouped['Other'] = other_rows
+
+    inferred_rows = [
+        (k, v) for k, v in sorted(vars(args).items())
+        if k.startswith('_') and k != '_parser_defaults' and v
+    ]
+
+    lines = ["Vaxrank run configuration:"]
+    for section, rows in grouped.items():
+        lines.append("  [%s]" % section)
+        for k, v, is_default in rows:
+            marker = " (default)" if is_default and verbose else ""
+            lines.append("    %-32s = %r%s" % (k, v, marker))
+        if not verbose:
+            hidden = sum(
+                1 for kk in dict(_ARG_GROUPS).get(section, ())
+                if kk in namespace
+                and namespace[kk] == parser_defaults.get(kk, _MISSING_SENTINEL)
+            )
+            if hidden:
+                lines.append(
+                    "    (%d default(s) hidden — pass --verbose for all)"
+                    % hidden)
+    if inferred_rows:
+        lines.append("  [auto-inferred]")
+        for k, v in inferred_rows:
+            lines.append("    %-32s = %r" % (k, v))
+    logger.info("\n".join(lines))
+
+
+_MISSING_SENTINEL = object()
+
+
+def _resolve_mhc_for_linker_optimizer(args):
+    """Find a usable (predictor, alleles) pair for the per-junction
+    linker optimizer.
+
+    Resolution:
+
+    1. Pipeline path (``--mhc-predictor`` + ``--mhc-alleles`` on the
+       CLI): build both from ``args``.
+    2. External path (LENS / pVACseq): the report carries the
+       alleles; the LENS loader stashes them on
+       ``args._inferred_mhc_alleles_from_lens``. Predictor still
+       has to come from ``--mhc-predictor`` (LENS bundles
+       pre-computed scores, not the predictor binary). When alleles
+       are inferred but the predictor isn't set, log a targeted
+       hint instead of the generic "missing both" warning.
+    3. Anything missing → optimizer falls back to the shared
+       linker at every junction.
+
+    Returns ``(predictor, alleles)`` with ``None`` for either piece
+    that's unavailable. Callers must handle ``None`` either side.
+    """
+    predictor = None
+    alleles = None
+    predictor_err = None
+    alleles_err = None
+    try:
+        predictor = mhc_binding_predictor_from_args(args)
+    except Exception as e:
+        predictor_err = e
+    try:
+        alleles = mhc_alleles_from_args(args)
+    except Exception as e:
+        alleles_err = e
+    inferred = getattr(args, '_inferred_mhc_alleles_from_lens', None) or None
+    if alleles is None and inferred:
+        alleles = inferred
+        logger.info(
+            "Per-junction linker optimization: using %d MHC allele(s) "
+            "inferred from the LENS / pVACseq report (%s).",
+            len(alleles), ", ".join(sorted(set(alleles))[:5])
+            + ("…" if len(set(alleles)) > 5 else ""))
+    if predictor is None or alleles is None:
+        # Targeted hints based on what's missing. Operator-friendly:
+        # the previous code lumped both failure modes into one
+        # message and pointed at both flags every time.
+        if alleles is None and predictor is None:
+            logger.warning(
+                "Per-junction linker optimization disabled: no MHC "
+                "alleles or predictor available. Pass --mhc-alleles "
+                "+ --mhc-predictor (pipeline path), or rely on "
+                "LENS / pVACseq inference + --mhc-predictor "
+                "(external path).")
+        elif predictor is None:
+            logger.warning(
+                "Per-junction linker optimization disabled: alleles "
+                "are available%s but no MHC predictor is set. Pass "
+                "--mhc-predictor (e.g. mhcflurry) to enable junction "
+                "scoring.",
+                " (inferred from report)" if inferred else "")
+        else:
+            logger.warning(
+                "Per-junction linker optimization disabled: predictor "
+                "loaded but no --mhc-alleles set.")
+        if predictor_err is not None:
+            logger.debug("MHC predictor load failed: %r", predictor_err)
+        if alleles_err is not None and inferred is None:
+            logger.debug("MHC alleles load failed: %r", alleles_err)
+        return (None, None)
+    return (predictor, alleles)
+
+
 def _emit_mrna_constructs(args, ranked, target_dir):
     """Build + write mRNA-vaccine constructs. Modality-specific."""
     yaml_kwargs = _construct_config_for_modality(args, 'mrna')
@@ -446,19 +665,7 @@ def _emit_mrna_constructs(args, ranked, target_dir):
             'mrna_poly_a_segment_linker', 'poly_a_segment_linker'),
     )
     if options.optimize_linkers:
-        try:
-            mhc_predictor = mhc_binding_predictor_from_args(args)
-            mhc_alleles = mhc_alleles_from_args(args)
-        except Exception as e:
-            logger.warning(
-                "Could not load MHC predictor / alleles for "
-                "per-junction linker optimization (%s). The optimizer "
-                "will fall back to the shared linker at every junction. "
-                "Set --mhc-predictor + --mhc-alleles to enable it.", e)
-            logger.debug(
-                "Predictor / alleles load traceback:", exc_info=True)
-            mhc_predictor = None
-            mhc_alleles = None
+        mhc_predictor, mhc_alleles = _resolve_mhc_for_linker_optimizer(args)
     else:
         mhc_predictor = None
         mhc_alleles = None
@@ -670,7 +877,7 @@ def main(args_list=None):
     # logic lives in exactly one place.
     if getattr(args, 'manufacturability', None) is None:
         args.manufacturability = 'peptide' in _resolve_vaccine_types(args)
-    logger.info(args)
+    _log_args_summary(args)
 
     # Fail fast when no output path is set, *before* loading inputs or
     # running predictions. Otherwise a long --input-lens run silently
@@ -721,6 +928,21 @@ def main(args_list=None):
                 "External input produced no ranked vaccine peptides; "
                 "writing only the per-(peptide, allele) neoepitope "
                 "report (if requested).")
+        # Stash MHC alleles inferred from the LENS / pVACseq report
+        # so the per-junction linker optimizer (which runs from
+        # ``_emit_mrna_constructs``) can pick them up without
+        # ``--mhc-alleles`` being on the CLI. The external arg
+        # parser doesn't include the mhctools args, so the predictor
+        # still has to come from ``--mhc-predictor`` if set —
+        # ``_resolve_mhc_for_linker_optimizer`` produces a targeted
+        # message when alleles are inferred but predictor is missing.
+        if patient_info is not None:
+            args._inferred_mhc_alleles_from_lens = [
+                a for a in (patient_info.mhc_alleles or [])
+                if a and not a.startswith('(')  # skip the
+                # ``(inferred from report)`` provenance marker added
+                # in ``_patient_info_from_external``.
+            ]
         # Per-(peptide, allele) CSV / XLSX report is unique to the
         # external-input path; emit it before the shared dispatch.
         _emit_neoepitope_report_external(args, report_df, predictions)

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -389,6 +389,9 @@ def _emit_peptide_constructs(args, ranked, target_dir):
         len(constructs), target_dir)
 
 
+_MISSING_SENTINEL = object()
+
+
 _ARG_GROUPS = (
     ("Inputs", (
         'vcf', 'bam', 'input_lens', 'input_pvacseq',
@@ -449,6 +452,12 @@ _ARG_GROUPS = (
     )),
 )
 
+# Cached lookup for the section -> keys mapping. Built once at module
+# import; the per-section "(N defaults hidden)" footer in
+# ``_log_args_summary`` reads from here instead of rebuilding the
+# dict on every call.
+_ARG_GROUPS_BY_NAME = dict(_ARG_GROUPS)
+
 
 def _log_args_summary(args):
     """Pretty-print the resolved args. Replaces ``logger.info(args)``
@@ -458,15 +467,14 @@ def _log_args_summary(args):
     * Section header per :data:`_ARG_GROUPS` group (only sections
       with at least one set value).
     * Within each section: ``key = value`` rows for keys whose value
-      *differs* from the parser default OR is a non-empty string —
-      the parser-defaults snapshot in ``args._parser_defaults``
-      lets us hide everything boring.
+      differs from the parser default. The parser-defaults snapshot
+      in ``args._parser_defaults`` lets us hide everything boring.
     * A single ``(N defaults hidden — pass --verbose to see all)``
       footer per section so the user knows the noise is suppressed,
       not lost.
 
-    With ``--verbose`` (or DEBUG), every key prints (including
-    defaults). On the LENS path, args carries auto-inferred state
+    With ``--verbose``, every key prints (including defaults). On
+    the LENS path, args carries auto-inferred state
     (``_inferred_mhc_alleles_from_lens``); those underscore-prefixed
     keys are surfaced separately so the operator can see what was
     auto-wired.
@@ -519,7 +527,7 @@ def _log_args_summary(args):
             lines.append("    %-32s = %r%s" % (k, v, marker))
         if not verbose:
             hidden = sum(
-                1 for kk in dict(_ARG_GROUPS).get(section, ())
+                1 for kk in _ARG_GROUPS_BY_NAME.get(section, ())
                 if kk in namespace
                 and namespace[kk] == parser_defaults.get(kk, _MISSING_SENTINEL)
             )
@@ -532,9 +540,6 @@ def _log_args_summary(args):
         for k, v in inferred_rows:
             lines.append("    %-32s = %r" % (k, v))
     logger.info("\n".join(lines))
-
-
-_MISSING_SENTINEL = object()
 
 
 def _resolve_mhc_for_linker_optimizer(args):
@@ -562,13 +567,21 @@ def _resolve_mhc_for_linker_optimizer(args):
     alleles = None
     predictor_err = None
     alleles_err = None
+    # ``mhc_binding_predictor_from_args`` / ``mhc_alleles_from_args``
+    # raise ``AttributeError`` when the LENS-path arg parser doesn't
+    # declare ``--mhc-predictor`` / ``--mhc-alleles``, ``ValueError``
+    # for empty / unparseable values, and ``KeyError`` if a registry
+    # name doesn't resolve. Anything else (e.g. a real model-load
+    # failure deep inside mhctools / mhcflurry) is a bug we want to
+    # propagate, not silently swallow into "linker optimizer disabled".
+    _ARG_LOAD_ERRORS = (AttributeError, ValueError, KeyError)
     try:
         predictor = mhc_binding_predictor_from_args(args)
-    except Exception as e:
+    except _ARG_LOAD_ERRORS as e:
         predictor_err = e
     try:
         alleles = mhc_alleles_from_args(args)
-    except Exception as e:
+    except _ARG_LOAD_ERRORS as e:
         alleles_err = e
     inferred = getattr(args, '_inferred_mhc_alleles_from_lens', None) or None
     if alleles is None and inferred:
@@ -937,11 +950,10 @@ def main(args_list=None):
         # ``_resolve_mhc_for_linker_optimizer`` produces a targeted
         # message when alleles are inferred but predictor is missing.
         if patient_info is not None:
+            from ..external_input import LENS_PROVENANCE_MARKER
             args._inferred_mhc_alleles_from_lens = [
                 a for a in (patient_info.mhc_alleles or [])
-                if a and not a.startswith('(')  # skip the
-                # ``(inferred from report)`` provenance marker added
-                # in ``_patient_info_from_external``.
+                if a and a != LENS_PROVENANCE_MARKER
             ]
         # Per-(peptide, allele) CSV / XLSX report is unique to the
         # external-input path; emit it before the shared dispatch.

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -467,14 +467,18 @@ def _emit_mrna_constructs(args, ranked, target_dir):
         mhc_predictor=mhc_predictor, mhc_alleles=mhc_alleles)
     # Canonical filenames inside the per-modality target directory:
     # cds.fasta + no_polyA.fasta + full.fasta + manifest.json +
-    # layers.csv. The cds/no_polyA/full FASTAs are written by
-    # ``write_mrna_outputs`` directly into ``target_dir``.
+    # mrna-sequence-parts.csv. The cds/no_polyA/full FASTAs are
+    # written by ``write_mrna_outputs`` directly into ``target_dir``.
+    # The CSV name was ``layers.csv`` through 2.17 — too cryptic
+    # next to ``cds.fasta`` / ``full.fasta``; renamed to spell out
+    # what the rows describe (per-element decomposition of each
+    # mRNA construct).
     os.makedirs(target_dir, exist_ok=True)
     write_mrna_outputs(
         constructs,
         output_dir=target_dir,
         manifest_path=os.path.join(target_dir, 'manifest.json'),
-        csv_path=os.path.join(target_dir, 'layers.csv'),
+        csv_path=os.path.join(target_dir, 'mrna-sequence-parts.csv'),
         csv_include_full_rows=getattr(
             args, 'mrna_csv_full_rows', True),
     )

--- a/vaxrank/config/default.yaml
+++ b/vaxrank/config/default.yaml
@@ -10,17 +10,37 @@
 #
 #     vaxrank --print-default-config > my-config.yaml
 #
-# The four sections below correspond to vaxrank's frozen config groups:
-#   epitopes           -> EpitopeConfig (filter / score MHC ligand predictions)
-#   vaccine_peptides   -> VaccineConfig (per-variant antigen-window selection,
-#                                        ranking; applies to BOTH peptide AND
-#                                        mRNA — name kept for back-compat)
-#   manufacturability  -> VaccineConfig (peptide-synthesis difficulty rules)
-#   vaccine_constructs -> per-modality construct-assembly knobs;
-#                         cross-modality values at the section top
-#                         level, modality-specific values under
-#                         `peptide:` / `mrna:` subsections (CLI flags
-#                         continue to work and override config)
+# Top-level sections (modality-agnostic unless noted):
+#
+#   epitopes           Filter / score MHC ligand predictions
+#                      (logistic IC50 / percentile-rank knobs, the
+#                      topiary DSL ``filter_expr`` / ``score_expr``,
+#                      and ``default_methods`` for multi-predictor
+#                      inputs).
+#
+#   vaccine_peptides   Per-variant antigen-window selection + the
+#                      *ranking* of those windows (length, padding,
+#                      ``combined_score_mode`` / ``combined_score_expr``,
+#                      ``ranking_rules``, ``score_fraction_of_best``).
+#                      Modality-agnostic — every active --vaccine-type
+#                      reads from here. (Section name kept for
+#                      back-compat with pre-mRNA configs.)
+#
+#   manufacturability  Peptide-synthesis difficulty rules + thresholds.
+#                      Used as a tie-break when ``vaccine_peptides.ranking_rules``
+#                      references the ``manufacturability`` sentinel.
+#                      Auto-skipped from peptide-only report sections
+#                      when --vaccine-type doesn't include 'peptide'.
+#
+#   vaccine_constructs Per-modality construct-assembly knobs.
+#                      Cross-modality values at the section top level;
+#                      modality-specific values under ``peptide:`` /
+#                      ``mrna:`` subsections.
+#
+# Resolution order (highest precedence first) for any single value:
+#
+#   explicit CLI flag  >  per-modality config  >  cross-modality config
+#                      >  built-in default
 
 
 epitopes:

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -651,7 +651,7 @@ def write_neoepitope_report(report_df, predictions, excel_report_path=None,
     # same score, which is the correct behavior for a per-row report.
     # The duplicate count is only useful when chasing a downstream
     # row-count mismatch — log at DEBUG, not INFO.
-    if len(report_df) > 0 and logger.isEnabledFor(__import__('logging').DEBUG):
+    if len(report_df) > 0 and logger.isEnabledFor(logging.DEBUG):
         dup_count = int(report_df.duplicated(
             subset=[peptide_col, allele_col]).sum())
         if dup_count:

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -649,11 +649,13 @@ def write_neoepitope_report(report_df, predictions, excel_report_path=None,
     # — that's expected, not an error. Each row retains its own source
     # provenance (variant_coords, gene_name, transcript) and gets the
     # same score, which is the correct behavior for a per-row report.
-    if len(report_df) > 0:
+    # The duplicate count is only useful when chasing a downstream
+    # row-count mismatch — log at DEBUG, not INFO.
+    if len(report_df) > 0 and logger.isEnabledFor(__import__('logging').DEBUG):
         dup_count = int(report_df.duplicated(
             subset=[peptide_col, allele_col]).sum())
         if dup_count:
-            logger.info(
+            logger.debug(
                 "report_df has %d duplicate (peptide, allele) row(s) "
                 "from multi-source input; the same score broadcasts "
                 "across each duplicate. Per-source provenance is "

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -461,6 +461,37 @@ def ranked_from_lens_predictions(predictions, lens_tsv_path, genome=None,
 
     # Group rows by variant. LENS uses lowercase snake_case columns.
     rows = df.to_dict('records')
+
+    # Up-front antigen_source breakdown — logged BEFORE any filter
+    # log lines so the operator sees the composition of the input
+    # before they see what got dropped. Order: SNV / INDEL first
+    # (the per-coord paths), then non-coord categories sorted by
+    # count. Missing values surface as ``(missing)``.
+    if rows:
+        full_kinds: dict[str, int] = {}
+        for r in rows:
+            kind = r.get('antigen_source')
+            kind_key = (
+                str(kind).strip() if kind is not None and not (
+                    isinstance(kind, float) and pd.isna(kind))
+                else '(missing)')
+            full_kinds[kind_key] = full_kinds.get(kind_key, 0) + 1
+        # Stable order: SNV / INDEL up-front (the variant-coord paths),
+        # then everything else by descending count, with (missing) last.
+        priority = {'SNV': 0, 'INDEL': 1}
+        def _bucket_order(item):
+            k, count = item
+            if k.upper() in priority:
+                return (priority[k.upper()], 0, k)
+            if k == '(missing)':
+                return (3, 0, k)
+            return (2, -count, k)
+        ordered = sorted(full_kinds.items(), key=_bucket_order)
+        breakdown = ', '.join("%s=%d" % (k, v) for k, v in ordered)
+        logger.info(
+            "LENS report contains %d row(s); antigen_source "
+            "breakdown: %s.", len(rows), breakdown)
+
     groups = {}
     n_skipped_empty_coords = 0
     # When a row has no variant_coords, the only sensible explanation
@@ -786,12 +817,31 @@ def ranked_from_lens_predictions(predictions, lens_tsv_path, genome=None,
                 "antigen kinds are expected to carry one. Likely "
                 "upstream LENS bug.", len(anomalous))
     if n_no_reads:
-        logger.warning(
-            "%d / %d LENS row(s) lack RNA-read counts "
-            "(rna_reads_covering_genomic_origin). Combined-score "
-            "ranking will collapse to epitope-only for those rows; "
-            "consider --combined-score-mode=epitope_only if RNA data "
-            "is consistently absent.", n_no_reads, len(rows))
+        rows_no_reads = [
+            r for r in rows
+            if _is_missing(r.get('rna_reads_covering_genomic_origin'))
+        ]
+        # Antigen kinds where ``rna_reads_covering_genomic_origin`` is
+        # legitimately missing: ERV / SPLICE / FUSION don't have a
+        # genome-coord origin in the same sense as SNV / INDEL —
+        # those rows are RNA-evidenced via different LENS columns
+        # (e.g. ERV expression). Surface SNV / INDEL gaps as the
+        # noteworthy anomaly and treat the rest as informational.
+        anomalous_no_reads = [
+            r for r in rows_no_reads
+            if _kind(r).upper() in _SNV_OR_INDEL_KINDS
+        ]
+        logger.info(
+            "%d / %d LENS row(s) lack rna_reads_covering_genomic_origin; "
+            "antigen_source breakdown: %s. Those rows score with "
+            "n_alt_reads=0 — combined-score ranking falls back to the "
+            "epitope-only branch for them.",
+            n_no_reads, len(rows), _kind_breakdown(rows_no_reads))
+        if anomalous_no_reads:
+            logger.warning(
+                "%d SNV / INDEL row(s) lack rna_reads_covering_genomic_origin "
+                "— those kinds are expected to carry RNA-read counts.",
+                len(anomalous_no_reads))
 
     # Transcript-resolution summary. The "no genome configured" case
     # is now caught pre-flight in ``arg_parser.check_args`` for any

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -57,6 +57,13 @@ _PVACSEQ_RANK_COLS = ('%ile MT', 'Best Percentile MT')
 logger = logging.getLogger(__name__)
 
 
+# Marker appended to ``patient_info.mhc_alleles`` so reports + the
+# linker-optimizer plumbing can tell user-supplied alleles from
+# alleles inferred from a LENS / pVACseq report. Shared with
+# ``vaxrank.cli.entry_point`` so producer + consumer can't drift.
+LENS_PROVENANCE_MARKER = '(inferred from report)'
+
+
 def _parse_variant_coords(coords):
     """Parse a LENS ``variant_coords`` string into ``(contig, pos)``
     or ``None`` if the cell is empty / malformed.
@@ -1138,7 +1145,7 @@ def _patient_info_from_external(ranked, source_path, patient_id,
                 seen.add(allele)
                 mhc_alleles.append(allele)
         if mhc_alleles:
-            mhc_alleles = sorted(mhc_alleles) + ['(inferred from report)']
+            mhc_alleles = sorted(mhc_alleles) + [LENS_PROVENANCE_MARKER]
     return PatientInfo(
         patient_id=patient_id or '',
         # Leave the legacy vcf_paths empty — the external path's

--- a/vaxrank/mrna.py
+++ b/vaxrank/mrna.py
@@ -171,7 +171,10 @@ class RNAConstructConfig:
     min_antigen_length_aa: int = 15
     max_antigen_length_aa: int = 25  # Sahin 2017 used 27mers; 25 is typical
     antigens_per_construct: int = 5
-    max_constructs: int = 1
+    # BioNTech FixVac canonical: 2× pentatope = 10 antigens at
+    # 5 antigens/construct (Sahin 2017). Set to 1 for a single
+    # construct; raise for broader coverage.
+    max_constructs: int = 2
     candidates_per_slot: int = 1
     max_length_nt: int = 4000
     avoid_patterns: tuple = ()
@@ -547,29 +550,32 @@ def _pack_constructs(antigen_pairs, options, signal_peptide_aa, linker,
             antigen_nt = len(aa) * 3
             linker_nt = 0
             if len(constructs) >= options.max_constructs:
-                # Count dropped antigens so the operator can tell
-                # whether they lost 1 or 379. ``total_antigens`` is
-                # known when the caller passes a list (the normal
-                # path); on a generator we fall back to "remaining"
-                # without a total.
-                remaining = (
-                    total_antigens - i if total_antigens is not None
-                    else None)
-                if remaining is not None:
-                    logger.warning(
-                        "Reached --mrna-max-constructs (%d); "
-                        "dropping %d / %d ranked antigen(s) past the "
-                        "cap (first dropped: %s). Bump "
-                        "--mrna-max-constructs to spill into more "
-                        "constructs.",
-                        options.max_constructs, remaining,
-                        total_antigens, name)
+                # Top-k selection log. Ranking N candidates and
+                # keeping the top k (the chosen 5 antigens × 1
+                # construct here) is *the whole point* — not a
+                # warning, not "spill" / "drop" panic language.
+                # Operators who want a different cut control it via
+                # ``--mrna-max-constructs`` /
+                # ``--mrna-antigens-per-construct``. ``total_antigens``
+                # is None on a generator caller; the count line is
+                # the only thing that requires it.
+                kept = sum(len(c) for c in constructs)
+                if total_antigens is not None:
+                    logger.info(
+                        "mRNA assembly: selected top %d / %d "
+                        "ranked antigen(s) into %d construct(s) at "
+                        "--mrna-max-constructs=%d. Lower-ranked "
+                        "antigens past the cap (e.g. %s) are "
+                        "available in --output-csv / "
+                        "--output-json-file for downstream review.",
+                        kept, total_antigens, len(constructs),
+                        options.max_constructs, name)
                 else:
-                    logger.warning(
-                        "Reached --mrna-max-constructs (%d); "
-                        "dropping remaining antigens (first: %s). "
-                        "Bump --mrna-max-constructs to spill into "
-                        "more constructs.",
+                    logger.info(
+                        "mRNA assembly: selected top %d ranked "
+                        "antigen(s) into %d construct(s) at "
+                        "--mrna-max-constructs=%d (next-best: %s).",
+                        kept, len(constructs),
                         options.max_constructs, name)
                 return constructs
         # A single antigen larger than the length cap is still emitted in

--- a/vaxrank/mrna.py
+++ b/vaxrank/mrna.py
@@ -530,7 +530,9 @@ def _pack_constructs(antigen_pairs, options, signal_peptide_aa, linker,
     constructs = []
     current = []
     current_aa_nt = 0
-    for name, aa in antigen_pairs:
+    total_antigens = (
+        len(antigen_pairs) if hasattr(antigen_pairs, '__len__') else None)
+    for i, (name, aa) in enumerate(antigen_pairs):
         antigen_nt = len(aa) * 3
         linker_nt = len(linker_aa) * 3 if current else 0
         projected = fixed_overhead_nt + current_aa_nt + linker_nt + antigen_nt
@@ -545,10 +547,30 @@ def _pack_constructs(antigen_pairs, options, signal_peptide_aa, linker,
             antigen_nt = len(aa) * 3
             linker_nt = 0
             if len(constructs) >= options.max_constructs:
-                logger.warning(
-                    "Reached --mrna-max-constructs (%d); dropping "
-                    "remaining antigens including %s.",
-                    options.max_constructs, name)
+                # Count dropped antigens so the operator can tell
+                # whether they lost 1 or 379. ``total_antigens`` is
+                # known when the caller passes a list (the normal
+                # path); on a generator we fall back to "remaining"
+                # without a total.
+                remaining = (
+                    total_antigens - i if total_antigens is not None
+                    else None)
+                if remaining is not None:
+                    logger.warning(
+                        "Reached --mrna-max-constructs (%d); "
+                        "dropping %d / %d ranked antigen(s) past the "
+                        "cap (first dropped: %s). Bump "
+                        "--mrna-max-constructs to spill into more "
+                        "constructs.",
+                        options.max_constructs, remaining,
+                        total_antigens, name)
+                else:
+                    logger.warning(
+                        "Reached --mrna-max-constructs (%d); "
+                        "dropping remaining antigens (first: %s). "
+                        "Bump --mrna-max-constructs to spill into "
+                        "more constructs.",
+                        options.max_constructs, name)
                 return constructs
         # A single antigen larger than the length cap is still emitted in
         # its own construct — splitting one antigen would corrupt the
@@ -822,7 +844,12 @@ def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
             components['junction_swap'] = junction_swap_meta
 
         constructs.append(RNAConstruct(
-            name="seq_%03d" % (i + 1),
+            # Modality-stamped namespace (was bare ``seq_NNN``):
+            # users mix peptide + mRNA outputs in the same downstream
+            # pipeline and a bare ``seq_001`` collides with peptide
+            # construct names. Mirrors the peptide writer's
+            # ``peptide_NNN`` scheme.
+            name="mrna_%03d" % (i + 1),
             antigen_names=names,
             sequence=full_nt,
             components=components,
@@ -908,8 +935,13 @@ def write_mrna_outputs(constructs, output_dir, manifest_path=None,
         with open(path, 'w') as f:
             for c in constructs:
                 seq = getattr(c, attr)
+                # Use ';' as the antigen separator: GenBank
+                # convention for compound description fields, and
+                # avoids the trap where downstream tools split the
+                # FASTA description on ',' (treating each antigen
+                # name as a separate token).
                 f.write(">%s antigens=%s length=%d\n" % (
-                    c.name, ','.join(c.antigen_names), len(seq)))
+                    c.name, ';'.join(c.antigen_names), len(seq)))
                 f.write(_wrap_fasta(seq))
                 f.write("\n")
 

--- a/vaxrank/processing.py
+++ b/vaxrank/processing.py
@@ -290,17 +290,14 @@ def annotate_processing(predictions, predictor=None,
             "EpitopePrediction(s) across %d unique source sequence(s).",
             n_annotated, len(predictions_list), len(by_source))
     if n_skipped_peptide_not_in_context:
-        # Show the first example with full context so the user can
-        # paste it into an upstream LENS bug report.
         ex_peptide, ex_source = skipped_examples[0]
         logger.warning(
             "Pepsickle credibility tagging: skipped %d / %d "
             "EpitopePrediction(s) because the peptide is not a "
-            "substring of its pep_context source — likely a LENS "
-            "issue where peptide and pep_context were built from "
-            "different isoforms / annotation snapshots. Example: "
-            "peptide=%r not found in pep_context=%r. File upstream "
-            "if this rate is non-trivial.",
+            "substring of its pep_context source — peptide and "
+            "pep_context were built from different isoforms / "
+            "annotation snapshots. Example: peptide=%r not found "
+            "in pep_context=%r.",
             n_skipped_peptide_not_in_context, len(predictions_list),
             ex_peptide, ex_source)
     return n_annotated

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.17.0"
+__version__ = "2.18.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Addresses #270 (mRNA output ergonomics). First batch lands in commit 1; the broader items (mRNA ranking-decisions report, configurable antigen-name template, signal-peptide / start-codon polish) ride in follow-up commits on this branch before merge.

### Commit 1 — naming, separators, dropped-count

- **Construct names:** ``seq_NNN`` → ``mrna_NNN``. Modality-stamped namespace mirrors the peptide writer's ``peptide_NNN`` scheme so mixed peptide+mRNA outputs in the same downstream pipeline don't collide on bare ``seq_001``.
- **FASTA ``antigens=`` separator:** ``,`` → ``;``. Comma is a token boundary in many FASTA-parsing tools' description-line handlers; ``;`` is the GenBank convention.
- **``layers.csv`` → ``mrna-sequence-parts.csv``.** Next to ``cds.fasta`` / ``full.fasta``, the legacy name was too cryptic — the new name spells out the per-element decomposition.
- **``--mrna-max-constructs`` cap warning** now reports dropped count: ``dropping 379 / 384 ranked antigen(s) past the cap`` instead of naming only one antigen as ``including X``. Operators can tell whether they lost 1 or 379.

### Coming on this branch (TODO)

- mRNA ranking-decisions report section (parity with peptide-side ASCII / HTML / PDF reports — which 5 antigens, why; which dropped past the cap).
- Configurable antigen-name template (``{gene}_{protein_change}`` style; long form retained in manifest).
- ``default.yaml`` header rewrite (drop pre-mRNA "frozen config groups" / EpitopeConfig / VaccineConfig language; commit ``d2a51bd``).

### Default.yaml header

Already in commit 0 on this branch. The PR also rewrites the header to match the post-2.17 layout (drops outdated class-name mappings, adds the resolution-order line at the top instead of repeating it per section).

## Test plan

- [x] ``./test.sh`` — 714 passed, 0 failures
- [x] New regression tests: FASTA ``;``-separator, dropped-count warning shape, cross-modality ``mrna|peptide_NNN`` pattern
- [ ] CI green on this branch
- [ ] End-to-end smoke on Pt02 LENS to confirm the new file names + warning ergonomics
- [ ] Add the mRNA ranking-decisions report (next commit)

Bumps version to 2.18.0.