### PR TITLE
MHC coverage selection + per-modality vaccine construction reports (#269)

### DIFF
--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,340 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for ``vaxrank.coverage`` (#269): MHC allele coverage
+measurement + greedy coverage-aware antigen selection.
+
+Pins:
+- Tier rule: best-of-two-axes (presentation_percentile, percentile_rank)
+  bucketed at 0.5 / 1.0 / 2.0 % cutoffs into strong / medium / low.
+- Animal-agnostic: same code path for HLA, mouse H-2, swine SLA — only
+  thing that varies is which predictor has data on which allele.
+- Greedy selector: lexicographic (strong, medium, low, score). Falls
+  back to pure score order when no candidate adds coverage.
+- Multi-predictor evidence aggregates: presentation %-rank from one
+  record + affinity %-rank from another for the same (peptide, allele)
+  combine (smaller of the two wins).
+"""
+
+from types import SimpleNamespace
+
+from vaxrank.coverage import (
+    AlleleCoverage,
+    antigen_tier_per_allele,
+    compute_coverage,
+    select_antigens_for_coverage,
+    summarize_construction_decisions,
+)
+
+
+def _ep(peptide, allele, *, presentation_pct=None, affinity_pct=None,
+        method=''):
+    """Minimal EpitopePrediction-like record."""
+    return SimpleNamespace(
+        peptide_sequence=peptide, allele=allele,
+        presentation_percentile=presentation_pct,
+        percentile_rank=affinity_pct,
+        prediction_method_name=method)
+
+
+def _vp(predictions, *, combined_score=1.0, gene_name='GENE'):
+    """Minimal VaccinePeptide-like record."""
+    return SimpleNamespace(
+        mutant_epitope_predictions=predictions,
+        mutant_protein_fragment=SimpleNamespace(
+            gene_name=gene_name, amino_acids='AAAAAAA'),
+        combined_score=combined_score,
+        manufacturability_scores=None)
+
+
+# -- compute_coverage --------------------------------------------------
+
+
+def test_compute_coverage_buckets_into_correct_tiers():
+    """0.4% → strong; 0.7% → medium; 1.5% → low; 3.0% → uncovered."""
+    preds = [
+        _ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.4),
+        _ep('AAAAAAAAA', 'HLA-B*07:02', presentation_pct=0.7),
+        _ep('CCCCCCCCC', 'HLA-C*03:04', presentation_pct=1.5),
+        _ep('DDDDDDDDD', 'HLA-A*68:01', presentation_pct=3.0),
+    ]
+    targets = ['HLA-A*02:01', 'HLA-B*07:02', 'HLA-C*03:04', 'HLA-A*68:01']
+    coverage = compute_coverage(preds, targets)
+    assert coverage['HLA-A*02:01'].tier == 'strong'
+    assert coverage['HLA-B*07:02'].tier == 'medium'
+    assert coverage['HLA-C*03:04'].tier == 'low'
+    assert coverage['HLA-A*68:01'].tier is None  # 3% > 2.0 = uncovered
+
+
+def test_compute_coverage_aggregates_across_predictors():
+    """When mhcflurry says presentation_pct=1.5 and netmhcpan says
+    affinity_pct=0.3 for the same (peptide, allele), the better axis
+    wins and the allele lands in tier-strong."""
+    preds = [
+        _ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=1.5,
+            method='mhcflurry'),
+        _ep('SIINFEKL', 'HLA-A*02:01', affinity_pct=0.3,
+            method='netmhcpan'),
+    ]
+    coverage = compute_coverage(preds, ['HLA-A*02:01'])
+    assert coverage['HLA-A*02:01'].tier == 'strong'
+
+
+def test_compute_coverage_uncovered_alleles_appear_as_none():
+    """Every target allele gets a row, even those with no
+    predictions. Drives the report's ``✗ uncovered`` line."""
+    preds = [_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.4)]
+    coverage = compute_coverage(preds, ['HLA-A*02:01', 'HLA-B*07:02'])
+    assert coverage['HLA-A*02:01'].tier == 'strong'
+    assert coverage['HLA-B*07:02'].tier is None
+    assert coverage['HLA-B*07:02'].n_peptides == 0
+
+
+def test_compute_coverage_animal_agnostic_mouse_alleles():
+    """Mouse H-2 alleles flow through the same code. mhcflurry
+    typically has no mouse coverage so only affinity % rank is
+    available; the model uses what it's given."""
+    preds = [
+        _ep('SIINFEKL', 'H-2-Kb', affinity_pct=0.3, method='netmhcpan'),
+        _ep('AAAAAAAA', 'H-2-Db', affinity_pct=1.5, method='netmhcpan'),
+    ]
+    coverage = compute_coverage(preds, ['H-2-Kb', 'H-2-Db'])
+    assert coverage['H-2-Kb'].tier == 'strong'
+    assert coverage['H-2-Db'].tier == 'low'
+
+
+def test_compute_coverage_skips_alleles_outside_target_set():
+    """Alleles outside the patient's set are ignored — coverage is
+    a per-patient view, not a directory of every allele the
+    predictor saw."""
+    preds = [
+        _ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.4),
+        _ep('SIINFEKL', 'HLA-X*99:99', presentation_pct=0.1),
+    ]
+    coverage = compute_coverage(preds, ['HLA-A*02:01'])
+    assert set(coverage) == {'HLA-A*02:01'}
+
+
+def test_compute_coverage_empty_targets_returns_empty():
+    """No targets → no coverage rows. Lets callers gate the report
+    section on ``if patient_info.mhc_alleles``."""
+    coverage = compute_coverage(
+        [_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.4)],
+        target_alleles=[])
+    assert coverage == {}
+
+
+# -- antigen_tier_per_allele ------------------------------------------
+
+
+def test_antigen_tier_per_allele_takes_best_peptide():
+    """One antigen has many sliding-window peptides; the antigen's
+    tier for an allele is the *best* tier any of its peptides
+    achieves."""
+    vp = _vp([
+        _ep('AAAAAAAA', 'HLA-A*02:01', presentation_pct=1.8),  # low
+        _ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3),  # strong
+        _ep('DDDDDDDD', 'HLA-A*02:01', presentation_pct=0.9),  # medium
+    ])
+    tiers = antigen_tier_per_allele(vp, ['HLA-A*02:01'])
+    assert tiers['HLA-A*02:01'] == 'strong'
+
+
+# -- select_antigens_for_coverage -------------------------------------
+
+
+def test_selector_prefers_coverage_over_score():
+    """When the top-scoring antigen covers no targets and a
+    lower-scoring one covers a strong-tier target, the selector
+    picks the lower-scoring one first."""
+    high_score_uncovered = _vp(
+        [_ep('AAAAAAAA', 'HLA-A*02:01', presentation_pct=3.0)],
+        combined_score=10.0, gene_name='HIGH')
+    low_score_strong = _vp(
+        [_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3)],
+        combined_score=1.0, gene_name='LOW')
+    candidates = [
+        ('var1', [high_score_uncovered]),
+        ('var2', [low_score_strong]),
+    ]
+    selected = select_antigens_for_coverage(
+        candidates, ['HLA-A*02:01'], n_to_select=2)
+    # Coverage-driving antigen comes first.
+    assert selected[0][0] == 'var2'
+    assert selected[1][0] == 'var1'
+
+
+def test_selector_falls_back_to_score_when_coverage_satisfied():
+    """Once every target allele is covered at strong tier, the
+    selector reverts to pure score order — so an already-covered
+    pool gives the same selection as today's behavior."""
+    a = _vp(
+        [_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3)],
+        combined_score=10.0, gene_name='A')
+    b = _vp(
+        [_ep('AAAAAAAA', 'HLA-A*02:01', presentation_pct=0.4)],
+        combined_score=8.0, gene_name='B')
+    c = _vp(
+        [_ep('DDDDDDDD', 'HLA-A*02:01', presentation_pct=0.5)],
+        combined_score=12.0, gene_name='C')
+    candidates = [('vA', [a]), ('vB', [b]), ('vC', [c])]
+    selected = select_antigens_for_coverage(
+        candidates, ['HLA-A*02:01'], n_to_select=3)
+    # First pick: any of the three covers strong; selector picks
+    # the highest-scoring one (C). Then coverage is satisfied —
+    # remaining slots fill in pure score order: A (10), B (8).
+    names = [s[0] for s in selected]
+    assert names[0] == 'vC'
+    # Ordering after coverage is satisfied should mirror
+    # combined_score among the rest.
+    assert names == ['vC', 'vA', 'vB']
+
+
+def test_selector_no_op_with_empty_targets():
+    """Empty target_alleles → return ranked[:n] unchanged."""
+    a = _vp([_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3)],
+            combined_score=10.0)
+    b = _vp([_ep('AAAAAAAA', 'HLA-B*07:02', presentation_pct=0.4)],
+            combined_score=8.0)
+    candidates = [('vA', [a]), ('vB', [b])]
+    selected = select_antigens_for_coverage(
+        candidates, target_alleles=[], n_to_select=2)
+    assert [s[0] for s in selected] == ['vA', 'vB']
+
+
+def test_selector_spreads_across_multiple_alleles():
+    """With three target alleles and three antigens each covering a
+    different one, the selector picks all three (one per allele)
+    rather than three of the same allele."""
+    a02 = _vp(
+        [_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.2)],
+        combined_score=5.0, gene_name='A02')
+    b07 = _vp(
+        [_ep('AAAAAAAA', 'HLA-B*07:02', presentation_pct=0.2)],
+        combined_score=5.0, gene_name='B07')
+    c03 = _vp(
+        [_ep('CCCCCCCC', 'HLA-C*03:04', presentation_pct=0.2)],
+        combined_score=5.0, gene_name='C03')
+    candidates = [('vA', [a02]), ('vB', [b07]), ('vC', [c03])]
+    selected = select_antigens_for_coverage(
+        candidates, ['HLA-A*02:01', 'HLA-B*07:02', 'HLA-C*03:04'],
+        n_to_select=3)
+    # All three picked — full spread.
+    assert {s[0] for s in selected} == {'vA', 'vB', 'vC'}
+
+
+# -- summarize_construction_decisions ---------------------------------
+
+
+def test_summarize_includes_coverage_for_selected_pool():
+    """The summary's ``coverage`` field is computed over the
+    *selected* antigens, not the full ranked input."""
+    selected_a = _vp(
+        [_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3)],
+        combined_score=10.0, gene_name='SELECTED')
+    dropped_b = _vp(
+        [_ep('DDDDDDDD', 'HLA-B*07:02', presentation_pct=0.3)],
+        combined_score=1.0, gene_name='DROPPED')
+    ranked = [
+        ('var1', [selected_a]),
+        ('var2', [dropped_b]),
+    ]
+    summary = summarize_construction_decisions(
+        ranked, cap=1, target_alleles=['HLA-A*02:01', 'HLA-B*07:02'])
+    assert summary['cap'] == 1
+    assert summary['total_ranked'] == 2
+    assert len(summary['selected']) == 1
+    assert len(summary['dropped']) == 1
+    coverage_by_allele = {c.allele: c for c in summary['coverage']}
+    assert coverage_by_allele['HLA-A*02:01'].tier == 'strong'
+    # B*07 is only available on the dropped antigen, so the
+    # selected-pool coverage is uncovered for B*07.
+    assert coverage_by_allele['HLA-B*07:02'].tier is None
+
+
+def test_ascii_report_renders_coverage_block_in_construction_section():
+    """End-to-end render: a populated ``vaccine_constructions``
+    block produces the new coverage section in the ASCII output —
+    section header, per-allele coverage lines, per-antigen
+    ``covers A (tier)`` annotations."""
+    import io
+    from vaxrank.report import _make_report
+
+    template_data = {
+        'patient_info': {'Patient ID': 'TEST'},
+        'package_versions': {},
+        'reviewers': [], 'final_review': '',
+        'input_json_file': None,
+        'include_manufacturability': False,
+        'include_wt_epitopes': False,
+        'args': [], 'variants': [],
+        'mrna_ranking': None,
+        'vaccine_constructions': {
+            'mrna': {
+                'antigens_per_construct': 5, 'max_constructs': 1,
+                'cap': 5, 'total_ranked': 5,
+                'selected': [
+                    {'rank': 1, 'gene_name': 'GENE_A',
+                     'description': 'GENE_A_chr1_100',
+                     'combined_score': 10.0,
+                     'allele_tiers': {'HLA-A*02:01': 'strong'},
+                     'manufacturability': {}},
+                ],
+                'dropped': [],
+                'coverage': [
+                    AlleleCoverage(
+                        allele='HLA-A*02:01', tier='strong',
+                        n_peptides=2,
+                        best_presentation_pct=0.3,
+                        best_affinity_pct=0.5,
+                        contributing_peptides=('SIINFEKL',)),
+                    AlleleCoverage(
+                        allele='HLA-B*07:02', tier=None,
+                        n_peptides=0,
+                        best_presentation_pct=None,
+                        best_affinity_pct=None,
+                        contributing_peptides=()),
+                ],
+            },
+        },
+    }
+    f = io.StringIO()
+    _make_report(template_data, f, 'templates/template.txt')
+    rendered = f.getvalue()
+    # Section header.
+    assert 'Vaccine construction — mrna' in rendered
+    # Per-allele coverage lines: one covered, one uncovered.
+    assert 'HLA-A*02:01' in rendered
+    assert 'HLA-B*07:02' in rendered
+    assert 'strong' in rendered
+    assert 'none' in rendered
+    # Per-antigen tier annotation.
+    assert 'covers HLA-A*02:01 (strong)' in rendered
+    # Best presentation %-rank surfaces in the coverage detail line.
+    assert '0.30' in rendered
+
+
+def test_summarize_per_row_has_allele_tiers_and_manufacturability():
+    """Each row in ``selected``/``dropped`` carries the per-allele
+    tier map (drives the ``covers A*02:01 (strong)`` annotation)
+    plus the manufacturability dict (peptide construction view
+    renders it)."""
+    vp = _vp(
+        [_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3)],
+        combined_score=5.0, gene_name='GENEX')
+    # Stub the manufacturability_scores like ManufacturabilityScores
+    # would (a namedtuple with _asdict).
+    from collections import namedtuple
+    Mfg = namedtuple('Mfg', ['cysteine_count', 'cterm_hydropathy'])
+    vp.manufacturability_scores = Mfg(0, 0.5)
+
+    summary = summarize_construction_decisions(
+        [('var1', [vp])], cap=1, target_alleles=['HLA-A*02:01'])
+    row = summary['selected'][0]
+    assert row['gene_name'] == 'GENEX'
+    assert row['allele_tiers'] == {'HLA-A*02:01': 'strong'}
+    assert row['manufacturability'] == {
+        'cysteine_count': 0, 'cterm_hydropathy': 0.5}

