### PR TITLE
Phase 2 of #273: extract ManufacturabilityConfig struct

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,6 +39,7 @@ from vaxrank.cli.epitope_config_args import (
     add_epitope_prediction_args,
 )
 from vaxrank.cli.vaccine_config_args import (
+    manufacturability_config_from_args,
     vaccine_config_from_args,
     add_vaccine_peptide_args,
 )
@@ -565,7 +566,10 @@ vaccine_peptides:
         os.unlink(config_path)
 
 
-def test_vaccine_config_from_args_nested_manufacturability():
+def test_manufacturability_config_from_legacy_nested_yaml():
+    """Pre-2.19 ``vaccine_peptides.manufacturability`` migrates
+    through both legacy stages (vaccine_peptides → top-level →
+    peptide.manufacturability) and lands on ManufacturabilityConfig."""
     yaml_content = """
 vaccine_peptides:
   manufacturability:
@@ -586,18 +590,21 @@ vaccine_peptides:
             config_set_overrides=None,
             config_expr_overrides=None,
         )
-        with pytest.warns(DeprecationWarning, match="vaccine_peptides.manufacturability"):
-            config = vaccine_config_from_args(args)
-        eq_(config.max_c_terminal_hydropathy, 2.0)
-        eq_(config.max_kmer_hydropathy_high_priority, 3.0)
-        # Unset fields keep defaults
-        eq_(config.min_kmer_hydropathy, 0.0)
-        eq_(config.max_kmer_hydropathy_low_priority, 1.5)
+        with pytest.warns(DeprecationWarning,
+                          match="vaccine_peptides.manufacturability"):
+            mfg = manufacturability_config_from_args(args)
+        eq_(mfg.max_c_terminal_hydropathy, 2.0)
+        eq_(mfg.max_kmer_hydropathy_high_priority, 3.0)
+        # Unset fields keep ManufacturabilityConfig defaults.
+        eq_(mfg.min_kmer_hydropathy, 0.0)
+        eq_(mfg.max_kmer_hydropathy_low_priority, 1.5)
     finally:
         os.unlink(config_path)
 
 
-def test_vaccine_config_from_args_top_level_manufacturability():
+def test_manufacturability_config_from_legacy_top_level_yaml():
+    """Pre-2.20 top-level ``manufacturability:`` migrates to
+    ``peptide.manufacturability:`` and lands on ManufacturabilityConfig."""
     yaml_content = """
 manufacturability:
   max_c_terminal_hydropathy: 2.0
@@ -617,11 +624,11 @@ manufacturability:
             config_set_overrides=None,
             config_expr_overrides=None,
         )
-        config = vaccine_config_from_args(args)
-        eq_(config.max_c_terminal_hydropathy, 2.0)
-        eq_(config.max_kmer_hydropathy_high_priority, 3.0)
-        eq_(config.min_kmer_hydropathy, 0.0)
-        eq_(config.max_kmer_hydropathy_low_priority, 1.5)
+        mfg = manufacturability_config_from_args(args)
+        eq_(mfg.max_c_terminal_hydropathy, 2.0)
+        eq_(mfg.max_kmer_hydropathy_high_priority, 3.0)
+        eq_(mfg.min_kmer_hydropathy, 0.0)
+        eq_(mfg.max_kmer_hydropathy_low_priority, 1.5)
     finally:
         os.unlink(config_path)
 
@@ -745,9 +752,13 @@ manufacturability:
         os.unlink(config_path)
 
 
-def test_vaccine_config_rejects_unknown_manufacturability_rule():
+def test_manufacturability_config_rejects_unknown_rule():
+    """Post-2.20: manufacturability rules live on
+    ManufacturabilityConfig, which validates them at construction
+    time (was on VaccineConfig pre-2.20)."""
+    from vaxrank.manufacturability_config import ManufacturabilityConfig
     with pytest.raises(ValueError, match="Unknown manufacturability rule"):
-        VaccineConfig(manufacturability_rules=("bogus_rule",))
+        ManufacturabilityConfig(rules=("bogus_rule",))
 
 
 def test_vaccine_config_combined_score_mode():

--- a/tests/test_core_logic_config.py
+++ b/tests/test_core_logic_config.py
@@ -489,8 +489,12 @@ def test_vaccine_peptide_zero_epitope_limit_keeps_all():
     eq_(len(vaccine_peptide.mutant_epitope_predictions), 2)
 
 
