### PR TITLE
Cleanup: PEPSICKLE_PREDICTOR_NAME public, drop pre-1.1.0 JSON shim

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -13,14 +13,17 @@
 """Pepsickle proteasome-cleavage credibility tagging (issue #249).
 
 Pins:
-- Annotation is purely additive — never mutates ranking.
-- Continuous (not binary) per-position scores attach to each
-  EpitopePrediction.
+- Annotation is purely additive — never mutates ranking, and (post-2.23,
+  see #272 Phase B) never mutates the EpitopePrediction objects either.
+  Per-(peptide, source) records land on
+  :class:`vaxrank.processing_prediction.ProcessingPrediction` and reach
+  report writers via the ``processing_predictions_by_key`` map.
+- Continuous (not binary) per-position cleavage scores.
 - Re-locates peptides in the source sequence when declared offset is
   off by one (off-by-one drift in offsets is common in upstream
   loaders).
-- Composite ``pepsickle_processing_score`` = sqrt(c_term × (1 − max_internal))
-  (geometric mean of the two factors).
+- Composite ``ProcessingPrediction.processing_score`` =
+  sqrt(c_term × (1 − max_internal)) (geometric mean of the two factors).
 - Single pepsickle pass per unique source sequence (not per peptide).
 """
 

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -110,28 +110,6 @@ def test_epitope_prediction_length_is_derived():
     assert "length" not in e.to_dict()
 
 
-def test_epitope_prediction_from_dict_drops_legacy_length_field():
-    """Old JSON blobs that include the retired `length` init arg still
-    load, via _SERIALIZABLE_KEYWORD_ALIASES."""
-    legacy_dict = {
-        "allele": "HLA-A*02:01",
-        "peptide_sequence": "SIINFEQL",
-        "wt_peptide_sequence": "SIINFEKL",
-        "ic50": 2.0,
-        "wt_ic50": 2000.0,
-        "percentile_rank": 0.3,
-        "prediction_method_name": "ImaginationMHCpan",
-        "overlaps_mutation": True,
-        "source_sequence": "SSIINFEQL",
-        "offset": 1,
-        "occurs_in_reference": False,
-        "length": 8,  # legacy field, should be silently dropped
-    }
-    e = EpitopePrediction.from_dict(legacy_dict)
-    assert e.peptide_sequence == "SIINFEQL"
-    assert e.length == 8  # derived from peptide_sequence
-
-
 # ---- MutantProteinFragment --------------------------------------------
 
 

--- a/vaxrank/epitope_prediction.py
+++ b/vaxrank/epitope_prediction.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import ClassVar, Optional
 
 import numpy as np
 from serializable import DataclassSerializable
@@ -75,12 +74,6 @@ class EpitopePrediction(DataclassSerializable):
     # dimension, processing doesn't — so conflating them on one record
     # was making it awkward to add a second per-position cleavage
     # predictor. See issue #272.
-
-    # `length` used to be a constructor arg; since 1.1.0 it is derived from
-    # `peptide_sequence`. Drop it from any old JSON blobs we happen to load.
-    _SERIALIZABLE_KEYWORD_ALIASES: ClassVar[dict[str, Optional[str]]] = {
-        "length": None,
-    }
 
     @property
     def length(self) -> int:

--- a/vaxrank/processing.py
+++ b/vaxrank/processing.py
@@ -78,8 +78,10 @@ logger = logging.getLogger(__name__)
 
 # Lowercase predictor identifier used in the ProcessingPrediction
 # join key. Future per-position cleavage predictors (NetChop,
-# PAProC, …) get their own constant.
-_PEPSICKLE_PREDICTOR_NAME = 'pepsickle'
+# PAProC, …) get their own constant. Public so report writers
+# (``vaxrank.report.TemplateDataCreator._processing_prediction_for``)
+# can build the same key without re-stringifying.
+PEPSICKLE_PREDICTOR_NAME = 'pepsickle'
 
 
 # ----------------------------------------------------------------------------
