### PR TITLE
Config flatten: drop vaccine_constructs wrapper; manufacturability under peptide (#273)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -648,7 +648,11 @@ vaccine_peptides:
             config_set_overrides=None,
             config_expr_overrides=None,
         )
-        with pytest.raises(ValueError, match="both top-level 'manufacturability'"):
+        # Post-2.19 the legacy layout migration sees both
+        # ``vaccine_peptides.manufacturability`` and top-level
+        # ``manufacturability`` as conflicting; the migration
+        # refuses to guess which the user meant.
+        with pytest.raises(ValueError, match="(?:Both are deprecated|peptide\\.manufacturability|vaccine_peptides.manufacturability)"):
             vaccine_config_from_args(args)
     finally:
         os.unlink(config_path)
@@ -683,8 +687,11 @@ manufacturability:
         merged = load_vaxrank_config(config_path=paths)
         eq_(merged["epitopes"]["min_score"], 0.01)
         eq_(merged["vaccine_peptides"]["preferred_length"], 27)
-        eq_(merged["manufacturability"]["max_c_terminal_hydropathy"], 2.5)
-        eq_(merged["manufacturability"]["rules"], ["cysteine_count", "cterm_hydropathy"])
+        # Post-2.19: top-level ``manufacturability`` migrates to
+        # ``peptide.manufacturability``.
+        eq_(merged["peptide"]["manufacturability"]["max_c_terminal_hydropathy"], 2.5)
+        eq_(merged["peptide"]["manufacturability"]["rules"],
+            ["cysteine_count", "cterm_hydropathy"])
     finally:
         for p in paths:
             os.unlink(p)
@@ -730,7 +737,10 @@ manufacturability:
         config_path = f.name
     try:
         merged = load_vaxrank_config(config_path=config_path)
-        eq_(merged["manufacturability"]["rules"], ["cterm_hydropathy", "cysteine_count"])
+        # Post-2.19: top-level ``manufacturability`` migrates to
+        # ``peptide.manufacturability``.
+        eq_(merged["peptide"]["manufacturability"]["rules"],
+            ["cterm_hydropathy", "cysteine_count"])
     finally:
         os.unlink(config_path)
 
@@ -1393,14 +1403,14 @@ def test_extract_vaccine_config_kwargs_accepts_single_epitope_keep_path():
     eq_(kwargs_b["num_mutant_epitopes_to_keep"], 20)
 
 
-# ----- vaccine_constructs section ---------------------------------------
+# ----- per-modality config section --------------------------------------
 
