### PR TITLE
Default mhcflurry for linker opt; auto-fill CSV/JSON in --output-dir

### DIFF
--- a/tests/test_entry_point_helpers.py
+++ b/tests/test_entry_point_helpers.py
@@ -64,30 +64,70 @@ def _args_with_inferred_alleles(alleles=None):
         _inferred_mhc_alleles_from_lens=list(alleles or []))
 
 
-def test_resolve_mhc_logs_inferred_alleles_then_predictor_missing():
-    """LENS-path: args lacks ``--mhc-alleles`` but the loader stashed
-    inferred alleles. The function still returns ``(None, None)``
-    because the optimizer needs *both* predictor and alleles — but
-    the ``inferred from report`` INFO surfaces, and the targeted
-    "predictor missing, alleles inferred" hint fires."""
-    from vaxrank.cli.entry_point import _resolve_mhc_for_linker_optimizer
+def test_resolve_mhc_defaults_to_mhcflurry_when_predictor_missing(monkeypatch):
+    """LENS-path: args lacks ``--mhc-predictor`` but the loader
+    stashed inferred alleles. Vaxrank should fall back to mhcflurry
+    as a credible default rather than refusing to optimize.
+
+    We don't actually instantiate mhcflurry here — loading it in
+    the test process triggers the macOS libomp clash that issue
+    #266 fixed for pepsickle (mhcflurry has the same constraint).
+    Instead, we patch ``mhctools.MHCflurry`` to a sentinel and
+    verify the function calls it with the inferred alleles + emits
+    the "defaulting to mhcflurry" INFO line."""
+    import mhctools
+    from vaxrank.cli import entry_point as ep
+
+    captured = {}
+
+    class _SentinelPredictor:
+        pass
+
+    def _stub_ctor(alleles, **kw):
+        captured['alleles'] = alleles
+        captured['kwargs'] = kw
+        return _SentinelPredictor()
+
+    monkeypatch.setattr(mhctools, 'MHCflurry', _stub_ctor)
     args = _args_with_inferred_alleles(['HLA-A*02:01', 'HLA-B*07:02'])
     with _capture_logger('vaxrank.cli.entry_point') as records:
-        predictor, alleles = _resolve_mhc_for_linker_optimizer(args)
+        predictor, alleles = ep._resolve_mhc_for_linker_optimizer(args)
+    assert isinstance(predictor, _SentinelPredictor)
+    assert alleles == ['HLA-A*02:01', 'HLA-B*07:02']
+    assert captured['alleles'] == ['HLA-A*02:01', 'HLA-B*07:02']
+    msgs = [r.getMessage() for r in records]
+    assert any('inferred from the LENS / pVACseq report' in m for m in msgs)
+    assert any('defaulting to mhcflurry' in m for m in msgs), \
+        "Expected the 'defaulting to mhcflurry' INFO line; got %r" % msgs
+
+
+def test_resolve_mhc_warns_when_mhcflurry_default_unavailable(monkeypatch):
+    """When the mhcflurry default can't load (not installed, weights
+    missing, …), the function returns ``(None, None)`` and surfaces
+    the targeted "predictor missing, alleles available" warning so
+    the operator knows what to fix.
+
+    Patches ``mhctools.MHCflurry`` itself to raise — replacing the
+    sys.modules entry would crater anything else that imports
+    mhctools concurrently.
+    """
+    import mhctools
+    from vaxrank.cli import entry_point as ep
+
+    def _broken_ctor(*_a, **_kw):
+        raise OSError("simulated: mhcflurry weights not available")
+    monkeypatch.setattr(mhctools, 'MHCflurry', _broken_ctor)
+
+    args = _args_with_inferred_alleles(['HLA-A*02:01'])
+    with _capture_logger('vaxrank.cli.entry_point') as records:
+        predictor, alleles = ep._resolve_mhc_for_linker_optimizer(args)
     assert predictor is None
-    # Function returns (None, None) because predictor is unset; alleles
-    # alone can't drive chimeric-k-mer scoring.
     assert alleles is None
     msgs = [r.getMessage() for r in records]
-    assert any('inferred from the LENS / pVACseq report' in m for m in msgs), \
-        "Expected the 'alleles inferred' INFO line; got %r" % msgs
-    pred_missing = [
-        r for r in records
-        if r.levelno == logging.WARNING
-        and 'alleles are available' in r.getMessage()
-    ]
-    assert pred_missing, \
-        "Expected the 'predictor missing, alleles available' hint"
+    assert any(
+        'alleles are available' in m and 'no MHC predictor' in m
+        for m in msgs), \
+        "Expected the 'predictor missing, alleles available' WARNING; got %r" % msgs
 
 
 def test_resolve_mhc_no_inputs_at_all():