@@ -309,7 +311,7 @@ def annotate_processing(predictions, predictor=None,
             pp = ProcessingPrediction(
                 peptide_sequence=peptide,
                 source_sequence=source,
-                predictor_name=_PEPSICKLE_PREDICTOR_NAME,
+                predictor_name=PEPSICKLE_PREDICTOR_NAME,
                 predictor_version=getattr(
                     predictor, 'version', None),
                 c_term_cleavage_prob=c_term,

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -25,6 +25,7 @@ from varcode import load_vcf_fast
 
 from .cancer_hotspots import get_hotspot_url
 from .manufacturability import ManufacturabilityScores
+from .processing import PEPSICKLE_PREDICTOR_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ class TemplateDataCreator(object):
         # ``vaxrank.processing``); a future per-position predictor
         # plugged in via the same EpitopePrediction fields would
         # show its own name here.
-        patient_info['Processing predictor'] = 'pepsickle'
+        patient_info['Processing predictor'] = PEPSICKLE_PREDICTOR_NAME
         patient_info['Total number of somatic variants'] = (
             self.patient_info.num_somatic_variants)
         patient_info['Somatic variants with predicted coding effects'] = (
@@ -278,19 +279,20 @@ class TemplateDataCreator(object):
 
     def _processing_prediction_for(self, epitope_prediction):
         """Look up the ProcessingPrediction for this epitope by
-        ``(peptide, source, 'pepsickle')``. Returns ``None`` when no
-        record exists (annotation pass didn't run, or this prediction
-        had no usable source sequence).
+        ``(peptide, source, predictor_name)``. Returns ``None`` when
+        no record exists (annotation pass didn't run, or this
+        prediction had no usable source sequence).
 
-        Hard-coded predictor name is ``'pepsickle'`` for now — when a
-        second per-position cleavage predictor lands, this method
-        becomes the swap point (read predictor name from a config knob
-        + fall back).
+        Predictor name is currently always
+        :data:`vaxrank.processing.PEPSICKLE_PREDICTOR_NAME`; when a
+        second per-position cleavage predictor (NetChop, PAProC, …)
+        lands, this method becomes the swap point — read the
+        predictor name from a config knob and fall back as needed.
         """
         key = (
             epitope_prediction.peptide_sequence or '',
             getattr(epitope_prediction, 'source_sequence', '') or '',
-            'pepsickle',
+            PEPSICKLE_PREDICTOR_NAME,
         )
         return self.processing_predictions_by_key.get(key)
 

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.23.0"
+__version__ = "2.23.1"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Three small follow-ups from the post-2.23 dead-code sweep.

1. **``PEPSICKLE_PREDICTOR_NAME`` is now public** in ``vaxrank.processing`` (was ``_PEPSICKLE_PREDICTOR_NAME``). ``vaxrank.report`` imports it instead of hard-coding ``'pepsickle'`` in two places — the ``Processing predictor:`` patient-info row and the ``_processing_prediction_for`` join key. Future predictor plumbing has one constant to swap.

2. **Test module docstring updated** in ``tests/test_processing.py`` — references ``ProcessingPrediction.processing_score`` (post-2.23) instead of the dropped ``EpitopePrediction.pepsickle_processing_score`` field.

3. **Pre-1.1.0 JSON shim removed.** ``EpitopePrediction._SERIALIZABLE_KEYWORD_ALIASES = {"length": None}`` was a deserialization aid for old JSON blobs that recorded ``length`` as an init arg. Vaxrank is at 2.23 — the migration window is long over. The shim's only consumer was a back-compat test, also removed. ``ClassVar`` / ``Optional`` imports gone with it.

## Test plan

- [x] ``./lint.sh`` clean
- [x] ``./test.sh`` — 736 passed (was 737; one back-compat test deleted with the shim)
- [ ] CI green

Patch-bumps to **2.23.1** since the changes are internal cleanup only.