### PR TITLE
ProcessingPrediction join + mRNA ranking-decisions report (#272 #270)

### DIFF
--- a/tests/test_mrna.py
+++ b/tests/test_mrna.py
@@ -24,6 +24,7 @@ from vaxrank.mrna import (
     RNAConstructConfig,
     assemble_mrna_constructs,
     codon_optimize,
+    summarize_mrna_ranking_decisions,
     write_mrna_outputs,
 )
 from vaxrank.mrna_library import (
@@ -84,6 +85,142 @@ def _peptide_stub(amino_acids, gene_name='GENE'):
 def _variant_pair(amino_acids, contig='1', start=1000, gene_name='GENE'):
     variant = Variant(contig, start, 'A', 'T')
     return (variant, [_peptide_stub(amino_acids, gene_name=gene_name)])
+
+
+# ---- mRNA ranking-decisions summary (#270) ------------------------------
+
+
+def _vp_with_score(amino_acids, gene_name, combined_score):
+    """Like ``_peptide_stub`` but with a settable ``combined_score``
+    so we can verify the ordered list comes through."""
+    fragment = SimpleNamespace(amino_acids=amino_acids, gene_name=gene_name)
+    return SimpleNamespace(
+        mutant_protein_fragment=fragment, combined_score=combined_score)
+
+
+def test_summarize_mrna_ranking_decisions_splits_at_cap():
+    """``selected`` = top ``antigens_per_construct × max_constructs``
+    of the ranked variants; ``dropped`` = the rest. ``cap`` and
+    ``total_ranked`` are surfaced for the report header."""
+    pairs = [
+        (Variant('1', 100 + i, 'A', 'T'),
+         [_vp_with_score("KLQGHSAPVLDVIVN", "GENE%d" % i, 100.0 - i)])
+        for i in range(7)
+    ]
+    options = RNAConstructConfig(
+        antigens_per_construct=2, max_constructs=2)  # cap = 4
+    summary = summarize_mrna_ranking_decisions(pairs, options)
+    assert summary['cap'] == 4
+    assert summary['total_ranked'] == 7
+    assert summary['antigens_per_construct'] == 2
+    assert summary['max_constructs'] == 2
+    assert len(summary['selected']) == 4
+    assert len(summary['dropped']) == 3
+    # Selected entries are the first 4 in ranked order with rank 1..4.
+    assert [a['rank'] for a in summary['selected']] == [1, 2, 3, 4]
+    assert [a['gene_name'] for a in summary['selected']] == \
+        ['GENE0', 'GENE1', 'GENE2', 'GENE3']
+    # Dropped entries continue the ranking from rank 5.
+    assert [a['rank'] for a in summary['dropped']] == [5, 6, 7]
+
+
+def test_summarize_mrna_ranking_decisions_no_drops_when_under_cap():
+    """When the ranked list is shorter than the cap, every variant
+    is selected and ``dropped`` is empty."""
+    pairs = [
+        (Variant('1', 100, 'A', 'T'),
+         [_vp_with_score("KLQGHSAPVLDVIVN", "GENE_A", 50.0)]),
+        (Variant('1', 200, 'A', 'T'),
+         [_vp_with_score("MNNVDEILGRWESPV", "GENE_B", 30.0)]),
+    ]
+    options = RNAConstructConfig(
+        antigens_per_construct=5, max_constructs=2)  # cap = 10
+    summary = summarize_mrna_ranking_decisions(pairs, options)
+    assert summary['cap'] == 10
+    assert summary['total_ranked'] == 2
+    assert len(summary['selected']) == 2
+    assert summary['dropped'] == []
+
+
+def test_summarize_mrna_ranking_decisions_empty_input():
+    """No ranked variants → both lists empty, cap still surfaces so
+    the report can still render the header."""
+    options = RNAConstructConfig(
+        antigens_per_construct=5, max_constructs=2)
+    summary = summarize_mrna_ranking_decisions([], options)
+    assert summary['cap'] == 10
+    assert summary['total_ranked'] == 0
+    assert summary['selected'] == []
+    assert summary['dropped'] == []
+
+
+def test_ascii_report_renders_mrna_ranking_section():
+    """End-to-end: the ASCII report includes a ``mRNA vaccine
+    antigen selection`` section when the
+    ``mrna_ranking`` template-data field is populated."""
+    from vaxrank.report import _make_report
+    import io
+
+    template_data = {
+        'patient_info': {'Patient ID': 'TEST'},
+        'package_versions': {},
+        'reviewers': [], 'final_review': '',
+        'input_json_file': None,
+        'include_manufacturability': False,
+        'include_wt_epitopes': True,
+        'args': [],
+        'variants': [],
+        'mrna_ranking': {
+            'antigens_per_construct': 5,
+            'max_constructs': 2,
+            'cap': 10,
+            'total_ranked': 12,
+            'selected': [
+                {'rank': 1, 'gene_name': 'GENEA',
+                 'description': 'GENEA_1_100_A_T', 'combined_score': 12.5},
+                {'rank': 2, 'gene_name': 'GENEB',
+                 'description': 'GENEB_2_200_A_T', 'combined_score': 11.1},
+            ],
+            'dropped': [
+                {'rank': 11, 'gene_name': 'GENEK',
+                 'description': 'GENEK_3_300_A_T', 'combined_score': 4.3},
+            ],
+        },
+    }
+    f = io.StringIO()
+    _make_report(template_data, f, 'templates/template.txt')
+    rendered = f.getvalue()
+    # Section header, selected rows, dropped rows all present.
+    assert 'mRNA vaccine antigen selection' in rendered
+    assert '2 of 12 ranked' in rendered
+    assert 'GENEA_1_100_A_T' in rendered
+    assert 'GENEB_2_200_A_T' in rendered
+    assert 'Not selected' in rendered
+    assert 'GENEK_3_300_A_T' in rendered
+    # Cap params named in the header.
+    assert '5' in rendered  # antigens_per_construct
+    assert '10' in rendered  # cap
+
+
+def test_ascii_report_skips_mrna_section_when_not_set():
+    """When ``mrna_ranking`` is None (peptide-only run), the section
+    doesn't render."""
+    from vaxrank.report import _make_report
+    import io
+    template_data = {
+        'patient_info': {'Patient ID': 'TEST'},
+        'package_versions': {},
+        'reviewers': [], 'final_review': '',
+        'input_json_file': None,
+        'include_manufacturability': False,
+        'include_wt_epitopes': True,
+        'args': [], 'variants': [],
+        'mrna_ranking': None,
+    }
+    f = io.StringIO()
+    _make_report(template_data, f, 'templates/template.txt')
+    rendered = f.getvalue()
+    assert 'mRNA vaccine antigen selection' not in rendered
 
 
 def test_resolve_named_accepts_dashes_and_case_variants():

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -82,28 +82,31 @@ def test_component_probs_out_of_range_returns_none_tuple():
 # ---- Annotation (integration with EpitopePrediction) ---------------------
 
 def test_annotate_processing_attaches_continuous_scores():
-    """Each EpitopePrediction gets c_term / max_internal / processing
-    set as floats. None of them should be left as the default (None)
-    for a successfully-annotated prediction."""
+    """Each (peptide, source) pair lands in the returned
+    ProcessingPrediction map with c_term / max_internal /
+    processing as floats. Post-2.23 (#272 Phase B) the
+    EpitopePrediction is *not* mutated — readers consume the map."""
     source = "AAAAKLMNPVAAAA"  # 14 aa
     # Peptide KLMNPV at offset 4, length 6
     probs = [0.0, 0.0, 0.0, 0.05,   # source positions 0-3
              0.10, 0.20, 0.05, 0.50, 0.30, 0.85,   # peptide positions 4-9
              0.0, 0.0, 0.0, 0.0]
     pred = _ep("KLMNPV", source, offset=4)
-    n, _ = annotate_processing(
+    n, by_key = annotate_processing(
         [pred], predictor=StubPepsickle({source: probs}))
     assert n == 1
+    pp = by_key[(pred.peptide_sequence, source, 'pepsickle')]
     # C-term = probs at index 9 = 0.85 (clean release)
-    assert abs(pred.pepsickle_c_term_cleavage_prob - 0.85) < 1e-9
+    assert abs(pp.c_term_cleavage_prob - 0.85) < 1e-9
     # max internal = max of probs[4..8] = max(0.10, 0.20, 0.05, 0.50, 0.30) = 0.50
-    assert abs(pred.pepsickle_max_internal_cut_prob - 0.50) < 1e-9
+    assert abs(pp.max_internal_cut_prob - 0.50) < 1e-9
     # processing = sqrt(0.85 * (1 - 0.50)) = sqrt(0.425) ≈ 0.6519
     # (geometric mean of c_term and (1 - max_internal); see
     # ``vaxrank.processing`` for the rationale).
     import math
-    assert abs(pred.pepsickle_processing_score
-               - math.sqrt(0.85 * 0.50)) < 1e-9
+    assert abs(pp.processing_score - math.sqrt(0.85 * 0.50)) < 1e-9
+    # The EpitopePrediction is NOT mutated.
+    assert not hasattr(pred, 'pepsickle_c_term_cleavage_prob')
 
 
 def test_annotate_processing_returns_processing_prediction_map():
@@ -131,8 +134,9 @@ def test_annotate_processing_returns_processing_prediction_map():
     assert pp.predictor_name == 'pepsickle'
     assert abs(pp.c_term_cleavage_prob - 0.85) < 1e-9
     assert abs(pp.max_internal_cut_prob - 0.50) < 1e-9
-    # Same processing_score as the in-place mutation.
-    assert pp.processing_score == pred.pepsickle_processing_score
+    # Composite is the geometric mean of c_term and (1 - max_internal).
+    import math
+    assert abs(pp.processing_score - math.sqrt(0.85 * 0.50)) < 1e-9
 
 
 def test_annotate_processing_one_pass_per_unique_source():
@@ -159,12 +163,15 @@ def test_annotate_processing_one_pass_per_unique_source():
 
 def test_annotate_processing_skips_predictions_without_source():
     """Predictions with empty source_sequence are passed through
-    untouched (annotation requires a source to slice probs against)."""
+    untouched (annotation requires a source to slice probs against)
+    and don't land in the ProcessingPrediction map."""
     pred = _ep("KLMNPV", source="", offset=0)
-    n, _ = annotate_processing(
+    n, by_key = annotate_processing(
         [pred], predictor=StubPepsickle({}))
     assert n == 0
-    assert pred.pepsickle_c_term_cleavage_prob is None
+    assert by_key == {}
+    # No mutation on the EpitopePrediction (post-2.23).
+    assert not hasattr(pred, 'pepsickle_c_term_cleavage_prob')
 
 
 def test_annotate_processing_relocates_peptide_when_offset_off():
@@ -178,11 +185,12 @@ def test_annotate_processing_relocates_peptide_when_offset_off():
     probs = [0.0, 0.0, 0.0,   # 0-2
              0.10, 0.20, 0.05, 0.50, 0.30, 0.95,   # peptide at 3-8
              0.0, 0.0, 0.0]
-    n, _ = annotate_processing(
+    n, by_key = annotate_processing(
         [pred], predictor=StubPepsickle({source: probs}))
     assert n == 1
+    pp = by_key[(pred.peptide_sequence, source, 'pepsickle')]
     # C-term should pick up probs[8] = 0.95 (re-located, not probs[1+5]=0.05)
-    assert abs(pred.pepsickle_c_term_cleavage_prob - 0.95) < 1e-9
+    assert abs(pp.c_term_cleavage_prob - 0.95) < 1e-9
 
 
 def test_annotate_processing_does_not_touch_ranking_score():
@@ -193,11 +201,13 @@ def test_annotate_processing_does_not_touch_ranking_score():
     pre_ic50 = pred.ic50
     pre_rank = pred.percentile_rank
     pre_logistic = pred.logistic_epitope_score()
-    annotate_processing(
+    n, by_key = annotate_processing(
         [pred],
         predictor=StubPepsickle({source: [0.1] * len(source)}))
-    # Annotation fields are now set
-    assert pred.pepsickle_c_term_cleavage_prob is not None
+    # ProcessingPrediction landed in the map (post-2.23, the
+    # canonical record).
+    assert n == 1
+    assert (pred.peptide_sequence, source, 'pepsickle') in by_key
     # Ranking-driving fields untouched
     assert pred.ic50 == pre_ic50
     assert pred.percentile_rank == pre_rank
@@ -217,12 +227,12 @@ def test_annotate_processing_predictor_failure_degrades_gracefully():
             return [0.5] * len(sequence)
     pred_ok = _ep("AAAAA", "AAAAAAAAAA", offset=2)
     pred_fail = _ep("FFFFF", "FFAILFFFFFF", offset=0)
-    n, _ = annotate_processing(
+    n, by_key = annotate_processing(
         [pred_ok, pred_fail], predictor=FlakyPredictor())
     # Only the OK one annotated; the failing source skipped, no crash.
     assert n == 1
-    assert pred_ok.pepsickle_c_term_cleavage_prob is not None
-    assert pred_fail.pepsickle_c_term_cleavage_prob is None
+    assert (pred_ok.peptide_sequence, "AAAAAAAAAA", 'pepsickle') in by_key
+    assert (pred_fail.peptide_sequence, "FFAILFFFFFF", 'pepsickle') not in by_key
 
 
 def test_annotate_processing_empty_input_returns_zero():
@@ -261,13 +271,13 @@ def test_load_default_predictor_returns_none_when_mhctools_missing(
 # ---- Report integration --------------------------------------------------
 
 def test_epitope_data_surfaces_processing_columns_when_annotated():
-    """report.TemplateDataCreator._epitope_data adds three extra
+    """``TemplateDataCreator._epitope_data`` adds three extra
     columns (Processing: C-term, Processing: max internal,
-    Processing: combined) when ``include_processing=True``.
-    Default ``include_processing=False`` keeps the original 6-column
-    shape so unannotated reports don't change. Predictor name is in
-    the column header so a future per-position predictor (NetChop, …)
-    can land alongside without ambiguity."""
+    Processing: combined) when ``include_processing=True`` — the
+    values come from the ProcessingPrediction map by joining on
+    ``(peptide, source, predictor_name)``. Default
+    ``include_processing=False`` keeps the original 6-column shape
+    so unannotated reports don't change."""
     from collections import OrderedDict
 
     source = "AAAAKLMNPVAAAA"
@@ -275,20 +285,26 @@ def test_epitope_data_surfaces_processing_columns_when_annotated():
 
     from vaxrank.report import TemplateDataCreator
     creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = {}
     # Default: 6-column legacy shape.
     pre = creator._epitope_data(pred)
     assert isinstance(pre, OrderedDict)
     assert 'Processing: C-term' not in pre
     assert 'Processing: combined' not in pre
 
-    # After annotation, ``include_processing=True`` surfaces the columns.
-    annotate_processing(
+    # After annotation, ``include_processing=True`` surfaces the
+    # columns — read from the ProcessingPrediction map (#272 Phase B).
+    n, by_key = annotate_processing(
         [pred],
         predictor=StubPepsickle({source: [0.1] * 9 + [0.85] + [0.0] * 4}))
+    creator.processing_predictions_by_key = by_key
     post = creator._epitope_data(pred, include_processing=True)
     assert 'Processing: C-term' in post
     assert 'Processing: max internal' in post
     assert 'Processing: combined' in post
+    # And the values are real (not '—' placeholders) since we have
+    # a ProcessingPrediction for this peptide.
+    assert post['Processing: C-term'] != '—'
 
 
 # ---- entry_point integration --------------------------------------------
@@ -391,13 +407,14 @@ def test_epitope_data_header_consistent_when_some_predictions_unannotated():
     source = "AAAAKLMNPVAAAA"
     annotated = _ep("KLMNPV", source, offset=4)
     unannotated = _ep("AAAAA", source, offset=0)
-    annotate_processing(
+    n, by_key = annotate_processing(
         [annotated],
         predictor=StubPepsickle(
             {source: [0.1] * 9 + [0.85] + [0.0] * 4}))
-    # Verify mixed state: only one of the two has the field set
-    assert annotated.pepsickle_c_term_cleavage_prob is not None
-    assert unannotated.pepsickle_c_term_cleavage_prob is None
+    # Verify mixed state: only one of the two has a record in the map.
+    assert (annotated.peptide_sequence, source, 'pepsickle') in by_key
+    assert (unannotated.peptide_sequence, source, 'pepsickle') not in by_key
+    creator.processing_predictions_by_key = by_key
 
     # When the caller turns include_processing on, BOTH rows have
     # the same key set — table renders cleanly.
@@ -427,15 +444,16 @@ def test_re_location_picks_closest_to_declared_offset():
     probs = [0.0, 0.0, 0.0, 0.0, 0.0,
              0.0, 0.0, 0.0,
              0.0, 0.0, 0.0, 0.0, 0.95]  # cleavage at last position only
-    annotate_processing(
+    n, by_key = annotate_processing(
         [pred], predictor=StubPepsickle({source: probs}))
+    pp = by_key[(pred.peptide_sequence, source, 'pepsickle')]
     # If re-location snapped to position 0 (first occurrence), c_term
     # would be probs[4] = 0.0; if it correctly snapped to position 8,
     # c_term = probs[12] = 0.95.
-    assert pred.pepsickle_c_term_cleavage_prob == 0.95, (
+    assert pp.c_term_cleavage_prob == 0.95, (
         "Re-location should pick the closest occurrence to declared "
         "offset (8 → 12), not the first occurrence (0 → 4); got "
-        "c_term=%s" % pred.pepsickle_c_term_cleavage_prob)
+        "c_term=%s" % pp.c_term_cleavage_prob)
 
 
 def test_re_location_warns_on_large_offset_drift(caplog):

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -311,15 +311,17 @@ def add_output_args(arg_parser):
         dest="processing_aware_annotation",
         action="store_true",
         default=True,
-        help="Annotate each predicted MHC ligand with pepsickle's "
-             "proteasome-cleavage credibility scores "
-             "(pepsickle_c_term_cleavage_prob, "
-             "pepsickle_max_internal_cut_prob, "
-             "pepsickle_processing_score). On by default. "
-             "Pepsickle runs in an isolated subprocess (issue #266) so "
-             "torch's libomp doesn't clash with the parent's pandas / "
-             "numpy / pyarrow OpenMP runtime. Doesn't change vaccine "
-             "ranking — adds info for review.")
+        help="Build pepsickle proteasome-cleavage credibility scores "
+             "for each predicted MHC ligand (c_term_cleavage_prob, "
+             "max_internal_cut_prob, processing_score). On by default. "
+             "Scores live on a separate ProcessingPrediction record "
+             "joined into the per-epitope report tables at render "
+             "time by (peptide, source, predictor); see "
+             "vaxrank/processing_prediction.py. Pepsickle runs in an "
+             "isolated subprocess (issue #266) so torch's libomp "
+             "doesn't clash with the parent's pandas / numpy / "
+             "pyarrow OpenMP runtime. Doesn't change vaccine ranking — "
+             "adds info for review.")
     output_args_group.add_argument(
         "--no-processing-aware-annotation",
         dest="processing_aware_annotation",

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -1055,13 +1055,14 @@ def main(args_list=None):
         args_for_report = data['args']
         source = 'pipeline'
 
-    # Issue #249: annotate epitope predictions with pepsickle proteasome-
-    # cleavage credibility. Mutates EpitopePredictions in place; doesn't
-    # affect ranking — purely additional information surfaced in the
-    # per-epitope report tables. On by default; opt-out via
-    # --no-processing-aware-annotation.
+    # Issue #249 / #272: build per-(peptide, source) ProcessingPrediction
+    # records via pepsickle. Doesn't affect ranking — purely additional
+    # information surfaced in the per-epitope report tables, joined in
+    # at render time by ``(peptide, source, predictor_name)``. On by
+    # default; opt-out via --no-processing-aware-annotation.
+    processing_predictions_by_key = {}
     if getattr(args, 'processing_aware_annotation', True):
-        _annotate_predictions_with_processing(
+        _, processing_predictions_by_key = _annotate_predictions_with_processing(
             ranked_variants_with_vaccine_peptides, predictions,
             human_only=getattr(args, 'pepsickle_human_only', False),
             threshold=getattr(args, 'pepsickle_threshold', 0.5))
@@ -1082,6 +1083,31 @@ def main(args_list=None):
     if not (args.output_ascii_report or args.output_html_report or args.output_pdf_report):
         return
 
+    # Issue #270: mRNA ranking-decisions section in the template
+    # report. Computed when 'mrna' is in the active --vaccine-type so
+    # an mRNA-only or peptide+mrna run shows which top-k antigens
+    # land in the mRNA construct(s) vs which fall past the cap.
+    mrna_ranking_decisions = None
+    if 'mrna' in _resolve_vaccine_types(args) \
+            and ranked_variants_with_vaccine_peptides:
+        from ..mrna import (
+            RNAConstructConfig, summarize_mrna_ranking_decisions,
+        )
+        # Reuse the same kwargs the writer uses so the cap matches
+        # what the user would actually get if they ran with
+        # --output-dir.
+        yaml_kwargs = _construct_config_for_modality(args, 'mrna')
+
+        def _cfg(cli_attr, yaml_key):
+            return _coalesce_from_config(args, cli_attr, yaml_kwargs, yaml_key)
+        mrna_options = RNAConstructConfig(
+            antigens_per_construct=_cfg(
+                'mrna_antigens_per_construct', 'antigens_per_construct'),
+            max_constructs=_cfg('mrna_max_constructs', 'max_constructs'),
+        )
+        mrna_ranking_decisions = summarize_mrna_ranking_decisions(
+            ranked_variants_with_vaccine_peptides, mrna_options)
+
     template_data_creator = TemplateDataCreator(
         ranked_variants_with_vaccine_peptides=ranked_variants_with_vaccine_peptides,
         patient_info=patient_info,
@@ -1090,7 +1116,9 @@ def main(args_list=None):
         args_for_report=args_for_report,
         input_json_file=getattr(args, 'input_json_file', None),
         cosmic_vcf_filename=getattr(args, 'cosmic_vcf_filename', ''),
-        dna_vaf_by_variant=data.get('dna_vaf_by_variant') or {})
+        dna_vaf_by_variant=data.get('dna_vaf_by_variant') or {},
+        processing_predictions_by_key=processing_predictions_by_key,
+        mrna_ranking_decisions=mrna_ranking_decisions)
 
     template_data = template_data_creator.compute_template_data()
 

--- a/vaxrank/epitope_prediction.py
+++ b/vaxrank/epitope_prediction.py
@@ -65,24 +65,16 @@ class EpitopePrediction(DataclassSerializable):
     # load_lens from column prefixes like "mhcflurry_2.1.1.aff".
     predictor_version: str = ""
 
-    # Pepsickle credibility annotations (issue #249). Populated by
-    # ``vaxrank.processing.annotate_processing`` when proteasome
-    # cleavage prediction is enabled. None means "not annotated";
-    # numeric values are in [0, 1]. The ``pepsickle_`` prefix names
-    # the predictor explicitly so a future per-position cleavage
-    # predictor (NetChop, PAProC, …) can land alongside without name
-    # collision. Per-position cleavage probability at the C-terminus
-    # of this peptide (probability the proteasome cuts between this
-    # peptide's last residue and its C+1 flank); higher = clean
-    # release.
-    pepsickle_c_term_cleavage_prob: Optional[float] = None
-    # Peak cleavage probability strictly inside the peptide (positions
-    # 0..N-2). Higher = ligand more likely to be destroyed before
-    # reaching MHC.
-    pepsickle_max_internal_cut_prob: Optional[float] = None
-    # Composite: c_term * (1 - max_internal). 1.0 = ideal release;
-    # near 0 = no clean C-term cut OR high internal-cut probability.
-    pepsickle_processing_score: Optional[float] = None
+    # Note (post-2.22): Pepsickle / proteasomal-cleavage scores are NOT
+    # carried on this struct. They live on
+    # :class:`vaxrank.processing_prediction.ProcessingPrediction` and
+    # are joined into the per-(peptide, allele) report at render time
+    # via the ``processing_predictions_by_key`` map (built by
+    # :func:`vaxrank.processing.annotate_processing`). The two
+    # prediction kinds are on different axes — binding has an allele
+    # dimension, processing doesn't — so conflating them on one record
+    # was making it awkward to add a second per-position cleavage
+    # predictor. See issue #272.
 
     # `length` used to be a constructor arg; since 1.1.0 it is derived from
     # `peptide_sequence`. Drop it from any old JSON blobs we happen to load.

--- a/vaxrank/mrna.py
+++ b/vaxrank/mrna.py
@@ -322,6 +322,87 @@ def codon_optimize(amino_acids, species="h_sapiens", method="use_best_codon",
     return problem.sequence
 
 
+def summarize_mrna_ranking_decisions(
+        ranked_variants_with_vaccine_peptides, options):
+    """Produce a "which antigens land in the mRNA vaccine?" summary
+    derived from the ranked-variants list and the
+    :class:`RNAConstructConfig` caps. Used by report writers (#270)
+    to surface the mRNA ranking-decision section of the ASCII / HTML
+    / PDF report next to the existing per-variant tables.
+
+    The mRNA assembler iterates the ranked variants in score order
+    and packs antigens into constructs until
+    ``antigens_per_construct × max_constructs`` is reached — so the
+    first ``cap`` variants in ``ranked_variants_with_vaccine_peptides``
+    are the ones that land in the vaccine, and the rest fall past the
+    cap. (Edge case: a single antigen too long to fit is still
+    emitted, which can shift the cut by one — the writer logs the
+    edge-case warning separately.)
+
+    Parameters
+    ----------
+    ranked_variants_with_vaccine_peptides : list[tuple]
+        ``[(Variant, [VaccinePeptide])]`` — vaxrank's canonical
+        ranked-output shape.
+    options : RNAConstructConfig
+        Construct-assembly knobs; the cap comes from
+        ``options.antigens_per_construct * options.max_constructs``.
+
+    Returns
+    -------
+    dict
+        Shape:
+
+        ``{
+            'antigens_per_construct': int,
+            'max_constructs': int,
+            'cap': int,        # antigens_per_construct × max_constructs
+            'total_ranked': int,
+            'selected': [{'rank': 1, 'description': 'GENE_X_...',
+                          'gene_name': 'GENE',
+                          'combined_score': float, ...}, ...],
+            'dropped': [...],   # past-cap, same shape
+          }``
+
+        ``selected`` and ``dropped`` are sorted by rank (ascending
+        index in the ranked list).
+    """
+    cap = options.antigens_per_construct * options.max_constructs
+
+    def _row(rank, variant, peptides):
+        vp = peptides[0] if peptides else None
+        gene_name = (
+            getattr(vp.mutant_protein_fragment, 'gene_name', '')
+            if vp is not None else '')
+        return {
+            'rank': rank,
+            'gene_name': gene_name or '',
+            'description': '%s_%s' % (
+                gene_name or '?',
+                getattr(variant, 'short_description', str(variant))),
+            'combined_score': (
+                float(vp.combined_score) if vp is not None else 0.0),
+        }
+
+    selected = []
+    dropped = []
+    for i, (variant, peptides) in enumerate(
+            ranked_variants_with_vaccine_peptides):
+        rank = i + 1
+        if i < cap:
+            selected.append(_row(rank, variant, peptides))
+        else:
+            dropped.append(_row(rank, variant, peptides))
+    return {
+        'antigens_per_construct': options.antigens_per_construct,
+        'max_constructs': options.max_constructs,
+        'cap': cap,
+        'total_ranked': len(ranked_variants_with_vaccine_peptides),
+        'selected': selected,
+        'dropped': dropped,
+    }
+
+
 def _antigen_aa_sequences(ranked_vaccine_peptides, max_antigen_length_aa,
                           min_antigen_length_aa=0, candidates_per_slot=1,
                           antigen_content="mutation_spanning",

--- a/vaxrank/processing.py
+++ b/vaxrank/processing.py
@@ -33,16 +33,13 @@ three scores:
                                     a balanced (0.6, 0.6) row scores
                                     ~0.6 instead of 0.36.
 
-``ProcessingPrediction`` is the canonical record post-2.22 (see
-:mod:`vaxrank.processing_prediction`). Pre-2.22 vaxrank annotated
-``EpitopePrediction`` objects in place with ``pepsickle_*`` fields
-— that conflated MHC-binding and processing predictions, which are
-on different axes (binding has an allele dimension; processing
-doesn't). The legacy in-place mutation is preserved for one
-deprecation cycle so existing report writers keep rendering;
-:func:`annotate_processing` returns a map of
-``(peptide, source, predictor_name) -> ProcessingPrediction`` that
-new readers can join into at render time.
+``ProcessingPrediction`` is the canonical record (see
+:mod:`vaxrank.processing_prediction`). Report writers join in by
+``(peptide, source, predictor_name)`` at render time. Pre-2.22
+vaxrank ALSO mutated ``EpitopePrediction`` objects in place with
+``pepsickle_*`` fields; that mutation is gone in 2.23 (closes
+#272). All readers must consume the
+``processing_predictions_by_key`` map returned here.
 
 The annotations are purely additive — vaccine ranking is unaffected.
 Reports surface the three columns when at least one prediction in
@@ -173,20 +170,15 @@ def _load_default_predictor(human_only=False, threshold=0.5):
 def annotate_processing(predictions, predictor=None,
                         human_only=False, threshold=0.5):
     """Build a map of pepsickle ``ProcessingPrediction`` records for
-    the given EpitopePredictions, and (for one deprecation cycle)
-    also annotate each EpitopePrediction in place with the legacy
-    ``pepsickle_*`` fields.
+    the given EpitopePredictions.
 
     Parameters
     ----------
     predictions : iterable of EpitopePrediction
-        Each prediction is processed against its ``source_sequence``.
-        Legacy in-place mutation: each gets
-        ``pepsickle_c_term_cleavage_prob`` /
-        ``pepsickle_max_internal_cut_prob`` /
-        ``pepsickle_processing_score`` populated when annotation
-        succeeds. Predictions with no usable source sequence pass
-        through unchanged.
+        Each prediction is processed against its ``source_sequence``
+        to compute one ProcessingPrediction. EpitopePrediction
+        objects are NOT mutated (was the case pre-2.23 — see #272).
+        Predictions with no usable source sequence are skipped.
     predictor : optional, object with a ``cleavage_probs(sequence) ->
         list[float]`` method
         Test seam. When None (default), constructs
@@ -205,11 +197,10 @@ def annotate_processing(predictions, predictor=None,
         ``(n_annotated, processing_predictions_by_key)``.
 
         * ``n_annotated`` (int): number of predictions successfully
-          annotated. Same number as before for back-compat.
+          scored.
         * ``processing_predictions_by_key`` (dict): keyed on
           ``(peptide_sequence, source_sequence, predictor_name)`` —
-          the canonical post-2.22 record (see :mod:`vaxrank.processing_prediction`).
-          Empty dict when nothing was annotated.
+          the canonical record. Empty dict when nothing was annotated.
     """
     predictions_list = list(predictions)
     processing_predictions: dict[tuple, ProcessingPrediction] = {}
@@ -326,11 +317,6 @@ def annotate_processing(predictions, predictor=None,
                 processing_score=processing_score,
             )
             processing_predictions[pp.key()] = pp
-            # Legacy in-place mutation (deprecated; kept for one
-            # cycle so existing report writers keep rendering).
-            p.pepsickle_c_term_cleavage_prob = c_term
-            p.pepsickle_max_internal_cut_prob = max_internal
-            p.pepsickle_processing_score = processing_score
             n_annotated += 1
 
     if n_annotated:

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -48,13 +48,29 @@ class TemplateDataCreator(object):
             args_for_report,
             input_json_file,
             cosmic_vcf_filename=None,
-            dna_vaf_by_variant=None):
+            dna_vaf_by_variant=None,
+            processing_predictions_by_key=None,
+            mrna_ranking_decisions=None):
         """
         Construct a TemplateDataCreator object, from the output of the vaxrank pipeline.
+
+        ``processing_predictions_by_key`` is the map returned by
+        :func:`vaxrank.processing.annotate_processing` —
+        ``(peptide, source, predictor_name) -> ProcessingPrediction``.
+        Report writers join this in at render time. ``None`` means
+        the processing-aware annotation pass didn't run; the
+        per-epitope tables then omit the processing columns.
         """
         self.ranked_variants_with_vaccine_peptides = ranked_variants_with_vaccine_peptides
         self.patient_info = patient_info
         self.dna_vaf_by_variant = dna_vaf_by_variant or {}
+        self.processing_predictions_by_key = (
+            processing_predictions_by_key or {})
+        # Issue #270: mRNA ranking-decisions section. Set when mRNA
+        # is in the active ``--vaccine-type``. ``None`` skips the
+        # section in the rendered report. See
+        # :func:`vaxrank.mrna.summarize_mrna_ranking_decisions`.
+        self.mrna_ranking_decisions = mrna_ranking_decisions
 
         # ``vaccine_type`` is rendered in the patient-info block so
         # the reader can tell at a glance what's being designed.
@@ -260,22 +276,47 @@ class TemplateDataCreator(object):
         ])
         return manufacturability_data
 
+    def _processing_prediction_for(self, epitope_prediction):
+        """Look up the ProcessingPrediction for this epitope by
+        ``(peptide, source, 'pepsickle')``. Returns ``None`` when no
+        record exists (annotation pass didn't run, or this prediction
+        had no usable source sequence).
+
+        Hard-coded predictor name is ``'pepsickle'`` for now — when a
+        second per-position cleavage predictor lands, this method
+        becomes the swap point (read predictor name from a config knob
+        + fall back).
+        """
+        key = (
+            epitope_prediction.peptide_sequence or '',
+            getattr(epitope_prediction, 'source_sequence', '') or '',
+            'pepsickle',
+        )
+        return self.processing_predictions_by_key.get(key)
+
     def _epitope_data(self, epitope_prediction, include_processing=False):
         """Returns an OrderedDict with epitope data from the given prediction.
 
         ``include_processing``: when True, always emit the three
-        pepsickle credibility columns (``C-term cut``, ``Max internal
-        cut``, ``Processing score``), using ``'—'`` as the placeholder
+        proteasomal-cleavage credibility columns
+        (``Processing: C-term`` / ``Processing: max internal`` /
+        ``Processing: combined``), using ``'—'`` as the placeholder
         for predictions that weren't annotated. The caller decides
         per-list (per-VaccinePeptide) whether *any* prediction in
-        the list is annotated; if so, every row gets the columns so
-        the rendered table has consistent headers and column widths.
+        the list has a ProcessingPrediction; if so, every row gets
+        the columns so the rendered table has consistent headers
+        and column widths.
 
         When False (default), the legacy 6-column dict is returned
         unchanged — reports that don't run pepsickle keep their
         original shape.
 
-        Issue #249.
+        Processing scores come from
+        ``self.processing_predictions_by_key`` (built by
+        :func:`vaxrank.processing.annotate_processing`), looked up
+        by ``(peptide, source, predictor_name)``. Pre-2.23 these
+        lived as ``pepsickle_*`` attributes on the EpitopePrediction
+        itself; the join is the new contract (#272).
         """
         # if the WT peptide is too short, it's possible that we're missing a prediction for it
         if epitope_prediction.wt_ic50 is not None:
@@ -311,12 +352,13 @@ class TemplateDataCreator(object):
             # The active predictor is named in the patient-info
             # header (``Processing predictor: pepsickle``) so the
             # reader can trace which model produced the values.
-            c_term = getattr(
-                epitope_prediction, 'pepsickle_c_term_cleavage_prob', None)
-            max_int = getattr(
-                epitope_prediction, 'pepsickle_max_internal_cut_prob', None)
-            proc = getattr(
-                epitope_prediction, 'pepsickle_processing_score', None)
+            pp = self._processing_prediction_for(epitope_prediction)
+            if pp is None:
+                c_term = max_int = proc = None
+            else:
+                c_term = pp.c_term_cleavage_prob
+                max_int = pp.max_internal_cut_prob
+                proc = pp.processing_score
             epitope_data['Processing: C-term'] = (
                 '%.2f' % c_term if c_term is not None else '—')
             epitope_data['Processing: max internal'] = (
@@ -407,17 +449,16 @@ class TemplateDataCreator(object):
                 peptide_data = self._peptide_data(vaccine_peptide, transcript_name)
                 manufacturability_data = self._manufacturability_data(vaccine_peptide)
 
-                # Issue #249: pepsickle credibility columns are added
-                # to every row in this VP's per-epitope table iff *any*
-                # mutant prediction in the list was annotated. This
-                # keeps the rendered HTML/PDF/ASCII table headers
-                # consistent with the rows even when some predictions
-                # failed annotation (per-source pepsickle errors are
-                # graceful, so mixed annotated/unannotated lists are
-                # possible).
+                # Issue #249 / #272: processing-credibility columns
+                # are added to every row in this VP's per-epitope
+                # table iff *any* mutant prediction in the list has a
+                # ProcessingPrediction in the map. Keeps the rendered
+                # HTML/PDF/ASCII table headers consistent with the
+                # rows even when some predictions failed annotation
+                # (per-source pepsickle errors are graceful, so
+                # mixed annotated/unannotated lists are possible).
                 any_processing = any(
-                    getattr(p, 'pepsickle_c_term_cleavage_prob', None)
-                    is not None
+                    self._processing_prediction_for(p) is not None
                     for p in vaccine_peptide.mutant_epitope_predictions)
 
                 epitopes = []
@@ -482,6 +523,11 @@ class TemplateDataCreator(object):
             'patient_info': patient_info,
             'variants': variants,
             'package_versions': package_versions,
+            # Issue #270: mRNA ranking decisions. ``None`` when not
+            # applicable (peptide-only run, or no ranked antigens).
+            # The template renders the section only when the value
+            # is truthy.
+            'mrna_ranking': self.mrna_ranking_decisions,
         })
         return self.template_data
 

--- a/vaxrank/templates/template.txt
+++ b/vaxrank/templates/template.txt
@@ -46,3 +46,20 @@ Package version info
 {% else %}
 No variants with sufficient ranked antigens were found.
 {% endif %}
+
+{% if mrna_ranking %}
+---
+
+mRNA vaccine antigen selection
+  Selected ({{ mrna_ranking.selected|length }} of {{ mrna_ranking.total_ranked }} ranked) at --mrna-antigens-per-construct={{ mrna_ranking.antigens_per_construct }} × --mrna-max-constructs={{ mrna_ranking.max_constructs }} = {{ mrna_ranking.cap }} antigen slots:
+  {% for a in mrna_ranking.selected %}
+    {{ a.rank }}. {{ a.description }}    combined_score = {{ '%.3f' % a.combined_score }}
+  {% endfor %}
+  {% if mrna_ranking.dropped %}
+
+  Not selected — past the cap (raise --mrna-max-constructs to include more):
+  {% for a in mrna_ranking.dropped %}
+    {{ a.rank }}. {{ a.description }}    combined_score = {{ '%.3f' % a.combined_score }}
+  {% endfor %}
+  {% endif %}
+{% endif %}

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.22.0"
+__version__ = "2.23.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Two distinct user-facing wins, paired into one PR because they share the report-rendering path.

### #272 Phase B — drop the legacy ``pepsickle_*`` mutation

Pepsickle results were the only thing left mutating EpitopePrediction objects in place. Phase A (in 2.22.0) introduced ``ProcessingPrediction`` as the canonical record; this PR removes the deprecated mirror.

- ``EpitopePrediction`` no longer carries ``pepsickle_*`` fields.
- ``annotate_processing`` returns ``(n, map)`` where ``map`` keys on ``(peptide, source, predictor_name)`` and the ProcessingPrediction record is the only source of truth.
- Report writers join by key at render time (``TemplateDataCreator._processing_prediction_for(epitope)``); the lookup helper is the swap point when a second per-position cleavage predictor lands (NetChop, PAProC, …).

### #270 — mRNA ranking-decisions report section

ASCII / HTML / PDF reports now show *which* antigens land in the mRNA construct(s) and which fall past the ``antigens_per_construct × max_constructs`` cap.

- New ``vaxrank.mrna.summarize_mrna_ranking_decisions`` builds the selected/dropped split from the ranked variants + RNAConstructConfig.
- main() computes it whenever ``mrna`` is in the active ``--vaccine-type``; the template renders a new section header naming the cap params and lists the selected + not-selected antigens with their combined_score.

## Test plan

- [x] ``./test.sh`` — 737 passed, 0 failed (+5 new tests vs main)
- New ranking-decisions tests pin the cap split, the no-drops-when-under-cap path, and empty-input.
- New end-to-end render tests confirm the ASCII section appears when ``mrna_ranking`` is set and is omitted when ``None``.
- Existing pepsickle tests rewritten to consume the map; new asserts pin "no in-place mutation".

Bumps version to 2.23.0.