@@ -233,6 +273,65 @@ def test_log_args_summary_verbose_shows_defaults():
     # Defaults visible with ``(default)`` annotation.
     assert 'peptide_mode' in msg
     assert '(default)' in msg
+
+
+# -- _auto_populate_output_paths_from_dir -----------------------------
+
+
+def test_auto_populate_pipeline_path_fills_csv_and_json():
+    """Pipeline run (no LENS / pVACseq input) with just
+    ``--output-dir`` set should auto-fill canonical CSV + JSON
+    paths inside the directory."""
+    from vaxrank.cli.entry_point import _auto_populate_output_paths_from_dir
+    args = SimpleNamespace(
+        output_dir='/tmp/run',
+        input_lens=None, input_pvacseq=None,
+        output_csv='', output_json_file='')
+    _auto_populate_output_paths_from_dir(args)
+    assert args.output_csv == '/tmp/run/ranked_vaccine_peptides.csv'
+    assert args.output_json_file == '/tmp/run/ranked_vaccine_peptides.json'
+
+
+def test_auto_populate_lens_path_fills_neoepitope_csv():
+    """LENS path's natural rank report is per-(peptide, allele) —
+    the auto-fill picks ``neoepitope_predictions.csv`` instead of
+    ``ranked_vaccine_peptides.csv`` so the filename matches the
+    content. JSON dump is skipped (the LENS path doesn't build the
+    rich in-memory result that --output-json-file serializes)."""
+    from vaxrank.cli.entry_point import _auto_populate_output_paths_from_dir
+    args = SimpleNamespace(
+        output_dir='/tmp/lens-run',
+        input_lens='/path/to/lens.tsv', input_pvacseq=None,
+        output_csv='', output_json_file='')
+    _auto_populate_output_paths_from_dir(args)
+    assert args.output_csv == '/tmp/lens-run/neoepitope_predictions.csv'
+    assert args.output_json_file == ''
+
+
+def test_auto_populate_explicit_paths_win():
+    """When the user explicitly passes ``--output-csv`` /
+    ``--output-json-file``, the auto-fill must not overwrite them."""
+    from vaxrank.cli.entry_point import _auto_populate_output_paths_from_dir
+    args = SimpleNamespace(
+        output_dir='/tmp/run',
+        input_lens=None, input_pvacseq=None,
+        output_csv='/elsewhere/custom.csv',
+        output_json_file='/elsewhere/custom.json')
+    _auto_populate_output_paths_from_dir(args)
+    assert args.output_csv == '/elsewhere/custom.csv'
+    assert args.output_json_file == '/elsewhere/custom.json'
+
+
+def test_auto_populate_no_output_dir_is_a_noop():
+    """Without ``--output-dir`` the helper does nothing — the
+    operator-passed flags determine output destinations as before."""
+    from vaxrank.cli.entry_point import _auto_populate_output_paths_from_dir
+    args = SimpleNamespace(
+        output_dir='', input_lens=None, input_pvacseq=None,
+        output_csv='', output_json_file='')
+    _auto_populate_output_paths_from_dir(args)
+    assert args.output_csv == ''
+    assert args.output_json_file == ''
 
 
 # -- LENS antigen-source breakdown ordering ---------------------------

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -591,6 +591,29 @@ def _resolve_mhc_for_linker_optimizer(args):
             "inferred from the LENS / pVACseq report (%s).",
             len(alleles), ", ".join(sorted(set(alleles))[:5])
             + ("…" if len(set(alleles)) > 5 else ""))
+    # When alleles are available but no predictor was supplied,
+    # fall back to mhcflurry as a credible default. Rationale:
+    # mhcflurry is pip-installable, the same tool LENS frequently
+    # uses, and the optimizer needs *some* live MHC predictor to
+    # score chimeric k-mers — refusing to optimize because the
+    # operator didn't pick one is worse than optimizing against a
+    # reasonable default. Operator can override with
+    # ``--mhc-predictor`` to pick something else (netmhcpan, …).
+    if predictor is None and alleles is not None:
+        try:
+            from mhctools import MHCflurry
+            predictor = MHCflurry(alleles=alleles)
+            logger.info(
+                "Per-junction linker optimization: --mhc-predictor "
+                "not set; defaulting to mhcflurry (presentation "
+                "score) for the chimeric-k-mer ranking. Pass "
+                "--mhc-predictor to override.")
+        except (ImportError, ValueError, KeyError, OSError) as e:
+            # mhcflurry not installed, or its weights aren't on
+            # disk. Stay with predictor=None and let the warning
+            # block below fire.
+            logger.debug("mhcflurry default-load failed: %r", e)
+            predictor_err = predictor_err or e
     if predictor is None or alleles is None:
         # Targeted hints based on what's missing. Operator-friendly:
         # the previous code lumped both failure modes into one
