### PR TITLE
Multi-predictor visibility across LENS / pVACseq / VCF+BAM (#261)

### DIFF
--- a/tests/test_core_logic_config.py
+++ b/tests/test_core_logic_config.py
@@ -123,7 +123,7 @@ def test_vaccine_peptides_for_variant_config_overrides_explicit_params():
     with patch('vaxrank.core_logic.MutantProteinFragment') as MockFragment:
         MockFragment.from_isovar_result.return_value = mock_fragment
         with patch('vaxrank.core_logic.predict_epitopes') as mock_predict:
-            mock_predict.return_value = {}
+            mock_predict.return_value = []
 
             vaccine_peptides_for_variant(
                 isovar_result=mock_isovar_result,
@@ -151,7 +151,7 @@ def test_vaccine_peptides_for_variant_explicit_params_used_without_config():
     with patch('vaxrank.core_logic.MutantProteinFragment') as MockFragment:
         MockFragment.from_isovar_result.return_value = mock_fragment
         with patch('vaxrank.core_logic.predict_epitopes') as mock_predict:
-            mock_predict.return_value = {}
+            mock_predict.return_value = []
 
             vaccine_peptides_for_variant(
                 isovar_result=mock_isovar_result,
@@ -180,7 +180,7 @@ def test_vaccine_peptides_for_variant_epitope_config_passed_to_predict():
     with patch('vaxrank.core_logic.MutantProteinFragment') as MockFragment:
         MockFragment.from_isovar_result.return_value = mock_fragment
         with patch('vaxrank.core_logic.predict_epitopes') as mock_predict:
-            mock_predict.return_value = {}
+            mock_predict.return_value = []
 
             vaccine_peptides_for_variant(
                 isovar_result=mock_isovar_result,

--- a/tests/test_epitope_prediction.py
+++ b/tests/test_epitope_prediction.py
@@ -48,9 +48,14 @@ def test_reference_peptide_logic():
         epitope_config=epitope_config,
         genome=mouse_genome)
 
+    # ``predict_epitopes`` returns a flat list (post-2.24, #261) so
+    # multi-predictor runs preserve every prediction. Single-predictor
+    # tests like this one look up by (peptide, allele) themselves.
+    by_key = {
+        (p.peptide_sequence, p.allele): p for p in epitope_predictions}
     # occurs in protein ENSMUSP00000033506
-    prediction_occurs_in_reference = epitope_predictions[('NCDESLLAS', 'H-2-Kb')]
-    prediction_does_not_occur_in_reference = epitope_predictions[('LDVIVNCDE', 'H-2-Kb')]
+    prediction_occurs_in_reference = by_key[('NCDESLLAS', 'H-2-Kb')]
+    prediction_does_not_occur_in_reference = by_key[('LDVIVNCDE', 'H-2-Kb')]
     ok_(prediction_occurs_in_reference.occurs_in_reference)
     ok_(not prediction_does_not_occur_in_reference.occurs_in_reference)
 
@@ -64,6 +69,79 @@ def test_reference_peptide_logic():
         vaccine_peptide.wildtype_epitope_score)
     eq_(prediction_does_not_occur_in_reference.logistic_epitope_score(),
         vaccine_peptide.mutant_epitope_score)
+
+def test_predict_epitopes_returns_one_row_per_predictor_for_multimodel():
+    """Multi-model TopiaryPredictor (post-2.24, #261) emits one
+    EpitopePrediction per (peptide, allele, predictor) instead of
+    overwriting via dict-keyed-on-(peptide,allele). Verifies the
+    flat-list return shape preserves every predictor's view."""
+    from unittest.mock import patch
+    import pandas as pd
+    from topiary import TopiaryPredictor
+
+    wdr13_transcript = mouse_genome.transcripts_by_name("Wdr13-201")[0]
+    protein_fragment = MutantProteinFragment(
+        variant=Variant('X', '8125624', 'C', 'A'),
+        gene_name='Wdr13',
+        amino_acids='KLQGHSAPVLDVIVNCDESLLASSD',
+        mutant_amino_acid_start_offset=12,
+        mutant_amino_acid_end_offset=13,
+        n_overlapping_reads=71, n_alt_reads=25, n_ref_reads=46,
+        n_alt_reads_supporting_protein_sequence=2,
+        supporting_reference_transcripts=[wdr13_transcript])
+
+    # Stub a Topiary DF with two predictors emitting the same
+    # (peptide, allele) pair — the situation that pre-2.24 collapsed
+    # to one row in the dict-keyed return value.
+    rows = []
+    for predictor in ('mhcflurry', 'netmhcpan'):
+        for offset, peptide in [(0, 'KLQGHSAP'), (1, 'LQGHSAPV')]:
+            rows.append({
+                'peptide': peptide, 'peptide_length': 8,
+                'peptide_offset': offset, 'allele': 'H-2-Kb',
+                'affinity': 100.0, 'percentile_rank': 0.5,
+                'value': 100.0, 'prediction_method_name': predictor,
+                'source_sequence_name': 'Wdr13',
+                'kind': 'pMHC_affinity',
+                'predictor_version': '',
+                'score': 0.5,
+            })
+    fake_df = pd.DataFrame(rows)
+
+    class _StubTopiary(TopiaryPredictor):
+        def __init__(self):
+            pass  # don't call super().__init__ — we don't need real models
+
+        def predict_from_named_sequences(self, _named_sequences):
+            return fake_df
+
+    # Multi-predictor mode: tell the topiary DSL which model to
+    # default ``affinity`` to (or use bracket syntax in score_expr).
+    # This is the real-world contract for multi-predictor scoring.
+    epitope_config = EpitopeConfig(
+        min_epitope_score=0,
+        default_methods={'pMHC_affinity': 'mhcflurry'})
+    with patch('vaxrank.epitope_logic.ReferenceProteome'):
+        preds = predict_epitopes(
+            mhc_predictor=_StubTopiary(),
+            protein_fragment=protein_fragment,
+            epitope_config=epitope_config,
+            genome=mouse_genome)
+    # 2 predictors × 2 peptides × 1 allele = 4 predictions; pre-fix
+    # this would collapse to 2 (one per (peptide, allele) key).
+    assert len(preds) == 4
+    methods = sorted({p.prediction_method_name for p in preds})
+    assert methods == ['mhcflurry', 'netmhcpan']
+    # Same (peptide, allele) appears twice, once per predictor.
+    by_pep_allele = {}
+    for p in preds:
+        by_pep_allele.setdefault(
+            (p.peptide_sequence, p.allele), []).append(p.prediction_method_name)
+    for key, names in by_pep_allele.items():
+        assert sorted(names) == ['mhcflurry', 'netmhcpan'], (
+            "Expected both predictors per (peptide, allele); got %r for %r"
+            % (names, key))
+
 
 def test_mhc_predictor_error():
     wdr13_transcript = mouse_genome.transcripts_by_name("Wdr13-201")[0]

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -273,6 +273,97 @@ def test_load_default_predictor_returns_none_when_mhctools_missing(
 
 # ---- Report integration --------------------------------------------------
 
+def test_ascii_report_surfaces_each_predictor_in_per_epitope_table():
+    """End-to-end render: when a VaccinePeptide carries two
+    EpitopePredictions for the same (peptide, allele) — one per
+    predictor — both rows appear in the rendered ASCII table with
+    a ``Predictor`` column distinguishing them. Pre-2.24 the
+    VCF/BAM path collapsed via dict-overwrite so this test would
+    have only seen one row."""
+    import io
+    from vaxrank.report import _make_report
+    template_data = {
+        'patient_info': {'Patient ID': 'TEST'},
+        'package_versions': {},
+        'reviewers': [], 'final_review': '',
+        'input_json_file': None,
+        'include_manufacturability': False,
+        'include_wt_epitopes': False,
+        'args': [], 'mrna_ranking': None,
+        'variants': [{
+            'num': 1,
+            'short_description': 'chr1:100 A>T',
+            'variant_data': {'Gene name': 'GENEA', 'Top score': 1.0},
+            'effect_data': {'effect': 'missense'},
+            'peptides': [{
+                'header_display_data': {
+                    'num': 1,
+                    'aa_before_mutation': 'KLQ',
+                    'aa_mutant': 'X',
+                    'aa_after_mutation': 'GHS'},
+                'peptide_data': {},
+                'manufacturability_data': {},
+                'wt_epitopes': [], 'ascii_wt_epitopes': None,
+                'epitopes': [
+                    {'Sequence': 'SIINFEKL', 'Predictor': 'mhcflurry',
+                     'IC50': '50.00 nM', 'Allele': 'A*02:01'},
+                    {'Sequence': 'SIINFEKL', 'Predictor': 'netmhcpan',
+                     'IC50': '75.00 nM', 'Allele': 'A*02:01'},
+                ],
+                'ascii_epitopes': (
+                    "Sequence Predictor IC50 Allele\n"
+                    "SIINFEKL mhcflurry 50.00 A*02:01\n"
+                    "SIINFEKL netmhcpan 75.00 A*02:01\n"),
+            }],
+        }],
+    }
+    f = io.StringIO()
+    _make_report(template_data, f, 'templates/template.txt')
+    rendered = f.getvalue()
+    # Both predictors named in the per-epitope ASCII table; same
+    # peptide+allele appears twice (one row per predictor).
+    assert 'mhcflurry' in rendered
+    assert 'netmhcpan' in rendered
+    assert rendered.count('SIINFEKL') >= 2
+
+
+def test_epitope_data_renders_one_row_per_predictor_for_same_pep_allele():
+    """Issue #261: when LENS / pVACseq / multi-predictor VCF runs
+    emit multiple EpitopePredictions per (peptide, allele) — one
+    per predictor — the per-epitope report table renders one row
+    per prediction with a ``Predictor`` column distinguishing them."""
+    from collections import OrderedDict
+    from vaxrank.report import TemplateDataCreator
+    from vaxrank.epitope_prediction import EpitopePrediction
+
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = {}
+
+    def _ep(method, ic50):
+        return EpitopePrediction(
+            allele='HLA-A*02:01', peptide_sequence='SIINFEKL',
+            wt_peptide_sequence='SIINFEKL', ic50=ic50, wt_ic50=2000.0,
+            percentile_rank=0.5, prediction_method_name=method,
+            overlaps_mutation=True, source_sequence='SSIINFEKL',
+            offset=1, occurs_in_reference=False)
+    preds = [_ep('mhcflurry', 50.0), _ep('netmhcpan', 75.0)]
+
+    rows = [creator._epitope_data(p) for p in preds]
+    assert len(rows) == 2
+    # Each row preserves its own predictor name + IC50 — no collapsing.
+    assert rows[0]['Predictor'] == 'mhcflurry'
+    assert rows[1]['Predictor'] == 'netmhcpan'
+    assert rows[0]['IC50'] == '50.00 nM'
+    assert rows[1]['IC50'] == '75.00 nM'
+    # Same allele + sequence (the join we want to surface, not collapse).
+    assert rows[0]['Sequence'] == rows[1]['Sequence'] == 'SIINFEKL'
+    assert rows[0]['Allele'] == rows[1]['Allele'] == 'A*02:01'
+    # Result is an OrderedDict so the rendered HTML/PDF table
+    # column order is stable across rows.
+    assert all(isinstance(r, OrderedDict) for r in rows)
+    assert list(rows[0].keys()) == list(rows[1].keys())
+
+
 def test_epitope_data_surfaces_processing_columns_when_annotated():
     """``TemplateDataCreator._epitope_data`` adds three extra
     columns (Processing: C-term, Processing: max internal,

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -35,6 +35,7 @@ from isovar.cli.filter_args import filter_threshold_dict_from_args
 from mhctools.cli import (
     mhc_alleles_from_args,
     mhc_binding_predictor_from_args,
+    predictors_from_args,
 )
 
 from .arg_parser import parse_vaxrank_args, check_args
@@ -1164,7 +1165,28 @@ def run_vaxrank_from_parsed_args(args):
     args.max_vaccine_peptides_per_mutation = vaccine_config.max_vaccine_peptides_per_variant
     args.num_epitopes_per_vaccine_peptide = vaccine_config.num_mutant_epitopes_to_keep
 
-    mhc_predictor = mhc_binding_predictor_from_args(args)
+    # Multi-predictor support (#261): mhctools' ``--mhc-predictor`` is
+    # nargs='+', so the user can configure
+    # ``--mhc-predictor mhcflurry netmhcpan`` and we run both, emitting
+    # one EpitopePrediction per (peptide, allele, predictor). Single-
+    # predictor runs unchanged (use the bare predictor; topiary wraps
+    # it inside ``predict_epitopes``). Multi-predictor runs use
+    # ``topiary.TopiaryPredictor(models=[...])`` so the per-row
+    # ``prediction_method_name`` ends up on every EpitopePrediction.
+    predictors_list = predictors_from_args(args)
+    if len(predictors_list) == 1:
+        mhc_predictor = predictors_list[0]
+    else:
+        from topiary import TopiaryPredictor
+        mhc_predictor = TopiaryPredictor(models=predictors_list)
+        logger.info(
+            "Running %d MHC predictors: %s. Each (peptide, allele) "
+            "lands in the report once per predictor; combine them via "
+            "``epitopes.score_expr`` (e.g. "
+            "``affinity[mhcflurry] * 0.5 + affinity[netmhcpan] * 0.5``).",
+            len(predictors_list),
+            [getattr(p, '__class__', type(p)).__name__
+             for p in predictors_list])
 
     prediction_cache = getattr(args, 'prediction_cache', None)
     if prediction_cache:

--- a/vaxrank/core_logic.py
+++ b/vaxrank/core_logic.py
@@ -232,13 +232,12 @@ def vaccine_peptides_for_variant(
 
     logger.info("Mutant protein fragment for %s: %s", variant, long_protein_fragment)
 
-    epitope_predictions_dict = predict_epitopes(
+    epitope_predictions = predict_epitopes(
         mhc_predictor=mhc_predictor,
         protein_fragment=long_protein_fragment,
         epitope_config=epitope_config,
         genome=variant.ensembl,
     )
-    epitope_predictions = list(epitope_predictions_dict.values())
     return vaccine_peptides_from_epitopes(
         variant=variant,
         long_protein_fragment=long_protein_fragment,

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 
-from collections import OrderedDict
 import traceback
 import logging
 from typing import Optional
@@ -45,20 +44,21 @@ def slice_epitope_predictions(
         if p.offset >= start_offset and p.offset + p.length <= end_offset
     ]
 
-Peptide = str
-Allele = str
-
 def predict_epitopes(
         mhc_predictor,
         protein_fragment : MutantProteinFragment,
         epitope_config : Optional[EpitopeConfig] = None,
-        genome : Optional[Genome] = None) -> dict[tuple[Peptide, Allele], EpitopePrediction]:
+        genome : Optional[Genome] = None) -> list[EpitopePrediction]:
     """
     Parameters
     ----------
     mhc_predictor
-        Either a topiary.TopiaryPredictor or a mhctools BasePredictor.
-        If a BasePredictor is given, it will be wrapped in a TopiaryPredictor.
+        Either a topiary.TopiaryPredictor (which can wrap multiple
+        models) or a mhctools BasePredictor. A bare BasePredictor is
+        wrapped in a single-model TopiaryPredictor; pass a multi-model
+        TopiaryPredictor (or use ``--mhc-predictor`` with multiple
+        names on the CLI) to get one EpitopePrediction per (peptide,
+        allele, predictor).
 
     protein_fragment
         Protein sub-sequence to run MHC binding predictor over
@@ -70,16 +70,22 @@ def predict_epitopes(
     genome
         Genome whose proteome to use for reference peptide filtering
 
-    Returns an OrderedDict of EpitopePrediction objects, keyed by a
-    (peptide sequence, allele) tuple, that have a normalized score greater
-    than min_epitope_score.
+    Returns
+    -------
+    list[EpitopePrediction]
+        One entry per (peptide, allele, predictor) tuple — multi-predictor
+        runs (mhcflurry + netmhcpan, …) yield multiple entries per
+        (peptide, allele) pair, with ``prediction_method_name``
+        distinguishing them. Pre-2.24 this was a dict keyed on
+        ``(peptide, allele)`` which silently overwrote when multiple
+        predictors were configured (issue #261).
 
     Uses the input genome to evaluate whether the epitope occurs in reference.
     """
     if epitope_config is None:
         epitope_config = EpitopeConfig()
 
-    results = OrderedDict()
+    results: list[EpitopePrediction] = []
     reference_proteome = ReferenceProteome(genome)
 
     # Wrap bare mhctools predictors in a TopiaryPredictor
@@ -101,18 +107,26 @@ def predict_epitopes(
     if predictions_df.empty:
         return results
 
+    # ``default_methods`` (per-kind ``prediction_method_name`` defaults
+    # for unqualified DSL refs) is required when multi-predictor data
+    # is in play — without it, ``affinity.value`` is ambiguous and
+    # topiary raises. Single-predictor runs leave ``default_methods``
+    # unset and the DSL resolves the only available method.
+    default_methods = getattr(epitope_config, 'default_methods', None) or None
+
     # Apply the configured filter (default: affinity or percentile-rank cutoff)
     # so that rows dropped by the filter are never scored or WT-predicted.
     filter_node = build_filter_node(epitope_config)
     if filter_node is not None:
-        predictions_df = apply_filter(predictions_df, filter_node)
+        predictions_df = apply_filter(
+            predictions_df, filter_node, default_methods=default_methods)
         if predictions_df.empty:
             return results
 
     # Evaluate the score expression once; indexed by
     # (source_sequence_name, peptide, peptide_offset, allele) group tuple.
     score_node = build_score_node(epitope_config)
-    score_ctx = EvalContext(predictions_df)
+    score_ctx = EvalContext(predictions_df, default_methods=default_methods)
     score_series = (
         score_node.eval(score_ctx).reindex(score_ctx.group_index).fillna(0.0)
     )
@@ -232,8 +246,7 @@ def predict_epitopes(
         epitope_score = float(score_series[group_key])
 
         if epitope_score >= epitope_config.min_epitope_score:
-            key = (epitope_prediction.peptide_sequence, epitope_prediction.allele)
-            results[key] = epitope_prediction
+            results.append(epitope_prediction)
         else:
             num_low_scoring += 1
 

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.23.1"
+__version__ = "2.24.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Closes #261. Every predictor's IC50 / score / rank now reaches the HTML / PDF / ASCII reports across all three input paths.

## Root cause (VCF/BAM only)

The VCF/BAM pipeline's ``predict_epitopes`` collapsed multi-predictor data via a dict keyed on ``(peptide, allele)`` — so when topiary's ``TopiaryPredictor(models=[mhcflurry, netmhcpan])`` produced two rows for the same (peptide, allele), the second silently overwrote the first. Pre-fix:

- **LENS**: already emitted N predictions per (peptide, allele) intact ✓
- **pVACseq**: single-predictor by file format ✓
- **VCF/BAM**: collapsed via dict overwrite ✗

## Fix

- ``predict_epitopes`` returns ``list[EpitopePrediction]`` (was dict). Every (peptide, allele, predictor) lands in the list.
- ``epitope_logic`` threads ``epitope_config.default_methods`` into topiary's ``EvalContext`` / ``apply_filter`` so the DSL has a per-kind tiebreaker for multi-predictor data.
- ``run_vaxrank_from_parsed_args`` switches from ``mhc_binding_predictor_from_args`` (single) to ``predictors_from_args`` (multi). ``--mhc-predictor mhcflurry netmhcpan`` now actually runs both.

## Report rendering — already correct

The HTML/PDF/ASCII per-epitope tables iterate ``vaccine_peptide.mutant_epitope_predictions``; with multiple predictions per (peptide, allele), the table now renders one row per prediction with the ``Predictor`` column distinguishing them.

## Multi-predictor contract

Either (a) ``epitopes.default_methods`` in YAML (or ``EpitopeConfig(default_methods=...)``), or (b) explicit bracket syntax in ``score_expr`` / ``filter_expr`` (e.g. ``affinity[mhcflurry] * 0.5 + affinity[netmhcpan] * 0.5``). The CLI logs an INFO line naming the active predictors when more than one is configured.

## Test plan

- [x] ``./lint.sh`` clean
- [x] ``./test.sh`` — 739 passed (was 736; +3 new tests)
- New tests:
  - Multi-model topiary stub returns one prediction per (peptide, allele, predictor)
  - ``_epitope_data`` renders two rows for two predictors on the same (peptide, allele)
  - End-to-end ASCII render surfaces both predictor names
- [ ] CI green

Bumps version to 2.24.0.