--- a/tests/test_mrna.py
+++ b/tests/test_mrna.py
@@ -170,28 +170,37 @@ def test_ascii_report_renders_mrna_ranking_section():
         'include_wt_epitopes': True,
         'args': [],
         'variants': [],
-        'mrna_ranking': {
-            'antigens_per_construct': 5,
-            'max_constructs': 2,
-            'cap': 10,
-            'total_ranked': 12,
-            'selected': [
-                {'rank': 1, 'gene_name': 'GENEA',
-                 'description': 'GENEA_1_100_A_T', 'combined_score': 12.5},
-                {'rank': 2, 'gene_name': 'GENEB',
-                 'description': 'GENEB_2_200_A_T', 'combined_score': 11.1},
-            ],
-            'dropped': [
-                {'rank': 11, 'gene_name': 'GENEK',
-                 'description': 'GENEK_3_300_A_T', 'combined_score': 4.3},
-            ],
+        'vaccine_constructions': {
+            'mrna': {
+                'antigens_per_construct': 5,
+                'max_constructs': 2,
+                'cap': 10,
+                'total_ranked': 12,
+                'selected': [
+                    {'rank': 1, 'gene_name': 'GENEA',
+                     'description': 'GENEA_1_100_A_T',
+                     'combined_score': 12.5,
+                     'allele_tiers': {}, 'manufacturability': {}},
+                    {'rank': 2, 'gene_name': 'GENEB',
+                     'description': 'GENEB_2_200_A_T',
+                     'combined_score': 11.1,
+                     'allele_tiers': {}, 'manufacturability': {}},
+                ],
+                'dropped': [
+                    {'rank': 11, 'gene_name': 'GENEK',
+                     'description': 'GENEK_3_300_A_T',
+                     'combined_score': 4.3,
+                     'allele_tiers': {}, 'manufacturability': {}},
+                ],
+                'coverage': [],
+            },
         },
     }
     f = io.StringIO()
     _make_report(template_data, f, 'templates/template.txt')
     rendered = f.getvalue()