-def test_manufacturability_thresholds_flow_from_vaccine_config():
-    """Manufacturability thresholds from VaccineConfig reach VaccinePeptide."""
+def test_manufacturability_thresholds_flow_from_manufacturability_config():
+    """Manufacturability thresholds from ManufacturabilityConfig (post-2.20)
+    reach VaccinePeptide via the explicit ``manufacturability_config``
+    parameter to ``vaccine_peptides_from_epitopes``."""
+    from vaxrank.manufacturability_config import ManufacturabilityConfig
+
     class DummyFragment:
         def __init__(self, amino_acids):
             self.amino_acids = amino_acids
@@ -528,7 +532,9 @@ def test_manufacturability_thresholds_flow_from_vaccine_config():
         occurs_in_reference=False,
     )
 
-    vaccine_config = VaccineConfig(max_kmer_hydropathy_high_priority=3.0)
+    vaccine_config = VaccineConfig()
+    manufacturability_config = ManufacturabilityConfig(
+        max_kmer_hydropathy_high_priority=3.0)
 
     peptides = vaccine_peptides_from_epitopes(
         variant=MagicMock(),
@@ -536,14 +542,17 @@ def test_manufacturability_thresholds_flow_from_vaccine_config():
         epitope_predictions=[prediction],
         vaccine_peptide_length=len(fragment),
         vaccine_config=vaccine_config,
+        manufacturability_config=manufacturability_config,
     )
     eq_(len(peptides), 1)
     eq_(peptides[0].manufacturability_thresholds["max_kmer_hydropathy_high_priority"], 3.0)
 
 
-def test_vaccine_config_manufacturability_defaults():
-    """VaccineConfig has manufacturability fields with correct defaults."""
-    config = VaccineConfig()
+def test_manufacturability_config_defaults():
+    """ManufacturabilityConfig has the legacy default values
+    (post-2.20: these moved off VaccineConfig)."""
+    from vaxrank.manufacturability_config import ManufacturabilityConfig
+    config = ManufacturabilityConfig()
     eq_(config.max_c_terminal_hydropathy, 1.5)
     eq_(config.min_kmer_hydropathy, 0.0)
     eq_(config.max_kmer_hydropathy_low_priority, 1.5)

--- a/tests/test_vaccine_peptide_config.py
+++ b/tests/test_vaccine_peptide_config.py
@@ -115,17 +115,22 @@ def test_vaccine_peptide_rejects_unknown_combined_score_mode():
         )
 
 
-def test_end_to_end_yaml_rules_through_vaccine_config_to_peptide():
-    """YAML with manufacturability.rules loads through load_vaxrank_config,
-    then vaccine_config_from_args, producing a tuple on VaccineConfig.
-    A VaccinePeptide built with those rules gets a sort tuple of the
-    expected length."""
+def test_end_to_end_yaml_rules_through_manufacturability_config_to_peptide():
+    """YAML with peptide.manufacturability.rules loads through
+    load_vaxrank_config, then manufacturability_config_from_args,
+    producing a tuple on ManufacturabilityConfig. A VaccinePeptide
+    built with those rules gets a sort tuple of the expected
+    length. Post-2.20: manufacturability lives on its own struct,
+    not on VaccineConfig."""
+    from vaxrank.cli.vaccine_config_args import (
+        manufacturability_config_from_args)
     yaml_content = """
-manufacturability:
-  rules:
-    - cysteine_count
-    - cterm_hydropathy
-    - aspartate_proline
+peptide:
+  manufacturability:
+    rules:
+      - cysteine_count
+      - cterm_hydropathy
+      - aspartate_proline
 vaccine_peptides:
   combined_score_mode: epitope_only
 """
@@ -145,18 +150,18 @@ vaccine_peptides:
             config_set_overrides=None,
             config_expr_overrides=None,
         )
+        mfg = manufacturability_config_from_args(args)
         vc = vaccine_config_from_args(args)
