### PR TITLE
ProcessingPrediction split (#272)

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -91,7 +91,7 @@ def test_annotate_processing_attaches_continuous_scores():
              0.10, 0.20, 0.05, 0.50, 0.30, 0.85,   # peptide positions 4-9
              0.0, 0.0, 0.0, 0.0]
     pred = _ep("KLMNPV", source, offset=4)
-    n = annotate_processing(
+    n, _ = annotate_processing(
         [pred], predictor=StubPepsickle({source: probs}))
     assert n == 1
     # C-term = probs at index 9 = 0.85 (clean release)
@@ -104,6 +104,35 @@ def test_annotate_processing_attaches_continuous_scores():
     import math
     assert abs(pred.pepsickle_processing_score
                - math.sqrt(0.85 * 0.50)) < 1e-9
+
+
+def test_annotate_processing_returns_processing_prediction_map():
+    """Post-2.22 ``annotate_processing`` returns a tuple of
+    ``(n_annotated, processing_predictions_by_key)`` — the map is
+    the canonical record (decoupled from EpitopePrediction).
+    Each entry is a ``ProcessingPrediction`` keyed on
+    ``(peptide, source, predictor_name)``."""
+    from vaxrank.processing_prediction import ProcessingPrediction
+    source = "AAAAKLMNPVAAAA"
+    probs = [0.0] * 4 + [0.10, 0.20, 0.05, 0.50, 0.30, 0.85] + [0.0] * 4
+    pred = _ep("KLMNPV", source, offset=4)
+    n, by_key = annotate_processing(
+        [pred], predictor=StubPepsickle({source: probs}))
+    assert n == 1
+    # Map carries one ProcessingPrediction keyed on
+    # (peptide, source, 'pepsickle').
+    assert len(by_key) == 1
+    key = ('KLMNPV', source, 'pepsickle')
+    assert key in by_key
+    pp = by_key[key]
+    assert isinstance(pp, ProcessingPrediction)
+    assert pp.peptide_sequence == 'KLMNPV'
+    assert pp.source_sequence == source
+    assert pp.predictor_name == 'pepsickle'
+    assert abs(pp.c_term_cleavage_prob - 0.85) < 1e-9
+    assert abs(pp.max_internal_cut_prob - 0.50) < 1e-9
+    # Same processing_score as the in-place mutation.
+    assert pp.processing_score == pred.pepsickle_processing_score
 
 
 def test_annotate_processing_one_pass_per_unique_source():
@@ -132,7 +161,7 @@ def test_annotate_processing_skips_predictions_without_source():
     """Predictions with empty source_sequence are passed through
     untouched (annotation requires a source to slice probs against)."""
     pred = _ep("KLMNPV", source="", offset=0)
-    n = annotate_processing(
+    n, _ = annotate_processing(
         [pred], predictor=StubPepsickle({}))
     assert n == 0
     assert pred.pepsickle_c_term_cleavage_prob is None
@@ -149,7 +178,7 @@ def test_annotate_processing_relocates_peptide_when_offset_off():
     probs = [0.0, 0.0, 0.0,   # 0-2
              0.10, 0.20, 0.05, 0.50, 0.30, 0.95,   # peptide at 3-8
              0.0, 0.0, 0.0]
-    n = annotate_processing(
+    n, _ = annotate_processing(
         [pred], predictor=StubPepsickle({source: probs}))
     assert n == 1
     # C-term should pick up probs[8] = 0.95 (re-located, not probs[1+5]=0.05)
@@ -188,7 +217,7 @@ def test_annotate_processing_predictor_failure_degrades_gracefully():
             return [0.5] * len(sequence)
     pred_ok = _ep("AAAAA", "AAAAAAAAAA", offset=2)
     pred_fail = _ep("FFFFF", "FFAILFFFFFF", offset=0)
-    n = annotate_processing(
+    n, _ = annotate_processing(
         [pred_ok, pred_fail], predictor=FlakyPredictor())
     # Only the OK one annotated; the failing source skipped, no crash.
     assert n == 1
@@ -197,7 +226,7 @@ def test_annotate_processing_predictor_failure_degrades_gracefully():
 
 
 def test_annotate_processing_empty_input_returns_zero():
-    n = annotate_processing([], predictor=StubPepsickle({}))
+    n, _ = annotate_processing([], predictor=StubPepsickle({}))
     assert n == 0
 
 
@@ -440,7 +469,7 @@ def test_warns_when_peptide_not_in_pep_context(caplog):
     source = "AAAAKLMNPVAAAA"
     pred = _ep("KLMXPV", source, offset=4)
     with caplog.at_level(logging.WARNING):
-        n = annotate_processing(
+        n, _ = annotate_processing(
             [pred],
             predictor=StubPepsickle({source: [0.5] * len(source)}))
     assert n == 0

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -179,7 +179,7 @@ def _annotate_predictions_with_processing(ranked_vaccine_peptides,
     for p in (lens_predictions or []):
         _maybe_add(p)
     if not all_predictions:
-        return 0
+        return 0, {}
     return annotate_processing(
         all_predictions, human_only=human_only, threshold=threshold)
 

--- a/vaxrank/processing.py
+++ b/vaxrank/processing.py
@@ -12,18 +12,18 @@
 
 """Proteasomal cleavage credibility tagging for MHC ligand predictions.
 
-For each predicted MHC ligand, attach three scores. All three carry
-the ``pepsickle_`` prefix so the predictor is unambiguous in CSVs,
-log lines, and report columns; a future per-position cleavage
-predictor (NetChop, PAProC, …) can land alongside without colliding.
+For each predicted MHC ligand, build a
+:class:`vaxrank.processing_prediction.ProcessingPrediction` record
+keyed on ``(peptide, source_sequence, predictor_name)``. Each carries
+three scores:
 
-  pepsickle_c_term_cleavage_prob    pepsickle's probability the
+  c_term_cleavage_prob              pepsickle's probability the
                                     proteasome cuts at the ligand's
                                     C-terminus (clean release)
-  pepsickle_max_internal_cut_prob   peak cleavage probability strictly
+  max_internal_cut_prob             peak cleavage probability strictly
                                     inside the ligand (high → ligand
                                     is destroyed before reaching MHC)
-  pepsickle_processing_score        composite ``sqrt(c_term *
+  processing_score                  composite ``sqrt(c_term *
                                     (1 - max_internal))`` — the
                                     geometric mean of the two factors;
                                     1.0 = ideal release, 0.0 = no
@@ -32,6 +32,17 @@ predictor (NetChop, PAProC, …) can land alongside without colliding.
                                     rather than the raw product so
                                     a balanced (0.6, 0.6) row scores
                                     ~0.6 instead of 0.36.
+
+``ProcessingPrediction`` is the canonical record post-2.22 (see
+:mod:`vaxrank.processing_prediction`). Pre-2.22 vaxrank annotated
+``EpitopePrediction`` objects in place with ``pepsickle_*`` fields
+— that conflated MHC-binding and processing predictions, which are
+on different axes (binding has an allele dimension; processing
+doesn't). The legacy in-place mutation is preserved for one
+deprecation cycle so existing report writers keep rendering;
+:func:`annotate_processing` returns a map of
+``(peptide, source, predictor_name) -> ProcessingPrediction`` that
+new readers can join into at render time.
 
 The annotations are purely additive — vaccine ranking is unaffected.
 Reports surface the three columns when at least one prediction in
@@ -63,7 +74,15 @@ import logging
 
 from mhctools.processing_predictor import ProcessingPredictor
 
+from .processing_prediction import ProcessingPrediction
+
 logger = logging.getLogger(__name__)
+
+
+# Lowercase predictor identifier used in the ProcessingPrediction
+# join key. Future per-position cleavage predictors (NetChop,
+# PAProC, …) get their own constant.
+_PEPSICKLE_PREDICTOR_NAME = 'pepsickle'
 
 
 # ----------------------------------------------------------------------------
@@ -153,17 +172,21 @@ def _load_default_predictor(human_only=False, threshold=0.5):
 
 def annotate_processing(predictions, predictor=None,
                         human_only=False, threshold=0.5):
-    """Attach pepsickle credibility scores to each EpitopePrediction
-    in place.
+    """Build a map of pepsickle ``ProcessingPrediction`` records for
+    the given EpitopePredictions, and (for one deprecation cycle)
+    also annotate each EpitopePrediction in place with the legacy
+    ``pepsickle_*`` fields.
 
     Parameters
     ----------
     predictions : iterable of EpitopePrediction
-        Mutated in place: each gets ``pepsickle_c_term_cleavage_prob``
-        / ``pepsickle_max_internal_cut_prob`` /
+        Each prediction is processed against its ``source_sequence``.
+        Legacy in-place mutation: each gets
+        ``pepsickle_c_term_cleavage_prob`` /
+        ``pepsickle_max_internal_cut_prob`` /
         ``pepsickle_processing_score`` populated when annotation
-        succeeds. Predictions with no usable source sequence are
-        passed through unchanged.
+        succeeds. Predictions with no usable source sequence pass
+        through unchanged.
     predictor : optional, object with a ``cleavage_probs(sequence) ->
         list[float]`` method
         Test seam. When None (default), constructs
@@ -178,12 +201,20 @@ def annotate_processing(predictions, predictor=None,
 
     Returns
     -------
-    int
-        Number of predictions successfully annotated.
+    tuple
+        ``(n_annotated, processing_predictions_by_key)``.
+
+        * ``n_annotated`` (int): number of predictions successfully
+          annotated. Same number as before for back-compat.
+        * ``processing_predictions_by_key`` (dict): keyed on
+          ``(peptide_sequence, source_sequence, predictor_name)`` —
+          the canonical post-2.22 record (see :mod:`vaxrank.processing_prediction`).
+          Empty dict when nothing was annotated.
     """
     predictions_list = list(predictions)
+    processing_predictions: dict[tuple, ProcessingPrediction] = {}
     if not predictions_list:
-        return 0
+        return 0, processing_predictions
 
     # Group by source so we score each unique sequence exactly once.
     by_source = {}
@@ -193,7 +224,7 @@ def annotate_processing(predictions, predictor=None,
             continue
         by_source.setdefault(source, []).append(p)
     if not by_source:
-        return 0
+        return 0, processing_predictions
 
     # Resolve the predictor, then ask it for per-position cleavage
     # probabilities on each unique source sequence. The default path
@@ -203,7 +234,7 @@ def annotate_processing(predictions, predictor=None,
         predictor = _load_default_predictor(
             human_only=human_only, threshold=threshold)
         if predictor is None:
-            return 0
+            return 0, processing_predictions
 
     # Batch every unique source into ONE predictor call when the
     # predictor exposes ``cleavage_probs_many`` (mhctools 3.13.3+).
@@ -268,8 +299,6 @@ def annotate_processing(predictions, predictor=None,
                 seq_probs, offset, len(peptide))
             if c_term is None:
                 continue
-            p.pepsickle_c_term_cleavage_prob = c_term
-            p.pepsickle_max_internal_cut_prob = max_internal
             # Composite score is the **geometric mean** of the two
             # factors — ``sqrt(c_term * (1 - max_internal))``. Range
             # [0, 1]; 1 = ideal release, 0 = no clean release OR
@@ -281,7 +310,27 @@ def annotate_processing(predictions, predictor=None,
             # max_internal)=0.6 should score ~0.6, not 0.36.
             import math
             anti_max = max(0.0, 1.0 - max_internal)
-            p.pepsickle_processing_score = math.sqrt(c_term * anti_max)
+            processing_score = math.sqrt(c_term * anti_max)
+            # Build the canonical ProcessingPrediction record (the
+            # post-2.22 source of truth — keyed on
+            # ``(peptide, source, predictor_name)`` so future
+            # per-position cleavage predictors land alongside).
+            pp = ProcessingPrediction(
+                peptide_sequence=peptide,
+                source_sequence=source,
+                predictor_name=_PEPSICKLE_PREDICTOR_NAME,
+                predictor_version=getattr(
+                    predictor, 'version', None),
+                c_term_cleavage_prob=c_term,
+                max_internal_cut_prob=max_internal,
+                processing_score=processing_score,
+            )
+            processing_predictions[pp.key()] = pp
+            # Legacy in-place mutation (deprecated; kept for one
+            # cycle so existing report writers keep rendering).
+            p.pepsickle_c_term_cleavage_prob = c_term
+            p.pepsickle_max_internal_cut_prob = max_internal
+            p.pepsickle_processing_score = processing_score
             n_annotated += 1
 
     if n_annotated:
@@ -300,7 +349,7 @@ def annotate_processing(predictions, predictor=None,
             "in pep_context=%r.",
             n_skipped_peptide_not_in_context, len(predictions_list),
             ex_peptide, ex_source)
-    return n_annotated
+    return n_annotated, processing_predictions
 
 
 def _resolve_peptide_offset(source, peptide, prediction):

--- a/vaxrank/processing_prediction.py
+++ b/vaxrank/processing_prediction.py
@@ -1,0 +1,93 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""``ProcessingPrediction`` — a per-(peptide, source_sequence)
+proteasomal-cleavage prediction.
+
+Distinct from :class:`vaxrank.epitope_prediction.EpitopePrediction`
+because the two prediction kinds are semantically different axes:
+
+- ``EpitopePrediction`` is a **(peptide, allele) MHC-binding** score
+  (output of an ``mhctools.BindingPredictor`` — pMHC affinity /
+  presentation / stability).
+- ``ProcessingPrediction`` is a **(peptide, source_sequence)
+  proteasomal-cleavage** score (output of an
+  ``mhctools.ProcessingPredictor`` — no allele axis, depends on
+  the peptide's flanking context within its source protein).
+
+Pre-2.22 vaxrank annotated EpitopePrediction objects in place by
+adding ``pepsickle_*`` attributes — that conflated the two
+prediction kinds. ``ProcessingPrediction`` (this module) is the
+post-2.22 canonical record. The legacy in-place mutation is still
+performed for one deprecation cycle so existing report writers keep
+rendering; downstream code should migrate to consume the map of
+``ProcessingPrediction`` records returned by
+:func:`vaxrank.processing.annotate_processing`.
+
+Issue: openvax/vaxrank#272.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ProcessingPrediction:
+    """One ``ProcessingPredictor`` score for a (peptide,
+    source_sequence) pair.
+
+    The composite ``processing_score`` is the geometric mean of
+    ``c_term_cleavage_prob`` and ``(1 - max_internal_cut_prob)`` —
+    bounded [0, 1], 1 = ideal release, 0 = no clean release OR
+    near-certain internal destruction. Geometric mean rather than
+    raw product so a balanced ``(0.6, 0.6)`` row scores ~0.6
+    instead of 0.36.
+
+    Attributes
+    ----------
+    peptide_sequence : str
+        The MHC-ligand peptide whose proteasomal cleavage was scored.
+    source_sequence : str
+        The protein context the peptide was scored within.
+    predictor_name : str
+        Lowercase predictor identifier (e.g. ``'pepsickle'``). Future
+        per-position cleavage predictors (NetChop, PAProC, …) plug in
+        with their own name; report writers join across predictors by
+        ``(peptide_sequence, source_sequence, predictor_name)``.
+    predictor_version : Optional[str]
+        Predictor version string when the predictor exposes one,
+        else ``None``.
+    c_term_cleavage_prob : float
+        Probability the proteasome cuts at the ligand's C-terminus
+        (clean release). Range [0, 1].
+    max_internal_cut_prob : float
+        Peak cleavage probability strictly inside the ligand
+        (high → ligand is destroyed before reaching MHC). Range
+        [0, 1].
+    processing_score : float
+        Composite ``sqrt(c_term_cleavage_prob *
+        (1 - max_internal_cut_prob))``.
+    """
+
+    peptide_sequence: str
+    source_sequence: str
+    predictor_name: str
+    predictor_version: Optional[str] = None
+    c_term_cleavage_prob: float = 0.0
+    max_internal_cut_prob: float = 0.0
+    processing_score: float = 0.0
+
+    def key(self) -> tuple:
+        """Stable join key used by report writers to look up the
+        ProcessingPrediction for a given EpitopePrediction at render
+        time. Includes the predictor name so a future second
+        per-position cleavage predictor (NetChop, …) lands in the
+        same map without colliding."""
+        return (
+            self.peptide_sequence, self.source_sequence,
+            self.predictor_name)

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.21.0"
+__version__ = "2.22.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Phase A of #272: extract ``ProcessingPrediction`` as its own record type, parallel to ``EpitopePrediction``.

The two prediction kinds were always on different axes:

- ``EpitopePrediction`` — (peptide, allele) MHC binding (``mhctools.BindingPredictor``)
- ``ProcessingPrediction`` — (peptide, source_sequence) proteasomal cleavage (``mhctools.ProcessingPredictor``)

Pre-2.22 vaxrank annotated EpitopePrediction objects in place with ``pepsickle_*`` fields. That conflated the two and made it awkward to add a second per-position cleavage predictor (NetChop, PAProC, …) alongside Pepsickle.

This PR:

- Adds ``vaxrank/processing_prediction.py`` with ``ProcessingPrediction`` (frozen dataclass).
- Modifies ``annotate_processing`` to return ``(n_annotated, map)`` where ``map`` keys on ``(peptide, source, predictor_name)`` and the canonical post-2.22 ``ProcessingPrediction`` record.
- Keeps the legacy in-place mutation on EpitopePrediction for one deprecation cycle so report writers continue rendering. Phase B drops the mutation and migrates report writers to look up by key.

## Test plan

- [x] ``./test.sh`` — 732 passed, 0 failed (new ``test_annotate_processing_returns_processing_prediction_map``)
- Existing tests updated to unpack ``(n, map)`` tuple
- [ ] CI green

Bumps version to 2.22.0.