-    # Section header, selected rows, dropped rows all present.
-    assert 'mRNA vaccine antigen selection' in rendered
+    # Post-2.25 section header (was "mRNA vaccine antigen selection").
+    assert 'Vaccine construction — mrna' in rendered
     assert '2 of 12 ranked' in rendered
     assert 'GENEA_1_100_A_T' in rendered
     assert 'GENEB_2_200_A_T' in rendered
@@ -202,9 +211,9 @@ def test_ascii_report_renders_mrna_ranking_section():
     assert '10' in rendered  # cap
 
 
-def test_ascii_report_skips_mrna_section_when_not_set():
-    """When ``mrna_ranking`` is None (peptide-only run), the section
-    doesn't render."""
+def test_ascii_report_skips_construction_section_when_no_modalities():
+    """When ``vaccine_constructions`` is empty (no active modality
+    or no ranked antigens), no construction sections render."""
     from vaxrank.report import _make_report
     import io
     template_data = {
@@ -215,12 +224,13 @@ def test_ascii_report_skips_mrna_section_when_not_set():
         'include_manufacturability': False,
         'include_wt_epitopes': True,
         'args': [], 'variants': [],
+        'vaccine_constructions': {},
         'mrna_ranking': None,
     }
     f = io.StringIO()
     _make_report(template_data, f, 'templates/template.txt')
     rendered = f.getvalue()
-    assert 'mRNA vaccine antigen selection' not in rendered
+    assert 'Vaccine construction' not in rendered
 
 
 def test_resolve_named_accepts_dashes_and_case_variants():

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -371,7 +371,14 @@ def _emit_peptide_constructs(args, ranked, target_dir):
     if antigen_content is not None:
         config_kwargs['antigen_content'] = antigen_content
     peptide_options = PeptideConstructConfig(**config_kwargs)
-    constructs = assemble_peptide_constructs(ranked, options=peptide_options)
+    # Coverage-aware antigen selection (#269): when patient alleles
+    # are known, the selector reorders ``ranked`` greedily by
+    # coverage tier before bin-packing. No-op when alleles aren't
+    # available (e.g. external arg parser without
+    # ``--mhc-alleles`` and no LENS-inferred set).
+    target_alleles = _resolve_target_alleles(args)
+    constructs = assemble_peptide_constructs(
+        ranked, options=peptide_options, target_alleles=target_alleles)
     # Canonical filenames inside the per-modality target directory:
     # vaccine.fasta + manifest.json + order_form.csv. Single-mode
     # runs land directly in args.output_dir; multi-mode runs land in
@@ -545,6 +552,33 @@ def _log_args_summary(args):
     logger.info("\n".join(lines))
 
 