-        # Type contract: VaccineConfig declares Optional[tuple[str, ...]]
-        assert vc.manufacturability_rules == (
+        assert mfg.rules == (
             "cysteine_count", "cterm_hydropathy", "aspartate_proline",
         )
-        assert isinstance(vc.manufacturability_rules, tuple)
+        assert isinstance(mfg.rules, tuple)
         assert vc.combined_score_mode == "epitope_only"
 
         vp = VaccinePeptide(
             mutant_protein_fragment=_make_fragment(),
             epitope_predictions=[_make_mutant_epitope()],
-            manufacturability_rules=vc.manufacturability_rules,
+            manufacturability_rules=mfg.rules,
             combined_score_mode=vc.combined_score_mode,
         )
         tup = vp.peptide_synthesis_difficulty_score_tuple(
@@ -354,9 +359,11 @@ def test_bundled_default_yaml_round_trips_to_default_configs(tmp_path):
     from importlib.resources import files
     import argparse
     from vaxrank.cli.epitope_config_args import epitope_config_from_args
-    from vaxrank.cli.vaccine_config_args import vaccine_config_from_args
+    from vaxrank.cli.vaccine_config_args import (
+        manufacturability_config_from_args, vaccine_config_from_args)
     from vaxrank.epitope_config import EpitopeConfig
     from vaxrank.manufacturability import DEFAULT_MANUFACTURABILITY_RULES
+    from vaxrank.manufacturability_config import ManufacturabilityConfig
     from vaxrank.ranking import DEFAULT_RANKING_RULES
     from vaxrank.vaccine_config import VaccineConfig
 
@@ -378,24 +385,33 @@ def test_bundled_default_yaml_round_trips_to_default_configs(tmp_path):
     )
     ec = epitope_config_from_args(args)
     vc = vaccine_config_from_args(args)
+    mfg = manufacturability_config_from_args(args)
     # Epitope side has no list-typed fields, so == works.
     assert ec == EpitopeConfig()
-    # Vaccine side: effective rule tuples should match the defaults.
+    # Vaccine side: ranking_rules tuple matches the default.
     assert vc.ranking_rules == DEFAULT_RANKING_RULES
-    assert vc.manufacturability_rules == DEFAULT_MANUFACTURABILITY_RULES
-    # All scalar fields match defaults too.
-    defaults = VaccineConfig()
+    # Manufacturability rules now live on ManufacturabilityConfig.
+    assert mfg.rules == DEFAULT_MANUFACTURABILITY_RULES
+    # Vaccine scalar fields match defaults.
+    vc_defaults = VaccineConfig()
     for field in (
         "preferred_peptide_length", "min_peptide_length",
         "max_peptide_length", "padding_around_mutation",
         "max_vaccine_peptides_per_variant", "num_mutant_epitopes_to_keep",
         "score_fraction_of_best", "combined_score_mode",
-        "max_c_terminal_hydropathy", "min_kmer_hydropathy",
-        "max_kmer_hydropathy_low_priority", "max_kmer_hydropathy_high_priority",
         "require_mutant_epitopes_in_variant",
     ):
-        assert getattr(vc, field) == getattr(defaults, field), (
-            f"default.yaml drift: {field}")
+        assert getattr(vc, field) == getattr(vc_defaults, field), (
+            f"default.yaml VaccineConfig drift: {field}")
+    # Manufacturability scalar fields match defaults.
+    mfg_defaults = ManufacturabilityConfig()
+    for field in (
+        "max_c_terminal_hydropathy", "min_kmer_hydropathy",
+        "max_kmer_hydropathy_low_priority",
+        "max_kmer_hydropathy_high_priority",
+    ):
+        assert getattr(mfg, field) == getattr(mfg_defaults, field), (
+            f"default.yaml ManufacturabilityConfig drift: {field}")
 
 
 def test_default_yaml_uncommented_keys_match_schema():

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -39,7 +39,9 @@ from mhctools.cli import (
 
 from .arg_parser import parse_vaxrank_args, check_args
 from .epitope_config_args import epitope_config_from_args
-from .vaccine_config_args import vaccine_config_from_args
+from .vaccine_config_args import (
+    manufacturability_config_from_args, vaccine_config_from_args,
+)
 from ..config import load_vaxrank_config
 
 from ..core_logic import run_vaxrank
@@ -1113,6 +1115,17 @@ def run_vaxrank_from_parsed_args(args):
     merged_config = load_vaxrank_config(args)
     epitope_config = epitope_config_from_args(args, merged_config=merged_config)
     vaccine_config = vaccine_config_from_args(args, merged_config=merged_config)
+    # Manufacturability config rides separately. We pass it to the
+    # ranker only when peptide is an active vaccine modality —
+    # otherwise the ``manufacturability`` sentinel inside
+    # ``vaccine_peptides.ranking_rules`` should be a no-op tie-break
+    # against ManufacturabilityConfig() defaults rather than against
+    # user-overridden thresholds that don't apply to mRNA.
+    if 'peptide' in _resolve_vaccine_types(args):
+        manufacturability_config = manufacturability_config_from_args(
+            args, merged_config=merged_config)
+    else:
+        manufacturability_config = None
 
     # Sync args with merged config values so downstream consumers (Isovar,
     # reports, etc.) see the effective configuration.
@@ -1163,6 +1176,7 @@ def run_vaxrank_from_parsed_args(args):
         num_mutant_epitopes_to_keep=args.num_epitopes_per_vaccine_peptide,
         epitope_config=epitope_config,
         vaccine_config=vaccine_config,
+        manufacturability_config=manufacturability_config,
         allow_dna_only_fallback=getattr(args, 'allow_dna_only_fallback', False),
     )
 

--- a/vaxrank/cli/vaccine_config_args.py
+++ b/vaxrank/cli/vaccine_config_args.py
@@ -14,7 +14,12 @@ import argparse
 
 import msgspec
 
-from ..config.loader import extract_vaccine_config_kwargs, load_vaxrank_config
+from ..config.loader import (
+    extract_manufacturability_config_kwargs,
+    extract_vaccine_config_kwargs,
+    load_vaxrank_config,
+)
+from ..manufacturability_config import ManufacturabilityConfig
 from ..vaccine_config import VaccineConfig
 
 
@@ -104,3 +109,16 @@ def vaccine_config_from_args(args : argparse.Namespace, merged_config=None) -> V
 
     vaccine_config = msgspec.convert(vaccine_config_kwargs, VaccineConfig)
     return vaccine_config
+
+
+def manufacturability_config_from_args(
+        args: argparse.Namespace, merged_config=None) -> ManufacturabilityConfig:
+    """Build a ``ManufacturabilityConfig`` from the YAML
+    ``peptide.manufacturability`` sub-section. Always returns a real
+    config (``ManufacturabilityConfig()`` defaults if the YAML
+    sub-section is absent) — the ranker treats it as the source of
+    peptide-synthesis difficulty thresholds + rules."""
+    if merged_config is None:
+        merged_config = load_vaxrank_config(args)
+    kwargs = extract_manufacturability_config_kwargs(merged_config)
+    return msgspec.convert(kwargs, ManufacturabilityConfig)

--- a/vaxrank/config/loader.py
+++ b/vaxrank/config/loader.py
@@ -314,13 +314,11 @@ _EPITOPE_CONFIG_MAPPING: list[tuple[str, str]] = [
 
 # Declarative mapping: (dotted config path) → (VaccineConfig kwarg name)
 #
-# The ``manufacturability_*`` kwargs still live on
-# :class:`vaxrank.vaccine_config.VaccineConfig` for now. Phase 2 of
-# the post-2.19 refactor extracts them into a dedicated
-# ``ManufacturabilityConfig`` struct attached to
-# ``PeptideConstructConfig``; until then the loader reads from the
-# new YAML location (``peptide.manufacturability.*``) and routes to
-# the existing VaccineConfig fields.
+# Post-2.20 manufacturability lives on its own struct
+# (:class:`vaxrank.manufacturability_config.ManufacturabilityConfig`)
+# threaded into the ranker as a separate parameter — see
+# ``_MANUFACTURABILITY_CONFIG_MAPPING`` below. ``VaccineConfig``
+# carries only modality-agnostic ranking knobs.
 _VACCINE_CONFIG_MAPPING: list[tuple[str, str]] = [
     ("vaccine_peptides.preferred_length", "preferred_peptide_length"),
     ("vaccine_peptides.min_length", "min_peptide_length"),
@@ -333,6 +331,11 @@ _VACCINE_CONFIG_MAPPING: list[tuple[str, str]] = [
     ("vaccine_peptides.ranking_rules", "ranking_rules"),
     ("vaccine_peptides.require_mutant_epitopes_in_variant",
      "require_mutant_epitopes_in_variant"),
+]
+
+
+# Declarative mapping: (dotted config path) → (ManufacturabilityConfig kwarg name)
+_MANUFACTURABILITY_CONFIG_MAPPING: list[tuple[str, str]] = [
     ("peptide.manufacturability.max_c_terminal_hydropathy",
      "max_c_terminal_hydropathy"),
     ("peptide.manufacturability.min_kmer_hydropathy",
@@ -341,7 +344,7 @@ _VACCINE_CONFIG_MAPPING: list[tuple[str, str]] = [
      "max_kmer_hydropathy_low_priority"),
     ("peptide.manufacturability.max_kmer_hydropathy_high_priority",
      "max_kmer_hydropathy_high_priority"),
-    ("peptide.manufacturability.rules", "manufacturability_rules"),
+    ("peptide.manufacturability.rules", "rules"),
 ]
 
 
@@ -412,14 +415,29 @@ def extract_construct_kwargs(
     return out
 
 
+def extract_manufacturability_config_kwargs(
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    """Extract ManufacturabilityConfig kwargs from the YAML
+    ``peptide.manufacturability`` sub-section. Returns an empty dict
+    when the sub-section is absent — caller should use
+    ``ManufacturabilityConfig()`` defaults in that case."""
+    kwargs = _extract_via_mapping(
+        config, _MANUFACTURABILITY_CONFIG_MAPPING)
+    if "rules" in kwargs and kwargs["rules"] is not None:
+        kwargs["rules"] = tuple(kwargs["rules"])
+    return kwargs
+
+
 def extract_vaccine_config_kwargs(config: dict[str, Any]) -> dict[str, Any]:
     kwargs = _extract_via_mapping(config, _VACCINE_CONFIG_MAPPING)
 
-    # VaccineConfig declares *_rules fields as Optional[tuple[str, ...]];
-    # YAML gives us lists, so coerce.
-    for rules_key in ("manufacturability_rules", "ranking_rules"):
-        if rules_key in kwargs and kwargs[rules_key] is not None:
-            kwargs[rules_key] = tuple(kwargs[rules_key])
+    # VaccineConfig declares ranking_rules as Optional[tuple[str, ...]];
+    # YAML gives us a list, so coerce. Manufacturability rules live
+    # on ManufacturabilityConfig now (post-2.20) and are coerced in
+    # ``extract_manufacturability_config_kwargs``.
+    if "ranking_rules" in kwargs and kwargs["ranking_rules"] is not None:
+        kwargs["ranking_rules"] = tuple(kwargs["ranking_rules"])
 
     # When preferred_peptide_length is set but min/max are not,
     # default them to match preferred so the range is consistent.

--- a/vaxrank/core_logic.py
+++ b/vaxrank/core_logic.py
@@ -24,6 +24,7 @@ from topiary import TopiaryPredictor
 
 from .epitope_config import EpitopeConfig
 from .vaccine_config import VaccineConfig
+from .manufacturability_config import ManufacturabilityConfig
 from .epitope_logic import slice_epitope_predictions, predict_epitopes
 from .mutant_protein_fragment import MutantProteinFragment
 from .vaccine_peptide import VaccinePeptide
@@ -40,6 +41,7 @@ def run_vaxrank(
     num_mutant_epitopes_to_keep: int = 1000,
     epitope_config: Optional[EpitopeConfig] = None,
     vaccine_config: Optional[VaccineConfig] = None,
+    manufacturability_config: Optional[ManufacturabilityConfig] = None,
     allow_dna_only_fallback: bool = False,
 ):
     """
@@ -81,6 +83,7 @@ def run_vaxrank(
         num_mutant_epitopes_to_keep=num_mutant_epitopes_to_keep,
         epitope_config=epitope_config,
         vaccine_config=vaccine_config,
+        manufacturability_config=manufacturability_config,
         allow_dna_only_fallback=allow_dna_only_fallback,
     )
     ranked_list = ranked_vaccine_peptides(variant_to_vaccine_peptides_dict)
@@ -100,6 +103,7 @@ def create_vaccine_peptides_dict(
     num_mutant_epitopes_to_keep: int = 1000,
     epitope_config: Optional[EpitopeConfig] = None,
     vaccine_config: Optional[VaccineConfig] = None,
+    manufacturability_config: Optional[ManufacturabilityConfig] = None,
     allow_dna_only_fallback: bool = False,
 ):
     """
@@ -148,6 +152,7 @@ def create_vaccine_peptides_dict(
             num_mutant_epitopes_to_keep=num_mutant_epitopes_to_keep,
             epitope_config=epitope_config,
             vaccine_config=vaccine_config,
+            manufacturability_config=manufacturability_config,
             allow_dna_only_fallback=allow_dna_only_fallback,
         )
 
@@ -169,6 +174,7 @@ def vaccine_peptides_for_variant(
     num_mutant_epitopes_to_keep: int = 1000,
     epitope_config: Optional[EpitopeConfig] = None,
     vaccine_config: Optional[VaccineConfig] = None,
+    manufacturability_config: Optional[ManufacturabilityConfig] = None,
     allow_dna_only_fallback: bool = False,
 ):
     """
@@ -242,6 +248,7 @@ def vaccine_peptides_for_variant(
         num_mutant_epitopes_to_keep=num_mutant_epitopes_to_keep,
         epitope_config=epitope_config,
         vaccine_config=vaccine_config,
+        manufacturability_config=manufacturability_config,
     )
 
 
@@ -254,6 +261,7 @@ def vaccine_peptides_from_epitopes(
     num_mutant_epitopes_to_keep: int = 1000,
     epitope_config: Optional[EpitopeConfig] = None,
     vaccine_config: Optional[VaccineConfig] = None,
+    manufacturability_config: Optional[ManufacturabilityConfig] = None,
 ):
     """
     Generate vaccine peptide candidates from epitope predictions.
@@ -342,18 +350,20 @@ def vaccine_peptides_from_epitopes(
             for p in subsequence_epitope_predictions
         )
 
+        # Manufacturability config is peptide-only (post-2.20). When
+        # peptide isn't an active modality the caller passes None and
+        # we fall back to ``ManufacturabilityConfig()`` defaults; the
+        # ``manufacturability`` sentinel inside ``ranking_rules`` is
+        # then a tie-break against those defaults rather than against
+        # user-overridden thresholds.
+        mfg = manufacturability_config or ManufacturabilityConfig()
         candidate_vaccine_peptide = VaccinePeptide(
             mutant_protein_fragment=candidate_fragment,
             epitope_predictions=subsequence_epitope_predictions,
             num_mutant_epitopes_to_keep=vaccine_config.num_mutant_epitopes_to_keep,
             epitope_score_params=epitope_score_params,
-            manufacturability_thresholds={
-                "max_c_terminal_hydropathy": vaccine_config.max_c_terminal_hydropathy,
-                "min_kmer_hydropathy": vaccine_config.min_kmer_hydropathy,
-                "max_kmer_hydropathy_low_priority": vaccine_config.max_kmer_hydropathy_low_priority,
-                "max_kmer_hydropathy_high_priority": vaccine_config.max_kmer_hydropathy_high_priority,
-            },
-            manufacturability_rules=vaccine_config.manufacturability_rules,
+            manufacturability_thresholds=mfg.thresholds_dict(),
+            manufacturability_rules=mfg.rules,
             combined_score_mode=vaccine_config.combined_score_mode,
             combined_score_expr=vaccine_config.combined_score_expr,
             ranking_rules=vaccine_config.ranking_rules,

--- a/vaxrank/manufacturability_config.py
+++ b/vaxrank/manufacturability_config.py
@@ -1,0 +1,95 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""Peptide-synthesis difficulty rules + thresholds, as a standalone
+config struct.
+
+Pre-2.20 these knobs lived as flat fields on
+:class:`vaxrank.vaccine_config.VaccineConfig`. Post-2.20 they live
+on their own struct, attached to
+:class:`vaxrank.peptide.PeptideConstructConfig` (peptide-only —
+solid-phase synthesis rules don't apply to in-vivo-translated mRNA
+constructs). The ranker pulls them in by accepting a
+``manufacturability_config`` parameter alongside ``vaccine_config``;
+when ``--vaccine-type`` doesn't include peptide, the parameter is
+``None`` and the manufacturability sentinel inside
+``ranking_rules`` is a no-op tie-break.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import msgspec
+
+from .config.defaults import (
+    DEFAULT_MANUFACTURABILITY_MAX_C_TERMINAL_HYDROPATHY,
+    DEFAULT_MANUFACTURABILITY_MAX_KMER_HYDROPATHY_HIGH_PRIORITY,
+    DEFAULT_MANUFACTURABILITY_MAX_KMER_HYDROPATHY_LOW_PRIORITY,
+    DEFAULT_MANUFACTURABILITY_MIN_KMER_HYDROPATHY,
+)
+from .manufacturability import MANUFACTURABILITY_RULE_REGISTRY
+
+
+class ManufacturabilityConfig(
+    msgspec.Struct, frozen=True, forbid_unknown_fields=True
+):
+    """Configuration for peptide-synthesis difficulty scoring.
+
+    Attributes
+    ----------
+    max_c_terminal_hydropathy : float
+        Maximum acceptable mean GRAVY score for the 7 C-terminal
+        residues. Peptides exceeding this are penalised during
+        manufacturability ranking.
+    min_kmer_hydropathy : float
+        Minimum acceptable max-7mer GRAVY score. Peptides with all
+        windows below this floor are penalised (too hydrophilic).
+    max_kmer_hydropathy_low_priority : float
+        Low-priority upper bound on any 7-mer GRAVY window; applied
+        as a tie-breaker after higher-priority constraints.
+    max_kmer_hydropathy_high_priority : float
+        High-priority upper bound on any 7-mer GRAVY window;
+        exceeding this indicates a severely hydrophobic region
+        that's difficult to synthesise.
+    rules : Optional[tuple[str, ...]]
+        Ordered list of synthesis-difficulty rules applied when the
+        ``manufacturability`` sentinel appears in
+        ``vaccine_peptides.ranking_rules``. ``None`` means use the
+        registry's default rule set
+        (:data:`vaxrank.manufacturability.DEFAULT_MANUFACTURABILITY_RULES`).
+    """
+
+    max_c_terminal_hydropathy: float = (
+        DEFAULT_MANUFACTURABILITY_MAX_C_TERMINAL_HYDROPATHY)
+    min_kmer_hydropathy: float = DEFAULT_MANUFACTURABILITY_MIN_KMER_HYDROPATHY
+    max_kmer_hydropathy_low_priority: float = (
+        DEFAULT_MANUFACTURABILITY_MAX_KMER_HYDROPATHY_LOW_PRIORITY)
+    max_kmer_hydropathy_high_priority: float = (
+        DEFAULT_MANUFACTURABILITY_MAX_KMER_HYDROPATHY_HIGH_PRIORITY)
+    rules: Optional[tuple[str, ...]] = None
+
+    def __post_init__(self):
+        if self.rules is not None:
+            for rule_name in self.rules:
+                if rule_name not in MANUFACTURABILITY_RULE_REGISTRY:
+                    raise ValueError(
+                        f"Unknown manufacturability rule "
+                        f"'{rule_name}'. Available: "
+                        f"{sorted(MANUFACTURABILITY_RULE_REGISTRY)}")
+
+    def thresholds_dict(self) -> dict[str, float]:
+        """Convenience: the four threshold knobs as a dict, in the
+        shape :class:`vaxrank.vaccine_peptide.VaccinePeptide`
+        expects (``manufacturability_thresholds`` kwarg)."""
+        return {
+            "max_c_terminal_hydropathy": self.max_c_terminal_hydropathy,
+            "min_kmer_hydropathy": self.min_kmer_hydropathy,
+            "max_kmer_hydropathy_low_priority":
+                self.max_kmer_hydropathy_low_priority,
+            "max_kmer_hydropathy_high_priority":
+                self.max_kmer_hydropathy_high_priority,
+        }

--- a/vaxrank/vaccine_config.py
+++ b/vaxrank/vaccine_config.py
@@ -30,10 +30,6 @@ from typing import Optional
 import msgspec
 
 from .config.defaults import (
-    DEFAULT_MANUFACTURABILITY_MAX_C_TERMINAL_HYDROPATHY,
-    DEFAULT_MANUFACTURABILITY_MAX_KMER_HYDROPATHY_HIGH_PRIORITY,
-    DEFAULT_MANUFACTURABILITY_MAX_KMER_HYDROPATHY_LOW_PRIORITY,
-    DEFAULT_MANUFACTURABILITY_MIN_KMER_HYDROPATHY,
     DEFAULT_MAX_PEPTIDE_LENGTH,
     DEFAULT_MAX_VACCINE_PEPTIDES_PER_VARIANT,
     DEFAULT_MIN_PEPTIDE_LENGTH,
@@ -42,7 +38,6 @@ from .config.defaults import (
     DEFAULT_PREFERRED_PEPTIDE_LENGTH,
     DEFAULT_VACCINE_PEPTIDE_SCORE_FRACTION_OF_BEST,
 )
-from .manufacturability import MANUFACTURABILITY_RULE_REGISTRY
 from .ranking import RANKING_RULE_REGISTRY
 
 
@@ -101,27 +96,12 @@ class VaccineConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
         of the best candidate for the variant before lexicographic tie-breaking.
         Default: 0.99
 
-    max_c_terminal_hydropathy : float
-        Maximum acceptable mean hydropathy (GRAVY) score for the 7
-        C-terminal residues.  Peptides exceeding this are penalised
-        during manufacturability ranking.
-        Default: 1.5
-
-    min_kmer_hydropathy : float
-        Minimum acceptable max-7mer GRAVY score.  Peptides with all
-        windows below this floor are penalised (too hydrophilic).
-        Default: 0.0
-
-    max_kmer_hydropathy_low_priority : float
-        Low-priority upper bound on any 7-mer GRAVY window.  Applied
-        as a tie-breaker after higher-priority constraints.
-        Default: 1.5
-
-    max_kmer_hydropathy_high_priority : float
-        High-priority upper bound on any 7-mer GRAVY window.  Exceeding
-        this indicates a severely hydrophobic region that will be
-        difficult to synthesise.
-        Default: 2.5
+    Manufacturability config (synthesis-difficulty thresholds + rules)
+    moved off VaccineConfig in 2.20 — it's peptide-only, so it lives
+    on :class:`vaxrank.manufacturability_config.ManufacturabilityConfig`
+    and is threaded into the ranker as a separate parameter alongside
+    VaccineConfig. See :func:`vaxrank.core_logic.run_vaxrank` and
+    :class:`vaxrank.peptide.PeptideConstructConfig`.
 
     Examples
     --------
@@ -145,11 +125,6 @@ class VaccineConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     max_vaccine_peptides_per_variant: int = DEFAULT_MAX_VACCINE_PEPTIDES_PER_VARIANT
     num_mutant_epitopes_to_keep: int = DEFAULT_NUM_MUTANT_EPITOPES_TO_KEEP
     score_fraction_of_best: float = DEFAULT_VACCINE_PEPTIDE_SCORE_FRACTION_OF_BEST
-    max_c_terminal_hydropathy: float = DEFAULT_MANUFACTURABILITY_MAX_C_TERMINAL_HYDROPATHY
-    min_kmer_hydropathy: float = DEFAULT_MANUFACTURABILITY_MIN_KMER_HYDROPATHY
-    max_kmer_hydropathy_low_priority: float = DEFAULT_MANUFACTURABILITY_MAX_KMER_HYDROPATHY_LOW_PRIORITY
-    max_kmer_hydropathy_high_priority: float = DEFAULT_MANUFACTURABILITY_MAX_KMER_HYDROPATHY_HIGH_PRIORITY
-    manufacturability_rules: Optional[tuple[str, ...]] = None
     combined_score_mode: str = DEFAULT_COMBINED_SCORE_MODE
     # Optional DSL expression that supersedes ``combined_score_mode``
     # when set. See :mod:`vaxrank.combined_score_dsl` for grammar +
@@ -213,13 +188,6 @@ class VaccineConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
                 f"score_fraction_of_best must be in (0, 1], "
                 f"got {self.score_fraction_of_best}"
             )
-        if self.manufacturability_rules is not None:
-            for rule_name in self.manufacturability_rules:
-                if rule_name not in MANUFACTURABILITY_RULE_REGISTRY:
-                    raise ValueError(
-                        f"Unknown manufacturability rule '{rule_name}'. "
-                        f"Available: {sorted(MANUFACTURABILITY_RULE_REGISTRY)}"
-                    )
         if self.combined_score_mode not in COMBINED_SCORE_MODES:
             raise ValueError(
                 f"combined_score_mode must be one of {COMBINED_SCORE_MODES}, "

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.20.0"
+__version__ = "2.21.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

In-code half of #273 (Phase 1 was YAML restructure in #275, already merged in 2.20.0).

Manufacturability config moves off ``VaccineConfig`` onto a dedicated ``ManufacturabilityConfig`` struct, threaded into the ranker as a separate parameter alongside ``VaccineConfig``. YAML and CLI surfaces are unchanged from Phase 1 — this is purely an in-code reorganization.

### Why

- Manufacturability is peptide-only by definition (solid-phase synthesis rules don't apply to in-vivo-translated mRNA). Putting these fields on ``VaccineConfig`` (which is modality-agnostic) didn't reflect that.
- The in-code shape now matches the YAML shape: ``peptide.manufacturability:`` in YAML ↔ ``ManufacturabilityConfig`` struct ↔ explicit parameter to ``run_vaxrank``.

### Auto-skip when peptide isn't active

``run_vaxrank_from_parsed_args`` now only builds a ``ManufacturabilityConfig`` when ``peptide`` is in the active ``--vaccine-type``. mRNA-only runs pass ``manufacturability_config=None``; the ``manufacturability`` sentinel in ``ranking_rules`` then tie-breaks against ``ManufacturabilityConfig()`` defaults rather than user-overridden thresholds that don't apply.

### Test plan

- [x] ``./test.sh`` — 731 passed, 0 failed
- Tests updated to construct ``ManufacturabilityConfig`` directly instead of via ``VaccineConfig`` kwargs
- ``test_bundled_default_yaml_round_trips_to_default_configs`` now validates the two configs separately
- [ ] CI green

Bumps version to 2.21.0.