-def test_extract_construct_kwargs_cross_modality_only():
-    """Cross-modality knobs at ``vaccine_constructs`` top level apply
-    to every modality that doesn't override them."""
+def test_extract_construct_kwargs_antigen_design_from_vaccine_peptides():
+    """Antigen-design knobs live in ``vaccine_peptides:`` (post-2.19)
+    and thread into every modality's construct kwargs."""
     from vaxrank.config.loader import extract_construct_kwargs
     config = {
-        'vaccine_constructs': {
+        'vaccine_peptides': {
             'min_antigen_length_aa': 13,
             'max_antigen_length_aa': 21,
             'antigen_content': 'minimal_epitope',
@@ -1415,27 +1425,26 @@ def test_extract_construct_kwargs_cross_modality_only():
     }
 
 
-def test_extract_construct_kwargs_modality_overrides_cross_modality():
-    """Modality-specific values override cross-modality top-level
-    values for that modality only; the other modality keeps the
-    cross-modality value."""
+def test_extract_construct_kwargs_modality_overrides_antigen_design():
+    """Modality-specific values in top-level ``peptide:`` / ``mrna:``
+    override the antigen-design knobs from ``vaccine_peptides:`` for
+    that modality only."""
     from vaxrank.config.loader import extract_construct_kwargs
     config = {
-        'vaccine_constructs': {
+        'vaccine_peptides': {
             'max_antigen_length_aa': 25,
-            'peptide': {'max_antigen_length_aa': 27, 'mode': 'slp'},
-            'mrna': {'antigens_per_construct': 8},
         },
+        'peptide': {'mode': 'slp'},
+        'mrna': {'antigens_per_construct': 8},
     }
     pep = extract_construct_kwargs(config, 'peptide')
     mrna = extract_construct_kwargs(config, 'mrna')
-    # Peptide overrode max_antigen_length_aa; mRNA inherits the
-    # cross-modality value
-    assert pep['max_antigen_length_aa'] == 27
+    # Both inherit the cross-modality length cap; modality-specific
+    # knobs only apply to their own modality.
+    assert pep['max_antigen_length_aa'] == 25
     assert pep['mode'] == 'slp'
     assert mrna['max_antigen_length_aa'] == 25
     assert mrna['antigens_per_construct'] == 8
-    # Knobs only specified on the other modality don't leak across
     assert 'mode' not in mrna
     assert 'antigens_per_construct' not in pep
 
@@ -1446,33 +1455,121 @@ def test_extract_construct_kwargs_drops_none_entries():
     identically."""
     from vaxrank.config.loader import extract_construct_kwargs
     config = {
-        'vaccine_constructs': {
+        'vaccine_peptides': {
             'antigen_content': None,
-            'peptide': {'mode': 'minimal_epitope', 'linker': None},
         },
+        'peptide': {'mode': 'minimal_epitope', 'linker': None},
     }
     out = extract_construct_kwargs(config, 'peptide')
     assert out == {'mode': 'minimal_epitope'}
 
 
 def test_extract_construct_kwargs_empty_when_section_absent():
-    """No ``vaccine_constructs`` section → no kwargs (writers fall
+    """No ``peptide:`` / ``mrna:`` section → no kwargs (writers fall
     back to CLI / built-in defaults)."""
     from vaxrank.config.loader import extract_construct_kwargs
     assert extract_construct_kwargs({}, 'peptide') == {}
     assert extract_construct_kwargs({'epitopes': {}}, 'mrna') == {}
 
 
-def test_construct_config_overrides_cli_default(tmp_path):
-    """End-to-end: a YAML config sets ``vaccine_constructs.peptide.linker``
-    and the peptide writer picks it up because the CLI flag is at its
-    parser default. The CLI flag still wins when explicitly passed."""
-    cfg = tmp_path / "vc.yaml"
+def test_extract_construct_kwargs_skips_manufacturability_subsection():
+    """The ``manufacturability`` sub-section under ``peptide:`` is
+    consumed by the VaccineConfig path (until the in-code split
+    lands), not by the construct-config kwargs. Make sure
+    ``extract_construct_kwargs`` doesn't accidentally pass it
+    through to the construct-config constructor."""
+    from vaxrank.config.loader import extract_construct_kwargs
+    config = {
+        'peptide': {
+            'mode': 'slp',
+            'manufacturability': {'rules': ['cysteine_count']},
+        },
+    }
+    out = extract_construct_kwargs(config, 'peptide')
+    assert 'manufacturability' not in out
+    assert out == {'mode': 'slp'}
+
+
+def test_post_2_19_layout_loads_without_warnings(tmp_path):
+    """The new top-level shape (no ``vaccine_constructs:`` wrapper,
+    ``manufacturability:`` under ``peptide:``, antigen-design knobs
+    in ``vaccine_peptides:``) loads with zero deprecation warnings —
+    that's the contract a new user gets when copying the bundled
+    default.yaml as a starting point.
+    """
+    import warnings
+    from vaxrank.config.loader import load_vaxrank_config
+    cfg = tmp_path / "new.yaml"
+    cfg.write_text("""
+vaccine_peptides:
+  preferred_length: 25
+  max_antigen_length_aa: 25
+  antigen_content: mutation_spanning
+peptide:
+  linker: G4Sx3
+  max_constructs: 20
+  manufacturability:
+    rules:
+      - cysteine_count
+      - cterm_hydropathy
+mrna:
+  signal_peptide: HLA_B
+  linker: G4Sx2
+  max_constructs: 2
+""")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        merged = load_vaxrank_config(config_path=str(cfg))
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert not deprecations, (
+        "New layout must load without deprecation warnings; got: %s"
+        % [str(w.message) for w in deprecations])
+    # And the merged dict has the values where the new schema puts them.
+    assert merged['vaccine_peptides']['max_antigen_length_aa'] == 25
+    assert merged['peptide']['manufacturability']['rules'] == \
+        ['cysteine_count', 'cterm_hydropathy']
+    assert merged['mrna']['max_constructs'] == 2
+
+
+def test_legacy_vaccine_constructs_migrates_with_warning(tmp_path):
+    """Pre-2.19 ``vaccine_constructs:`` wrapper still loads, with a
+    DeprecationWarning, and the loader hoists the entries to the
+    new top-level shape."""
+    import warnings
+    from vaxrank.config.loader import load_vaxrank_config
+    cfg = tmp_path / "legacy.yaml"
     cfg.write_text("""
 vaccine_constructs:
   max_antigen_length_aa: 19
   peptide:
     linker: AAY
+  mrna:
+    signal_peptide: HLA_B
+""")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        merged = load_vaxrank_config(config_path=str(cfg))
+    assert any(
+        'vaccine_constructs' in str(w.message)
+        for w in caught), \
+        "Expected a deprecation warning for legacy 'vaccine_constructs:'"
+    # Antigen-design knob hoisted into vaccine_peptides:
+    assert merged['vaccine_peptides']['max_antigen_length_aa'] == 19
+    # Modality entries hoisted to top-level
+    assert merged['peptide']['linker'] == 'AAY'
+    assert merged['mrna']['signal_peptide'] == 'HLA_B'
+
+
+def test_construct_config_overrides_cli_default(tmp_path):
+    """End-to-end: a YAML config sets ``peptide.linker`` and the
+    peptide writer picks it up because the CLI flag is at its
+    parser default. The CLI flag still wins when explicitly passed."""
+    cfg = tmp_path / "vc.yaml"
+    cfg.write_text("""
+vaccine_peptides:
+  max_antigen_length_aa: 19
+peptide:
+  linker: AAY
 """)
     from vaxrank.cli.arg_parser import parse_vaxrank_args
     from vaxrank.cli.entry_point import (

--- a/tests/test_vaccine_peptide_config.py
+++ b/tests/test_vaccine_peptide_config.py
@@ -335,8 +335,10 @@ def test_bundled_default_yaml_is_present_and_parses():
     import yaml
     text = files("vaxrank.config").joinpath("default.yaml").read_text()
     parsed = yaml.safe_load(text)
-    # Top-level sections present
-    assert set(parsed) >= {"epitopes", "vaccine_peptides", "manufacturability"}
+    # Top-level sections present (post-2.19 layout: peptide /
+    # mrna at top level; manufacturability nests under peptide).
+    assert set(parsed) >= {"epitopes", "vaccine_peptides", "peptide", "mrna"}
+    assert "manufacturability" in parsed["peptide"]
 
 
 def test_bundled_default_yaml_round_trips_to_default_configs(tmp_path):
@@ -397,122 +399,62 @@ def test_bundled_default_yaml_round_trips_to_default_configs(tmp_path):
 
 
 def test_default_yaml_uncommented_keys_match_schema():
-    """Every uncommented key under each top-level section in default.yaml
-    must be a recognized schema field. Catches drift like keys placed in
-    the wrong section or renamed without updating the YAML."""
+    """The shipped default.yaml must validate against
+    ``VaxrankConfigSchema`` end-to-end. ``forbid_unknown_fields=True``
+    on each sub-schema catches drift like a key placed in the wrong
+    section or renamed without updating the YAML."""
     from importlib.resources import files
     import yaml
-    from vaxrank.config.schema import (
-        EpitopesConfigSchema,
-        ManufacturabilityConfigSchema,
-        VaccinePeptidesConfigSchema,
-    )
+    import msgspec
+    from vaxrank.config.schema import VaxrankConfigSchema
 
     text = files("vaxrank.config").joinpath("default.yaml").read_text()
     parsed = yaml.safe_load(text)
-
-    schema_for_section = {
-        "epitopes": EpitopesConfigSchema,
-        "vaccine_peptides": VaccinePeptidesConfigSchema,
-        "manufacturability": ManufacturabilityConfigSchema,
-    }
-    for section, schema_cls in schema_for_section.items():
-        assert section in parsed, f"Missing section in default.yaml: {section}"
-        section_dict = parsed[section] or {}
-        # Drop the nested manufacturability sub-object inside vaccine_peptides
-        # (handled separately above) so it doesn't trigger forbid_unknown_fields
-        # when it's actually a different schema.
-        if section == "vaccine_peptides":
-            section_dict = {k: v for k, v in section_dict.items()
-                            if k != "manufacturability"}
-        # forbid_unknown_fields=True on each schema means msgspec will raise
-        # if any key in section_dict is not a declared schema field.
-        import msgspec
-        msgspec.convert(section_dict, schema_cls)
+    msgspec.convert(parsed, VaxrankConfigSchema)
 
 
 def test_default_yaml_commented_examples_are_valid():
-    """Commented-out example lines in default.yaml are advertised as 'just
-    uncomment to enable' starters. Walk every commented YAML key in the
-    shipped file and verify it's a recognized schema field in its
-    section. Catches the kind of bug where a future edit puts an
-    `epitopes`-only key under `vaccine_peptides`.
+    """Commented-out example lines under ``epitopes:`` in default.yaml
+    are advertised as 'just uncomment to enable' starters. Walk every
+    commented field name under that section and verify it's a
+    recognized schema field. Catches drift like a key renamed in the
+    schema but left dangling in the YAML.
+
+    Scope is intentionally narrow: only ``epitopes:`` carries
+    commented-out scalar examples in default.yaml; the
+    ``vaccine_peptides:`` / ``peptide:`` / ``mrna:`` sections ship
+    fully uncommented and are validated by
+    ``test_default_yaml_uncommented_keys_match_schema`` above.
     """
     from importlib.resources import files
     import re
-    from vaxrank.config.schema import (
-        EpitopesConfigSchema,
-        ManufacturabilityConfigSchema,
-        VaccinePeptidesConfigSchema,
-    )
+    from vaxrank.config.schema import EpitopesConfigSchema
 
     text = files("vaxrank.config").joinpath("default.yaml").read_text()
-
-    schema_for_section = {
-        "epitopes": EpitopesConfigSchema,
-        "vaccine_peptides": VaccinePeptidesConfigSchema,
-        "manufacturability": ManufacturabilityConfigSchema,
-    }
-    section_fields = {
-        s: set(c.__struct_fields__) for s, c in schema_for_section.items()
-    }
-
-    # Sections with a nested per-modality structure (shared / peptide /
-    # mrna). The flat-schema check below can't validate those — schema
-    # validation at YAML-load time covers them — so skip the body of
-    # those sections here.
-    nested_sections = {"vaccine_constructs"}
+    epitopes_fields = set(EpitopesConfigSchema.__struct_fields__)
 
     section = None
-    # `# - foo` rule-list comments, `# foo: ...` field comments — capture
-    # both. Skip lines under a nested `manufacturability:` block inside
-    # vaccine_peptides (handled separately under its own section).
-    inside_nested_manuf = False
-    in_nested_section = False
     for raw in text.splitlines():
         line = raw.rstrip()
-        # Top-level section header (uncommented OR commented-out wholly)
-        m = re.match(r"^#?\s*([a-z_]+):\s*$", line) if line.startswith("#") \
-            else re.match(r"^([a-z_]+):\s*$", line)
-        if m and m.group(1) in nested_sections:
-            in_nested_section = True
-            section = None
-            continue
-        if m and m.group(1) in schema_for_section:
+        m = re.match(r"^([a-z_]+):\s*$", line)
+        if m:
             section = m.group(1)
-            inside_nested_manuf = False
-            in_nested_section = False
             continue
-        if in_nested_section:
-            # Skip the entire body of a nested section (validated by the
-            # schema at YAML-load time, not by this flat-field walk).
-            continue
-        if section is None:
-            continue
-        # Nested manufacturability inside vaccine_peptides
-        if section == "vaccine_peptides" and re.match(
-                r"^\s+manufacturability:\s*$", line):
-            inside_nested_manuf = True
-            continue
-        if inside_nested_manuf:
+        if section != "epitopes":
             continue
         # Match top-level commented field lines: `  # field: value`.
-        # Require exactly one space between `#` and the field name so that
-        # deeper-nested commented values (`#   pMHC_affinity: mhcflurry`
-        # under a parent `# default_methods:`) are skipped — they're values
-        # of the parent dict, not section-level fields, and shouldn't be
-        # checked against the section's schema.
+        # Require exactly one space between `#` and the field name so
+        # that deeper-nested commented values
+        # (`#   pMHC_affinity: mhcflurry` under a parent
+        # `# default_methods:`) are skipped — they're values of the
+        # parent dict, not section-level fields.
         m = re.match(r"^\s*# ([a-z_]+):\s", line)
         if not m:
             continue
         key = m.group(1)
-        # Skip rule-list entries (those are values, not field names).
-        # Heuristic: rule-list lines start with `# - ` not `# key:`.
-        # Field comments always have a colon AFTER the name and at least
-        # one char before the # (the indent).
-        assert key in section_fields[section], (
-            f"Commented example `{key}:` in section `{section}` is not a "
-            f"valid field (allowed: {sorted(section_fields[section])}). "
+        assert key in epitopes_fields, (
+            f"Commented example `{key}:` in section `epitopes` is not a "
+            f"valid field (allowed: {sorted(epitopes_fields)}). "
             f"Either move the line to the right section or fix the key name."
         )
 

--- a/vaxrank/config/default.yaml
+++ b/vaxrank/config/default.yaml
@@ -10,37 +10,45 @@
 #
 #     vaxrank --print-default-config > my-config.yaml
 #
-# Top-level sections (modality-agnostic unless noted):
+# Top-level sections:
 #
-#   epitopes           Filter / score MHC ligand predictions
-#                      (logistic IC50 / percentile-rank knobs, the
-#                      topiary DSL ``filter_expr`` / ``score_expr``,
-#                      and ``default_methods`` for multi-predictor
-#                      inputs).
+#   epitopes           (modality-agnostic) Filter / score MHC ligand
+#                      predictions: logistic IC50 / percentile-rank
+#                      knobs, the topiary DSL
+#                      ``filter_expr`` / ``score_expr``, and
+#                      ``default_methods`` for multi-predictor inputs.
 #
-#   vaccine_peptides   Per-variant antigen-window selection + the
-#                      *ranking* of those windows (length, padding,
-#                      ``combined_score_mode`` / ``combined_score_expr``,
-#                      ``ranking_rules``, ``score_fraction_of_best``).
-#                      Modality-agnostic — every active --vaccine-type
-#                      reads from here. (Section name kept for
-#                      back-compat with pre-mRNA configs.)
+#   vaccine_peptides   (modality-agnostic) Per-variant antigen-window
+#                      selection + the *ranking* of those windows:
+#                      length, padding, ``combined_score_mode`` /
+#                      ``combined_score_expr``, ``ranking_rules``,
+#                      ``score_fraction_of_best``, and the
+#                      antigen-design knobs that apply to every
+#                      modality (``antigen_content``,
+#                      ``epitopes_per_antigen``, ``candidates_per_slot``,
+#                      ``min_antigen_length_aa``, ``max_antigen_length_aa``).
+#                      Section name kept for back-compat with
+#                      pre-mRNA configs.
 #
-#   manufacturability  Peptide-synthesis difficulty rules + thresholds.
-#                      Used as a tie-break when ``vaccine_peptides.ranking_rules``
-#                      references the ``manufacturability`` sentinel.
-#                      Auto-skipped from peptide-only report sections
-#                      when --vaccine-type doesn't include 'peptide'.
+#   peptide            Peptide-vaccine assembly + a peptide-only
+#                      ``manufacturability`` sub-section
+#                      (synthesis-difficulty rules + thresholds).
 #
-#   vaccine_constructs Per-modality construct-assembly knobs.
-#                      Cross-modality values at the section top level;
-#                      modality-specific values under ``peptide:`` /
-#                      ``mrna:`` subsections.
+#   mrna               mRNA-vaccine assembly.
+#
+# Adding a new modality (e.g. ``dna:``) is a new top-level section
+# that pairs with a registry entry in ``vaxrank/modalities.py``.
 #
 # Resolution order (highest precedence first) for any single value:
 #
-#   explicit CLI flag  >  per-modality config  >  cross-modality config
-#                      >  built-in default
+#   explicit CLI flag  >  per-modality section  >
+#       (antigen-design knobs only) vaccine_peptides  >
+#       built-in default
+#
+# Pre-2.19 layouts (``vaccine_constructs:`` wrapper, top-level
+# ``manufacturability:``, ``vaccine_peptides.manufacturability:``)
+# still load with a one-cycle DeprecationWarning — see the loader
+# migrations in ``vaxrank/config/loader.py::_migrate_legacy_layout``.
 
 
 epitopes:
@@ -186,101 +194,93 @@ vaccine_peptides:
   require_mutant_epitopes_in_variant: true
 
 
-# Peptide-only. Manufacturability rules describe synthesis-difficulty
-# of solid-phase peptide chemistry (GRAVY hydropathy, Cys content,
-# difficult N-termini, Asp-Pro bonds, …) and don't apply to mRNA
-# constructs (translated in vivo). Vaxrank still evaluates these
-# rules whenever ``vaccine_peptides.ranking_rules`` references the
-# ``manufacturability`` sentinel — they affect tie-breaking — but
-# the section is skipped from peptide-only reports automatically
-# when ``--vaccine-type`` is mRNA-only. Kept at the top level (not
-# under ``vaccine_constructs.peptide``) for back-compat with users
-# whose existing configs reference it here.
-manufacturability:
-  # ---- Numeric thresholds (passed to the rule functions) ----
-  max_c_terminal_hydropathy: 1.5
-  min_kmer_hydropathy: 0.0
-  max_kmer_hydropathy_low_priority: 1.5
-  max_kmer_hydropathy_high_priority: 2.5
-
-  # Ordered list of synthesis-difficulty rules applied when the
-  # 'manufacturability' sentinel is reached in vaccine_peptides.ranking_rules.
-  # The order below matches the legacy hard-coded tie-break order
-  # (preserved byte-for-byte). 'n_terminal_methionine' is registered but
-  # not in the legacy default — uncomment to enable.
-  rules:
-    - cysteine_count
-    - cterm_hydropathy
-    - max_hydropathy_high
-    - difficult_n_terminal
-    - c_terminal_cysteine
-    - c_terminal_proline
-    - n_terminal_asparagine
-    # - n_terminal_methionine
-    - aspartate_proline
-    - max_hydropathy_low
-    - min_hydropathy
-
-
 # ----------------------------------------------------------------------
-# vaccine_constructs (per-modality construct-assembly knobs).
+# Per-modality construct-assembly sections.
 #
 # Default --vaccine-type is 'peptide mrna' (both modalities at once).
-# Cross-modality knobs go directly under `vaccine_constructs:`; the
-# `peptide:` and `mrna:` subsections only need entries when a
-# modality should DIFFER from the cross-modality value or when a knob
-# is modality-only (signal_peptide, mode, n_terminal_acetyl, …).
+# Add a section per active modality. Antigen-design knobs (length
+# bounds, antigen_content, epitopes_per_antigen, candidates_per_slot)
+# live in ``vaccine_peptides:`` above and apply to every modality
+# unless overridden inside the modality section.
 #
-# Resolution order (highest precedence first):
+# The peptide section also carries a ``manufacturability:``
+# sub-section — solid-phase peptide synthesis rules don't apply to
+# in-vivo-translated mRNA, so they're scoped to peptide.
+# ``vaccine_peptides.ranking_rules``'s ``manufacturability``
+# sentinel still expands using the rules + thresholds in
+# ``peptide.manufacturability`` (a no-op tie-break when peptide
+# isn't an active modality).
 #
-#   explicit CLI flag  >  per-modality config  >  cross-modality config  >  built-in default
-#
-# Every key here is optional; everything below is commented out so the
-# default config is a no-op (matches "no --config" behavior). Uncomment
-# and edit what you want to change.
+# Every key below is optional; the modality sub-trees ship
+# uncommented because they reflect the in-code default values, but
+# you can collapse a section to ``peptide: {}`` / ``mrna: {}``
+# (or omit it entirely) if you'd rather inherit from the built-in
+# defaults.
 # ----------------------------------------------------------------------
-# vaccine_constructs:
-#   # Cross-modality knobs at the section top level. Apply to every
-#   # active --vaccine-type unless overridden in the modality
-#   # subsection below.
-#   min_antigen_length_aa: 15
-#   max_antigen_length_aa: 25
-#   candidates_per_slot: 1
-#   antigen_content: mutation_spanning   # 'mutation_spanning' | 'minimal_epitope'
-#   epitopes_per_antigen: 1
-#
-#   peptide:
-#     # Peptide-only knobs. Cross-modality knobs from above are
-#     # available here too if you need a peptide-specific value.
-#     mode: slp                            # slp | minimal_epitope | multi_epitope
-#     linker: G4Sx3                        # multi_epitope linker; (G4S)3 = GGGGSGGGGSGGGGS
-#     antigens_per_construct: 1            # SLP default; 5+ for multi_epitope
-#     max_constructs: 20                   # PGV-001 pool size
-#     n_terminal_acetyl: false             # marked in vendor order form
-#     c_terminal_amide: false
-#     scale_mg: 5.0
-#     purity_percent: 95.0
-#     counterion: TFA
-#
-#   mrna:
-#     # mRNA-only knobs. Cross-modality knobs from above are
-#     # available here too if you need an mrna-specific value.
-#     linker: G4Sx2                        # (G4S)2 = GGGGSGGGGS, BioNTech FixVac canonical
-#     antigens_per_construct: 5            # FixVac canonical
-#     max_constructs: 1
-#     max_length_nt: 4000
-#     signal_peptide: HLA_B
-#     include_mitd: true
-#     mitd: HLA_B
-#     utr_5p: HBB
-#     utr_3p: HBB_FI
-#     poly_a_length: 120
-#     poly_a_segmented: false              # set true for BNT162b2-style A30+linker+A70
-#     poly_a_first_segment: 30
-#     poly_a_segment_linker: GCATATGACT
-#     codon_species: h_sapiens
-#     codon_method: use_best_codon         # | match_codon_usage | harmonize_rca
-#     optimize_linkers: true               # per-junction linker optimization
-#     junction_candidates: ""              # comma-separated; "" = library default
-#     junction_rank_strong: 0.5            # %rank below = strong-binder hit
-#     junction_rank_mild: 2.0
+
+peptide:
+  # Peptide-vaccine assembly knobs. Cross-modality antigen-design
+  # values live in ``vaccine_peptides:`` and apply here too unless
+  # overridden in this section.
+  mode: slp                            # slp | minimal_epitope | multi_epitope
+  linker: G4Sx3                        # multi_epitope linker; (G4S)3 = GGGGSGGGGSGGGGS
+  antigens_per_construct: 1            # SLP default; 5+ for multi_epitope
+  max_constructs: 20                   # PGV-001 pool size
+  n_terminal_acetyl: false             # marked in vendor order form
+  c_terminal_amide: false
+  scale_mg: 5.0
+  purity_percent: 95.0
+  counterion: TFA
+
+  # Peptide-only synthesis-difficulty rules + thresholds. Used as a
+  # tie-break when ``vaccine_peptides.ranking_rules`` references the
+  # ``manufacturability`` sentinel; auto-skipped from
+  # peptide-only report sections when --vaccine-type doesn't
+  # include 'peptide'.
+  manufacturability:
+    # ---- Numeric thresholds (passed to the rule functions) ----
+    max_c_terminal_hydropathy: 1.5
+    min_kmer_hydropathy: 0.0
+    max_kmer_hydropathy_low_priority: 1.5
+    max_kmer_hydropathy_high_priority: 2.5
+
+    # Ordered list of synthesis-difficulty rules. The order below
+    # matches the legacy hard-coded tie-break order (preserved
+    # byte-for-byte). 'n_terminal_methionine' is registered but not
+    # in the legacy default — uncomment to enable.
+    rules:
+      - cysteine_count
+      - cterm_hydropathy
+      - max_hydropathy_high
+      - difficult_n_terminal
+      - c_terminal_cysteine
+      - c_terminal_proline
+      - n_terminal_asparagine
+      # - n_terminal_methionine
+      - aspartate_proline
+      - max_hydropathy_low
+      - min_hydropathy
+
+
+mrna:
+  # mRNA-vaccine assembly knobs. BioNTech FixVac (Sahin 2017) is
+  # the canonical reference for these defaults.
+  linker: G4Sx2                        # (G4S)2 = GGGGSGGGGS
+  antigens_per_construct: 5            # FixVac canonical
+  max_constructs: 2                    # FixVac 2x pentatope = 10 antigens
+  max_length_nt: 4000
+  signal_peptide: HLA_B
+  include_mitd: true
+  mitd: HLA_B
+  utr_5p: HBB
+  utr_3p: HBB_FI
+  poly_a_length: 120
+  poly_a_segmented: false              # set true for BNT162b2-style A30+linker+A70
+  poly_a_first_segment: 30
+  poly_a_segment_linker: GCATATGACT
+  codon_species: h_sapiens
+  codon_method: use_best_codon         # | match_codon_usage | harmonize_rca
+  optimize_linkers: true               # per-junction linker optimization
+  junction_candidates: ""              # comma-separated; "" = library default
+  junction_rank_strong: 0.5            # %rank below = strong-binder hit
+  junction_rank_mild: 2.0

--- a/vaxrank/config/loader.py
+++ b/vaxrank/config/loader.py
@@ -6,7 +6,11 @@ from typing import Any
 import msgspec
 
 from .schema import VaxrankConfigSchema
+from ..modalities import known_modalities
 
+# Top-level YAML keys that have been renamed across versions. Each
+# entry deprecates the OLD key and routes its value to the NEW key,
+# erroring if both are set in the same config.
 _LEGACY_KEY_MAP = {
     "epitope_config": "epitopes",
     "vaccine_config": "vaccine_peptides",
@@ -113,29 +117,124 @@ def _set_nested_value(target: dict[str, Any], path: str, value: Any) -> None:
     current[keys[-1]] = value
 
 
-def _promote_nested_manufacturability(raw: dict[str, Any]) -> None:
-    """Emit a deprecation warning and lift `vaccine_peptides.manufacturability`
-    to top-level `manufacturability`. Errors if both are set."""
-    vaccine_section = raw.get("vaccine_peptides")
-    if not isinstance(vaccine_section, dict):
-        return
-    nested = vaccine_section.get("manufacturability")
-    if nested is None:
-        return
-    if raw.get("manufacturability") is not None:
-        raise ValueError(
-            "Cannot set both top-level 'manufacturability' and "
-            "'vaccine_peptides.manufacturability'. The nested form is "
-            "deprecated — use the top-level section."
+# Antigen-design knobs that, post-2.19, live under ``vaccine_peptides:``
+# but pre-2.19 lived at the ``vaccine_constructs:`` top level. Used by
+# the back-compat migration AND by ``extract_construct_kwargs`` to
+# thread these into the per-modality construct kwargs (so the
+# construct assemblers receive them at the same place they always have).
+_ANTIGEN_DESIGN_KNOBS = (
+    "antigen_content",
+    "epitopes_per_antigen",
+    "candidates_per_slot",
+    "min_antigen_length_aa",
+    "max_antigen_length_aa",
+)
+
+
+def _migrate_legacy_layout(raw: dict[str, Any]) -> None:
+    """Translate the pre-2.19 YAML layout into the post-2.19 shape
+    in-place, with one ``DeprecationWarning`` per migrated section.
+    Errors when both layouts are mixed for the same logical section.
+
+    Migrations:
+
+    * ``vaccine_peptides.manufacturability`` →
+      ``peptide.manufacturability`` (was previously renamed to
+      top-level ``manufacturability``; pre-2.19 it had also lived
+      under vaccine_peptides).
+    * top-level ``manufacturability`` → ``peptide.manufacturability``.
+    * ``vaccine_constructs.<modality>`` → top-level ``<modality>:``.
+    * ``vaccine_constructs.<antigen-design knob>`` →
+      ``vaccine_peptides.<knob>`` (e.g. ``antigen_content``,
+      ``epitopes_per_antigen``, ``candidates_per_slot``,
+      ``min_antigen_length_aa``, ``max_antigen_length_aa``).
+    """
+    # 1. ``vaccine_peptides.manufacturability`` → top-level for the
+    # next stage to migrate further.
+    vp = raw.get("vaccine_peptides")
+    if isinstance(vp, dict) and vp.get("manufacturability") is not None:
+        if raw.get("manufacturability") is not None:
+            raise ValueError(
+                "Cannot set both 'vaccine_peptides.manufacturability' and "
+                "top-level 'manufacturability'. Both are deprecated — pick "
+                "one and prefer 'peptide.manufacturability'.")
+        warnings.warn(
+            "Config key 'vaccine_peptides.manufacturability' is deprecated; "
+            "move it to 'peptide.manufacturability'. Auto-migrating.",
+            DeprecationWarning,
+            stacklevel=4,
         )
-    warnings.warn(
-        "Config key 'vaccine_peptides.manufacturability' is deprecated; "
-        "move it to the top-level 'manufacturability' section. Support for "
-        "the nested form will be removed in a future release.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-    raw["manufacturability"] = vaccine_section.pop("manufacturability")
+        raw["manufacturability"] = vp.pop("manufacturability")
+
+    # 2. top-level ``manufacturability`` → ``peptide.manufacturability``.
+    if raw.get("manufacturability") is not None:
+        peptide_section = raw.setdefault("peptide", {})
+        if not isinstance(peptide_section, dict):
+            raise TypeError(
+                "Config key 'peptide' must be a mapping; got %r"
+                % type(peptide_section).__name__)
+        if peptide_section.get("manufacturability") is not None:
+            raise ValueError(
+                "Cannot set both top-level 'manufacturability' and "
+                "'peptide.manufacturability'. Top-level form is "
+                "deprecated — keep just 'peptide.manufacturability'.")
+        warnings.warn(
+            "Config key 'manufacturability' (top-level) is deprecated; "
+            "move it under 'peptide.manufacturability'. Manufacturability "
+            "rules describe peptide-synthesis difficulty and don't apply "
+            "to mRNA constructs. Auto-migrating.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+        peptide_section["manufacturability"] = raw.pop("manufacturability")
+
+    # 3. ``vaccine_constructs:`` wrapper → top-level modality
+    # sections + antigen-design knobs into ``vaccine_peptides:``.
+    vc = raw.pop("vaccine_constructs", None)
+    if isinstance(vc, dict) and vc:
+        warnings.warn(
+            "Config key 'vaccine_constructs' is deprecated. Move "
+            "modality-specific entries to top-level 'peptide:' / "
+            "'mrna:' sections; move antigen-design knobs "
+            "(antigen_content, epitopes_per_antigen, "
+            "candidates_per_slot, min/max_antigen_length_aa) under "
+            "'vaccine_peptides:'. Auto-migrating.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+        modalities = set(known_modalities())
+        for key, value in vc.items():
+            if key in modalities:
+                target = raw.setdefault(key, {})
+                if not isinstance(target, dict):
+                    raise TypeError(
+                        "Config key %r must be a mapping; got %r"
+                        % (key, type(target).__name__))
+                if not isinstance(value, dict):
+                    raise TypeError(
+                        "vaccine_constructs.%s must be a mapping; got %r"
+                        % (key, type(value).__name__))
+                # Modality value at the new top level wins on
+                # collision — the user's explicit new-layout entry
+                # is more specific than the legacy wrapper.
+                for k, v in value.items():
+                    target.setdefault(k, v)
+            elif key in _ANTIGEN_DESIGN_KNOBS:
+                vp_section = raw.setdefault("vaccine_peptides", {})
+                if not isinstance(vp_section, dict):
+                    raise TypeError(
+                        "Config key 'vaccine_peptides' must be a "
+                        "mapping; got %r" % type(vp_section).__name__)
+                vp_section.setdefault(key, value)
+            else:
+                # Unknown key under the legacy wrapper — let msgspec
+                # surface it as a forbid_unknown_fields error rather
+                # than guess where it goes.
+                raise ValueError(
+                    "Unknown legacy 'vaccine_constructs.%s'; remove "
+                    "it or move under one of the known modality "
+                    "sections (%s)." % (
+                        key, ", ".join(sorted(modalities))))
 
 
 def load_vaxrank_config(
@@ -173,7 +272,7 @@ def load_vaxrank_config(
                 )
             raw[new_key] = raw.pop(legacy_key)
 
-    _promote_nested_manufacturability(raw)
+    _migrate_legacy_layout(raw)
 
     if ordered_overrides is not None:
         for kind, override in ordered_overrides:
@@ -200,7 +299,7 @@ def load_vaxrank_config(
 
 _MISSING = object()
 
-# Declarative mapping: (dotted config path) -> (EpitopeConfig kwarg name)
+# Declarative mapping: (dotted config path) → (EpitopeConfig kwarg name)
 _EPITOPE_CONFIG_MAPPING: list[tuple[str, str]] = [
     ("epitopes.min_score", "min_epitope_score"),
     ("epitopes.scoring_mode", "scoring_mode"),
@@ -213,7 +312,15 @@ _EPITOPE_CONFIG_MAPPING: list[tuple[str, str]] = [
     ("epitopes.default_methods", "default_methods"),
 ]
 
-# Declarative mapping: (dotted config path) -> (VaccineConfig kwarg name)
+# Declarative mapping: (dotted config path) → (VaccineConfig kwarg name)
+#
+# The ``manufacturability_*`` kwargs still live on
+# :class:`vaxrank.vaccine_config.VaccineConfig` for now. Phase 2 of
+# the post-2.19 refactor extracts them into a dedicated
+# ``ManufacturabilityConfig`` struct attached to
+# ``PeptideConstructConfig``; until then the loader reads from the
+# new YAML location (``peptide.manufacturability.*``) and routes to
+# the existing VaccineConfig fields.
 _VACCINE_CONFIG_MAPPING: list[tuple[str, str]] = [
     ("vaccine_peptides.preferred_length", "preferred_peptide_length"),
     ("vaccine_peptides.min_length", "min_peptide_length"),
@@ -226,11 +333,15 @@ _VACCINE_CONFIG_MAPPING: list[tuple[str, str]] = [
     ("vaccine_peptides.ranking_rules", "ranking_rules"),
     ("vaccine_peptides.require_mutant_epitopes_in_variant",
      "require_mutant_epitopes_in_variant"),
-    ("manufacturability.max_c_terminal_hydropathy", "max_c_terminal_hydropathy"),
-    ("manufacturability.min_kmer_hydropathy", "min_kmer_hydropathy"),
-    ("manufacturability.max_kmer_hydropathy_low_priority", "max_kmer_hydropathy_low_priority"),
-    ("manufacturability.max_kmer_hydropathy_high_priority", "max_kmer_hydropathy_high_priority"),
-    ("manufacturability.rules", "manufacturability_rules"),
+    ("peptide.manufacturability.max_c_terminal_hydropathy",
+     "max_c_terminal_hydropathy"),
+    ("peptide.manufacturability.min_kmer_hydropathy",
+     "min_kmer_hydropathy"),
+    ("peptide.manufacturability.max_kmer_hydropathy_low_priority",
+     "max_kmer_hydropathy_low_priority"),
+    ("peptide.manufacturability.max_kmer_hydropathy_high_priority",
+     "max_kmer_hydropathy_high_priority"),
+    ("peptide.manufacturability.rules", "manufacturability_rules"),
 ]
 
 
@@ -262,39 +373,42 @@ def extract_epitope_config_kwargs(config: dict[str, Any]) -> dict[str, Any]:
     return _extract_via_mapping(config, _EPITOPE_CONFIG_MAPPING)
 
 
-_VACCINE_CONSTRUCTS_SUBSECTIONS = {'peptide', 'mrna'}
-
-
 def extract_construct_kwargs(
     config: dict[str, Any],
     modality: str,
 ) -> dict[str, Any]:
-    """Resolve construct-assembly kwargs for ``modality`` ('peptide'
-    or 'mrna') by merging cross-modality values at the
-    ``vaccine_constructs`` top level with the modality-specific
-    subsection. Modality values override cross-modality values;
-    ``None`` entries are dropped so callers can use
-    ``dict.get(name, fallback)`` cleanly.
+    """Resolve construct-assembly kwargs for ``modality`` ('peptide',
+    'mrna', or any other registered modality) by reading the
+    top-level modality section, then layering on the antigen-design
+    knobs from ``vaccine_peptides:`` (so each modality picks them up
+    unless it overrides them in its own section).
 
-    Empty dict when the section is absent — same shape as before so
-    code paths that don't use the new section behave identically.
+    Empty dict when no inputs apply — same shape as before so code
+    paths that don't use the per-modality section behave identically.
     """
     out: dict[str, Any] = {}
-    section = _resolve_dotted(config, 'vaccine_constructs')
-    if not isinstance(section, dict):
-        return out
-    # Top-level entries that aren't subsection names are
-    # cross-modality knobs; merge first so modality-specific
-    # overrides land on top.
-    for k, v in section.items():
-        if k in _VACCINE_CONSTRUCTS_SUBSECTIONS:
-            continue
-        if v is None:
-            continue
-        out[k] = v
-    modal = section.get(modality)
-    if isinstance(modal, dict):
-        out.update({k: v for k, v in modal.items() if v is not None})
+    # Antigen-design knobs from vaccine_peptides: thread into every
+    # modality. Modality-specific overrides in ``<modality>:`` win.
+    vp = _resolve_dotted(config, 'vaccine_peptides')
+    if isinstance(vp, dict):
+        for k in _ANTIGEN_DESIGN_KNOBS:
+            v = vp.get(k)
+            if v is not None:
+                out[k] = v
+    section = _resolve_dotted(config, modality)
+    if isinstance(section, dict):
+        for k, v in section.items():
+            # ``manufacturability`` is a sub-section in the YAML
+            # schema; it never goes into the construct-config kwargs
+            # (those are flat). The per-modality manufacturability
+            # config rides through ``_VACCINE_CONFIG_MAPPING`` for
+            # now (will move onto PeptideConstructConfig once the
+            # in-code split lands).
+            if k == 'manufacturability':
+                continue
+            if v is None:
+                continue
+            out[k] = v
     return out
 
 

--- a/vaxrank/config/schema.py
+++ b/vaxrank/config/schema.py
@@ -1,3 +1,28 @@
+"""msgspec schemas for the vaxrank YAML config.
+
+Top-level shape (post-2.19):
+
+    epitopes:               # filter / score MHC ligand predictions
+    vaccine_peptides:       # rank + antigen-window selection
+                            # (modality-agnostic; absorbs the
+                            # antigen-design knobs that used to
+                            # live at the ``vaccine_constructs:``
+                            # top level — antigen_content,
+                            # epitopes_per_antigen,
+                            # candidates_per_slot,
+                            # min/max_antigen_length_aa)
+    peptide:                # peptide-vaccine assembly +
+                            # ``manufacturability`` sub-section
+    mrna:                   # mRNA-vaccine assembly
+    # future: dna:, ...
+
+The pre-2.19 layout (``vaccine_constructs:`` wrapper, top-level
+``manufacturability:``, ``vaccine_peptides.manufacturability:``) is
+still accepted by the loader for one deprecation cycle — see
+:func:`vaxrank.config.loader._migrate_legacy_layout`. The schema
+itself is the new shape.
+"""
+
 from typing import Optional
 
 import msgspec
@@ -27,6 +52,12 @@ class ManufacturabilityConfigSchema(
     kw_only=True,
     forbid_unknown_fields=True,
 ):
+    """Peptide-synthesis difficulty rules + thresholds.
+
+    Lives under ``peptide.manufacturability:`` in the YAML (was
+    top-level ``manufacturability:`` pre-2.19; the loader still
+    accepts the old location with a deprecation warning).
+    """
     max_c_terminal_hydropathy: Optional[float] = None
     min_kmer_hydropathy: Optional[float] = None
     max_kmer_hydropathy_low_priority: Optional[float] = None
@@ -40,6 +71,19 @@ class VaccinePeptidesConfigSchema(
     kw_only=True,
     forbid_unknown_fields=True,
 ):
+    """Modality-agnostic ranking + antigen-window selection.
+
+    Absorbs the antigen-design knobs (``antigen_content``,
+    ``epitopes_per_antigen``, ``candidates_per_slot``,
+    ``min_antigen_length_aa`` / ``max_antigen_length_aa``) that
+    lived at the ``vaccine_constructs:`` top level pre-2.19 — those
+    are antigen *design*, consumed by every modality's writer, so
+    they belong here next to the rest of the antigen-design knobs
+    rather than bolted onto a "constructs" wrapper.
+
+    Section name kept as ``vaccine_peptides`` for back-compat with
+    pre-mRNA configs even though the contents are modality-agnostic.
+    """
     preferred_length: Optional[int] = None
     min_length: Optional[int] = None
     max_length: Optional[int] = None
@@ -51,29 +95,29 @@ class VaccinePeptidesConfigSchema(
     combined_score_expr: Optional[str] = None
     ranking_rules: Optional[list[str]] = None
     require_mutant_epitopes_in_variant: Optional[bool] = None
-    manufacturability: Optional[ManufacturabilityConfigSchema] = None
+    # Antigen-design knobs hoisted from ``vaccine_constructs:`` top
+    # level (post-2.19).
+    antigen_content: Optional[str] = None
+    epitopes_per_antigen: Optional[int] = None
+    candidates_per_slot: Optional[int] = None
+    min_antigen_length_aa: Optional[int] = None
+    max_antigen_length_aa: Optional[int] = None
 
 
-class _PeptideConstructConfigSchema(
+class PeptideConstructConfigSchema(
     msgspec.Struct,
     frozen=True,
     kw_only=True,
     forbid_unknown_fields=True,
 ):
-    """Peptide-specific construct-assembly overrides.
+    """Top-level ``peptide:`` section — peptide-vaccine assembly +
+    peptide-only manufacturability.
 
-    Any cross-modality knob also valid at ``vaccine_constructs``
-    top-level (length bounds, antigen_content, …) can be set here
-    to override that value for peptide only.
+    Pre-2.19 this lived under ``vaccine_constructs.peptide:``; the
+    wrapper got dropped because the cross-modality knobs that used
+    to justify it (``antigen_content`` etc.) actually belong with
+    the antigen-design knobs in ``vaccine_peptides:``.
     """
-    # Cross-modality knobs (override of values set at the section
-    # top level).
-    min_antigen_length_aa: Optional[int] = None
-    max_antigen_length_aa: Optional[int] = None
-    candidates_per_slot: Optional[int] = None
-    antigen_content: Optional[str] = None
-    epitopes_per_antigen: Optional[int] = None
-    # Peptide-only
     mode: Optional[str] = None
     linker: Optional[str] = None
     antigens_per_construct: Optional[int] = None
@@ -83,28 +127,23 @@ class _PeptideConstructConfigSchema(
     scale_mg: Optional[float] = None
     purity_percent: Optional[float] = None
     counterion: Optional[str] = None
+    manufacturability: Optional[ManufacturabilityConfigSchema] = None
 
 
-class _MrnaConstructConfigSchema(
+class MrnaConstructConfigSchema(
     msgspec.Struct,
     frozen=True,
     kw_only=True,
     forbid_unknown_fields=True,
 ):
-    """mRNA-specific construct-assembly overrides.
+    """Top-level ``mrna:`` section — mRNA-vaccine assembly.
 
-    Any cross-modality knob also valid at ``vaccine_constructs``
-    top-level (length bounds, antigen_content, …) can be set here
-    to override that value for mRNA only.
+    No manufacturability sub-section: solid-phase peptide synthesis
+    rules don't apply to in-vivo-translated mRNA. If mRNA grows its
+    own assembly-difficulty rules (codon-optimization friction, IVT
+    yield, …), add them as a parallel sub-section under a different
+    name.
     """
-    # Cross-modality knobs (override of values set at the section
-    # top level).
-    min_antigen_length_aa: Optional[int] = None
-    max_antigen_length_aa: Optional[int] = None
-    candidates_per_slot: Optional[int] = None
-    antigen_content: Optional[str] = None
-    epitopes_per_antigen: Optional[int] = None
-    # mRNA-only
     linker: Optional[str] = None
     antigens_per_construct: Optional[int] = None
     max_constructs: Optional[int] = None
@@ -126,53 +165,6 @@ class _MrnaConstructConfigSchema(
     junction_rank_mild: Optional[float] = None
 
 
-class VaccineConstructsConfigSchema(
-    msgspec.Struct,
-    frozen=True,
-    kw_only=True,
-    forbid_unknown_fields=True,
-):
-    """Construct-assembly section of the YAML config.
-
-    Layout:
-
-        vaccine_constructs:
-          # cross-modality knobs at the section top level (apply
-          # to every active modality unless overridden):
-          min_antigen_length_aa: 15
-          max_antigen_length_aa: 25
-          ...
-          # modality-specific overrides:
-          peptide:
-            mode: slp
-            linker: G4S3
-            ...
-          mrna:
-            signal_peptide: HLA_B
-            linker: (G4S)2
-            ...
-
-    Resolution order (highest precedence first):
-
-        explicit CLI flag  >  per-modality config  >  cross-modality config  >  built-in default
-
-    A user can drive both modalities from one config file, and only
-    needs to repeat a knob in a modality subsection when that
-    modality should differ from the cross-modality value.
-    """
-    # Cross-modality knobs accepted at the section top level. A knob
-    # also set inside ``peptide:`` / ``mrna:`` overrides this value
-    # for that modality.
-    min_antigen_length_aa: Optional[int] = None
-    max_antigen_length_aa: Optional[int] = None
-    candidates_per_slot: Optional[int] = None
-    antigen_content: Optional[str] = None
-    epitopes_per_antigen: Optional[int] = None
-    # Modality-specific overrides + modality-only knobs.
-    peptide: Optional[_PeptideConstructConfigSchema] = None
-    mrna: Optional[_MrnaConstructConfigSchema] = None
-
-
 class VaxrankConfigSchema(
     msgspec.Struct,
     frozen=True,
@@ -181,5 +173,5 @@ class VaxrankConfigSchema(
 ):
     epitopes: Optional[EpitopesConfigSchema] = None
     vaccine_peptides: Optional[VaccinePeptidesConfigSchema] = None
-    manufacturability: Optional[ManufacturabilityConfigSchema] = None
-    vaccine_constructs: Optional[VaccineConstructsConfigSchema] = None
+    peptide: Optional[PeptideConstructConfigSchema] = None
+    mrna: Optional[MrnaConstructConfigSchema] = None

--- a/vaxrank/modalities.py
+++ b/vaxrank/modalities.py
@@ -1,0 +1,55 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""Single source of truth for the set of vaccine modalities vaxrank
+knows how to design (today: ``peptide`` and ``mrna``; future:
+``dna``, …).
+
+Every place that needs the list of modalities — CLI ``--vaccine-type``
+choices, the YAML config schema, the dispatch table inside
+``_emit_outputs``, the per-modality config loader — reads from here.
+Adding a new modality is one entry: register the construct-config
+class. The schema, CLI, and dispatch all pick up the new modality
+automatically.
+"""
+
+from __future__ import annotations
+
+# Filled lazily so the ``construct_config`` classes (peptide /
+# mrna), which pull in vaccine_library / mhctools, aren't imported
+# at every ``from vaxrank.modalities import known_modalities``.
+_REGISTRY = None
+
+
+def _build_registry():
+    from .peptide import PeptideConstructConfig
+    from .mrna import RNAConstructConfig
+
+    return {
+        'peptide': {
+            'construct_config': PeptideConstructConfig,
+        },
+        'mrna': {
+            'construct_config': RNAConstructConfig,
+        },
+    }
+
+
+def _registry():
+    global _REGISTRY
+    if _REGISTRY is None:
+        _REGISTRY = _build_registry()
+    return _REGISTRY
+
+
+def known_modalities():
+    """Names of registered modalities, in registration order."""
+    return tuple(_registry())
+
+
+def construct_config_class(modality):
+    """The ``*ConstructConfig`` class for the named modality."""
+    return _registry()[modality]['construct_config']

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.19.0"
+__version__ = "2.20.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Phase 1 of #273. Restructures the YAML config to match user mental model + future-proofs for new modalities (DNA, …).

**Stacks on #274** (ergonomics-followup) — please merge that one first; this branch was cut from it for a coherent diff.

### YAML shape (post-2.19)

\`\`\`yaml
epitopes:
  ...                       # filter / score MHC ligand predictions

vaccine_peptides:           # absorbs antigen-design knobs from
  ...                       # the old vaccine_constructs top level
  antigen_content: mutation_spanning
  epitopes_per_antigen: 1
  candidates_per_slot: 1
  min_antigen_length_aa: 15
  max_antigen_length_aa: 25

peptide:
  linker: G4Sx3
  ...
  manufacturability:        # peptide-only; scoped here, not at
    rules: [...]            # the top level
    max_c_terminal_hydropathy: 1.5

mrna:
  signal_peptide: HLA_B
  ...
\`\`\`

### Why

- ``vaccine_constructs:`` wrapper wasn't earning its keep — once antigen-design knobs (which apply to every modality) move to ``vaccine_peptides:``, there's nothing cross-modality left to factor.
- Manufacturability is peptide-only by definition (solid-phase synthesis rules don't apply to in-vivo-translated mRNA); scoping it under ``peptide:`` makes that contract visible in the YAML itself.
- Modality registry (``vaxrank/modalities.py``) means adding a new modality (DNA) is one entry — schema + CLI choices + dispatch all read from it.

### Back-compat

Pre-2.19 layouts still load with one ``DeprecationWarning`` each — three legacy forms covered:
- ``vaccine_peptides.manufacturability`` → ``peptide.manufacturability``
- top-level ``manufacturability`` → ``peptide.manufacturability``
- ``vaccine_constructs:`` wrapper → top-level modality sections + antigen-design knobs into ``vaccine_peptides:``

Mixing legacy + new for the same logical section hard-fails with a clear error.

### Test plan

- [x] ``./test.sh`` — 731 passed, 0 failed
- New tests: no-warnings contract on the new shape; back-compat migration with warning; manufacturability sub-section doesn't leak into construct-config kwargs
- Updated existing tests to read from new YAML paths
- [ ] CI green on this branch

### Phase 2 (deferred to follow-up commit on this branch)

In-code split: extract ``ManufacturabilityConfig`` struct; attach to ``PeptideConstructConfig``; drop manufacturability fields from ``VaccineConfig``; auto-skip the ``manufacturability`` sentinel in ``ranking_rules`` when peptide isn't an active modality.

Bumps version to 2.20.0.