+def _resolve_target_alleles(args):
+    """Return the list of patient MHC alleles for coverage-aware
+    antigen selection (and for report-time coverage display).
+
+    Resolution mirrors :func:`_resolve_mhc_for_linker_optimizer`:
+
+    * Pipeline path: from ``--mhc-alleles`` on the CLI.
+    * External path (LENS / pVACseq): the loader stashes inferred
+      alleles on ``args._inferred_mhc_alleles_from_lens``.
+
+    Returns an empty list when neither source has data — callers
+    treat that as "coverage selection / display disabled, fall back
+    to pure-score order." Animal-agnostic: HLA, mouse H-2, swine
+    SLA all flow through here.
+    """
+    _ARG_LOAD_ERRORS = (AttributeError, ValueError, KeyError)
+    alleles = None
+    try:
+        alleles = mhc_alleles_from_args(args)
+    except _ARG_LOAD_ERRORS:
+        pass
+    if not alleles:
+        alleles = (
+            getattr(args, '_inferred_mhc_alleles_from_lens', None) or [])
+    return list(alleles or [])
+
+
 def _resolve_mhc_for_linker_optimizer(args):
     """Find a usable (predictor, alleles) pair for the per-junction
     linker optimizer.
@@ -708,9 +742,11 @@ def _emit_mrna_constructs(args, ranked, target_dir):
     else:
         mhc_predictor = None
         mhc_alleles = None
+    target_alleles = _resolve_target_alleles(args)
     constructs = assemble_mrna_constructs(
         ranked, options=options,
-        mhc_predictor=mhc_predictor, mhc_alleles=mhc_alleles)
+        mhc_predictor=mhc_predictor, mhc_alleles=mhc_alleles,
+        target_alleles=target_alleles)
     # Canonical filenames inside the per-modality target directory:
     # cds.fasta + no_polyA.fasta + full.fasta + manifest.json +
     # mrna-sequence-parts.csv. The cds/no_polyA/full FASTAs are
@@ -1084,30 +1120,87 @@ def main(args_list=None):
     if not (args.output_ascii_report or args.output_html_report or args.output_pdf_report):
         return
 
-    # Issue #270: mRNA ranking-decisions section in the template
-    # report. Computed when 'mrna' is in the active --vaccine-type so
-    # an mRNA-only or peptide+mrna run shows which top-k antigens
-    # land in the mRNA construct(s) vs which fall past the cap.
-    mrna_ranking_decisions = None
-    if 'mrna' in _resolve_vaccine_types(args) \
-            and ranked_variants_with_vaccine_peptides:
-        from ..mrna import (
-            RNAConstructConfig, summarize_mrna_ranking_decisions,
+    # Per-modality "Vaccine construction" blocks (#269 + #270).
+    # Each active modality gets a coverage-aware view of which
+    # antigens landed in the vaccine, plus per-allele coverage of
+    # the selected pool. The selector is the same one
+    # ``_emit_*_constructs`` runs at write time, so the report
+    # matches what would actually be assembled with --output-dir.
+    target_alleles = _resolve_target_alleles(args)
+    vaccine_constructions = {}
+    if ranked_variants_with_vaccine_peptides:
+        from ..coverage import (
+            select_antigens_for_coverage, summarize_construction_decisions,
         )
-        # Reuse the same kwargs the writer uses so the cap matches
-        # what the user would actually get if they ran with
-        # --output-dir.
-        yaml_kwargs = _construct_config_for_modality(args, 'mrna')
+        active_types = _resolve_vaccine_types(args)
+        if 'mrna' in active_types:
+            from ..mrna import RNAConstructConfig
+            yaml_kwargs = _construct_config_for_modality(args, 'mrna')
 
-        def _cfg(cli_attr, yaml_key):
-            return _coalesce_from_config(args, cli_attr, yaml_kwargs, yaml_key)
-        mrna_options = RNAConstructConfig(
-            antigens_per_construct=_cfg(
-                'mrna_antigens_per_construct', 'antigens_per_construct'),
-            max_constructs=_cfg('mrna_max_constructs', 'max_constructs'),
-        )
-        mrna_ranking_decisions = summarize_mrna_ranking_decisions(
-            ranked_variants_with_vaccine_peptides, mrna_options)
+            def _mrna_cfg(cli_attr, yaml_key):
+                return _coalesce_from_config(
+                    args, cli_attr, yaml_kwargs, yaml_key)
+            mrna_options = RNAConstructConfig(
+                antigens_per_construct=_mrna_cfg(
+                    'mrna_antigens_per_construct',
+                    'antigens_per_construct'),
+                max_constructs=_mrna_cfg(
+                    'mrna_max_constructs', 'max_constructs'),
+            )
+            cap = (
+                mrna_options.antigens_per_construct
+                * mrna_options.max_constructs)
+            selected = (
+                select_antigens_for_coverage(
+                    ranked_variants_with_vaccine_peptides,
+                    target_alleles, cap)
+                if target_alleles else
+                list(ranked_variants_with_vaccine_peptides[:cap]))
+            vaccine_constructions['mrna'] = {
+                **summarize_construction_decisions(
+                    ranked_variants_with_vaccine_peptides,
+                    cap=cap, target_alleles=target_alleles,
+                    selected=selected),
+                'antigens_per_construct': mrna_options.antigens_per_construct,
+                'max_constructs': mrna_options.max_constructs,
+            }
+        if 'peptide' in active_types:
+            from ..peptide import PeptideConstructConfig
+            yaml_kwargs = _construct_config_for_modality(args, 'peptide')
+
+            def _pep_cfg(cli_attr, yaml_key):
+                return _coalesce_from_config(
+                    args, cli_attr, yaml_kwargs, yaml_key)
+            pep_options = PeptideConstructConfig(
+                antigens_per_construct=_pep_cfg(
+                    'peptide_antigens_per_construct',
+                    'antigens_per_construct'),
+                max_constructs=_pep_cfg(
+                    'peptide_max_constructs', 'max_constructs'),
+            )
+            cap = (
+                pep_options.antigens_per_construct
+                * pep_options.max_constructs)
+            selected = (
+                select_antigens_for_coverage(
+                    ranked_variants_with_vaccine_peptides,
+                    target_alleles, cap)
+                if target_alleles else
+                list(ranked_variants_with_vaccine_peptides[:cap]))
+            vaccine_constructions['peptide'] = {
+                **summarize_construction_decisions(
+                    ranked_variants_with_vaccine_peptides,
+                    cap=cap, target_alleles=target_alleles,
+                    selected=selected),
+                'antigens_per_construct': pep_options.antigens_per_construct,
+                'max_constructs': pep_options.max_constructs,
+            }
+
+    # Back-compat: ``mrna_ranking_decisions`` is the legacy field
+    # name TemplateDataCreator already understands; we still pass
+    # it so older callers / tests keep working. New section is
+    # ``vaccine_constructions``.
+    mrna_ranking_decisions = vaccine_constructions.get('mrna')
 
     template_data_creator = TemplateDataCreator(
         ranked_variants_with_vaccine_peptides=ranked_variants_with_vaccine_peptides,
@@ -1119,7 +1212,9 @@ def main(args_list=None):
         cosmic_vcf_filename=getattr(args, 'cosmic_vcf_filename', ''),
         dna_vaf_by_variant=data.get('dna_vaf_by_variant') or {},
         processing_predictions_by_key=processing_predictions_by_key,
-        mrna_ranking_decisions=mrna_ranking_decisions)
+        mrna_ranking_decisions=mrna_ranking_decisions,
+        vaccine_constructions=vaccine_constructions,
+        target_alleles=target_alleles)
 
     template_data = template_data_creator.compute_template_data()
 

--- a/vaxrank/coverage.py
+++ b/vaxrank/coverage.py
@@ -1,0 +1,460 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""MHC allele coverage measurement + greedy selection.
+
+A vaccine's job is to engage a set of MHC alleles. Today vaxrank picks
+top-k antigens by ``combined_score`` only — that can leave alleles
+uncovered while others are over-engaged. This module adds the missing
+piece: a measurement of which alleles each antigen covers, and a
+greedy selector that prefers antigens which add the most uncovered
+alleles before falling back to ``combined_score`` order.
+
+## Two-axis evidence
+
+For each (peptide, allele) pair we look at two complementary axes:
+
+  presentation_percentile  — mhcflurry-pres: probability the peptide
+                             is generated + presented at meaningful
+                             abundance.
+  percentile_rank          — netmhcpan-affinity: binding strength once
+                             the peptide is in the ER.
+
+A peptide-allele pair is "covered" at a given tier when the **better**
+of the two axes (the smaller %-rank we have data for) is at-or-below
+the tier threshold.
+
+## Tiers
+
+  strong  : %-rank ≤ 0.5  — top-priority for coverage spreading
+  medium  : %-rank ≤ 1.0  — the selection objective
+  low     : %-rank ≤ 2.0  — bonus signal, not driving selection
+  none    : %-rank > 2.0  — not considered covered
+
+## Animal-agnostic
+
+Driven entirely off the patient's allele set
+(``patient_info.mhc_alleles``). HLA, mouse H-2, swine SLA, … all work
+the same way; predictors that don't have data for a given allele
+simply don't contribute. No species-specific code anywhere.
+
+## Selector
+
+Greedy, lexicographic key per candidate antigen:
+
+  (strong_alleles_added, medium_alleles_added, low_alleles_added,
+   combined_score)
+
+Pick the next antigen that maximizes new strong-tier coverage; ties
+broken by medium, then low, then today's ``combined_score``. Once
+every target allele is covered at strong tier, the selector
+degenerates to pure ``combined_score`` order — so when coverage is
+already complete, the rebalancer is a no-op.
+
+Issue: openvax/vaxrank#269.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+# Default tier thresholds (% rank). Stable, hardcoded for now —
+# expose as CLI knobs later if a user actually needs to tune them.
+TIER_STRONG = 0.5
+TIER_MEDIUM = 1.0
+TIER_LOW = 2.0
+
+# Names ordered most → least stringent. Shared between the report
+# writers and the selector.
+TIER_NAMES = ('strong', 'medium', 'low')
+
+
+def _tier_for_percentile(pct: Optional[float]) -> Optional[str]:
+    """Bucket one peptide-allele %-rank into a tier name, or
+    ``None`` if it doesn't reach any tier."""
+    if pct is None:
+        return None
+    if pct <= TIER_STRONG:
+        return 'strong'
+    if pct <= TIER_MEDIUM:
+        return 'medium'
+    if pct <= TIER_LOW:
+        return 'low'
+    return None
+
+
+def _better_tier(a: Optional[str], b: Optional[str]) -> Optional[str]:
+    """Return the more stringent of two tier names. ``None`` is the
+    weakest. Order is: strong > medium > low > None."""
+    rank = {'strong': 3, 'medium': 2, 'low': 1, None: 0}
+    return a if rank[a] >= rank[b] else b
+
+
+def _peptide_tier(p) -> Optional[str]:
+    """Best tier achieved by one EpitopePrediction, taking the
+    smaller of presentation_percentile and percentile_rank when
+    both are available. Predictors that don't expose a given axis
+    don't contribute (None on that axis is ignored)."""
+    pres = getattr(p, 'presentation_percentile', None)
+    aff = getattr(p, 'percentile_rank', None)
+    return _better_tier(_tier_for_percentile(pres), _tier_for_percentile(aff))
+
+
+@dataclass(frozen=True)
+class AlleleCoverage:
+    """Per-allele binding-evidence summary at one selection scope.
+
+    Attributes
+    ----------
+    allele : str
+        Allele name as it appears in the input (mhcgnomes-normalized
+        upstream — e.g. ``'HLA-A*02:01'``, ``'H-2-Kb'``,
+        ``'SLA-1*04:01'``).
+    tier : Optional[str]
+        Best tier achieved across all evidence in this scope.
+        ``'strong' | 'medium' | 'low' | None``. ``None`` means
+        uncovered at the tier-3 (low) cutoff.
+    n_peptides : int
+        Number of distinct peptide sequences in this scope that
+        cleared the tier-3 (low) cutoff for this allele.
+    best_presentation_pct : Optional[float]
+        Smallest presentation percentile_rank seen for this allele,
+        or ``None`` when no presentation predictor has data.
+    best_affinity_pct : Optional[float]
+        Smallest affinity percentile_rank seen for this allele,
+        or ``None``.
+    contributing_peptides : tuple[str, ...]
+        Peptide sequences that hit at least the ``low`` tier
+        (capped at 5 entries — full list lives in DEBUG logs).
+    """
+
+    allele: str
+    tier: Optional[str]
+    n_peptides: int
+    best_presentation_pct: Optional[float]
+    best_affinity_pct: Optional[float]
+    contributing_peptides: tuple
+
+
+def _min(a: Optional[float], b: Optional[float]) -> Optional[float]:
+    """min() that treats None as 'no data' rather than raising."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a if a < b else b
+
+
+def compute_coverage(
+    epitope_predictions,
+    target_alleles,
+) -> dict[str, AlleleCoverage]:
+    """Build {allele: AlleleCoverage} for ``target_alleles`` against
+    the evidence in ``epitope_predictions``.
+
+    Every allele in ``target_alleles`` gets a row, even alleles with
+    no predictions (tier=None, n=0). Alleles outside the target set
+    are skipped — this is a coverage view, not a directory of every
+    allele the predictor saw.
+
+    ``epitope_predictions`` is the flat list shape that vaxrank uses
+    everywhere post-#261 — one record per (peptide, allele,
+    predictor). When multi-predictor data is in play (e.g.
+    mhcflurry-presentation + netmhcpan-affinity for the same
+    (peptide, allele)), the predictions land here as separate
+    objects and ``compute_coverage`` aggregates evidence across
+    them.
+    """
+    targets = set(target_alleles or [])
+    if not targets:
+        return {}
+    # Two passes: collect best %-ranks per (peptide, allele), then
+    # bucket into tiers. The first pass merges multi-predictor
+    # evidence — for one (peptide, allele) we may see two records,
+    # one with presentation and one with affinity.
+    by_pep_allele: dict[tuple, dict] = {}
+    for p in epitope_predictions:
+        allele = getattr(p, 'allele', None)
+        if allele not in targets:
+            continue
+        peptide = getattr(p, 'peptide_sequence', None) or ''
+        if not peptide:
+            continue
+        key = (peptide, allele)
+        slot = by_pep_allele.setdefault(
+            key, {'pres': None, 'aff': None})
+        slot['pres'] = _min(
+            slot['pres'], getattr(p, 'presentation_percentile', None))
+        slot['aff'] = _min(
+            slot['aff'], getattr(p, 'percentile_rank', None))
+
+    # Aggregate to per-allele coverage.
+    out: dict[str, AlleleCoverage] = {}
+    for allele in targets:
+        peptides = []
+        best_pres = None
+        best_aff = None
+        best_tier: Optional[str] = None
+        for (peptide, a), slot in by_pep_allele.items():
+            if a != allele:
+                continue
+            best_pres = _min(best_pres, slot['pres'])
+            best_aff = _min(best_aff, slot['aff'])
+            tier = _better_tier(
+                _tier_for_percentile(slot['pres']),
+                _tier_for_percentile(slot['aff']))
+            if tier is not None:
+                peptides.append(peptide)
+                best_tier = _better_tier(best_tier, tier)
+        out[allele] = AlleleCoverage(
+            allele=allele,
+            tier=best_tier,
+            n_peptides=len(peptides),
+            best_presentation_pct=best_pres,
+            best_affinity_pct=best_aff,
+            contributing_peptides=tuple(sorted(set(peptides))[:5]),
+        )
+    return out
+
+
+def _antigen_predictions(vaccine_peptide):
+    """All EpitopePredictions on this VaccinePeptide. Defensive:
+    tolerates duck-typed test fixtures that don't carry the field."""
+    return list(getattr(vaccine_peptide, 'mutant_epitope_predictions', []) or [])
+
+
+def antigen_tier_per_allele(
+    vaccine_peptide, target_alleles,
+) -> dict[str, Optional[str]]:
+    """Return ``{allele: tier}`` for one antigen — the best tier
+    each target allele reaches via this antigen's epitope
+    predictions. ``None`` for alleles the antigen doesn't cover at
+    any tier."""
+    coverage = compute_coverage(
+        _antigen_predictions(vaccine_peptide), target_alleles)
+    return {a: coverage[a].tier for a in target_alleles}
+
+
+def summarize_construction_decisions(
+    ranked_variants_with_vaccine_peptides,
+    *,
+    cap,
+    target_alleles,
+    selected=None,
+):
+    """Modality-agnostic "what landed in the vaccine?" summary used
+    by the report writers (#269 + #270).
+
+    Parameters
+    ----------
+    ranked_variants_with_vaccine_peptides : list[tuple]
+        ``[(Variant, [VaccinePeptide])]`` — the score-ranked input.
+    cap : int
+        Number of antigens this modality can hold
+        (``antigens_per_construct × max_constructs`` for both
+        peptide and mRNA today; future modalities supply their own).
+    target_alleles : list[str]
+        Patient MHC alleles for the coverage view. Empty disables
+        the per-allele coverage block.
+    selected : optional list[tuple]
+        The antigen list actually picked by the assembler (post
+        coverage rebalancing). Defaults to ``ranked[:cap]`` for
+        callers that don't run the rebalancer.
+
+    Returns
+    -------
+    dict
+        ``{
+            'cap': int,
+            'total_ranked': int,
+            'selected': [{...}, ...],     # rank, gene_name, description,
+                                          # combined_score, allele_tiers
+            'dropped': [...],             # same row shape
+            'coverage': [AlleleCoverage, ...],  # one per target_allele
+          }``
+    """
+    if selected is None:
+        selected = list(ranked_variants_with_vaccine_peptides[:cap])
+
+    selected_ids = {id(item) for item in selected}
+    rank_by_id = {
+        id(item): i + 1
+        for i, item in enumerate(ranked_variants_with_vaccine_peptides)
+    }
+
+    def _row(item):
+        variant, peptides = item
+        vp = peptides[0] if peptides else None
+        gene_name = (
+            getattr(vp.mutant_protein_fragment, 'gene_name', '')
+            if vp is not None else '')
+        rank = rank_by_id.get(id(item), 0)
+        # Per-allele tier for this antigen — drives the
+        # ``covers A*02:01 (strong)`` annotation in the report.
+        allele_tiers = (
+            antigen_tier_per_allele(vp, target_alleles)
+            if (vp is not None and target_alleles) else {})
+        # Manufacturability tuple for the per-modality block (used
+        # by the peptide construction view; mRNA renders ignore it).
+        # Structured as a flat dict so the template can render
+        # without knowing the namedtuple's field names.
+        scores = getattr(vp, 'manufacturability_scores', None) if vp else None
+        manufacturability = (
+            dict(scores._asdict()) if scores is not None
+            and hasattr(scores, '_asdict') else {})
+        return {
+            'rank': rank,
+            'gene_name': gene_name or '',
+            'description': '%s_%s' % (
+                gene_name or '?',
+                getattr(variant, 'short_description', str(variant))),
+            'combined_score': (
+                float(vp.combined_score) if vp is not None else 0.0),
+            'allele_tiers': {
+                a: tier for a, tier in allele_tiers.items()
+                if tier is not None
+            },
+            'manufacturability': manufacturability,
+        }
+
+    selected_rows = [_row(item) for item in selected]
+    dropped_rows = [
+        _row(item) for item in ranked_variants_with_vaccine_peptides
+        if id(item) not in selected_ids
+    ]
+
+    # Coverage of the SELECTED pool: aggregate evidence across
+    # every selected antigen's mutant-epitope predictions.
+    coverage_records: list = []
+    if target_alleles:
+        all_predictions = []
+        for variant, peptides in selected:
+            for vp in (peptides or [])[:1]:
+                all_predictions.extend(
+                    getattr(vp, 'mutant_epitope_predictions', None) or [])
+        coverage = compute_coverage(all_predictions, target_alleles)
+        # Sort: covered (strong > medium > low) before uncovered;
+        # within same tier, alphabetical.
+        tier_rank = {'strong': 0, 'medium': 1, 'low': 2, None: 3}
+        coverage_records = sorted(
+            coverage.values(),
+            key=lambda c: (tier_rank.get(c.tier, 3), c.allele))
+
+    return {
+        'cap': cap,
+        'total_ranked': len(ranked_variants_with_vaccine_peptides),
+        'selected': selected_rows,
+        'dropped': dropped_rows,
+        'coverage': coverage_records,
+    }
+
+
+def select_antigens_for_coverage(
+    candidates,
+    target_alleles,
+    n_to_select,
+    *,
+    score_attr: str = 'combined_score',
+):
+    """Greedy coverage-aware selector.
+
+    Picks ``n_to_select`` antigens from ``candidates`` (the
+    ranked-by-score list of ``(variant, [VaccinePeptide])`` tuples)
+    using the lexicographic key:
+
+      (strong_alleles_added, medium_alleles_added, low_alleles_added,
+       combined_score)
+
+    Stops either when ``n_to_select`` is hit or when no remaining
+    candidate adds new coverage at any tier — at which point the
+    fallback runs and the rest of the slots are filled in
+    ``combined_score`` order.
+
+    No-op for empty ``target_alleles`` (returns ``candidates[:n_to_select]``
+    unchanged) — the function is safe to call unconditionally.
+
+    Returns the same shape as the input: a list of
+    ``(variant, [VaccinePeptide])`` tuples in selection order.
+    """
+    if n_to_select <= 0:
+        return []
+    if not candidates:
+        return []
+    if not target_alleles:
+        return list(candidates[:n_to_select])
+    # Targets we'd like covered. We track tier achieved for each.
+    target = list(target_alleles)
+    achieved: dict[str, Optional[str]] = {a: None for a in target}
+
+    def _new_tier_counts(antigen_tiers: dict[str, Optional[str]]):
+        """How many *new* alleles this antigen would cover at each
+        tier, given current ``achieved`` state."""
+        new_strong = new_medium = new_low = 0
+        for a, tier in antigen_tiers.items():
+            cur = achieved[a]
+            if tier == 'strong' and cur != 'strong':
+                new_strong += 1
+            elif tier == 'medium' and cur not in ('strong', 'medium'):
+                new_medium += 1
+            elif tier == 'low' and cur is None:
+                new_low += 1
+        return new_strong, new_medium, new_low
+
+    # Pre-compute per-candidate (antigen) tier maps once.
+    pool = list(candidates)
+    tier_maps = []
+    for variant, peptides in pool:
+        # Antigen-level tier = best tier achieved by any peptide on
+        # this variant; we use the top vaccine peptide as the
+        # representative since constructs ship one-per-variant.
+        if not peptides:
+            tier_maps.append({a: None for a in target})
+            continue
+        tier_maps.append(antigen_tier_per_allele(peptides[0], target))
+
+    selected: list = []
+    selected_idx = set()
+    while len(selected) < n_to_select and len(selected_idx) < len(pool):
+        best_i = None
+        best_key = None
+        # Score ties broken by original (combined_score) rank — pool
+        # was already sorted by score, so iterating in index order
+        # gives us that for free.
+        for i, (variant, peptides) in enumerate(pool):
+            if i in selected_idx:
+                continue
+            new_strong, new_medium, new_low = _new_tier_counts(tier_maps[i])
+            score = (
+                float(getattr(peptides[0], score_attr, 0.0))
+                if peptides else 0.0)
+            # Lexicographic: max strong, then medium, then low,
+            # then score (larger wins).
+            key = (new_strong, new_medium, new_low, score, -i)
+            if best_key is None or key > best_key:
+                best_key = key
+                best_i = i
+        # If the best candidate adds no new coverage, the greedy
+        # stage is done — fill remaining slots in score order.
+        new_strong, new_medium, new_low = best_key[:3]
+        if new_strong == 0 and new_medium == 0 and new_low == 0:
+            break
+        selected.append(pool[best_i])
+        selected_idx.add(best_i)
+        # Bookkeeping: update achieved tiers from this antigen.
+        for a, tier in tier_maps[best_i].items():
+            achieved[a] = _better_tier(achieved[a], tier)
+    # Score-order fallback for the remaining slots.
+    if len(selected) < n_to_select:
+        for i, item in enumerate(pool):
+            if i in selected_idx:
+                continue
+            selected.append(item)
+            selected_idx.add(i)
+            if len(selected) >= n_to_select:
+                break
+    return selected