@@ -807,6 +830,59 @@ def _emit_outputs(args, ranked, source):
         source, vaccine_types, fired)
 
 
+_AUTO_OUTPUT_FILENAMES = {
+    # Pipeline path → ranked-peptides CSV / JSON.
+    'pipeline': {
+        'output_csv': 'ranked_vaccine_peptides.csv',
+        'output_json_file': 'ranked_vaccine_peptides.json',
+    },
+    # External path → per-(peptide, allele) neoepitope CSV; no
+    # JSON dump (the LENS / pVACseq path doesn't build the rich
+    # in-memory result that ``--output-json-file`` serializes).
+    'external': {
+        'output_csv': 'neoepitope_predictions.csv',
+    },
+}
+
+
+def _auto_populate_output_paths_from_dir(args):
+    """When ``--output-dir`` is set and the per-format output flags
+    are not, default them to canonical filenames inside the
+    directory. Lets ``--output-dir DIR`` produce the full bundle
+    (FASTAs + manifest + ranked-peptides CSV + JSON) without making
+    the operator list every flag.
+
+    Source-aware filename pick: pipeline (VCF/BAM) writes
+    ``ranked_vaccine_peptides.{csv,json}``; LENS / pVACseq writes
+    ``neoepitope_predictions.csv`` (the per-(peptide, allele) report
+    that's the LENS path's natural rank-report shape).
+
+    Explicit ``--output-csv`` / ``--output-json-file`` always win;
+    we only fill when the attribute is empty / None.
+    """
+    output_dir = getattr(args, 'output_dir', '') or ''
+    if not output_dir:
+        return
+    source = (
+        'external'
+        if (getattr(args, 'input_lens', None)
+            or getattr(args, 'input_pvacseq', None))
+        else 'pipeline')
+    auto_paths = _AUTO_OUTPUT_FILENAMES[source]
+    filled = []
+    for attr, filename in auto_paths.items():
+        if not getattr(args, attr, ''):
+            path = os.path.join(output_dir, filename)
+            setattr(args, attr, path)
+            filled.append((attr, path))
+    if filled:
+        logger.info(
+            "Auto-populating output paths inside --output-dir (%s): %s. "
+            "Pass the explicit flag to override.",
+            output_dir,
+            ", ".join("%s -> %s" % (a, p) for a, p in filled))
+
+
 def configure_logging(args):
     logging.config.fileConfig(
         str(files('vaxrank').joinpath('logging.conf')),
@@ -890,6 +966,13 @@ def main(args_list=None):
     # logic lives in exactly one place.
     if getattr(args, 'manufacturability', None) is None:
         args.manufacturability = 'peptide' in _resolve_vaccine_types(args)
+    # When ``--output-dir`` is set, auto-fill the canonical
+    # CSV / JSON output paths inside the directory so a user
+    # who passes just ``--output-dir mydir/`` gets the full
+    # bundle (FASTAs + manifest + ranked-peptides CSV +
+    # JSON dump) without listing every flag. Explicit
+    # ``--output-csv`` / ``--output-json-file`` paths win.
+    _auto_populate_output_paths_from_dir(args)
     _log_args_summary(args)
 
     # Fail fast when no output path is set, *before* loading inputs or

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.18.0"
+__version__ = "2.19.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Two small UX wins from running 2.18.0 against Pt02:

1. **Default `mhcflurry` predictor for the per-junction linker optimizer** when `--mhc-predictor` isn't set but alleles are available. The optimizer needs *some* live MHC predictor to score chimeric k-mers — falling back to mhcflurry is friendlier than refusing to optimize. Operator-specified `--mhc-predictor` still wins.
2. **Auto-fill canonical CSV / JSON paths inside `--output-dir`** so `vaxrank --input-lens X --output-dir mydir/` writes the full bundle (FASTAs + manifest + CSV + JSON) without listing every output flag.

Source-aware filename pick:
- Pipeline (VCF/BAM): `ranked_vaccine_peptides.csv` + `ranked_vaccine_peptides.json`
- LENS / pVACseq: `neoepitope_predictions.csv` (per-(peptide, allele) — the LENS path's natural rank-report shape; JSON dump skipped since the LENS path doesn't build the rich in-memory result)

## Test plan

- [x] `./test.sh` — 728 passed, 0 failed
- New tests for both helpers: 6 cases covering pipeline / external / explicit-wins / no-output-dir / mhcflurry-default-loads / mhcflurry-default-unavailable
- [ ] CI green
- [ ] End-to-end smoke on Pt02 LENS to confirm

Bumps version to 2.19.0.