--- a/vaxrank/mrna.py
+++ b/vaxrank/mrna.py
@@ -680,7 +680,8 @@ def _pack_constructs(antigen_pairs, options, signal_peptide_aa, linker,
 
 def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
                              mhc_predictor=None, mhc_alleles=None,
-                             reference_proteome=None):
+                             reference_proteome=None, *,
+                             target_alleles=None):
     """Assemble mRNA constructs from ranked vaccine peptides.
 
     Parameters
@@ -697,12 +698,31 @@ def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
         Container that answers ``kmer in reference_proteome``. Junction
         k-mers found in the reference proteome are filtered out before
         scoring (already-tolerated, not new presentation).
+    target_alleles : optional, list[str]
+        Patient MHC alleles for coverage-aware antigen selection.
+        When non-empty, the selector reorders the ranked list to
+        maximize coverage before bin-packing into constructs — see
+        :func:`vaxrank.coverage.select_antigens_for_coverage`. When
+        empty / None, today's pure-score order is preserved.
+        Typically the same list as ``mhc_alleles`` (the linker
+        optimizer's input); kept separate so the two can diverge if
+        a future caller wants to optimize against a population
+        cohort while ranking against the patient.
 
     Returns
     -------
     list[RNAConstruct]
     """
     options = options or RNAConstructConfig()
+    if target_alleles:
+        from .coverage import select_antigens_for_coverage
+        cap = options.antigens_per_construct * options.max_constructs
+        head = select_antigens_for_coverage(
+            ranked_vaccine_peptides, target_alleles, cap)
+        head_keys = {id(item) for item in head}
+        tail = [item for item in ranked_vaccine_peptides
+                if id(item) not in head_keys]
+        ranked_vaccine_peptides = head + tail
     signal_peptide_aa = (
         _resolve_named(SIGNAL_PEPTIDES, options.signal_peptide,
                        'signal peptide')

--- a/vaxrank/peptide.py
+++ b/vaxrank/peptide.py
@@ -252,19 +252,40 @@ def _pack_multi_epitope(records, options, linker):
     return constructs
 
 
-def assemble_peptide_constructs(ranked_vaccine_peptides, options=None):
+def assemble_peptide_constructs(
+        ranked_vaccine_peptides, options=None, *,
+        target_alleles=None):
     """Assemble peptide constructs from ranked vaccine peptides.
 
     Parameters
     ----------
     ranked_vaccine_peptides : list[(varcode.Variant, list[VaccinePeptide])]
     options : PeptideConstructConfig or None
+    target_alleles : optional, list[str]
+        Patient MHC alleles. When non-empty, the selector reorders
+        the ranked list to maximize allele coverage before packing
+        — see :func:`vaxrank.coverage.select_antigens_for_coverage`.
+        When empty / None, the input order is preserved (today's
+        pure-score behavior). Animal-agnostic: HLA, mouse H-2, swine
+        SLA all work the same way.
 
     Returns
     -------
     list[PeptideConstruct]
     """
     options = options or PeptideConstructConfig()
+    if target_alleles:
+        from .coverage import select_antigens_for_coverage
+        cap = options.antigens_per_construct * options.max_constructs
+        # Reorder up to ``cap`` antigens for coverage; leave the
+        # rest in their original score order so the report's
+        # not-selected list is still meaningful.
+        head = select_antigens_for_coverage(
+            ranked_vaccine_peptides, target_alleles, cap)
+        head_keys = {id(item) for item in head}
+        tail = [item for item in ranked_vaccine_peptides
+                if id(item) not in head_keys]
+        ranked_vaccine_peptides = head + tail
 
     records = list(_antigen_records(
         ranked_vaccine_peptides, options.antigen_content,

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -51,7 +51,9 @@ class TemplateDataCreator(object):
             cosmic_vcf_filename=None,
             dna_vaf_by_variant=None,
             processing_predictions_by_key=None,
-            mrna_ranking_decisions=None):
+            mrna_ranking_decisions=None,
+            vaccine_constructions=None,
+            target_alleles=None):
         """
         Construct a TemplateDataCreator object, from the output of the vaxrank pipeline.
 
@@ -67,11 +69,18 @@ class TemplateDataCreator(object):
         self.dna_vaf_by_variant = dna_vaf_by_variant or {}
         self.processing_predictions_by_key = (
             processing_predictions_by_key or {})
-        # Issue #270: mRNA ranking-decisions section. Set when mRNA
-        # is in the active ``--vaccine-type``. ``None`` skips the
-        # section in the rendered report. See
-        # :func:`vaxrank.mrna.summarize_mrna_ranking_decisions`.
+        # Issue #270: mRNA ranking-decisions section. Legacy field;
+        # superseded by ``vaccine_constructions['mrna']`` in the new
+        # report layout (#269). Both reach the template so existing
+        # tests / consumers keep working.
         self.mrna_ranking_decisions = mrna_ranking_decisions
+        # Issue #269: per-modality "Vaccine construction" sections —
+        # coverage block + selected antigens with allele tiers
+        # + dropped-past-cap list. Keys are modality names; values
+        # are the dicts produced by
+        # :func:`vaxrank.coverage.summarize_construction_decisions`.
+        self.vaccine_constructions = vaccine_constructions or {}
+        self.target_alleles = list(target_alleles or [])
 
         # ``vaccine_type`` is rendered in the patient-info block so
         # the reader can tell at a glance what's being designed.
@@ -525,11 +534,17 @@ class TemplateDataCreator(object):
             'patient_info': patient_info,
             'variants': variants,
             'package_versions': package_versions,
-            # Issue #270: mRNA ranking decisions. ``None`` when not
-            # applicable (peptide-only run, or no ranked antigens).
-            # The template renders the section only when the value
-            # is truthy.
+            # Issue #270: legacy mRNA-only ranking block. Kept for
+            # back-compat with older templates / tests; new
+            # consumers read ``vaccine_constructions['mrna']``.
             'mrna_ranking': self.mrna_ranking_decisions,
+            # Issue #269: per-modality "Vaccine construction"
+            # blocks. Keyed by modality name (``'peptide'`` /
+            # ``'mrna'`` / future ``'dna'``). Empty dict when no
+            # ranked antigens exist; the template renders blocks
+            # only for keys present here.
+            'vaccine_constructions': self.vaccine_constructions,
+            'target_alleles': self.target_alleles,
         })
         return self.template_data
 

--- a/vaxrank/templates/template.txt
+++ b/vaxrank/templates/template.txt
@@ -9,6 +9,12 @@ Package version info
 ---
 
 {% if variants %}
+=== Antigen ranking ===
+Per-variant ranked antigen windows by combined_score. Modality-agnostic;
+modality-specific decisions (which antigens land in the vaccine, the
+manufacturability tuple, allele coverage) are in the "Vaccine construction"
+sections below.
+
 {% for v in variants %}
 {{ v.num }}) {{ v.short_description }} ({{ v.variant_data['Gene name'] }})
         {% for key, val in v.variant_data.items() %}
@@ -25,14 +31,7 @@ Package version info
                   {% for key, val in p.peptide_data.items() %}
                   - {{ key }}: {{ val }}
                   {% endfor %}
-                  {% if include_manufacturability %}
 
-                  Manufacturability:
-                  {% for key, val in p.manufacturability_data.items() %}
-                  - {{ key }}: {{ val }}
-                  {% endfor %}
-                  {% endif %}
-                  
                   Predicted mutant epitopes:
                   {{ p.ascii_epitopes|indent(18) }}
 
@@ -47,19 +46,52 @@ Package version info
 No variants with sufficient ranked antigens were found.
 {% endif %}
 
-{% if mrna_ranking %}
+{% for modality, vc in (vaccine_constructions|default({})).items() %}
 ---
 
-mRNA vaccine antigen selection
-  Selected ({{ mrna_ranking.selected|length }} of {{ mrna_ranking.total_ranked }} ranked) at --mrna-antigens-per-construct={{ mrna_ranking.antigens_per_construct }} × --mrna-max-constructs={{ mrna_ranking.max_constructs }} = {{ mrna_ranking.cap }} antigen slots:
-  {% for a in mrna_ranking.selected %}
-    {{ a.rank }}. {{ a.description }}    combined_score = {{ '%.3f' % a.combined_score }}
-  {% endfor %}
-  {% if mrna_ranking.dropped %}
+=== Vaccine construction — {{ modality }} ===
+Cap: {{ vc.antigens_per_construct }} antigens × {{ vc.max_constructs }} constructs = {{ vc.cap }} antigen slots.
+Selected {{ vc.selected|length }} of {{ vc.total_ranked }} ranked antigen(s).
 
-  Not selected — past the cap (raise --mrna-max-constructs to include more):
-  {% for a in mrna_ranking.dropped %}
-    {{ a.rank }}. {{ a.description }}    combined_score = {{ '%.3f' % a.combined_score }}
+  {% if vc.coverage %}
+  Allele coverage of the selected pool:
+    {% for ac in vc.coverage %}
+    {% if ac.tier %}{{ '✓' }} {{ '%-7s' % ac.tier }}{% else %}{{ '✗' }} {{ '%-7s' % 'none' }}{% endif %}  {{ ac.allele }}{% if ac.tier %}  (n={{ ac.n_peptides }}{% if ac.best_presentation_pct is not none %}, best presentation_pct={{ '%.2f' % ac.best_presentation_pct }}{% endif %}{% if ac.best_affinity_pct is not none %}, best affinity_pct={{ '%.2f' % ac.best_affinity_pct }}{% endif %}){% endif %}
+    {% endfor %}
+  {% endif %}
+
+  Selected antigens:
+  {% for a in vc.selected %}
+    {{ a.rank }}. {{ a.description }}    combined_score = {{ '%.3f' % a.combined_score }}{% if a.allele_tiers %}    covers {% for allele, tier in a.allele_tiers.items() %}{{ allele }} ({{ tier }}){% if not loop.last %}, {% endif %}{% endfor %}{% endif %}
+        {% if include_manufacturability and modality == 'peptide' and a.manufacturability %}
+        Manufacturability:
+        {% for key, val in a.manufacturability.items() %}
+        - {{ key }}: {{ val }}
+        {% endfor %}
+        {% endif %}
+  {% endfor %}
+  {% if vc.dropped %}
+
+  Not selected — past the cap (raise --{{ modality }}-max-constructs to include more):
+  {% for a in vc.dropped %}
+    {{ a.rank }}. {{ a.description }}    combined_score = {{ '%.3f' % a.combined_score }}{% if a.allele_tiers %}    would add: {% for allele, tier in a.allele_tiers.items() %}{{ allele }} ({{ tier }}){% if not loop.last %}, {% endif %}{% endfor %}{% endif %}
   {% endfor %}
   {% endif %}
+{% endfor %}
+
+{% if not vaccine_constructions and mrna_ranking %}
+---
+
+=== Vaccine construction — mrna (legacy block) ===
+Selected ({{ mrna_ranking.selected|length }} of {{ mrna_ranking.total_ranked }} ranked) at cap = {{ mrna_ranking.cap }} antigen slots.
+{% for a in mrna_ranking.selected %}
+  {{ a.rank }}. {{ a.description }}    combined_score = {{ '%.3f' % a.combined_score }}
+{% endfor %}
+{% if mrna_ranking.dropped %}
+
+Not selected — past the cap:
+{% for a in mrna_ranking.dropped %}
+  {{ a.rank }}. {{ a.description }}    combined_score = {{ '%.3f' % a.combined_score }}
+{% endfor %}
+{% endif %}
 {% endif %}

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "2.24.0"
+__version__ = "2.25.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Closes #269. Adds general MHC allele coverage measurement and a greedy coverage-aware antigen selector. Works the same way for peptide / mRNA / future DNA constructs, and across HLA / mouse H-2 / swine SLA.

## Coverage model — two axes, three tiers

For each (peptide, allele) pair, the **better of two axes** buckets into tiers:

| Axis | Default predictor | Biology |
|------|-------------------|---------|
| `presentation_percentile` | mhcflurry-pres | "fraction reaching MHC at meaningful abundance" |
| `percentile_rank` | netmhcpan-affinity | "binding strength once in the ER" |

Tiers: **strong** (≤ 0.5%), **medium** (≤ 1.0%), **low** (≤ 2.0%), **none** (> 2.0%).

## Greedy selector

```
key = (strong_added, medium_added, low_added, combined_score)
```

Picks the next antigen that maximizes new strong-tier coverage; ties broken by medium / low / score. Falls back to pure `combined_score` when coverage is satisfied. **Always on** when patient alleles are known — no flag.

## Report restructure

Two top-level sections now:

1. **`=== Antigen ranking ===`** — modality-agnostic per-variant view (the old per-variant block, with manufacturability removed).
2. **`=== Vaccine construction — <modality> ===`** — per-modality view with:
   - **Allele coverage** of the selected pool (✓ strong / ✗ none)
   - **Selected antigens** with `covers <allele> (<tier>)` per-antigen annotations, plus manufacturability tuple (peptide section only)
   - **Not selected — past the cap** with `would add: <allele> (<tier>)` so the operator sees what raising the cap would buy

Legacy `mrna_ranking` template field stays for back-compat; new key is `vaccine_constructions`.

## Animal-agnostic

Driven entirely off `patient_info.mhc_alleles`. No `startswith("HLA-")` anywhere; mouse / swine / etc. flow through the same code paths. Predictors that don't have data for a given allele simply don't contribute.

## What's deferred

- Per-construct coverage *splitting* (distributing uncovered alleles across multiple mRNA constructs) → Phase 2.
- `expected_pmhc_density` ranking mode (presentation × RNA → abundance proxy) → separate PR with benchmark; expressible today via the `combined_score_expr` DSL.
- CLI knobs for tier thresholds / metric choice → expose only if a user wants to tune.

## Test plan

- [x] `./lint.sh` clean
- [x] `./test.sh` — 753 passed (was 739; **+14 new** in `tests/test_coverage.py`)
- New tests: tier bucketing, multi-predictor evidence aggregation, mouse-allele case, selector prefers coverage / falls back / spreads, end-to-end ASCII render with coverage block.
- [ ] CI green

Bumps version to 2.25.0.