### PR TITLE
PeptideContext + CandidateEpitope: multi-axis per-peptide model (Phase 1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,9 @@ platformdirs
 msgspec>=0.18.6,<1.0.0
 dnachisel>=3.2.0,<4.0.0
 serializable>=1.1.0,<2.0.0
+# Used by vaxrank.peptide_context for PEP 440 ordering of
+# Prediction.predictor_version when ``best`` auto-resolves
+# multi-version data to the most recent. Effectively always
+# present (transitive via setuptools / pip) but declared here so
+# minimal installs resolve cleanly.
+packaging>=21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,3 @@ platformdirs
 msgspec>=0.18.6,<1.0.0
 dnachisel>=3.2.0,<4.0.0
 serializable>=1.1.0,<2.0.0
-# Used by vaxrank.peptide_context for PEP 440 ordering of
-# Prediction.predictor_version when ``best`` auto-resolves
-# multi-version data to the most recent. Effectively always
-# present (transitive via setuptools / pip) but declared here so
-# minimal installs resolve cleanly.
-packaging>=21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,8 @@ platformdirs
 msgspec>=0.18.6,<1.0.0
 dnachisel>=3.2.0,<4.0.0
 serializable>=1.1.0,<2.0.0
+# vaxrank.peptide_context imports packaging.version for PEP 440 ordering
+# of predictor_version strings. Always pulled in transitively via setuptools
+# / pip, but pinned explicitly so minimal / --no-deps installs don't break
+# at import time.
+packaging>=21.0

--- a/tests/test_peptide_context.py
+++ b/tests/test_peptide_context.py
@@ -8,19 +8,19 @@
 the flat ``EpitopePrediction``).
 
 Pins:
-- Storage stays as a flat tuple of ``mhctools.Prediction``s, but
-  every access path goes through methods that respect the
-  (kind, predictor, version, allele) structure.
-- ``best`` raises on multi-predictor ambiguity (cross-predictor
-  ``max(score)`` is meaningless — each predictor's score scale is
-  its own) and auto-resolves multi-version ambiguity to the most
-  recent version (PEP 440).
-- ``best`` accepts kind aliases (``'ba'`` / ``'el'`` / etc).
-- ``predictors_for_kind`` / ``alleles_for`` / ``versions_for`` give
-  callers the structured view they need to walk per-predictor.
+- Native nested storage: ``{kind: {predictor: {version: tuple}}}``.
+  Constructor accepts flat ``Sequence[Prediction]`` for producer
+  ergonomics; ``__post_init__`` groups.
+- Allele is a *record property*, not a structural key — works
+  cleanly for processing kinds (no allele) and for affinity /
+  presentation (per-allele records).
+- ``best`` / ``predictions_for`` raise on multi-predictor ambiguity
+  (cross-predictor ranking is meaningless); auto-resolve multi-
+  version to the most recent (PEP 440).
+- Kind aliases defer to ``topiary.ranking._KIND_ALIASES``.
 - ``CandidateEpitope.comparators`` dict accommodates ``'wt'`` plus
-  future ``nearest_self`` / ``nearest_vital_self`` / ``nearest_nonCTA``
-  / ``nearest_oncovirus`` records (#254 / #257 / #258).
+  future ``nearest_self`` / ``nearest_vital_self`` /
+  ``nearest_nonCTA`` / ``nearest_oncovirus`` (#254 / #257 / #258).
 """
 
 import pytest
@@ -45,14 +45,13 @@ def _pred(kind, *, predictor='mhcflurry', version='', allele='HLA-A*02:01',
     )
 
 
-# ---- PeptideContext storage / structured views --------------------------
+# ---- Storage shape: native nested with auto-grouping --------------------
 
 
-def test_peptide_context_predictions_by_kind_and_predictor_groups_correctly():
-    """The flat storage tuple is the source of truth; the nested
-    view is built on demand. Four levels: kind → predictor →
-    version → allele. Version axis prevents collision when the same
-    (kind, predictor, allele) was scored at multiple versions."""
+def test_constructor_auto_groups_flat_input():
+    """Producers hand back flat ``list[Prediction]``; the
+    constructor groups into the nested store. Pin so producer
+    ergonomics stay intact even though storage is nested."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
         predictions=(
@@ -63,75 +62,90 @@ def test_peptide_context_predictions_by_kind_and_predictor_groups_correctly():
             _pred('pMHC_presentation', predictor='mhcflurry',
                   version='2.1.1', allele='HLA-A*02:01'),
         ))
-    nested = ctx.predictions_by_kind_and_predictor()
-    assert set(nested.keys()) == {'pMHC_affinity', 'pMHC_presentation'}
-    assert set(nested['pMHC_affinity'].keys()) == {'mhcflurry', 'netmhcpan'}
-    assert set(nested['pMHC_affinity']['mhcflurry'].keys()) == {'2.1.1'}
-    assert 'HLA-A*02:01' in nested['pMHC_affinity']['mhcflurry']['2.1.1']
-    assert 'HLA-A*02:01' in (
-        nested['pMHC_presentation']['mhcflurry']['2.1.1'])
+    assert set(ctx.predictions.keys()) == {
+        'pMHC_affinity', 'pMHC_presentation'}
+    assert set(ctx.predictions['pMHC_affinity'].keys()) == {
+        'mhcflurry', 'netmhcpan'}
+    assert set(ctx.predictions['pMHC_affinity']['mhcflurry'].keys()) == {
+        '2.1.1'}
+    # Leaf is a tuple of Predictions, not allele-keyed.
+    leaf = ctx.predictions['pMHC_affinity']['mhcflurry']['2.1.1']
+    assert isinstance(leaf, tuple)
+    assert len(leaf) == 1
+    assert leaf[0].allele == 'HLA-A*02:01'
 
 
-def test_predictions_by_kind_and_predictor_separates_versions():
-    """Same (kind, predictor, allele) at two versions stays
-    addressable — without the version axis this would be one record
-    silently overwriting the other."""
+def test_constructor_accepts_already_nested_input():
+    """Pre-grouped nested dict passes through unchanged. Lets
+    callers bypass auto-grouping when they've already done it."""
+    nested = {
+        'pMHC_affinity': {
+            'mhcflurry': {
+                '2.1.1': (_pred('pMHC_affinity', version='2.1.1'),)
+            }
+        }
+    }
+    ctx = PeptideContext(peptide_sequence='SIINFEKL', predictions=nested)
+    assert ctx.predictions is nested
+
+
+def test_storage_collects_per_allele_records_in_leaf_tuple():
+    """Affinity emits one Prediction per allele under one
+    (predictor, version). The leaf tuple holds them all — alleles
+    aren't structural keys, so no collision."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
         predictions=(
-            _pred('pMHC_affinity', predictor='mhcflurry',
-                  version='2.1.0', allele='HLA-A*02:01', score=0.4),
-            _pred('pMHC_affinity', predictor='mhcflurry',
-                  version='2.1.1', allele='HLA-A*02:01', score=0.7),
+            _pred('pMHC_affinity', allele='HLA-A*02:01', score=0.4),
+            _pred('pMHC_affinity', allele='HLA-B*07:02', score=0.9),
+            _pred('pMHC_affinity', allele='HLA-C*03:04', score=0.3),
         ))
-    nested = ctx.predictions_by_kind_and_predictor()
-    versions = nested['pMHC_affinity']['mhcflurry']
-    assert set(versions.keys()) == {'2.1.0', '2.1.1'}
-    assert versions['2.1.0']['HLA-A*02:01'].score == 0.4
-    assert versions['2.1.1']['HLA-A*02:01'].score == 0.7
+    leaf = ctx.predictions['pMHC_affinity']['mhcflurry']['']
+    assert len(leaf) == 3
+    assert {p.allele for p in leaf} == {
+        'HLA-A*02:01', 'HLA-B*07:02', 'HLA-C*03:04'}
 
 
-def test_predictors_for_kind_lists_emitting_predictors():
-    """Drives multi-predictor disambiguation: callers ask "what
-    predictors emitted ``kind`` for this peptide?" before deciding
-    how to combine."""
+def test_storage_handles_no_allele_kinds():
+    """Processing kinds (proteasome_cleavage, antigen_processing)
+    emit Predictions with empty ``allele``. The nested store
+    accommodates them naturally — leaf is a one-element tuple,
+    no allele-keyed dict to collapse into."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
         predictions=(
-            _pred('pMHC_affinity', predictor='mhcflurry'),
-            _pred('pMHC_affinity', predictor='netmhcpan'),
-            _pred('pMHC_presentation', predictor='mhcflurry'),
+            _pred('proteasome_cleavage', predictor='pepsickle',
+                  allele='', score=0.6),
+            _pred('antigen_processing', predictor='netchop',
+                  allele='', score=0.8),
         ))
-    assert ctx.predictors_for_kind('pMHC_affinity') == (
-        'mhcflurry', 'netmhcpan')
-    # Presentation only from mhcflurry — typical real data shape.
-    assert ctx.predictors_for_kind('pMHC_presentation') == ('mhcflurry',)
-    # No data → empty tuple.
-    assert ctx.predictors_for_kind('immunogenicity') == ()
+    cleavage_leaf = ctx.predictions['proteasome_cleavage']['pepsickle']['']
+    assert len(cleavage_leaf) == 1
+    assert cleavage_leaf[0].allele == ''
 
 
-def test_alleles_for_kind_predictor_lists_alleles_only():
-    """Alleles per (kind, predictor) — used by coverage code that
-    walks per-allele evidence without picking a single 'best'."""
-    ctx = PeptideContext(
+def test_predictions_flat_round_trips_through_constructor():
+    """``predictions_flat()`` flattens the nested store back to a
+    tuple. Feeding that tuple back through the constructor
+    reproduces the same nested shape — round-trip pinned for
+    serialization paths."""
+    original = PeptideContext(
         peptide_sequence='SIINFEKL',
         predictions=(
-            _pred('pMHC_affinity', predictor='mhcflurry',
-                  allele='HLA-A*02:01'),
-            _pred('pMHC_affinity', predictor='mhcflurry',
-                  allele='HLA-B*07:02'),
-            _pred('pMHC_affinity', predictor='netmhcpan',
-                  allele='HLA-A*02:01'),
+            _pred('pMHC_affinity', allele='HLA-A*02:01'),
+            _pred('pMHC_presentation', allele='HLA-A*02:01'),
         ))
-    assert ctx.alleles_for('pMHC_affinity', 'mhcflurry') == (
-        'HLA-A*02:01', 'HLA-B*07:02')
-    assert ctx.alleles_for('pMHC_affinity', 'netmhcpan') == ('HLA-A*02:01',)
-    assert ctx.alleles_for('pMHC_affinity', 'unknown_predictor') == ()
+    flat = original.predictions_flat()
+    rebuilt = PeptideContext(
+        peptide_sequence=original.peptide_sequence,
+        predictions=flat)
+    assert rebuilt.predictions == original.predictions
+
+
+# ---- Structured views --------------------------------------------------
 
 
 def test_kinds_returns_sorted_distinct_values():
-    """Helps report code render only the kinds present without
-    iterating predictions."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
         predictions=(
@@ -143,19 +157,253 @@ def test_kinds_returns_sorted_distinct_values():
 
 
 def test_kinds_empty_when_no_predictions():
-    """A bare PeptideContext (e.g. a comparator that hasn't been
-    binding-probed yet) has no kinds."""
     ctx = PeptideContext(peptide_sequence='SIINFEKL')
     assert ctx.kinds() == ()
-    assert ctx.predictors_for_kind('pMHC_affinity') == ()
+    assert ctx.predictors_for('pMHC_affinity') == ()
 
 
-# ---- best: single-predictor unambiguous case ------------------
+def test_predictors_for_lists_emitting_predictors():
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry'),
+            _pred('pMHC_affinity', predictor='netmhcpan'),
+            _pred('pMHC_presentation', predictor='mhcflurry'),
+        ))
+    assert ctx.predictors_for('pMHC_affinity') == ('mhcflurry', 'netmhcpan')
+    assert ctx.predictors_for('pMHC_presentation') == ('mhcflurry',)
+    assert ctx.predictors_for('immunogenicity') == ()
+
+
+def test_alleles_for_lists_alleles_only():
+    """Returns alleles among leaf records. Filters out empty
+    strings (processing kinds)."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', allele='HLA-A*02:01'),
+            _pred('pMHC_affinity', allele='HLA-B*07:02'),
+            _pred('proteasome_cleavage', predictor='pepsickle', allele=''),
+        ))
+    assert ctx.alleles_for('pMHC_affinity') == (
+        'HLA-A*02:01', 'HLA-B*07:02')
+    # Processing kind: no alleles surfaced.
+    assert ctx.alleles_for('proteasome_cleavage') == ()
+
+
+# ---- Kind aliases (delegated to topiary) -------------------------------
+
+
+@pytest.mark.parametrize('alias,canonical', [
+    ('ba', 'pMHC_affinity'),
+    ('BA', 'pMHC_affinity'),
+    ('aff', 'pMHC_affinity'),
+    ('ic50', 'pMHC_affinity'),
+    ('affinity', 'pMHC_affinity'),
+    ('pMHC_affinity', 'pMHC_affinity'),
+    ('PMHC_AFFINITY', 'pMHC_affinity'),
+    ('el', 'pMHC_presentation'),
+    ('EL', 'pMHC_presentation'),
+    ('presentation', 'pMHC_presentation'),
+    ('stability', 'pMHC_stability'),
+    ('processing', 'antigen_processing'),
+])
+def test_best_resolves_kind_aliases_via_topiary(alias, canonical):
+    """vaxrank doesn't maintain its own alias table — defers to
+    topiary's ``_KIND_ALIASES``. Pin the entries vaxrank cares
+    about so a topiary change shows up here."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(_pred(canonical, score=0.7),))
+    result = ctx.best(alias)
+    assert result is not None
+    assert result.kind == canonical
+
+
+def test_predictors_for_accepts_aliases():
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_presentation', predictor='mhcflurry'),
+            _pred('pMHC_presentation', predictor='bigmhc'),
+        ))
+    assert ctx.predictors_for('el') == ('bigmhc', 'mhcflurry')
+    assert ctx.predictors_for('presentation') == ('bigmhc', 'mhcflurry')
+
+
+# ---- predictions_for: leaf access + disambiguation ---------------------
+
+
+def test_predictions_for_returns_leaf_tuple():
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', allele='HLA-A*02:01', score=0.4),
+            _pred('pMHC_affinity', allele='HLA-B*07:02', score=0.9),
+        ))
+    records = ctx.predictions_for('pMHC_affinity')
+    assert len(records) == 2
+    assert {p.allele for p in records} == {'HLA-A*02:01', 'HLA-B*07:02'}
+
+
+def test_predictions_for_empty_when_no_records():
+    ctx = PeptideContext(peptide_sequence='SIINFEKL')
+    assert ctx.predictions_for('pMHC_affinity') == ()
+
+
+def test_predictions_for_multi_predictor_raises():
+    """Same disambiguation contract as ``best`` — predictor
+    required when multiple emit ``kind``."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry', score=0.4),
+            _pred('pMHC_affinity', predictor='netmhcpan', score=0.9),
+        ))
+    with pytest.raises(ValueError, match='multiple predictors'):
+        ctx.predictions_for('pMHC_affinity')
+
+
+def test_predictions_for_with_predictor_disambiguates():
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-A*02:01', score=0.4),
+            _pred('pMHC_affinity', predictor='netmhcpan',
+                  allele='HLA-A*02:01', score=0.9),
+        ))
+    mhcf = ctx.predictions_for('pMHC_affinity', predictor='mhcflurry')
+    assert len(mhcf) == 1
+    assert mhcf[0].score == 0.4
+    nmp = ctx.predictions_for('pMHC_affinity', predictor='netmhcpan')
+    assert nmp[0].score == 0.9
+
+
+def test_predictions_for_unknown_predictor_returns_empty():
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry', score=0.4),
+        ))
+    assert ctx.predictions_for(
+        'pMHC_affinity', predictor='netmhcpan') == ()
+
+
+def test_predictions_for_lets_caller_rank_on_arbitrary_axis():
+    """The whole point of exposing the leaf tuple: callers rank
+    on whatever axis they want. ``best`` does the common
+    ``max(score)`` case; for "lowest IC50" / "lowest %-rank" /
+    custom DSL, iterate ``predictions_for`` directly. This is
+    *the* parametric-scoring affordance — no callable plumbed
+    through ``best``."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', allele='HLA-A*02:01',
+                  score=0.9, value=10.0, percentile_rank=2.5),
+            _pred('pMHC_affinity', allele='HLA-B*07:02',
+                  score=0.4, value=2.0, percentile_rank=0.3),
+        ))
+    records = ctx.predictions_for('pMHC_affinity')
+    # Default best (by score): A*02 wins.
+    assert ctx.best('pMHC_affinity').allele == 'HLA-A*02:01'
+    # Caller-driven: rank by lowest IC50 (value).
+    by_ic50 = min(records, key=lambda p: p.value)
+    assert by_ic50.allele == 'HLA-B*07:02'
+    # Caller-driven: rank by lowest percentile_rank.
+    by_rank = min(records, key=lambda p: p.percentile_rank)
+    assert by_rank.allele == 'HLA-B*07:02'
+
+
+# ---- Version disambiguation --------------------------------------------
+
+
+def test_predictions_for_multi_version_picks_most_recent():
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='2.1.0', score=0.9),
+            _pred('pMHC_affinity', version='2.1.1', score=0.4),
+        ))
+    records = ctx.predictions_for('pMHC_affinity')
+    assert len(records) == 1
+    assert records[0].predictor_version == '2.1.1'
+
+
+def test_predictions_for_with_explicit_version_pins():
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='2.1.0', score=0.9),
+            _pred('pMHC_affinity', version='2.1.1', score=0.4),
+        ))
+    pinned = ctx.predictions_for('pMHC_affinity', version='2.1.0')
+    assert len(pinned) == 1
+    assert pinned[0].predictor_version == '2.1.0'
+
+
+def test_predictions_for_unknown_version_returns_empty():
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(_pred('pMHC_affinity', version='2.1.1'),))
+    assert ctx.predictions_for(
+        'pMHC_affinity', version='99.0.0') == ()
+
+
+def test_predictions_for_handles_empty_version_strings():
+    """Pre-#261 records had empty ``predictor_version``. Mixed
+    with a real version, the real version wins (empty parses as
+    InvalidVersion and falls below all PEP 440 versions)."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='', score=0.9),
+            _pred('pMHC_affinity', version='2.1.1', score=0.4),
+        ))
+    records = ctx.predictions_for('pMHC_affinity')
+    assert records[0].predictor_version == '2.1.1'
+
+
+def test_predictions_for_all_invalid_versions_falls_back_lex():
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='legacy_a', score=0.4),
+            _pred('pMHC_affinity', version='legacy_z', score=0.7),
+        ))
+    records = ctx.predictions_for('pMHC_affinity')
+    assert records[0].predictor_version == 'legacy_z'
+
+
+def test_versions_for_returns_oldest_to_newest():
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='2.1.1'),
+            _pred('pMHC_affinity', version='2.1.0'),
+            _pred('pMHC_affinity', version='2.0.0'),
+        ))
+    assert ctx.versions_for('pMHC_affinity', 'mhcflurry') == (
+        '2.0.0', '2.1.0', '2.1.1')
+
+
+def test_versions_for_invalid_strings_sort_first():
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='legacy'),
+            _pred('pMHC_affinity', version='2.1.1'),
+            _pred('pMHC_affinity', version='2.1.0'),
+        ))
+    assert ctx.versions_for('pMHC_affinity', 'mhcflurry') == (
+        'legacy', '2.1.0', '2.1.1')
+
+
+# ---- best: thin wrapper over predictions_for ---------------------------
 
 
 def test_best_single_predictor_picks_best_allele():
-    """One predictor, multiple alleles → best-by-score across
-    alleles. ``predictor=`` not required when there's only one."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
         predictions=(
@@ -170,20 +418,11 @@ def test_best_single_predictor_picks_best_allele():
 
 
 def test_best_returns_none_when_no_records():
-    """Coverage / report code can call this safely; absence reads
-    as ``None``."""
     ctx = PeptideContext(peptide_sequence='SIINFEKL')
     assert ctx.best('pMHC_affinity') is None
-    assert ctx.best('immunogenicity') is None
-
-
-# ---- best: multi-predictor disambiguation ---------------------
 
 
 def test_best_multi_predictor_raises_without_predictor_arg():
-    """The architectural fix from this design pass: cross-predictor
-    ``max(score)`` is meaningless — score scales differ per
-    predictor — so the API forces an explicit choice."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
         predictions=(
@@ -194,51 +433,7 @@ def test_best_multi_predictor_raises_without_predictor_arg():
         ctx.best('pMHC_affinity')
 
 
-def test_best_with_predictor_arg_picks_within_that_predictor():
-    """Per-predictor disambiguation: caller picks the predictor,
-    accessor returns the best allele for it."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', predictor='mhcflurry',
-                  allele='HLA-A*02:01', score=0.4),
-            _pred('pMHC_affinity', predictor='mhcflurry',
-                  allele='HLA-B*07:02', score=0.7),
-            _pred('pMHC_affinity', predictor='netmhcpan',
-                  allele='HLA-A*02:01', score=0.9),
-            _pred('pMHC_affinity', predictor='netmhcpan',
-                  allele='HLA-B*07:02', score=0.5),
-        ))
-    # Best within mhcflurry: B*07 (0.7), not netmhcpan's A*02 (0.9).
-    best_mhcf = ctx.best('pMHC_affinity', predictor='mhcflurry')
-    assert best_mhcf.allele == 'HLA-B*07:02'
-    assert best_mhcf.predictor_name == 'mhcflurry'
-    # Best within netmhcpan: A*02.
-    best_nmp = ctx.best('pMHC_affinity', predictor='netmhcpan')
-    assert best_nmp.allele == 'HLA-A*02:01'
-    assert best_nmp.predictor_name == 'netmhcpan'
-
-
-def test_best_unknown_predictor_returns_none():
-    """Asking for a predictor that didn't emit ``kind`` gives
-    ``None`` (not an error). Lets callers iterate
-    ``predictors_for_kind`` and call ``best`` without
-    pre-checking."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', predictor='mhcflurry', score=0.4),
-        ))
-    assert ctx.best(
-        'pMHC_affinity', predictor='netmhcpan') is None
-
-
-# ---- Kind-named helpers ------------------------------------------------
-
-
 def test_kind_named_helpers_forward_to_best():
-    """``best_affinity`` / ``best_presentation`` / etc. are thin
-    forwards. Verify each names the right ``kind`` string."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
         predictions=(
@@ -246,8 +441,8 @@ def test_kind_named_helpers_forward_to_best():
             _pred('pMHC_presentation', score=0.5),
             _pred('pMHC_stability', score=0.8),
             _pred('immunogenicity', score=0.3),
-            _pred('proteasome_cleavage', score=0.6),
-            _pred('antigen_processing', score=0.4),
+            _pred('proteasome_cleavage', allele='', score=0.6),
+            _pred('antigen_processing', allele='', score=0.4),
         ))
     assert ctx.best_affinity().kind == 'pMHC_affinity'
     assert ctx.best_presentation().kind == 'pMHC_presentation'
@@ -257,357 +452,26 @@ def test_kind_named_helpers_forward_to_best():
     assert ctx.best_antigen_processing().kind == 'antigen_processing'
 
 
-def test_kind_named_helpers_raise_on_multi_predictor_ambiguity():
-    """Same disambiguation contract as ``best``."""
+def test_best_for_processing_kind_works_without_allele():
+    """Processing kinds emit ``allele=''``. ``best`` returns the
+    one record without complaining about a missing allele key —
+    proves allele-as-record-property handles this naturally."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
         predictions=(
-            _pred('pMHC_presentation', predictor='mhcflurry'),
-            _pred('pMHC_presentation', predictor='bigmhc'),
+            _pred('proteasome_cleavage', predictor='pepsickle',
+                  allele='', score=0.6),
         ))
-    with pytest.raises(ValueError):
-        ctx.best_presentation()
-    # Disambiguated form works.
-    assert ctx.best_presentation(predictor='mhcflurry') is not None
-
-
-# ---- Kind aliases ------------------------------------------------------
-
-
-@pytest.mark.parametrize('alias,canonical', [
-    ('ba', 'pMHC_affinity'),
-    ('BA', 'pMHC_affinity'),
-    ('affinity', 'pMHC_affinity'),
-    ('binding', 'pMHC_affinity'),
-    ('pMHC_affinity', 'pMHC_affinity'),
-    ('PMHC_AFFINITY', 'pMHC_affinity'),
-    ('el', 'pMHC_presentation'),
-    ('EL', 'pMHC_presentation'),
-    ('presentation', 'pMHC_presentation'),
-    ('elution', 'pMHC_presentation'),
-    ('stability', 'pMHC_stability'),
-    ('cleavage', 'proteasome_cleavage'),
-    ('proteasome', 'proteasome_cleavage'),
-    ('processing', 'antigen_processing'),
-    ('ap', 'antigen_processing'),
-    ('tap', 'tap_transport'),
-    ('erap', 'erap_trimming'),
-])
-def test_best_resolves_kind_aliases(alias, canonical):
-    """mhcflurry / netmhcpan / pVACseq use BA / EL / etc. as
-    shorthand for the canonical ``pMHC_*`` strings — accept both
-    so call sites can stay terse without knowing which spelling
-    vaxrank stores."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(_pred(canonical, score=0.7),))
-    result = ctx.best(alias)
+    result = ctx.best_cleavage()
     assert result is not None
-    assert result.kind == canonical
+    assert result.score == 0.6
+    assert result.allele == ''
 
 
-def test_predictors_for_kind_accepts_aliases():
-    """Same alias contract on the structured-view accessors so
-    callers don't have to switch spellings between methods."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_presentation', predictor='mhcflurry'),
-            _pred('pMHC_presentation', predictor='bigmhc'),
-        ))
-    assert ctx.predictors_for_kind('el') == ('bigmhc', 'mhcflurry')
-    assert ctx.predictors_for_kind('presentation') == ('bigmhc', 'mhcflurry')
-
-
-def test_alleles_for_accepts_aliases():
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', allele='HLA-A*02:01'),
-            _pred('pMHC_affinity', allele='HLA-B*07:02'),
-        ))
-    assert ctx.alleles_for('ba', 'mhcflurry') == (
-        'HLA-A*02:01', 'HLA-B*07:02')
-
-
-# ---- Version disambiguation --------------------------------------------
-
-
-def test_best_multi_version_picks_most_recent():
-    """When the same predictor ran at two versions (e.g. mhcflurry
-    2.1.0 and 2.1.1 both on file), ``best`` defaults to the newest
-    by PEP 440. Score scales are comparable across versions of the
-    same predictor — only freshness differs — so this auto-resolves
-    rather than raising."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', version='2.1.0', score=0.9),
-            _pred('pMHC_affinity', version='2.1.1', score=0.4),
-        ))
-    result = ctx.best('pMHC_affinity')
-    assert result is not None
-    # Newer version wins even though its score is lower.
-    assert result.predictor_version == '2.1.1'
-    assert result.score == 0.4
-
-
-def test_best_with_explicit_version_pins_to_that_version():
-    """``version=`` overrides the most-recent default — useful
-    when reproducing an older run or comparing version-over-version."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', version='2.1.0', score=0.9),
-            _pred('pMHC_affinity', version='2.1.1', score=0.4),
-        ))
-    result = ctx.best('pMHC_affinity', version='2.1.0')
-    assert result is not None
-    assert result.predictor_version == '2.1.0'
-    assert result.score == 0.9
-
-
-def test_best_unknown_version_returns_none():
-    """Asking for a version that isn't on file gives ``None``,
-    not an error — same shape as unknown predictor."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', version='2.1.1', score=0.7),
-        ))
-    assert ctx.best('pMHC_affinity', version='99.0.0') is None
-
-
-def test_best_picks_best_allele_within_most_recent_version():
-    """Combination: multiple versions × multiple alleles. Pin to
-    newest version, then take best-by-score across alleles."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', version='2.1.0',
-                  allele='HLA-A*02:01', score=0.95),
-            _pred('pMHC_affinity', version='2.1.1',
-                  allele='HLA-A*02:01', score=0.4),
-            _pred('pMHC_affinity', version='2.1.1',
-                  allele='HLA-B*07:02', score=0.7),
-        ))
-    result = ctx.best('pMHC_affinity')
-    assert result.predictor_version == '2.1.1'
-    assert result.allele == 'HLA-B*07:02'  # best within 2.1.1
-
-
-def test_best_per_predictor_with_version_disambiguation():
-    """Two predictors, each with multiple versions. ``predictor=``
-    picks the predictor; version then auto-resolves within it."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', predictor='mhcflurry',
-                  version='2.1.0', score=0.9),
-            _pred('pMHC_affinity', predictor='mhcflurry',
-                  version='2.1.1', score=0.4),
-            _pred('pMHC_affinity', predictor='netmhcpan',
-                  version='4.0', score=0.5),
-            _pred('pMHC_affinity', predictor='netmhcpan',
-                  version='4.1', score=0.3),
-        ))
-    mhcf = ctx.best('pMHC_affinity', predictor='mhcflurry')
-    assert mhcf.predictor_version == '2.1.1'
-    nmp = ctx.best('pMHC_affinity', predictor='netmhcpan')
-    assert nmp.predictor_version == '4.1'
-
-
-def test_best_handles_empty_version_strings():
-    """Pre-#261 records had empty ``predictor_version`` strings.
-    Mixed with a real version, the real version wins (empty parses
-    as InvalidVersion and falls below all PEP 440 versions)."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', version='', score=0.9),
-            _pred('pMHC_affinity', version='2.1.1', score=0.4),
-        ))
-    result = ctx.best('pMHC_affinity')
-    assert result.predictor_version == '2.1.1'
-
-
-def test_best_all_invalid_version_strings_falls_back_to_lex_max():
-    """If every ``predictor_version`` on file is unparseable
-    (legacy / non-semver / pre-#261), there's no PEP 440 ordering
-    to apply. Lexicographic ``max`` is the consistent fallback so
-    behavior remains deterministic."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', version='legacy_a', score=0.4),
-            _pred('pMHC_affinity', version='legacy_z', score=0.7),
-        ))
-    result = ctx.best('pMHC_affinity')
-    assert result is not None
-    assert result.predictor_version == 'legacy_z'
-
-
-def test_versions_for_handles_invalid_version_strings():
-    """Invalid versions sort before valid ones in the returned
-    tuple (legacy first, semver after) so ``versions[-1]`` still
-    yields the most recent valid version."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', version='legacy', score=0.5),
-            _pred('pMHC_affinity', version='2.1.0', score=0.5),
-            _pred('pMHC_affinity', version='2.1.1', score=0.5),
-        ))
-    versions = ctx.versions_for('pMHC_affinity', 'mhcflurry')
-    assert versions == ('legacy', '2.1.0', '2.1.1')
-
-
-def test_versions_for_returns_oldest_to_newest():
-    """``versions_for`` exposes every version on file, sorted
-    oldest → newest by PEP 440. ``versions[-1]`` is the latest."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', version='2.1.1'),
-            _pred('pMHC_affinity', version='2.1.0'),
-            _pred('pMHC_affinity', version='2.0.0'),
-        ))
-    versions = ctx.versions_for('pMHC_affinity', 'mhcflurry')
-    assert versions == ('2.0.0', '2.1.0', '2.1.1')
-
-
-def test_kind_named_helpers_forward_version_arg():
-    """``best_affinity(version=…)`` forwards through to ``best``
-    so the version override works on the convenience helpers too."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', version='2.1.0', score=0.9),
-            _pred('pMHC_affinity', version='2.1.1', score=0.4),
-        ))
-    # No version → newest.
-    assert ctx.best_affinity().predictor_version == '2.1.1'
-    # Pinned version overrides.
-    assert ctx.best_affinity(version='2.1.0').predictor_version == '2.1.0'
-
-
-# ---- Parametric scoring (score_key) ------------------------------------
-
-
-def test_best_default_score_key_uses_score_field():
-    """Default ``score_key`` is ``Prediction.score`` (mhctools'
-    normalized higher-is-better axis). Keep this pinned so a
-    refactor of the default doesn't silently flip ranking."""
-    from vaxrank.peptide_context import default_score_key
-    p = _pred('pMHC_affinity', score=0.42, value=100.0)
-    assert default_score_key(p) == 0.42
-
-
-def test_best_with_custom_score_key_picks_by_that_axis():
-    """Override ``score_key`` to rank by a different axis — e.g.
-    lowest percentile_rank. Higher return value still wins, so
-    invert the sign for lower-is-better axes."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', allele='HLA-A*02:01',
-                  score=0.9, percentile_rank=2.5),
-            _pred('pMHC_affinity', allele='HLA-B*07:02',
-                  score=0.4, percentile_rank=0.3),
-        ))
-    # Default score-based: A*02 wins (0.9 > 0.4).
-    assert ctx.best('pMHC_affinity').allele == 'HLA-A*02:01'
-    # Custom: rank by lowest percentile_rank → B*07 wins (0.3 < 2.5).
-    by_rank = ctx.best(
-        'pMHC_affinity', score_key=lambda p: -p.percentile_rank)
-    assert by_rank.allele == 'HLA-B*07:02'
-
-
-def test_kind_named_helpers_forward_score_key():
-    """``best_affinity(score_key=…)`` etc. forward through to
-    ``best`` — the convenience helpers stay in lockstep with the
-    primitive's contract."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', allele='HLA-A*02:01',
-                  score=0.9, value=10.0),
-            _pred('pMHC_affinity', allele='HLA-B*07:02',
-                  score=0.4, value=2.0),
-        ))
-    # Custom: rank by lowest IC50 (lower nM = better binder).
-    result = ctx.best_affinity(score_key=lambda p: -p.value)
-    assert result.allele == 'HLA-B*07:02'
-    assert result.value == 2.0
-
-
-def test_best_score_key_respects_predictor_disambiguation():
-    """``score_key`` doesn't escape the multi-predictor raise —
-    cross-predictor ranking is meaningless under any axis since
-    each predictor's score scales are independent. Keep the raise
-    in place even when a custom key is provided."""
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        predictions=(
-            _pred('pMHC_affinity', predictor='mhcflurry',
-                  percentile_rank=2.5),
-            _pred('pMHC_affinity', predictor='netmhcpan',
-                  percentile_rank=0.3),
-        ))
-    with pytest.raises(ValueError, match='multiple predictors'):
-        ctx.best(
-            'pMHC_affinity', score_key=lambda p: -p.percentile_rank)
-
-
-# ---- Serialization round-trip ------------------------------------------
-
-
-def test_peptide_context_roundtrips_through_asdict():
-    """Frozen dataclass + ``mhctools.Prediction.to_dict``/``from_dict``
-    let the whole structure round-trip through plain dicts. Pin the
-    contract so downstream code can persist these to JSON / msgspec
-    without surprise."""
-    from dataclasses import asdict
-    ctx = PeptideContext(
-        peptide_sequence='SIINFEKL',
-        n_flank='AAAAA',
-        c_flank='BBBBB',
-        source_sequence='AAAAASIINFEKLBBBBB',
-        source_name='OVA',
-        offset=5,
-        predictions=(
-            _pred('pMHC_affinity', allele='HLA-A*02:01',
-                  score=0.7, value=120.0, percentile_rank=0.5),
-            _pred('pMHC_presentation', allele='HLA-A*02:01',
-                  score=0.85, percentile_rank=0.3),
-        ))
-    d = asdict(ctx)
-    # Predictions came back as a tuple of dicts (asdict recurses).
-    assert d['peptide_sequence'] == 'SIINFEKL'
-    assert d['n_flank'] == 'AAAAA'
-    assert d['c_flank'] == 'BBBBB'
-    assert d['offset'] == 5
-    assert len(d['predictions']) == 2
-    # Reconstruct via Prediction.from_dict.
-    rebuilt = PeptideContext(
-        peptide_sequence=d['peptide_sequence'],
-        n_flank=d['n_flank'],
-        c_flank=d['c_flank'],
-        source_sequence=d['source_sequence'],
-        source_name=d['source_name'],
-        offset=d['offset'],
-        predictions=tuple(Prediction.from_dict(p) for p in d['predictions']))
-    assert rebuilt == ctx
-
-
-# ---- Flanking residues -------------------------------------------------
+# ---- Flanking residues + provenance -------------------------------------
 
 
 def test_peptide_context_carries_flanks():
-    """Flanks land at the PeptideContext level (not on each
-    Prediction) because they describe the peptide's position in its
-    source, not the prediction. Pin the storage so downstream code
-    can read them directly."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
         n_flank='AAAAA',
@@ -623,9 +487,6 @@ def test_peptide_context_carries_flanks():
 
 
 def test_peptide_context_flanks_default_to_empty():
-    """Comparator contexts (``nearest_self``, ``nearest_oncovirus``)
-    may not have flanks available — empty defaults keep the type
-    usable without forcing every producer to know flanks."""
     ctx = PeptideContext(peptide_sequence='SIINFEKL')
     assert ctx.n_flank == ''
     assert ctx.c_flank == ''
@@ -637,26 +498,19 @@ def test_peptide_context_flanks_default_to_empty():
 
 
 def test_candidate_epitope_wt_shortcut():
-    """``candidate.wt`` is a convenience for
-    ``candidate.comparators['wt']``. Most callers reach for the WT
-    pair without thinking about the dict."""
     mutant = PeptideContext(peptide_sequence='SIINFEKL')
-    wt = PeptideContext(peptide_sequence='SIINFEKM')  # ref-allele variant
+    wt = PeptideContext(peptide_sequence='SIINFEKM')
     candidate = CandidateEpitope(
         mutant=mutant,
         comparators={COMPARATOR_WT: wt},
         overlaps_mutation=True)
     assert candidate.wt is wt
     assert candidate.comparator('wt') is wt
-    # Pass-through for the most common reads.
     assert candidate.peptide_sequence == 'SIINFEKL'
     assert candidate.length == 8
 
 
 def test_candidate_epitope_no_wt_returns_none():
-    """A WT-less candidate (e.g. a frameshift where there's no
-    aligned reference position) has no ``'wt'`` entry — accessor
-    is ``None`` rather than KeyError."""
     candidate = CandidateEpitope(
         mutant=PeptideContext(peptide_sequence='SIINFEKL'),
         comparators={})
@@ -684,19 +538,13 @@ def test_candidate_epitope_holds_arbitrary_comparators():
             'custom_comparator': PeptideContext(peptide_sequence='SIINFEEK'),
         })
     assert candidate.comparator('nearest_self') is nearest_self
-    # The nearest-self comparator carries its own predictions —
-    # which is what lets a safety scorer ask "does the patient's
-    # MHC also bind the self peptide?"
-    assert candidate.comparator('nearest_self').best_affinity().value == 80.0
-    # Open-ended: arbitrary keys also work.
+    assert candidate.comparator(
+        'nearest_self').best_affinity().value == 80.0
     assert candidate.comparator('custom_comparator') is not None
     assert candidate.comparator('not_present') is None
 
 
 def test_candidate_epitope_freezes_mutation_context():
-    """``overlaps_mutation`` / ``occurs_in_reference`` live at the
-    candidate level (they're about the mutant-vs-source
-    relationship, not the peptide itself)."""
     candidate = CandidateEpitope(
         mutant=PeptideContext(peptide_sequence='SIINFEKL'),
         comparators={},
@@ -704,6 +552,5 @@ def test_candidate_epitope_freezes_mutation_context():
         occurs_in_reference=False)
     assert candidate.overlaps_mutation is True
     assert candidate.occurs_in_reference is False
-    # Frozen dataclass — direct attribute mutation raises.
     with pytest.raises(Exception):
         candidate.overlaps_mutation = False  # type: ignore

--- a/tests/test_peptide_context.py
+++ b/tests/test_peptide_context.py
@@ -50,22 +50,45 @@ def _pred(kind, *, predictor='mhcflurry', version='', allele='HLA-A*02:01',
 
 def test_peptide_context_predictions_by_kind_and_predictor_groups_correctly():
     """The flat storage tuple is the source of truth; the nested
-    view is built on demand."""
+    view is built on demand. Four levels: kind → predictor →
+    version → allele. Version axis prevents collision when the same
+    (kind, predictor, allele) was scored at multiple versions."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
         predictions=(
             _pred('pMHC_affinity', predictor='mhcflurry',
-                  allele='HLA-A*02:01'),
+                  version='2.1.1', allele='HLA-A*02:01'),
             _pred('pMHC_affinity', predictor='netmhcpan',
-                  allele='HLA-A*02:01'),
+                  version='4.1', allele='HLA-A*02:01'),
             _pred('pMHC_presentation', predictor='mhcflurry',
-                  allele='HLA-A*02:01'),
+                  version='2.1.1', allele='HLA-A*02:01'),
         ))
     nested = ctx.predictions_by_kind_and_predictor()
     assert set(nested.keys()) == {'pMHC_affinity', 'pMHC_presentation'}
     assert set(nested['pMHC_affinity'].keys()) == {'mhcflurry', 'netmhcpan'}
-    assert 'HLA-A*02:01' in nested['pMHC_affinity']['mhcflurry']
-    assert 'HLA-A*02:01' in nested['pMHC_presentation']['mhcflurry']
+    assert set(nested['pMHC_affinity']['mhcflurry'].keys()) == {'2.1.1'}
+    assert 'HLA-A*02:01' in nested['pMHC_affinity']['mhcflurry']['2.1.1']
+    assert 'HLA-A*02:01' in (
+        nested['pMHC_presentation']['mhcflurry']['2.1.1'])
+
+
+def test_predictions_by_kind_and_predictor_separates_versions():
+    """Same (kind, predictor, allele) at two versions stays
+    addressable — without the version axis this would be one record
+    silently overwriting the other."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  version='2.1.0', allele='HLA-A*02:01', score=0.4),
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  version='2.1.1', allele='HLA-A*02:01', score=0.7),
+        ))
+    nested = ctx.predictions_by_kind_and_predictor()
+    versions = nested['pMHC_affinity']['mhcflurry']
+    assert set(versions.keys()) == {'2.1.0', '2.1.1'}
+    assert versions['2.1.0']['HLA-A*02:01'].score == 0.4
+    assert versions['2.1.1']['HLA-A*02:01'].score == 0.7
 
 
 def test_predictors_for_kind_lists_emitting_predictors():
@@ -466,6 +489,148 @@ def test_kind_named_helpers_forward_version_arg():
     assert ctx.best_affinity().predictor_version == '2.1.1'
     # Pinned version overrides.
     assert ctx.best_affinity(version='2.1.0').predictor_version == '2.1.0'
+
+
+# ---- Parametric scoring (score_key) ------------------------------------
+
+
+def test_best_default_score_key_uses_score_field():
+    """Default ``score_key`` is ``Prediction.score`` (mhctools'
+    normalized higher-is-better axis). Keep this pinned so a
+    refactor of the default doesn't silently flip ranking."""
+    from vaxrank.peptide_context import default_score_key
+    p = _pred('pMHC_affinity', score=0.42, value=100.0)
+    assert default_score_key(p) == 0.42
+
+
+def test_best_with_custom_score_key_picks_by_that_axis():
+    """Override ``score_key`` to rank by a different axis — e.g.
+    lowest percentile_rank. Higher return value still wins, so
+    invert the sign for lower-is-better axes."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', allele='HLA-A*02:01',
+                  score=0.9, percentile_rank=2.5),
+            _pred('pMHC_affinity', allele='HLA-B*07:02',
+                  score=0.4, percentile_rank=0.3),
+        ))
+    # Default score-based: A*02 wins (0.9 > 0.4).
+    assert ctx.best('pMHC_affinity').allele == 'HLA-A*02:01'
+    # Custom: rank by lowest percentile_rank → B*07 wins (0.3 < 2.5).
+    by_rank = ctx.best(
+        'pMHC_affinity', score_key=lambda p: -p.percentile_rank)
+    assert by_rank.allele == 'HLA-B*07:02'
+
+
+def test_kind_named_helpers_forward_score_key():
+    """``best_affinity(score_key=…)`` etc. forward through to
+    ``best`` — the convenience helpers stay in lockstep with the
+    primitive's contract."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', allele='HLA-A*02:01',
+                  score=0.9, value=10.0),
+            _pred('pMHC_affinity', allele='HLA-B*07:02',
+                  score=0.4, value=2.0),
+        ))
+    # Custom: rank by lowest IC50 (lower nM = better binder).
+    result = ctx.best_affinity(score_key=lambda p: -p.value)
+    assert result.allele == 'HLA-B*07:02'
+    assert result.value == 2.0
+
+
+def test_best_score_key_respects_predictor_disambiguation():
+    """``score_key`` doesn't escape the multi-predictor raise —
+    cross-predictor ranking is meaningless under any axis since
+    each predictor's score scales are independent. Keep the raise
+    in place even when a custom key is provided."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  percentile_rank=2.5),
+            _pred('pMHC_affinity', predictor='netmhcpan',
+                  percentile_rank=0.3),
+        ))
+    with pytest.raises(ValueError, match='multiple predictors'):
+        ctx.best(
+            'pMHC_affinity', score_key=lambda p: -p.percentile_rank)
+
+
+# ---- Serialization round-trip ------------------------------------------
+
+
+def test_peptide_context_roundtrips_through_asdict():
+    """Frozen dataclass + ``mhctools.Prediction.to_dict``/``from_dict``
+    let the whole structure round-trip through plain dicts. Pin the
+    contract so downstream code can persist these to JSON / msgspec
+    without surprise."""
+    from dataclasses import asdict
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        n_flank='AAAAA',
+        c_flank='BBBBB',
+        source_sequence='AAAAASIINFEKLBBBBB',
+        source_name='OVA',
+        offset=5,
+        predictions=(
+            _pred('pMHC_affinity', allele='HLA-A*02:01',
+                  score=0.7, value=120.0, percentile_rank=0.5),
+            _pred('pMHC_presentation', allele='HLA-A*02:01',
+                  score=0.85, percentile_rank=0.3),
+        ))
+    d = asdict(ctx)
+    # Predictions came back as a tuple of dicts (asdict recurses).
+    assert d['peptide_sequence'] == 'SIINFEKL'
+    assert d['n_flank'] == 'AAAAA'
+    assert d['c_flank'] == 'BBBBB'
+    assert d['offset'] == 5
+    assert len(d['predictions']) == 2
+    # Reconstruct via Prediction.from_dict.
+    rebuilt = PeptideContext(
+        peptide_sequence=d['peptide_sequence'],
+        n_flank=d['n_flank'],
+        c_flank=d['c_flank'],
+        source_sequence=d['source_sequence'],
+        source_name=d['source_name'],
+        offset=d['offset'],
+        predictions=tuple(Prediction.from_dict(p) for p in d['predictions']))
+    assert rebuilt == ctx
+
+
+# ---- Flanking residues -------------------------------------------------
+
+
+def test_peptide_context_carries_flanks():
+    """Flanks land at the PeptideContext level (not on each
+    Prediction) because they describe the peptide's position in its
+    source, not the prediction. Pin the storage so downstream code
+    can read them directly."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        n_flank='AAAAA',
+        c_flank='CCCCC',
+        source_sequence='AAAAASIINFEKLCCCCC',
+        source_name='OVA',
+        offset=5)
+    assert ctx.n_flank == 'AAAAA'
+    assert ctx.c_flank == 'CCCCC'
+    assert ctx.source_sequence == 'AAAAASIINFEKLCCCCC'
+    assert ctx.source_name == 'OVA'
+    assert ctx.offset == 5
+
+
+def test_peptide_context_flanks_default_to_empty():
+    """Comparator contexts (``nearest_self``, ``nearest_oncovirus``)
+    may not have flanks available — empty defaults keep the type
+    usable without forcing every producer to know flanks."""
+    ctx = PeptideContext(peptide_sequence='SIINFEKL')
+    assert ctx.n_flank == ''
+    assert ctx.c_flank == ''
+    assert ctx.source_sequence == ''
+    assert ctx.source_name == ''
 
 
 # ---- CandidateEpitope ---------------------------------------------------

--- a/tests/test_peptide_context.py
+++ b/tests/test_peptide_context.py
@@ -142,6 +142,47 @@ def test_predictions_flat_round_trips_through_constructor():
     assert rebuilt.predictions == original.predictions
 
 
+def test_predictions_flat_is_deterministic():
+    """Output sorted by (kind, predictor, version, allele) so two
+    contexts built from differently-ordered input emit the same
+    flat tuple. Pin so callers diffing serialized output across
+    runs don't see producer-order noise."""
+    a = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_presentation', predictor='mhcflurry',
+                  allele='HLA-B*07:02'),
+            _pred('pMHC_affinity', predictor='netmhcpan',
+                  allele='HLA-A*02:01'),
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-B*07:02'),
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-A*02:01'),
+        ))
+    b = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(  # same records, shuffled
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-A*02:01'),
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-B*07:02'),
+            _pred('pMHC_affinity', predictor='netmhcpan',
+                  allele='HLA-A*02:01'),
+            _pred('pMHC_presentation', predictor='mhcflurry',
+                  allele='HLA-B*07:02'),
+        ))
+    assert a.predictions_flat() == b.predictions_flat()
+    # Verify the sort order: kind primary, predictor secondary,
+    # allele tertiary (version is constant at '' here).
+    flat = a.predictions_flat()
+    assert [(p.kind, p.predictor_name, p.allele) for p in flat] == [
+        ('pMHC_affinity', 'mhcflurry', 'HLA-A*02:01'),
+        ('pMHC_affinity', 'mhcflurry', 'HLA-B*07:02'),
+        ('pMHC_affinity', 'netmhcpan', 'HLA-A*02:01'),
+        ('pMHC_presentation', 'mhcflurry', 'HLA-B*07:02'),
+    ]
+
+
 # ---- Structured views --------------------------------------------------
 
 
@@ -189,6 +230,57 @@ def test_alleles_for_lists_alleles_only():
         'HLA-A*02:01', 'HLA-B*07:02')
     # Processing kind: no alleles surfaced.
     assert ctx.alleles_for('proteasome_cleavage') == ()
+
+
+def test_alleles_for_unions_across_predictors():
+    """Unlike ``best`` / ``predictions_for``, ``alleles_for``
+    is predictor-agnostic — alleles are a set property, not
+    score-bound, so when multiple predictors emitted ``kind``
+    we union their alleles instead of raising. Pin so callers
+    asking "what alleles do we have evidence for?" don't get
+    surprised by a ValueError."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-A*02:01'),
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-B*07:02'),
+            _pred('pMHC_affinity', predictor='netmhcpan',
+                  allele='HLA-A*02:01'),
+            _pred('pMHC_affinity', predictor='netmhcpan',
+                  allele='HLA-C*03:04'),
+        ))
+    # No predictor= → union across mhcflurry + netmhcpan.
+    assert ctx.alleles_for('pMHC_affinity') == (
+        'HLA-A*02:01', 'HLA-B*07:02', 'HLA-C*03:04')
+    # predictor= still filters.
+    assert ctx.alleles_for(
+        'pMHC_affinity', predictor='mhcflurry') == (
+            'HLA-A*02:01', 'HLA-B*07:02')
+    assert ctx.alleles_for(
+        'pMHC_affinity', predictor='netmhcpan') == (
+            'HLA-A*02:01', 'HLA-C*03:04')
+
+
+def test_alleles_for_unions_across_versions():
+    """Same predictor-agnostic logic for versions: when a
+    predictor ran at multiple versions on different alleles,
+    union rather than auto-resolving to the latest version's
+    alleles only."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='2.1.0',
+                  allele='HLA-A*02:01'),
+            _pred('pMHC_affinity', version='2.1.1',
+                  allele='HLA-B*07:02'),
+        ))
+    assert ctx.alleles_for('pMHC_affinity') == (
+        'HLA-A*02:01', 'HLA-B*07:02')
+    # Explicit version= restricts.
+    assert ctx.alleles_for(
+        'pMHC_affinity', version='2.1.1') == ('HLA-B*07:02',)
 
 
 # ---- Kind aliases (delegated to topiary) -------------------------------

--- a/tests/test_peptide_context.py
+++ b/tests/test_peptide_context.py
@@ -183,6 +183,31 @@ def test_predictions_flat_is_deterministic():
     ]
 
 
+def test_predictions_flat_tiebreaker_for_duplicate_keys():
+    """If a producer ever emits duplicate ``(kind, predictor,
+    version, allele)`` records, the score / value / %-rank tail
+    of the sort key keeps order deterministic across input
+    shuffles. Pin so future producers can't sneak in an order
+    dependency on input order."""
+    a = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', score=0.5),
+            _pred('pMHC_affinity', score=0.9),
+            _pred('pMHC_affinity', score=0.3),
+        ))
+    b = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(  # same records, shuffled
+            _pred('pMHC_affinity', score=0.9),
+            _pred('pMHC_affinity', score=0.3),
+            _pred('pMHC_affinity', score=0.5),
+        ))
+    assert a.predictions_flat() == b.predictions_flat()
+    # Within-key sort is by score ascending.
+    assert [p.score for p in a.predictions_flat()] == [0.3, 0.5, 0.9]
+
+
 # ---- Structured views --------------------------------------------------
 
 
@@ -263,6 +288,49 @@ def test_alleles_for_unions_across_predictors():
             'HLA-A*02:01', 'HLA-C*03:04')
 
 
+def test_alleles_for_raises_on_unknown_predictor():
+    """Explicit ``predictor=`` that doesn't match any predictor
+    for the kind raises ``ValueError`` rather than silently
+    returning ``()`` — silent empty-on-typo masks call-site
+    bugs."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-A*02:01'),
+        ))
+    with pytest.raises(ValueError, match='no predictions from predictor'):
+        ctx.alleles_for('pMHC_affinity', predictor='nonexistent')
+
+
+def test_alleles_for_raises_on_unknown_version():
+    """Same strictness for ``version=``: a typo raises rather
+    than masquerading as an empty result."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='2.1.1',
+                  allele='HLA-A*02:01'),
+        ))
+    with pytest.raises(ValueError, match='no predictions at version'):
+        ctx.alleles_for('pMHC_affinity', version='99.0.0')
+
+
+def test_alleles_for_silent_on_missing_kind():
+    """Asking about a kind we don't have isn't a typo — that's
+    the standard "this peptide didn't get scored on X" case.
+    Returns ``()`` silently. Distinguishes "kind missing" from
+    "predictor / version missing" — the latter is a call-site
+    bug worth flagging."""
+    ctx = PeptideContext(peptide_sequence='SIINFEKL')
+    assert ctx.alleles_for('pMHC_affinity') == ()
+    # Even with explicit predictor= against a kind that has no
+    # records: still silent (no validation possible against an
+    # empty kind).
+    assert ctx.alleles_for(
+        'pMHC_affinity', predictor='mhcflurry') == ()
+
+
 def test_alleles_for_unions_across_versions():
     """Same predictor-agnostic logic for versions: when a
     predictor ran at multiple versions on different alleles,
@@ -330,7 +398,9 @@ def test_load_kind_aliases_prefers_public_name(monkeypatch):
     """When topiary publishes a public ``KIND_ALIASES``, vaxrank
     prefers it over the legacy private ``_KIND_ALIASES``. Pins the
     upgrade path so when topiary promotes the name, vaxrank picks
-    it up without code changes."""
+    it up without code changes. The result is wrapped in a
+    read-only view so vaxrank can't mutate topiary's table."""
+    from types import MappingProxyType
     import topiary.ranking
     from vaxrank import peptide_context as pc
 
@@ -339,7 +409,10 @@ def test_load_kind_aliases_prefers_public_name(monkeypatch):
     monkeypatch.setattr(
         topiary.ranking, 'KIND_ALIASES', sentinel, raising=False)
     try:
-        assert pc._load_kind_aliases() is sentinel
+        result = pc._load_kind_aliases()
+        assert isinstance(result, MappingProxyType)
+        assert dict(result) == sentinel  # content equal
+        assert result is not sentinel    # but wrapped, not aliased
     finally:
         pc._load_kind_aliases.cache_clear()
 
@@ -379,9 +452,10 @@ def test_load_kind_aliases_is_cached(monkeypatch):
         topiary.ranking, 'KIND_ALIASES', sentinel, raising=False)
     try:
         assert pc._load_kind_aliases() is first  # cached
-        # After cache_clear, the new attr wins.
+        # After cache_clear, the new attr wins (still wrapped).
         pc._load_kind_aliases.cache_clear()
-        assert pc._load_kind_aliases() is sentinel
+        result = pc._load_kind_aliases()
+        assert dict(result) == sentinel
     finally:
         pc._load_kind_aliases.cache_clear()
 
@@ -539,7 +613,7 @@ def test_versions_for_returns_oldest_to_newest():
             _pred('pMHC_affinity', version='2.1.0'),
             _pred('pMHC_affinity', version='2.0.0'),
         ))
-    assert ctx.versions_for('pMHC_affinity', 'mhcflurry') == (
+    assert ctx.versions_for('pMHC_affinity', predictor='mhcflurry') == (
         '2.0.0', '2.1.0', '2.1.1')
 
 
@@ -551,7 +625,7 @@ def test_versions_for_invalid_strings_sort_first():
             _pred('pMHC_affinity', version='2.1.1'),
             _pred('pMHC_affinity', version='2.1.0'),
         ))
-    assert ctx.versions_for('pMHC_affinity', 'mhcflurry') == (
+    assert ctx.versions_for('pMHC_affinity', predictor='mhcflurry') == (
         'legacy', '2.1.0', '2.1.1')
 
 

--- a/tests/test_peptide_context.py
+++ b/tests/test_peptide_context.py
@@ -10,12 +10,14 @@ the flat ``EpitopePrediction``).
 Pins:
 - Storage stays as a flat tuple of ``mhctools.Prediction``s, but
   every access path goes through methods that respect the
-  (kind, predictor, allele) structure.
-- ``best_for_kind`` raises on multi-predictor ambiguity. Cross-
-  predictor ``max(score)`` is meaningless because each predictor's
-  score scale is its own.
-- ``predictors_for_kind`` / ``alleles_for`` give callers the
-  structured view they need to walk per-predictor.
+  (kind, predictor, version, allele) structure.
+- ``best`` raises on multi-predictor ambiguity (cross-predictor
+  ``max(score)`` is meaningless — each predictor's score scale is
+  its own) and auto-resolves multi-version ambiguity to the most
+  recent version (PEP 440).
+- ``best`` accepts kind aliases (``'ba'`` / ``'el'`` / etc).
+- ``predictors_for_kind`` / ``alleles_for`` / ``versions_for`` give
+  callers the structured view they need to walk per-predictor.
 - ``CandidateEpitope.comparators`` dict accommodates ``'wt'`` plus
   future ``nearest_self`` / ``nearest_vital_self`` / ``nearest_nonCTA``
   / ``nearest_oncovirus`` records (#254 / #257 / #258).
@@ -33,12 +35,12 @@ from vaxrank.peptide_context import (
 )
 
 
-def _pred(kind, *, predictor='mhcflurry', allele='HLA-A*02:01',
+def _pred(kind, *, predictor='mhcflurry', version='', allele='HLA-A*02:01',
           score=0.7, value=100.0, percentile_rank=0.5):
     """Concise factory for an ``mhctools.Prediction``."""
     return Prediction(
-        kind=kind, predictor_name=predictor, allele=allele,
-        peptide='SIINFEKL',
+        kind=kind, predictor_name=predictor, predictor_version=version,
+        allele=allele, peptide='SIINFEKL',
         score=score, value=value, percentile_rank=percentile_rank,
     )
 
@@ -125,10 +127,10 @@ def test_kinds_empty_when_no_predictions():
     assert ctx.predictors_for_kind('pMHC_affinity') == ()
 
 
-# ---- best_for_kind: single-predictor unambiguous case ------------------
+# ---- best: single-predictor unambiguous case ------------------
 
 
-def test_best_for_kind_single_predictor_picks_best_allele():
+def test_best_single_predictor_picks_best_allele():
     """One predictor, multiple alleles → best-by-score across
     alleles. ``predictor=`` not required when there's only one."""
     ctx = PeptideContext(
@@ -138,24 +140,24 @@ def test_best_for_kind_single_predictor_picks_best_allele():
             _pred('pMHC_affinity', allele='HLA-B*07:02', score=0.9),
             _pred('pMHC_affinity', allele='HLA-C*03:04', score=0.3),
         ))
-    best = ctx.best_for_kind('pMHC_affinity')
+    best = ctx.best('pMHC_affinity')
     assert best is not None
     assert best.allele == 'HLA-B*07:02'
     assert best.score == 0.9
 
 
-def test_best_for_kind_returns_none_when_no_records():
+def test_best_returns_none_when_no_records():
     """Coverage / report code can call this safely; absence reads
     as ``None``."""
     ctx = PeptideContext(peptide_sequence='SIINFEKL')
-    assert ctx.best_for_kind('pMHC_affinity') is None
-    assert ctx.best_for_kind('immunogenicity') is None
+    assert ctx.best('pMHC_affinity') is None
+    assert ctx.best('immunogenicity') is None
 
 
-# ---- best_for_kind: multi-predictor disambiguation ---------------------
+# ---- best: multi-predictor disambiguation ---------------------
 
 
-def test_best_for_kind_multi_predictor_raises_without_predictor_arg():
+def test_best_multi_predictor_raises_without_predictor_arg():
     """The architectural fix from this design pass: cross-predictor
     ``max(score)`` is meaningless — score scales differ per
     predictor — so the API forces an explicit choice."""
@@ -166,10 +168,10 @@ def test_best_for_kind_multi_predictor_raises_without_predictor_arg():
             _pred('pMHC_affinity', predictor='netmhcpan', score=0.9),
         ))
     with pytest.raises(ValueError, match='multiple predictors'):
-        ctx.best_for_kind('pMHC_affinity')
+        ctx.best('pMHC_affinity')
 
 
-def test_best_for_kind_with_predictor_arg_picks_within_that_predictor():
+def test_best_with_predictor_arg_picks_within_that_predictor():
     """Per-predictor disambiguation: caller picks the predictor,
     accessor returns the best allele for it."""
     ctx = PeptideContext(
@@ -185,33 +187,33 @@ def test_best_for_kind_with_predictor_arg_picks_within_that_predictor():
                   allele='HLA-B*07:02', score=0.5),
         ))
     # Best within mhcflurry: B*07 (0.7), not netmhcpan's A*02 (0.9).
-    best_mhcf = ctx.best_for_kind('pMHC_affinity', predictor='mhcflurry')
+    best_mhcf = ctx.best('pMHC_affinity', predictor='mhcflurry')
     assert best_mhcf.allele == 'HLA-B*07:02'
     assert best_mhcf.predictor_name == 'mhcflurry'
     # Best within netmhcpan: A*02.
-    best_nmp = ctx.best_for_kind('pMHC_affinity', predictor='netmhcpan')
+    best_nmp = ctx.best('pMHC_affinity', predictor='netmhcpan')
     assert best_nmp.allele == 'HLA-A*02:01'
     assert best_nmp.predictor_name == 'netmhcpan'
 
 
-def test_best_for_kind_unknown_predictor_returns_none():
+def test_best_unknown_predictor_returns_none():
     """Asking for a predictor that didn't emit ``kind`` gives
     ``None`` (not an error). Lets callers iterate
-    ``predictors_for_kind`` and call ``best_for_kind`` without
+    ``predictors_for_kind`` and call ``best`` without
     pre-checking."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
         predictions=(
             _pred('pMHC_affinity', predictor='mhcflurry', score=0.4),
         ))
-    assert ctx.best_for_kind(
+    assert ctx.best(
         'pMHC_affinity', predictor='netmhcpan') is None
 
 
 # ---- Kind-named helpers ------------------------------------------------
 
 
-def test_kind_named_helpers_forward_to_best_for_kind():
+def test_kind_named_helpers_forward_to_best():
     """``best_affinity`` / ``best_presentation`` / etc. are thin
     forwards. Verify each names the right ``kind`` string."""
     ctx = PeptideContext(
@@ -233,7 +235,7 @@ def test_kind_named_helpers_forward_to_best_for_kind():
 
 
 def test_kind_named_helpers_raise_on_multi_predictor_ambiguity():
-    """Same disambiguation contract as ``best_for_kind``."""
+    """Same disambiguation contract as ``best``."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
         predictions=(
@@ -244,6 +246,226 @@ def test_kind_named_helpers_raise_on_multi_predictor_ambiguity():
         ctx.best_presentation()
     # Disambiguated form works.
     assert ctx.best_presentation(predictor='mhcflurry') is not None
+
+
+# ---- Kind aliases ------------------------------------------------------
+
+
+@pytest.mark.parametrize('alias,canonical', [
+    ('ba', 'pMHC_affinity'),
+    ('BA', 'pMHC_affinity'),
+    ('affinity', 'pMHC_affinity'),
+    ('binding', 'pMHC_affinity'),
+    ('pMHC_affinity', 'pMHC_affinity'),
+    ('PMHC_AFFINITY', 'pMHC_affinity'),
+    ('el', 'pMHC_presentation'),
+    ('EL', 'pMHC_presentation'),
+    ('presentation', 'pMHC_presentation'),
+    ('elution', 'pMHC_presentation'),
+    ('stability', 'pMHC_stability'),
+    ('cleavage', 'proteasome_cleavage'),
+    ('proteasome', 'proteasome_cleavage'),
+    ('processing', 'antigen_processing'),
+    ('ap', 'antigen_processing'),
+    ('tap', 'tap_transport'),
+    ('erap', 'erap_trimming'),
+])
+def test_best_resolves_kind_aliases(alias, canonical):
+    """mhcflurry / netmhcpan / pVACseq use BA / EL / etc. as
+    shorthand for the canonical ``pMHC_*`` strings — accept both
+    so call sites can stay terse without knowing which spelling
+    vaxrank stores."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(_pred(canonical, score=0.7),))
+    result = ctx.best(alias)
+    assert result is not None
+    assert result.kind == canonical
+
+
+def test_predictors_for_kind_accepts_aliases():
+    """Same alias contract on the structured-view accessors so
+    callers don't have to switch spellings between methods."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_presentation', predictor='mhcflurry'),
+            _pred('pMHC_presentation', predictor='bigmhc'),
+        ))
+    assert ctx.predictors_for_kind('el') == ('bigmhc', 'mhcflurry')
+    assert ctx.predictors_for_kind('presentation') == ('bigmhc', 'mhcflurry')
+
+
+def test_alleles_for_accepts_aliases():
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', allele='HLA-A*02:01'),
+            _pred('pMHC_affinity', allele='HLA-B*07:02'),
+        ))
+    assert ctx.alleles_for('ba', 'mhcflurry') == (
+        'HLA-A*02:01', 'HLA-B*07:02')
+
+
+# ---- Version disambiguation --------------------------------------------
+
+
+def test_best_multi_version_picks_most_recent():
+    """When the same predictor ran at two versions (e.g. mhcflurry
+    2.1.0 and 2.1.1 both on file), ``best`` defaults to the newest
+    by PEP 440. Score scales are comparable across versions of the
+    same predictor — only freshness differs — so this auto-resolves
+    rather than raising."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='2.1.0', score=0.9),
+            _pred('pMHC_affinity', version='2.1.1', score=0.4),
+        ))
+    result = ctx.best('pMHC_affinity')
+    assert result is not None
+    # Newer version wins even though its score is lower.
+    assert result.predictor_version == '2.1.1'
+    assert result.score == 0.4
+
+
+def test_best_with_explicit_version_pins_to_that_version():
+    """``version=`` overrides the most-recent default — useful
+    when reproducing an older run or comparing version-over-version."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='2.1.0', score=0.9),
+            _pred('pMHC_affinity', version='2.1.1', score=0.4),
+        ))
+    result = ctx.best('pMHC_affinity', version='2.1.0')
+    assert result is not None
+    assert result.predictor_version == '2.1.0'
+    assert result.score == 0.9
+
+
+def test_best_unknown_version_returns_none():
+    """Asking for a version that isn't on file gives ``None``,
+    not an error — same shape as unknown predictor."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='2.1.1', score=0.7),
+        ))
+    assert ctx.best('pMHC_affinity', version='99.0.0') is None
+
+
+def test_best_picks_best_allele_within_most_recent_version():
+    """Combination: multiple versions × multiple alleles. Pin to
+    newest version, then take best-by-score across alleles."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='2.1.0',
+                  allele='HLA-A*02:01', score=0.95),
+            _pred('pMHC_affinity', version='2.1.1',
+                  allele='HLA-A*02:01', score=0.4),
+            _pred('pMHC_affinity', version='2.1.1',
+                  allele='HLA-B*07:02', score=0.7),
+        ))
+    result = ctx.best('pMHC_affinity')
+    assert result.predictor_version == '2.1.1'
+    assert result.allele == 'HLA-B*07:02'  # best within 2.1.1
+
+
+def test_best_per_predictor_with_version_disambiguation():
+    """Two predictors, each with multiple versions. ``predictor=``
+    picks the predictor; version then auto-resolves within it."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  version='2.1.0', score=0.9),
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  version='2.1.1', score=0.4),
+            _pred('pMHC_affinity', predictor='netmhcpan',
+                  version='4.0', score=0.5),
+            _pred('pMHC_affinity', predictor='netmhcpan',
+                  version='4.1', score=0.3),
+        ))
+    mhcf = ctx.best('pMHC_affinity', predictor='mhcflurry')
+    assert mhcf.predictor_version == '2.1.1'
+    nmp = ctx.best('pMHC_affinity', predictor='netmhcpan')
+    assert nmp.predictor_version == '4.1'
+
+
+def test_best_handles_empty_version_strings():
+    """Pre-#261 records had empty ``predictor_version`` strings.
+    Mixed with a real version, the real version wins (empty parses
+    as InvalidVersion and falls below all PEP 440 versions)."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='', score=0.9),
+            _pred('pMHC_affinity', version='2.1.1', score=0.4),
+        ))
+    result = ctx.best('pMHC_affinity')
+    assert result.predictor_version == '2.1.1'
+
+
+def test_best_all_invalid_version_strings_falls_back_to_lex_max():
+    """If every ``predictor_version`` on file is unparseable
+    (legacy / non-semver / pre-#261), there's no PEP 440 ordering
+    to apply. Lexicographic ``max`` is the consistent fallback so
+    behavior remains deterministic."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='legacy_a', score=0.4),
+            _pred('pMHC_affinity', version='legacy_z', score=0.7),
+        ))
+    result = ctx.best('pMHC_affinity')
+    assert result is not None
+    assert result.predictor_version == 'legacy_z'
+
+
+def test_versions_for_handles_invalid_version_strings():
+    """Invalid versions sort before valid ones in the returned
+    tuple (legacy first, semver after) so ``versions[-1]`` still
+    yields the most recent valid version."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='legacy', score=0.5),
+            _pred('pMHC_affinity', version='2.1.0', score=0.5),
+            _pred('pMHC_affinity', version='2.1.1', score=0.5),
+        ))
+    versions = ctx.versions_for('pMHC_affinity', 'mhcflurry')
+    assert versions == ('legacy', '2.1.0', '2.1.1')
+
+
+def test_versions_for_returns_oldest_to_newest():
+    """``versions_for`` exposes every version on file, sorted
+    oldest → newest by PEP 440. ``versions[-1]`` is the latest."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='2.1.1'),
+            _pred('pMHC_affinity', version='2.1.0'),
+            _pred('pMHC_affinity', version='2.0.0'),
+        ))
+    versions = ctx.versions_for('pMHC_affinity', 'mhcflurry')
+    assert versions == ('2.0.0', '2.1.0', '2.1.1')
+
+
+def test_kind_named_helpers_forward_version_arg():
+    """``best_affinity(version=…)`` forwards through to ``best``
+    so the version override works on the convenience helpers too."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', version='2.1.0', score=0.9),
+            _pred('pMHC_affinity', version='2.1.1', score=0.4),
+        ))
+    # No version → newest.
+    assert ctx.best_affinity().predictor_version == '2.1.1'
+    # Pinned version overrides.
+    assert ctx.best_affinity(version='2.1.0').predictor_version == '2.1.0'
 
 
 # ---- CandidateEpitope ---------------------------------------------------

--- a/tests/test_peptide_context.py
+++ b/tests/test_peptide_context.py
@@ -1,0 +1,322 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for ``vaxrank.peptide_context`` (replaces #282 / supersedes
+the flat ``EpitopePrediction``).
+
+Pins:
+- Storage stays as a flat tuple of ``mhctools.Prediction``s, but
+  every access path goes through methods that respect the
+  (kind, predictor, allele) structure.
+- ``best_for_kind`` raises on multi-predictor ambiguity. Cross-
+  predictor ``max(score)`` is meaningless because each predictor's
+  score scale is its own.
+- ``predictors_for_kind`` / ``alleles_for`` give callers the
+  structured view they need to walk per-predictor.
+- ``CandidateEpitope.comparators`` dict accommodates ``'wt'`` plus
+  future ``nearest_self`` / ``nearest_vital_self`` / ``nearest_nonCTA``
+  / ``nearest_oncovirus`` records (#254 / #257 / #258).
+"""
+
+import pytest
+
+from mhctools.pred import Prediction
+
+from vaxrank.peptide_context import (
+    COMPARATOR_NEAREST_SELF,
+    COMPARATOR_WT,
+    CandidateEpitope,
+    PeptideContext,
+)
+
+
+def _pred(kind, *, predictor='mhcflurry', allele='HLA-A*02:01',
+          score=0.7, value=100.0, percentile_rank=0.5):
+    """Concise factory for an ``mhctools.Prediction``."""
+    return Prediction(
+        kind=kind, predictor_name=predictor, allele=allele,
+        peptide='SIINFEKL',
+        score=score, value=value, percentile_rank=percentile_rank,
+    )
+
+
+# ---- PeptideContext storage / structured views --------------------------
+
+
+def test_peptide_context_predictions_by_kind_and_predictor_groups_correctly():
+    """The flat storage tuple is the source of truth; the nested
+    view is built on demand."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-A*02:01'),
+            _pred('pMHC_affinity', predictor='netmhcpan',
+                  allele='HLA-A*02:01'),
+            _pred('pMHC_presentation', predictor='mhcflurry',
+                  allele='HLA-A*02:01'),
+        ))
+    nested = ctx.predictions_by_kind_and_predictor()
+    assert set(nested.keys()) == {'pMHC_affinity', 'pMHC_presentation'}
+    assert set(nested['pMHC_affinity'].keys()) == {'mhcflurry', 'netmhcpan'}
+    assert 'HLA-A*02:01' in nested['pMHC_affinity']['mhcflurry']
+    assert 'HLA-A*02:01' in nested['pMHC_presentation']['mhcflurry']
+
+
+def test_predictors_for_kind_lists_emitting_predictors():
+    """Drives multi-predictor disambiguation: callers ask "what
+    predictors emitted ``kind`` for this peptide?" before deciding
+    how to combine."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry'),
+            _pred('pMHC_affinity', predictor='netmhcpan'),
+            _pred('pMHC_presentation', predictor='mhcflurry'),
+        ))
+    assert ctx.predictors_for_kind('pMHC_affinity') == (
+        'mhcflurry', 'netmhcpan')
+    # Presentation only from mhcflurry — typical real data shape.
+    assert ctx.predictors_for_kind('pMHC_presentation') == ('mhcflurry',)
+    # No data → empty tuple.
+    assert ctx.predictors_for_kind('immunogenicity') == ()
+
+
+def test_alleles_for_kind_predictor_lists_alleles_only():
+    """Alleles per (kind, predictor) — used by coverage code that
+    walks per-allele evidence without picking a single 'best'."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-A*02:01'),
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-B*07:02'),
+            _pred('pMHC_affinity', predictor='netmhcpan',
+                  allele='HLA-A*02:01'),
+        ))
+    assert ctx.alleles_for('pMHC_affinity', 'mhcflurry') == (
+        'HLA-A*02:01', 'HLA-B*07:02')
+    assert ctx.alleles_for('pMHC_affinity', 'netmhcpan') == ('HLA-A*02:01',)
+    assert ctx.alleles_for('pMHC_affinity', 'unknown_predictor') == ()
+
+
+def test_kinds_returns_sorted_distinct_values():
+    """Helps report code render only the kinds present without
+    iterating predictions."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity'),
+            _pred('pMHC_presentation'),
+            _pred('pMHC_affinity', predictor='netmhcpan'),
+        ))
+    assert ctx.kinds() == ('pMHC_affinity', 'pMHC_presentation')
+
+
+def test_kinds_empty_when_no_predictions():
+    """A bare PeptideContext (e.g. a comparator that hasn't been
+    binding-probed yet) has no kinds."""
+    ctx = PeptideContext(peptide_sequence='SIINFEKL')
+    assert ctx.kinds() == ()
+    assert ctx.predictors_for_kind('pMHC_affinity') == ()
+
+
+# ---- best_for_kind: single-predictor unambiguous case ------------------
+
+
+def test_best_for_kind_single_predictor_picks_best_allele():
+    """One predictor, multiple alleles → best-by-score across
+    alleles. ``predictor=`` not required when there's only one."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', allele='HLA-A*02:01', score=0.4),
+            _pred('pMHC_affinity', allele='HLA-B*07:02', score=0.9),
+            _pred('pMHC_affinity', allele='HLA-C*03:04', score=0.3),
+        ))
+    best = ctx.best_for_kind('pMHC_affinity')
+    assert best is not None
+    assert best.allele == 'HLA-B*07:02'
+    assert best.score == 0.9
+
+
+def test_best_for_kind_returns_none_when_no_records():
+    """Coverage / report code can call this safely; absence reads
+    as ``None``."""
+    ctx = PeptideContext(peptide_sequence='SIINFEKL')
+    assert ctx.best_for_kind('pMHC_affinity') is None
+    assert ctx.best_for_kind('immunogenicity') is None
+
+
+# ---- best_for_kind: multi-predictor disambiguation ---------------------
+
+
+def test_best_for_kind_multi_predictor_raises_without_predictor_arg():
+    """The architectural fix from this design pass: cross-predictor
+    ``max(score)`` is meaningless — score scales differ per
+    predictor — so the API forces an explicit choice."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry', score=0.4),
+            _pred('pMHC_affinity', predictor='netmhcpan', score=0.9),
+        ))
+    with pytest.raises(ValueError, match='multiple predictors'):
+        ctx.best_for_kind('pMHC_affinity')
+
+
+def test_best_for_kind_with_predictor_arg_picks_within_that_predictor():
+    """Per-predictor disambiguation: caller picks the predictor,
+    accessor returns the best allele for it."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-A*02:01', score=0.4),
+            _pred('pMHC_affinity', predictor='mhcflurry',
+                  allele='HLA-B*07:02', score=0.7),
+            _pred('pMHC_affinity', predictor='netmhcpan',
+                  allele='HLA-A*02:01', score=0.9),
+            _pred('pMHC_affinity', predictor='netmhcpan',
+                  allele='HLA-B*07:02', score=0.5),
+        ))
+    # Best within mhcflurry: B*07 (0.7), not netmhcpan's A*02 (0.9).
+    best_mhcf = ctx.best_for_kind('pMHC_affinity', predictor='mhcflurry')
+    assert best_mhcf.allele == 'HLA-B*07:02'
+    assert best_mhcf.predictor_name == 'mhcflurry'
+    # Best within netmhcpan: A*02.
+    best_nmp = ctx.best_for_kind('pMHC_affinity', predictor='netmhcpan')
+    assert best_nmp.allele == 'HLA-A*02:01'
+    assert best_nmp.predictor_name == 'netmhcpan'
+
+
+def test_best_for_kind_unknown_predictor_returns_none():
+    """Asking for a predictor that didn't emit ``kind`` gives
+    ``None`` (not an error). Lets callers iterate
+    ``predictors_for_kind`` and call ``best_for_kind`` without
+    pre-checking."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', predictor='mhcflurry', score=0.4),
+        ))
+    assert ctx.best_for_kind(
+        'pMHC_affinity', predictor='netmhcpan') is None
+
+
+# ---- Kind-named helpers ------------------------------------------------
+
+
+def test_kind_named_helpers_forward_to_best_for_kind():
+    """``best_affinity`` / ``best_presentation`` / etc. are thin
+    forwards. Verify each names the right ``kind`` string."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', score=0.7),
+            _pred('pMHC_presentation', score=0.5),
+            _pred('pMHC_stability', score=0.8),
+            _pred('immunogenicity', score=0.3),
+            _pred('proteasome_cleavage', score=0.6),
+            _pred('antigen_processing', score=0.4),
+        ))
+    assert ctx.best_affinity().kind == 'pMHC_affinity'
+    assert ctx.best_presentation().kind == 'pMHC_presentation'
+    assert ctx.best_stability().kind == 'pMHC_stability'
+    assert ctx.best_immunogenicity().kind == 'immunogenicity'
+    assert ctx.best_cleavage().kind == 'proteasome_cleavage'
+    assert ctx.best_antigen_processing().kind == 'antigen_processing'
+
+
+def test_kind_named_helpers_raise_on_multi_predictor_ambiguity():
+    """Same disambiguation contract as ``best_for_kind``."""
+    ctx = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_presentation', predictor='mhcflurry'),
+            _pred('pMHC_presentation', predictor='bigmhc'),
+        ))
+    with pytest.raises(ValueError):
+        ctx.best_presentation()
+    # Disambiguated form works.
+    assert ctx.best_presentation(predictor='mhcflurry') is not None
+
+
+# ---- CandidateEpitope ---------------------------------------------------
+
+
+def test_candidate_epitope_wt_shortcut():
+    """``candidate.wt`` is a convenience for
+    ``candidate.comparators['wt']``. Most callers reach for the WT
+    pair without thinking about the dict."""
+    mutant = PeptideContext(peptide_sequence='SIINFEKL')
+    wt = PeptideContext(peptide_sequence='SIINFEKM')  # ref-allele variant
+    candidate = CandidateEpitope(
+        mutant=mutant,
+        comparators={COMPARATOR_WT: wt},
+        overlaps_mutation=True)
+    assert candidate.wt is wt
+    assert candidate.comparator('wt') is wt
+    # Pass-through for the most common reads.
+    assert candidate.peptide_sequence == 'SIINFEKL'
+    assert candidate.length == 8
+
+
+def test_candidate_epitope_no_wt_returns_none():
+    """A WT-less candidate (e.g. a frameshift where there's no
+    aligned reference position) has no ``'wt'`` entry — accessor
+    is ``None`` rather than KeyError."""
+    candidate = CandidateEpitope(
+        mutant=PeptideContext(peptide_sequence='SIINFEKL'),
+        comparators={})
+    assert candidate.wt is None
+    assert candidate.comparator('wt') is None
+
+
+def test_candidate_epitope_holds_arbitrary_comparators():
+    """Open-ended comparator names — future safety scorers (#254 /
+    #257 / #258) populate ``nearest_self`` / ``nearest_vital_self``
+    / ``nearest_nonCTA`` / ``nearest_oncovirus`` without changing
+    the data shape."""
+    mutant = PeptideContext(peptide_sequence='SIINFEKL')
+    nearest_self = PeptideContext(
+        peptide_sequence='SIINFEKM',
+        source_name='HumanProteome:OVA',
+        predictions=(
+            _pred('pMHC_affinity', allele='HLA-A*02:01', value=80.0),
+        ))
+    candidate = CandidateEpitope(
+        mutant=mutant,
+        comparators={
+            COMPARATOR_WT: PeptideContext(peptide_sequence='SIINFEKM'),
+            COMPARATOR_NEAREST_SELF: nearest_self,
+            'custom_comparator': PeptideContext(peptide_sequence='SIINFEEK'),
+        })
+    assert candidate.comparator('nearest_self') is nearest_self
+    # The nearest-self comparator carries its own predictions —
+    # which is what lets a safety scorer ask "does the patient's
+    # MHC also bind the self peptide?"
+    assert candidate.comparator('nearest_self').best_affinity().value == 80.0
+    # Open-ended: arbitrary keys also work.
+    assert candidate.comparator('custom_comparator') is not None
+    assert candidate.comparator('not_present') is None
+
+
+def test_candidate_epitope_freezes_mutation_context():
+    """``overlaps_mutation`` / ``occurs_in_reference`` live at the
+    candidate level (they're about the mutant-vs-source
+    relationship, not the peptide itself)."""
+    candidate = CandidateEpitope(
+        mutant=PeptideContext(peptide_sequence='SIINFEKL'),
+        comparators={},
+        overlaps_mutation=True,
+        occurs_in_reference=False)
+    assert candidate.overlaps_mutation is True
+    assert candidate.occurs_in_reference is False
+    # Frozen dataclass — direct attribute mutation raises.
+    with pytest.raises(Exception):
+        candidate.overlaps_mutation = False  # type: ignore

--- a/tests/test_peptide_context.py
+++ b/tests/test_peptide_context.py
@@ -231,6 +231,69 @@ def test_predictors_for_accepts_aliases():
     assert ctx.predictors_for('presentation') == ('bigmhc', 'mhcflurry')
 
 
+# ---- _load_kind_aliases: defensive topiary import ----------------------
+
+
+def test_load_kind_aliases_prefers_public_name(monkeypatch):
+    """When topiary publishes a public ``KIND_ALIASES``, vaxrank
+    prefers it over the legacy private ``_KIND_ALIASES``. Pins the
+    upgrade path so when topiary promotes the name, vaxrank picks
+    it up without code changes."""
+    import topiary.ranking
+    from vaxrank import peptide_context as pc
+
+    sentinel = {'sentinel_alias': 'pMHC_affinity'}
+    pc._load_kind_aliases.cache_clear()
+    monkeypatch.setattr(
+        topiary.ranking, 'KIND_ALIASES', sentinel, raising=False)
+    try:
+        assert pc._load_kind_aliases() is sentinel
+    finally:
+        pc._load_kind_aliases.cache_clear()
+
+
+def test_load_kind_aliases_raises_when_neither_present(monkeypatch):
+    """If a future topiary refactor removes both names, vaxrank
+    raises ``ImportError`` with a clear diagnostic instead of
+    letting an opaque ``AttributeError`` surface from inside
+    PeptideContext construction. Proves the safety net actually
+    fires + the message is well-formed."""
+    import topiary.ranking
+    from vaxrank import peptide_context as pc
+
+    pc._load_kind_aliases.cache_clear()
+    monkeypatch.delattr(topiary.ranking, 'KIND_ALIASES', raising=False)
+    monkeypatch.delattr(topiary.ranking, '_KIND_ALIASES', raising=False)
+    try:
+        with pytest.raises(ImportError, match='KIND_ALIASES'):
+            pc._load_kind_aliases()
+    finally:
+        pc._load_kind_aliases.cache_clear()
+
+
+def test_load_kind_aliases_is_cached(monkeypatch):
+    """``_load_kind_aliases`` is on the per-record hot path of
+    ``best`` / ``predictions_for``; the result is module-constant
+    so we cache it (``functools.lru_cache``) instead of redoing
+    the ``getattr`` chain on every call."""
+    import topiary.ranking
+    from vaxrank import peptide_context as pc
+
+    pc._load_kind_aliases.cache_clear()
+    first = pc._load_kind_aliases()
+    # Swap the underlying table; cached call should NOT see the swap.
+    sentinel = {'sentinel_alias': 'pMHC_affinity'}
+    monkeypatch.setattr(
+        topiary.ranking, 'KIND_ALIASES', sentinel, raising=False)
+    try:
+        assert pc._load_kind_aliases() is first  # cached
+        # After cache_clear, the new attr wins.
+        pc._load_kind_aliases.cache_clear()
+        assert pc._load_kind_aliases() is sentinel
+    finally:
+        pc._load_kind_aliases.cache_clear()
+
+
 # ---- predictions_for: leaf access + disambiguation ---------------------
 
 

--- a/tests/test_peptide_context.py
+++ b/tests/test_peptide_context.py
@@ -208,6 +208,38 @@ def test_predictions_flat_tiebreaker_for_duplicate_keys():
     assert [p.score for p in a.predictions_flat()] == [0.3, 0.5, 0.9]
 
 
+def test_predictions_flat_handles_nan_in_float_keys():
+    """mhctools sometimes emits NaN for ``percentile_rank``.
+    Python's ``sorted`` is undefined on NaN — wrap floats so
+    NaN-bearing entries sort consistently rather than producing
+    nondeterministic order."""
+    import math
+    nan = float('nan')
+    a = PeptideContext(
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', allele='HLA-A*02:01',
+                  score=0.5, percentile_rank=nan),
+            _pred('pMHC_affinity', allele='HLA-B*07:02',
+                  score=0.7, percentile_rank=2.5),
+        ))
+    b = PeptideContext(  # same records, shuffled
+        peptide_sequence='SIINFEKL',
+        predictions=(
+            _pred('pMHC_affinity', allele='HLA-B*07:02',
+                  score=0.7, percentile_rank=2.5),
+            _pred('pMHC_affinity', allele='HLA-A*02:01',
+                  score=0.5, percentile_rank=nan),
+        ))
+    flat_a = a.predictions_flat()
+    flat_b = b.predictions_flat()
+    # Allele order matches between shuffled inputs.
+    assert ([p.allele for p in flat_a]
+            == [p.allele for p in flat_b])
+    # NaN-bearing entries didn't crash the sort.
+    assert any(math.isnan(p.percentile_rank) for p in flat_a)
+
+
 # ---- Structured views --------------------------------------------------
 
 

--- a/vaxrank/peptide_context.py
+++ b/vaxrank/peptide_context.py
@@ -38,9 +38,10 @@ property*, not a structural key — that way:
   allele's score — see ``mhctools/mhcflurry.py`` line 246).
 
 The constructor accepts either nested form *or* a flat
-``Sequence[Prediction]`` for producer ergonomics — flat input is
-auto-grouped on construction. ``predictions_flat()`` flattens back
-out for serialization or iteration.
+``list``/``tuple`` of ``Prediction`` records for producer
+ergonomics — flat input is auto-grouped on construction.
+``predictions_flat()`` flattens back out for serialization or
+iteration.
 
 ## Disambiguation contract
 
@@ -219,18 +220,14 @@ class PeptideContext:
             object.__setattr__(
                 self, 'predictions', _group_predictions(self.predictions))
 
-    # ------------------------------------------------------------------
-    # Structured views — read-only, computed against the nested store.
-    # ------------------------------------------------------------------
-
-    def kinds(self) -> tuple:
+    def kinds(self) -> tuple[str, ...]:
         """Sorted tuple of distinct ``kind`` values in this context.
         Empty when the context has no predictions (e.g. a
         ``nearest_self`` comparator that's just a sequence with no
         binding probe yet)."""
         return tuple(sorted(self.predictions))
 
-    def predictors_for(self, kind: str) -> tuple:
+    def predictors_for(self, kind: str) -> tuple[str, ...]:
         """Predictors that emitted ``kind`` for this peptide.
         Drives multi-predictor disambiguation in ``best`` and
         ``predictions_for``. Accepts kind aliases (``'ba'`` /
@@ -238,7 +235,7 @@ class PeptideContext:
         canonical = _resolve_kind(kind)
         return tuple(sorted(self.predictions.get(canonical, {})))
 
-    def versions_for(self, kind: str, predictor: str) -> tuple:
+    def versions_for(self, kind: str, predictor: str) -> tuple[str, ...]:
         """All versions of ``predictor`` that emitted ``kind``.
 
         Ordering: legacy / unparseable strings (lex-sorted) come
@@ -253,7 +250,7 @@ class PeptideContext:
 
     def alleles_for(self, kind: str, *,
                     predictor: Optional[str] = None,
-                    version: Optional[str] = None) -> tuple:
+                    version: Optional[str] = None) -> tuple[str, ...]:
         """Alleles attested in the leaf tuple for
         ``(kind, predictor, version)``. Filters out empty-string
         alleles (processing kinds emit ``allele=""``). Used by
@@ -268,10 +265,6 @@ class PeptideContext:
         records = self.predictions_for(
             kind, predictor=predictor, version=version)
         return tuple(sorted({p.allele for p in records if p.allele}))
-
-    # ------------------------------------------------------------------
-    # Leaf access + best-of.
-    # ------------------------------------------------------------------
 
     def predictions_for(self, kind: str, *,
                         predictor: Optional[str] = None,
@@ -353,12 +346,7 @@ class PeptideContext:
     def best_cleavage(self): return self.best('proteasome_cleavage')
     def best_antigen_processing(self): return self.best('antigen_processing')
 
-    # ------------------------------------------------------------------
-    # Flatten — for serialization / iteration when you don't care
-    # about the nesting.
-    # ------------------------------------------------------------------
-
-    def predictions_flat(self) -> tuple:
+    def predictions_flat(self) -> tuple["Prediction", ...]:
         """Flatten the nested store back to a tuple of
         ``Prediction`` records. Useful for serialization round-trips
         and any code that just wants to iterate every prediction

--- a/vaxrank/peptide_context.py
+++ b/vaxrank/peptide_context.py
@@ -85,6 +85,7 @@ Issue: openvax/vaxrank#282 (replaces).
 from __future__ import annotations
 
 import functools
+import math
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Optional
@@ -142,6 +143,18 @@ def _resolve_kind(kind: str) -> str:
     kind-alias table so vaxrank doesn't fork the canonical list.
     Unknown inputs pass through unchanged."""
     return _load_kind_aliases().get(kind.lower(), kind)
+
+
+def _nan_safe(x: float) -> tuple[bool, float]:
+    """Wrap a float so it sorts deterministically even when NaN.
+    Python's ``sorted`` is undefined on NaN keys (NaN comparisons
+    return False both ways). Returns ``(is_nan, x_or_zero)`` —
+    NaN-bearing entries sort *after* finite ones; within the NaN
+    bucket they all tie at ``(True, 0.0)`` and stable sort
+    preserves their relative order from the preceding key
+    components, which is the best we can do."""
+    is_nan = math.isnan(x)
+    return (is_nan, 0.0 if is_nan else x)
 
 
 def _sort_versions(versions) -> list:
@@ -389,7 +402,9 @@ class PeptideContext:
         so the output is fully deterministic — even if a producer
         ever emits duplicate ``(kind, predictor, version, allele)``
         records, the score / value / %-rank tail breaks ties
-        without falling back on input order."""
+        without falling back on input order. Float keys are wrapped
+        with ``_nan_safe`` because mhctools sometimes emits NaN
+        for ``percentile_rank`` and ``sorted`` is undefined on NaN."""
         flat = (
             p
             for by_predictor in self.predictions.values()
@@ -398,7 +413,8 @@ class PeptideContext:
             for p in records)
         return tuple(sorted(flat, key=lambda p: (
             p.kind, p.predictor_name, p.predictor_version, p.allele,
-            p.score, p.value, p.percentile_rank)))
+            _nan_safe(p.score), _nan_safe(p.value),
+            _nan_safe(p.percentile_rank))))
 
 
 @dataclass(frozen=True)

--- a/vaxrank/peptide_context.py
+++ b/vaxrank/peptide_context.py
@@ -1,0 +1,261 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""Per-peptide context records used by ``VaccinePeptide``.
+
+Two layers:
+
+  ``PeptideContext`` — one peptide sequence + flanks + multi-axis
+  binding predictions. Generic shape used for the antigenic
+  candidate AND for any reference comparator (WT pair, nearest_self,
+  nearest_vital_self, nearest_nonCTA, nearest_oncovirus, …).
+
+  ``CandidateEpitope`` — one sliding-window position from a
+  VaccinePeptide. Holds the mutant ``PeptideContext`` plus a
+  ``comparators`` dict keyed by name. Future safety / homology
+  features (#254 / #257 / #258) populate comparators with their
+  respective contexts; today only ``'wt'`` is canonical.
+
+## Why this shape
+
+Replaces the legacy flat ``EpitopePrediction`` (single-axis
+affinity-only record). Predictions live in ``mhctools.Prediction``
+form so multi-axis data (pMHC_affinity / pMHC_presentation /
+pMHC_stability / immunogenicity / proteasome_cleavage /
+antigen_processing) flows through unchanged. Multi-predictor
+support (post-#261) is native to mhctools' record — vaxrank just
+holds them.
+
+## Design choice: cross-predictor disambiguation is explicit
+
+mhctools' ``Prediction.score`` is normalized so higher = better
+*within one predictor*. Cross-predictor ``max(score)`` is
+meaningless — mhcflurry's score scale and netmhcpan's score scale
+are independent transforms. So ``best_for_kind(kind)`` raises
+when there's no unambiguous answer and the caller hasn't passed
+``predictor=``. Callers that legitimately want a per-predictor
+loop iterate ``predictors_for_kind(kind)`` and call
+``best_for_kind(kind, predictor=…)`` per predictor.
+
+Issue: openvax/vaxrank#282 (replaces).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# Reserved comparator names. Open-ended — callers can add new ones —
+# but these are the canonical entries vaxrank knows about today or
+# will populate as the related issues land. Documented here so
+# downstream readers know what to expect.
+COMPARATOR_WT = 'wt'                                # same position, ref allele
+COMPARATOR_NEAREST_SELF = 'nearest_self'            # closest self-peptide (#254)
+COMPARATOR_NEAREST_VITAL_SELF = 'nearest_vital_self'  # closest in vital tissues (#254)
+COMPARATOR_NEAREST_NONCTA = 'nearest_nonCTA'        # closest non-CTA self (#257)
+COMPARATOR_NEAREST_ONCOVIRUS = 'nearest_oncovirus'  # closest oncoviral peptide (#258)
+
+
+@dataclass(frozen=True)
+class PeptideContext:
+    """One peptide sequence + flanking residues + (optional) MHC
+    binding predictions.
+
+    Generic — the same shape is used for the antigenic candidate
+    (the mutant) and for every reference comparator (WT pair,
+    nearest_self, …). When a comparator carries predictions, it's
+    answering "does the patient's MHC also bind this comparator?"
+    — which is the actual safety question for autoimmunity scoring.
+
+    Predictions follow mhctools' multi-kind / multi-predictor /
+    multi-allele shape: one ``mhctools.Prediction`` per
+    (kind, predictor, allele) tuple. Stored as a flat tuple for
+    serializability; structured access is via the methods below.
+    """
+
+    peptide_sequence: str
+    n_flank: str = ''
+    c_flank: str = ''
+    # Source provenance — for the mutant: the assembled mutant
+    # protein fragment. For ``nearest_self``: the matching self
+    # protein. For ``nearest_oncovirus``: the viral genome / ORF.
+    source_sequence: str = ''
+    source_name: str = ''         # gene / virus / "self_proteome" / …
+    offset: int = 0
+    # tuple[mhctools.Prediction, ...] — left untyped so this module
+    # stays import-light (mhctools pulls in heavy deps).
+    predictions: tuple = ()
+
+    # ------------------------------------------------------------------
+    # Structured views — read-only, computed on demand.
+    # ------------------------------------------------------------------
+
+    def predictions_by_kind_and_predictor(self) -> dict:
+        """Three-level nested view:
+        ``{kind: {predictor_name: {allele: Prediction}}}``.
+
+        Built fresh each call (the storage tuple is the source of
+        truth). Use this when you need full structure; the
+        ``best_*`` methods cover the common case.
+        """
+        nested: dict = {}
+        for p in self.predictions:
+            (nested.setdefault(p.kind, {})
+                   .setdefault(p.predictor_name, {})[p.allele]) = p
+        return nested
+
+    def kinds(self) -> tuple:
+        """Sorted tuple of distinct ``kind`` values in this context.
+        Empty when the context has no predictions (e.g. a
+        ``nearest_self`` comparator that's just a sequence with no
+        binding probe yet)."""
+        return tuple(sorted({p.kind for p in self.predictions}))
+
+    def predictors_for_kind(self, kind: str) -> tuple:
+        """Predictors that emitted ``kind`` for this peptide.
+        Drives multi-predictor disambiguation in
+        ``best_for_kind``."""
+        return tuple(sorted({
+            p.predictor_name for p in self.predictions
+            if p.kind == kind}))
+
+    def alleles_for(self, kind: str, predictor: str) -> tuple:
+        """Alleles a given (kind, predictor) covers. Used by
+        coverage / report code that walks per-allele evidence
+        without forcing a single 'best' allele."""
+        return tuple(sorted({
+            p.allele for p in self.predictions
+            if p.kind == kind and p.predictor_name == predictor
+            and p.allele}))
+
+    # ------------------------------------------------------------------
+    # Best-of accessors — kind-named, predictor-aware.
+    # ------------------------------------------------------------------
+
+    def best_for_kind(self, kind: str, *,
+                       predictor: Optional[str] = None):
+        """Best prediction for ``kind`` across alleles for one
+        predictor. Returns the ``mhctools.Prediction`` (carries
+        allele, score, value, percentile_rank, …) or ``None`` when
+        no record matches.
+
+        Disambiguation:
+        - If only one predictor emitted ``kind`` for this peptide,
+          ``predictor`` may be omitted.
+        - If multiple predictors emitted ``kind``, ``predictor`` is
+          required — cross-predictor ``max(score)`` is meaningless
+          since each predictor's score scale is its own.
+
+        Raises ``ValueError`` when the call is ambiguous.
+        """
+        candidates = [p for p in self.predictions if p.kind == kind]
+        if not candidates:
+            return None
+        predictor_set = {p.predictor_name for p in candidates}
+        if predictor is None:
+            if len(predictor_set) > 1:
+                raise ValueError(
+                    "%s has predictions from multiple predictors "
+                    "(%s); pass predictor= to disambiguate. "
+                    "Each predictor's score scale is its own — "
+                    "cross-predictor max() is meaningless."
+                    % (kind, sorted(predictor_set)))
+            # Single predictor → unambiguous.
+        else:
+            candidates = [
+                p for p in candidates if p.predictor_name == predictor]
+            if not candidates:
+                return None
+        # mhctools normalizes ``score`` so higher = better within a
+        # predictor regardless of whether the underlying axis is
+        # IC50 (lower = better) or a probability (higher = better).
+        # Best-across-alleles is unambiguously max(score).
+        return max(candidates, key=lambda p: p.score)
+
+    # Kind-specific helpers. Each forwards to ``best_for_kind``
+    # with the same disambiguation contract.
+    def best_affinity(self, *, predictor: Optional[str] = None):
+        return self.best_for_kind('pMHC_affinity', predictor=predictor)
+
+    def best_presentation(self, *, predictor: Optional[str] = None):
+        return self.best_for_kind('pMHC_presentation', predictor=predictor)
+
+    def best_stability(self, *, predictor: Optional[str] = None):
+        return self.best_for_kind('pMHC_stability', predictor=predictor)
+
+    def best_immunogenicity(self, *, predictor: Optional[str] = None):
+        return self.best_for_kind('immunogenicity', predictor=predictor)
+
+    def best_cleavage(self, *, predictor: Optional[str] = None):
+        return self.best_for_kind('proteasome_cleavage', predictor=predictor)
+
+    def best_antigen_processing(self, *, predictor: Optional[str] = None):
+        return self.best_for_kind('antigen_processing', predictor=predictor)
+
+
+@dataclass(frozen=True)
+class CandidateEpitope:
+    """One sliding-window peptide position from a VaccinePeptide,
+    with its mutation context + reference comparators for safety
+    / immunogenicity scoring.
+
+    Comparator names are open-ended; vaxrank populates these as
+    their respective issues land:
+
+      ``'wt'``                  same position, reference allele
+                                (drives mutation-specificity +
+                                today's wt_ic50 column)
+      ``'nearest_self'``        closest match in the patient's
+                                reference proteome (#254 —
+                                autoimmunity risk)
+      ``'nearest_vital_self'``  closest match in vital-tissue
+                                proteins (#254)
+      ``'nearest_nonCTA'``      closest self-peptide that isn't
+                                a cancer-testis antigen (#257)
+      ``'nearest_oncovirus'``   closest match in oncovirus
+                                reference genomes (#258)
+
+    Each value is a ``PeptideContext`` carrying its own peptide
+    sequence + (optionally) its own MHC predictions. When a
+    comparator carries predictions, scorers can ask "does the
+    patient's MHC also bind this comparator?" — the actual safety
+    question for autoimmunity / off-target presentation.
+    """
+
+    mutant: PeptideContext
+    # ``field(default_factory=dict)`` would normally be required
+    # for mutable defaults, but the class is frozen so callers
+    # construct dicts explicitly. Keeps the dataclass simple.
+    comparators: dict = field(default_factory=dict)
+
+    # Mutation-specific context. Lives at this level (not on
+    # ``PeptideContext``) because it's about the mutant-vs-source
+    # relationship, not a property of the peptide itself.
+    overlaps_mutation: bool = False
+    occurs_in_reference: bool = False
+
+    # Convenience: most call sites today read the WT alongside the
+    # mutant. Common-case shortcut.
+    @property
+    def wt(self) -> Optional[PeptideContext]:
+        return self.comparators.get(COMPARATOR_WT)
+
+    def comparator(self, name: str) -> Optional[PeptideContext]:
+        """Generic accessor for any comparator. Returns ``None``
+        when the comparator isn't present for this candidate
+        (typical when a safety scorer hasn't run yet)."""
+        return self.comparators.get(name)
+
+    # Convenience pass-throughs to the mutant context — most
+    # callers read these on the candidate level.
+    @property
+    def peptide_sequence(self) -> str:
+        return self.mutant.peptide_sequence
+
+    @property
+    def length(self) -> int:
+        return len(self.mutant.peptide_sequence)

--- a/vaxrank/peptide_context.py
+++ b/vaxrank/peptide_context.py
@@ -86,6 +86,7 @@ from __future__ import annotations
 
 import functools
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Optional
 
 from packaging.version import InvalidVersion, Version
@@ -130,7 +131,9 @@ def _load_kind_aliases():
             "neither name is present. topiary may have refactored "
             "the alias table — open an issue on vaxrank."
         )
-    return table
+    # Wrap as a read-only view so a misbehaving caller can't
+    # mutate topiary's alias table for the rest of the session.
+    return MappingProxyType(table)
 
 
 def _resolve_kind(kind: str) -> str:
@@ -235,7 +238,7 @@ class PeptideContext:
         canonical = _resolve_kind(kind)
         return tuple(sorted(self.predictions.get(canonical, {})))
 
-    def versions_for(self, kind: str, predictor: str) -> tuple[str, ...]:
+    def versions_for(self, kind: str, *, predictor: str) -> tuple[str, ...]:
         """All versions of ``predictor`` that emitted ``kind``.
 
         Ordering: legacy / unparseable strings (lex-sorted) come
@@ -243,6 +246,9 @@ class PeptideContext:
         That matches ``best`` / ``predictions_for`` defaulting to
         the *last* entry — i.e. the most-recent valid version when
         any exist, with legacy strings falling below.
+
+        ``predictor`` is keyword-only for consistency with
+        ``alleles_for`` / ``predictions_for``.
         """
         canonical = _resolve_kind(kind)
         by_version = self.predictions.get(canonical, {}).get(predictor, {})
@@ -261,17 +267,40 @@ class PeptideContext:
         than raise. This is unlike ``best`` / ``predictions_for``,
         where score scales differ across predictors so ranking
         requires explicit disambiguation.
+
+        Explicit ``predictor=`` / ``version=`` arguments are
+        validated against what's actually present — a typo raises
+        ``ValueError`` rather than silently returning ``()``.
+        Missing kind itself still returns ``()`` (asking about a
+        kind we don't have isn't a typo).
         """
         canonical = _resolve_kind(kind)
-        alleles: set[str] = set()
-        for pn, by_version in self.predictions.get(canonical, {}).items():
-            if predictor is not None and pn != predictor:
-                continue
-            for ver, records in by_version.items():
-                if version is not None and ver != version:
-                    continue
-                alleles.update(p.allele for p in records if p.allele)
-        return tuple(sorted(alleles))
+        by_predictor = self.predictions.get(canonical, {})
+        if not by_predictor:
+            return ()
+        if predictor is not None and predictor not in by_predictor:
+            raise ValueError(
+                f"{canonical} has no predictions from predictor "
+                f"{predictor!r}; available: {sorted(by_predictor)}.")
+        leaves = [
+            (ver, records)
+            for pn, by_ver in by_predictor.items()
+            if predictor is None or pn == predictor
+            for ver, records in by_ver.items()
+        ]
+        available_versions = {ver for ver, _ in leaves}
+        if version is not None and version not in available_versions:
+            raise ValueError(
+                f"{canonical} has no predictions at version "
+                f"{version!r}; available: "
+                f"{sorted(available_versions)}.")
+        return tuple(sorted({
+            p.allele
+            for ver, records in leaves
+            if version is None or ver == version
+            for p in records
+            if p.allele
+        }))
 
     def predictions_for(self, kind: str, *,
                         predictor: Optional[str] = None,
@@ -355,10 +384,12 @@ class PeptideContext:
 
     def predictions_flat(self) -> tuple["Prediction", ...]:
         """Flatten the nested store back to a tuple of
-        ``Prediction`` records, sorted by ``(kind, predictor_name,
-        predictor_version, allele)``. Sorted output is deterministic
-        across runs and through serialization round-trips even when
-        the input arrived in producer-specific order."""
+        ``Prediction`` records. Sorted by ``(kind, predictor_name,
+        predictor_version, allele, score, value, percentile_rank)``
+        so the output is fully deterministic — even if a producer
+        ever emits duplicate ``(kind, predictor, version, allele)``
+        records, the score / value / %-rank tail breaks ties
+        without falling back on input order."""
         flat = (
             p
             for by_predictor in self.predictions.values()
@@ -366,7 +397,8 @@ class PeptideContext:
             for records in by_version.values()
             for p in records)
         return tuple(sorted(flat, key=lambda p: (
-            p.kind, p.predictor_name, p.predictor_version, p.allele)))
+            p.kind, p.predictor_name, p.predictor_version, p.allele,
+            p.score, p.value, p.percentile_rank)))
 
 
 @dataclass(frozen=True)

--- a/vaxrank/peptide_context.py
+++ b/vaxrank/peptide_context.py
@@ -54,21 +54,39 @@ accept those aliases (case-insensitive) so callers don't have to
 remember which canonical string vaxrank stores. The canonical
 ``pMHC_*`` strings keep working unchanged.
 
+## Parametric scoring
+
+``best`` accepts ``score_key`` — a ``Prediction -> float`` callable
+that names the ranking axis (higher = better). Default is
+:func:`default_score_key` (uses ``Prediction.score``, mhctools'
+normalized higher-is-better axis). Pass a custom key for a
+different axis (``lambda p: -p.percentile_rank`` for "lowest %-rank
+wins") so the score-normalization assumption isn't load-bearing in
+silent ways. Higher-level pipelines drive ranking via the topiary
+DSL on row-frames (``EpitopeConfig.score_expr``); ``best`` stays
+the per-record primitive.
+
 Issue: openvax/vaxrank#282 (replaces).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Callable, Optional
 
 from packaging.version import InvalidVersion, Version
+
+if TYPE_CHECKING:
+    from mhctools.pred import Prediction
 
 
 # Lowercase alias → canonical mhctools.Prediction.kind. The canonical
 # strings also resolve through this map (since ``str.lower`` is
-# applied first), so callers can pass either form.
-_KIND_ALIASES = {
+# applied first), so callers can pass either form. Wrapped in a
+# read-only ``MappingProxyType`` so accidental monkeypatching from
+# tests doesn't bleed into other tests.
+_KIND_ALIASES: MappingProxyType = MappingProxyType({
     # pMHC_affinity — "BA" in mhcflurry / netmhcpan parlance.
     'pmhc_affinity': 'pMHC_affinity',
     'affinity': 'pMHC_affinity',
@@ -94,7 +112,7 @@ _KIND_ALIASES = {
     'tap': 'tap_transport',
     'erap_trimming': 'erap_trimming',
     'erap': 'erap_trimming',
-}
+})
 
 
 def _resolve_kind(kind: str) -> str:
@@ -103,6 +121,22 @@ def _resolve_kind(kind: str) -> str:
     unchanged (so future predictor kinds work without a registry
     update — they just won't have short aliases until added)."""
     return _KIND_ALIASES.get(kind.lower(), kind)
+
+
+def _split_versions(versions) -> tuple:
+    """Split a set of ``predictor_version`` strings into PEP 440
+    parseable + fallback. Returns ``(parsed_oldest_to_newest,
+    fallback_lex_sorted)`` — both are lists of the original strings.
+    Shared helper for the version-disambiguation paths."""
+    parsed = []
+    fallback = []
+    for v in versions:
+        try:
+            parsed.append((Version(v), v))
+        except (InvalidVersion, TypeError):
+            fallback.append(v)
+    return ([v for _, v in sorted(parsed, key=lambda x: x[0])],
+            sorted(fallback))
 
 
 def _most_recent_version(versions) -> str:
@@ -114,16 +148,32 @@ def _most_recent_version(versions) -> str:
     none parse, lexicographic ``max`` is the fallback. Returning a
     single string lets callers filter ``candidates`` by exact match.
     """
-    parsed = []
-    fallback = []
-    for v in versions:
-        try:
-            parsed.append((Version(v), v))
-        except (InvalidVersion, TypeError):
-            fallback.append(v)
+    parsed, fallback = _split_versions(versions)
     if parsed:
-        return max(parsed, key=lambda x: x[0])[1]
-    return max(fallback)
+        return parsed[-1]
+    return fallback[-1]
+
+
+def default_score_key(prediction) -> float:
+    """Default ranking key for ``PeptideContext.best`` and friends.
+
+    CONTRACT: relies on mhctools normalizing ``Prediction.score`` so
+    that **higher = better within one predictor** — across IC50
+    (lower-is-better-natively) and probability (higher-is-better-
+    natively) underlying axes. The contract is mhctools' to enforce
+    on producers; vaxrank just consumes ``score`` directly.
+
+    Override by passing ``score_key=`` to ``best`` if you want a
+    different axis (e.g. ``score_key=lambda p: -p.percentile_rank``
+    for "lowest %-rank wins") or a custom DSL-derived ranking. Higher
+    return value = better, regardless of underlying scale.
+
+    Cross-predictor comparison is *still* not meaningful even with a
+    custom ``score_key`` — that disambiguation is enforced by
+    ``best`` raising ``ValueError`` when multiple predictors emit
+    ``kind`` and the caller hasn't pinned ``predictor=``.
+    """
+    return prediction.score
 
 
 # Reserved comparator names. Open-ended — callers can add new ones —
@@ -163,26 +213,33 @@ class PeptideContext:
     source_sequence: str = ''
     source_name: str = ''         # gene / virus / "self_proteome" / …
     offset: int = 0
-    # tuple[mhctools.Prediction, ...] — left untyped so this module
-    # stays import-light (mhctools pulls in heavy deps).
-    predictions: tuple = ()
+    # ``predictions`` is a flat tuple for serializability. Annotated
+    # under ``TYPE_CHECKING`` to give static analyzers the full type
+    # without importing ``mhctools.Prediction`` at runtime (mhctools
+    # pulls in heavy deps).
+    predictions: tuple["Prediction", ...] = ()
 
     # ------------------------------------------------------------------
     # Structured views — read-only, computed on demand.
     # ------------------------------------------------------------------
 
     def predictions_by_kind_and_predictor(self) -> dict:
-        """Three-level nested view:
-        ``{kind: {predictor_name: {allele: Prediction}}}``.
+        """Four-level nested view:
+        ``{kind: {predictor_name: {predictor_version: {allele:
+        Prediction}}}}``.
 
         Built fresh each call (the storage tuple is the source of
         truth). Use this when you need full structure; the
-        ``best_*`` methods cover the common case.
+        ``best_*`` methods cover the common case. The version axis
+        prevents collision when the same (kind, predictor, allele)
+        was scored at multiple ``predictor_version`` values — every
+        record stays addressable.
         """
         nested: dict = {}
         for p in self.predictions:
             (nested.setdefault(p.kind, {})
-                   .setdefault(p.predictor_name, {})[p.allele]) = p
+                   .setdefault(p.predictor_name, {})
+                   .setdefault(p.predictor_version, {})[p.allele]) = p
         return nested
 
     def kinds(self) -> tuple:
@@ -205,21 +262,18 @@ class PeptideContext:
         """Versions of ``predictor`` that emitted ``kind``, sorted
         oldest → newest by PEP 440. When multiple coexist, ``best``
         picks the last entry by default; this accessor exposes the
-        full set for callers that want to walk every version."""
+        full set for callers that want to walk every version.
+
+        Unparseable strings (legacy / pre-#261) sort before parseable
+        ones — so ``versions[-1]`` still yields the most recent valid
+        version when both styles coexist.
+        """
         canonical = _resolve_kind(kind)
         versions = {
             p.predictor_version for p in self.predictions
             if p.kind == canonical and p.predictor_name == predictor}
-        # Sort newest last so callers can do versions[-1] for "latest".
-        parsed = []
-        fallback = []
-        for v in versions:
-            try:
-                parsed.append((Version(v), v))
-            except (InvalidVersion, TypeError):
-                fallback.append(v)
-        return tuple(sorted(fallback) +
-                     [v for _, v in sorted(parsed, key=lambda x: x[0])])
+        parsed, fallback = _split_versions(versions)
+        return tuple(fallback + parsed)
 
     def alleles_for(self, kind: str, predictor: str) -> tuple:
         """Alleles a given (kind, predictor) covers. Used by
@@ -237,7 +291,8 @@ class PeptideContext:
 
     def best(self, kind: str, *,
              predictor: Optional[str] = None,
-             version: Optional[str] = None):
+             version: Optional[str] = None,
+             score_key: Optional[Callable] = None):
         """Best prediction for ``kind`` across alleles. Returns the
         ``mhctools.Prediction`` (carries allele, score, value,
         percentile_rank, …) or ``None`` when no record matches.
@@ -255,9 +310,9 @@ class PeptideContext:
         - One predictor emitted ``kind`` → ``predictor`` may be
           omitted.
         - Multiple predictors emitted ``kind`` → ``predictor`` is
-          required (cross-predictor ``max(score)`` is meaningless;
-          each predictor's score scale is its own). Raises
-          ``ValueError`` otherwise.
+          required (cross-predictor ranking is meaningless under
+          *any* score key, since each predictor's score scale is its
+          own). Raises ``ValueError`` otherwise.
 
         Version disambiguation:
         - One ``predictor_version`` on file → unambiguous.
@@ -266,6 +321,17 @@ class PeptideContext:
           Versions auto-resolve (vs. predictor's hard-raise) because
           the score scale is comparable across versions of the same
           predictor — just freshness differs.
+
+        Score selection:
+        - ``score_key`` is a callable ``Prediction -> float`` (higher
+          return value wins). Default is :func:`default_score_key`,
+          which uses ``Prediction.score`` (mhctools' normalized,
+          higher-is-better axis). Pass a custom key when you want
+          per-call ranking on a different axis — e.g.
+          ``score_key=lambda p: -p.percentile_rank`` for
+          "lowest %-rank wins". Higher-level pipelines use the
+          topiary DSL (``EpitopeConfig.score_expr``) on a row-frame
+          of predictions; ``best()`` is the per-record primitive.
         """
         canonical = _resolve_kind(kind)
         candidates = [p for p in self.predictions if p.kind == canonical]
@@ -278,7 +344,8 @@ class PeptideContext:
                     "%s has predictions from multiple predictors "
                     "(%s); pass predictor= to disambiguate. "
                     "Each predictor's score scale is its own — "
-                    "cross-predictor max() is meaningless."
+                    "cross-predictor ranking is meaningless under "
+                    "any score_key."
                     % (canonical, sorted(predictor_set)))
             # Single predictor → unambiguous.
         else:
@@ -297,44 +364,55 @@ class PeptideContext:
                 p for p in candidates if p.predictor_version == version]
             if not candidates:
                 return None
-        # mhctools normalizes ``score`` so higher = better within a
-        # predictor regardless of whether the underlying axis is
-        # IC50 (lower = better) or a probability (higher = better).
-        # Best-across-alleles is unambiguously max(score).
-        return max(candidates, key=lambda p: p.score)
+        if score_key is None:
+            score_key = default_score_key
+        return max(candidates, key=score_key)
 
     # Kind-specific helpers. Each forwards to ``best`` with the same
     # disambiguation contract — predictor required when ambiguous,
-    # version auto-resolves to most recent.
+    # version auto-resolves to most recent, ``score_key`` overridable
+    # for per-call ranking customization.
     def best_affinity(self, *, predictor: Optional[str] = None,
-                      version: Optional[str] = None):
+                      version: Optional[str] = None,
+                      score_key: Optional[Callable] = None):
         return self.best(
-            'pMHC_affinity', predictor=predictor, version=version)
+            'pMHC_affinity', predictor=predictor, version=version,
+            score_key=score_key)
 
     def best_presentation(self, *, predictor: Optional[str] = None,
-                          version: Optional[str] = None):
+                          version: Optional[str] = None,
+                          score_key: Optional[Callable] = None):
         return self.best(
-            'pMHC_presentation', predictor=predictor, version=version)
+            'pMHC_presentation', predictor=predictor, version=version,
+            score_key=score_key)
 
     def best_stability(self, *, predictor: Optional[str] = None,
-                       version: Optional[str] = None):
+                       version: Optional[str] = None,
+                       score_key: Optional[Callable] = None):
         return self.best(
-            'pMHC_stability', predictor=predictor, version=version)
+            'pMHC_stability', predictor=predictor, version=version,
+            score_key=score_key)
 
     def best_immunogenicity(self, *, predictor: Optional[str] = None,
-                            version: Optional[str] = None):
+                            version: Optional[str] = None,
+                            score_key: Optional[Callable] = None):
         return self.best(
-            'immunogenicity', predictor=predictor, version=version)
+            'immunogenicity', predictor=predictor, version=version,
+            score_key=score_key)
 
     def best_cleavage(self, *, predictor: Optional[str] = None,
-                      version: Optional[str] = None):
+                      version: Optional[str] = None,
+                      score_key: Optional[Callable] = None):
         return self.best(
-            'proteasome_cleavage', predictor=predictor, version=version)
+            'proteasome_cleavage', predictor=predictor, version=version,
+            score_key=score_key)
 
     def best_antigen_processing(self, *, predictor: Optional[str] = None,
-                                version: Optional[str] = None):
+                                version: Optional[str] = None,
+                                score_key: Optional[Callable] = None):
         return self.best(
-            'antigen_processing', predictor=predictor, version=version)
+            'antigen_processing', predictor=predictor, version=version,
+            score_key=score_key)
 
 
 @dataclass(frozen=True)

--- a/vaxrank/peptide_context.py
+++ b/vaxrank/peptide_context.py
@@ -19,61 +19,71 @@ Two layers:
   features (#254 / #257 / #258) populate comparators with their
   respective contexts; today only ``'wt'`` is canonical.
 
-## Why this shape
+## Storage shape
 
-Replaces the legacy flat ``EpitopePrediction`` (single-axis
-affinity-only record). Predictions live in ``mhctools.Prediction``
-form so multi-axis data (pMHC_affinity / pMHC_presentation /
-pMHC_stability / immunogenicity / proteasome_cleavage /
-antigen_processing) flows through unchanged. Multi-predictor
-support (post-#261) is native to mhctools' record — vaxrank just
-holds them.
+``predictions`` is a *natively nested* dict:
+``{kind: {predictor_name: {predictor_version: tuple[Prediction, ...]}}}``.
 
-## Design choice: cross-predictor disambiguation is explicit
+The leaf tuple holds whatever ``mhctools.Prediction`` records exist
+for that ``(kind, predictor, version)`` triple. Allele is a *record
+property*, not a structural key — that way:
+
+- ``proteasome_cleavage`` / ``antigen_processing`` (no allele) live
+  cleanly as one-element leaves.
+- ``pMHC_affinity`` / ``pMHC_stability`` (one record per allele)
+  live as N-element leaves.
+- ``pMHC_presentation`` lives as N-element leaves under mhctools'
+  current per-allele emission (mhcflurry-pres deconvolutes across
+  alleles internally; mhctools calls it per-allele to capture each
+  allele's score — see ``mhctools/mhcflurry.py`` line 246).
+
+The constructor accepts either nested form *or* a flat
+``Sequence[Prediction]`` for producer ergonomics — flat input is
+auto-grouped on construction. ``predictions_flat()`` flattens back
+out for serialization or iteration.
+
+## Disambiguation contract
 
 mhctools' ``Prediction.score`` is normalized so higher = better
 *within one predictor*. Cross-predictor ``max(score)`` is
 meaningless — mhcflurry's score scale and netmhcpan's score scale
-are independent transforms. So ``best(kind)`` raises when multiple
-predictors emitted ``kind`` and the caller hasn't passed
-``predictor=``. Callers that legitimately want a per-predictor
-loop iterate ``predictors_for_kind(kind)`` and call
-``best(kind, predictor=…)`` per predictor.
+are independent transforms. So ``best(kind)`` and
+``predictions_for(kind)`` raise when multiple predictors emitted
+``kind`` and the caller hasn't passed ``predictor=``.
 
 Versions, however, *do* auto-resolve: when one predictor has
 multiple ``predictor_version`` strings on file (e.g. mhcflurry
-2.1.0 and 2.1.1 both ran), ``best`` defaults to the most recent
-version (PEP 440 ordering). Pass ``version=`` to pin to a specific
-version explicitly.
-
-## Kind aliases
-
-mhcflurry / netmhcpan / pVACseq / LENS use shorthand for the same
-underlying kinds (``BA`` / ``EL`` / etc). ``best`` and friends
-accept those aliases (case-insensitive) so callers don't have to
-remember which canonical string vaxrank stores. The canonical
-``pMHC_*`` strings keep working unchanged.
+2.1.0 and 2.1.1 both ran), the leaf accessor defaults to the most
+recent version (PEP 440 ordering). Pass ``version=`` to pin.
 
 ## Parametric scoring
 
-``best`` accepts ``score_key`` — a ``Prediction -> float`` callable
-that names the ranking axis (higher = better). Default is
-:func:`default_score_key` (uses ``Prediction.score``, mhctools'
-normalized higher-is-better axis). Pass a custom key for a
-different axis (``lambda p: -p.percentile_rank`` for "lowest %-rank
-wins") so the score-normalization assumption isn't load-bearing in
-silent ways. Higher-level pipelines drive ranking via the topiary
-DSL on row-frames (``EpitopeConfig.score_expr``); ``best`` stays
-the per-record primitive.
+``best`` uses ``Prediction.score`` (mhctools' normalized
+higher-is-better axis). For a different ranking axis, use
+``predictions_for(...)`` to get the leaf tuple and rank yourself —
+the records expose ``value`` (e.g. IC50) and ``percentile_rank``
+alongside ``score``.
+
+Higher-level *peptide* ranking across the report is driven by the
+topiary DSL (``EpitopeConfig.score_expr`` / row-frame
+``apply_filter``); ``best`` is the per-record primitive and stays
+deliberately simple.
+
+## Kind aliases
+
+Defers to ``topiary.ranking._KIND_ALIASES`` for canonical
+resolution (``ba`` / ``el`` / ``aff`` / ``ic50`` / ``presentation``
+/ etc. → canonical ``pMHC_*``). vaxrank does not maintain its own
+alias table.
 
 Issue: openvax/vaxrank#282 (replaces).
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from types import MappingProxyType
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Optional
 
 from packaging.version import InvalidVersion, Version
 
@@ -81,53 +91,21 @@ if TYPE_CHECKING:
     from mhctools.pred import Prediction
 
 
-# Lowercase alias → canonical mhctools.Prediction.kind. The canonical
-# strings also resolve through this map (since ``str.lower`` is
-# applied first), so callers can pass either form. Wrapped in a
-# read-only ``MappingProxyType`` so accidental monkeypatching from
-# tests doesn't bleed into other tests.
-_KIND_ALIASES: MappingProxyType = MappingProxyType({
-    # pMHC_affinity — "BA" in mhcflurry / netmhcpan parlance.
-    'pmhc_affinity': 'pMHC_affinity',
-    'affinity': 'pMHC_affinity',
-    'ba': 'pMHC_affinity',
-    'binding': 'pMHC_affinity',
-    # pMHC_presentation — "EL" (elution likelihood) in mhcflurry-pres.
-    'pmhc_presentation': 'pMHC_presentation',
-    'presentation': 'pMHC_presentation',
-    'el': 'pMHC_presentation',
-    'elution': 'pMHC_presentation',
-    # pMHC_stability.
-    'pmhc_stability': 'pMHC_stability',
-    'stability': 'pMHC_stability',
-    # Single-word kinds — keep canonical and short alias both routed.
-    'immunogenicity': 'immunogenicity',
-    'antigen_processing': 'antigen_processing',
-    'processing': 'antigen_processing',
-    'ap': 'antigen_processing',
-    'proteasome_cleavage': 'proteasome_cleavage',
-    'cleavage': 'proteasome_cleavage',
-    'proteasome': 'proteasome_cleavage',
-    'tap_transport': 'tap_transport',
-    'tap': 'tap_transport',
-    'erap_trimming': 'erap_trimming',
-    'erap': 'erap_trimming',
-})
-
-
 def _resolve_kind(kind: str) -> str:
     """Map an alias / case-variant onto the canonical
-    ``mhctools.Prediction.kind`` string. Unknown inputs pass through
-    unchanged (so future predictor kinds work without a registry
-    update — they just won't have short aliases until added)."""
+    ``mhctools.Prediction.kind`` string. Defers to topiary's
+    ``_KIND_ALIASES`` so vaxrank doesn't fork the canonical list.
+    Unknown inputs pass through unchanged."""
+    # Imported lazily so this module stays import-light.
+    from topiary.ranking import _KIND_ALIASES
     return _KIND_ALIASES.get(kind.lower(), kind)
 
 
 def _split_versions(versions) -> tuple:
     """Split a set of ``predictor_version`` strings into PEP 440
     parseable + fallback. Returns ``(parsed_oldest_to_newest,
-    fallback_lex_sorted)`` — both are lists of the original strings.
-    Shared helper for the version-disambiguation paths."""
+    fallback_lex_sorted)`` — both are lists of the original
+    strings."""
     parsed = []
     fallback = []
     for v in versions:
@@ -145,8 +123,7 @@ def _most_recent_version(versions) -> str:
     PEP 440 ordering via ``packaging.version.Version``. Strings that
     don't parse (empty / non-semver / pre-#261 unset) sort below any
     valid version — so when both styles coexist, valid wins; when
-    none parse, lexicographic ``max`` is the fallback. Returning a
-    single string lets callers filter ``candidates`` by exact match.
+    none parse, lexicographic ``max`` is the fallback.
     """
     parsed, fallback = _split_versions(versions)
     if parsed:
@@ -154,26 +131,22 @@ def _most_recent_version(versions) -> str:
     return fallback[-1]
 
 
-def default_score_key(prediction) -> float:
-    """Default ranking key for ``PeptideContext.best`` and friends.
-
-    CONTRACT: relies on mhctools normalizing ``Prediction.score`` so
-    that **higher = better within one predictor** — across IC50
-    (lower-is-better-natively) and probability (higher-is-better-
-    natively) underlying axes. The contract is mhctools' to enforce
-    on producers; vaxrank just consumes ``score`` directly.
-
-    Override by passing ``score_key=`` to ``best`` if you want a
-    different axis (e.g. ``score_key=lambda p: -p.percentile_rank``
-    for "lowest %-rank wins") or a custom DSL-derived ranking. Higher
-    return value = better, regardless of underlying scale.
-
-    Cross-predictor comparison is *still* not meaningful even with a
-    custom ``score_key`` — that disambiguation is enforced by
-    ``best`` raising ``ValueError`` when multiple predictors emit
-    ``kind`` and the caller hasn't pinned ``predictor=``.
-    """
-    return prediction.score
+def _group_predictions(predictions) -> dict:
+    """Flat ``Sequence[Prediction]`` → nested
+    ``{kind: {predictor: {version: tuple}}}``. Producer-friendly:
+    most call sites already have a flat list of ``Prediction``s
+    coming out of mhctools / topiary."""
+    nested: dict = {}
+    for p in predictions:
+        (nested.setdefault(p.kind, {})
+               .setdefault(p.predictor_name, {})
+               .setdefault(p.predictor_version, [])
+               .append(p))
+    return {
+        k: {pn: {pv: tuple(records) for pv, records in by_version.items()}
+            for pn, by_version in by_predictor.items()}
+        for k, by_predictor in nested.items()
+    }
 
 
 # Reserved comparator names. Open-ended — callers can add new ones —
@@ -198,10 +171,8 @@ class PeptideContext:
     answering "does the patient's MHC also bind this comparator?"
     — which is the actual safety question for autoimmunity scoring.
 
-    Predictions follow mhctools' multi-kind / multi-predictor /
-    multi-allele shape: one ``mhctools.Prediction`` per
-    (kind, predictor, allele) tuple. Stored as a flat tuple for
-    serializability; structured access is via the methods below.
+    See module docstring for the storage shape and disambiguation
+    contract.
     """
 
     peptide_sequence: str
@@ -213,206 +184,196 @@ class PeptideContext:
     source_sequence: str = ''
     source_name: str = ''         # gene / virus / "self_proteome" / …
     offset: int = 0
-    # ``predictions`` is a flat tuple for serializability. Annotated
-    # under ``TYPE_CHECKING`` to give static analyzers the full type
-    # without importing ``mhctools.Prediction`` at runtime (mhctools
-    # pulls in heavy deps).
-    predictions: tuple["Prediction", ...] = ()
+    # Nested storage. Constructor accepts either this form or a
+    # flat ``Sequence[Prediction]`` (auto-grouped via
+    # ``__post_init__``). Annotated under ``TYPE_CHECKING`` to keep
+    # mhctools off the runtime import path.
+    predictions: dict = field(default_factory=dict)
+
+    def __post_init__(self):
+        # Flat producer input → nested storage. Flat is the common
+        # case (mhctools / topiary hand back ``list[Prediction]``);
+        # converting at construction means read accessors don't
+        # have to repeat the work on every call.
+        if isinstance(self.predictions, Sequence):
+            object.__setattr__(
+                self, 'predictions', _group_predictions(self.predictions))
 
     # ------------------------------------------------------------------
-    # Structured views — read-only, computed on demand.
+    # Structured views — read-only, computed against the nested store.
     # ------------------------------------------------------------------
-
-    def predictions_by_kind_and_predictor(self) -> dict:
-        """Four-level nested view:
-        ``{kind: {predictor_name: {predictor_version: {allele:
-        Prediction}}}}``.
-
-        Built fresh each call (the storage tuple is the source of
-        truth). Use this when you need full structure; the
-        ``best_*`` methods cover the common case. The version axis
-        prevents collision when the same (kind, predictor, allele)
-        was scored at multiple ``predictor_version`` values — every
-        record stays addressable.
-        """
-        nested: dict = {}
-        for p in self.predictions:
-            (nested.setdefault(p.kind, {})
-                   .setdefault(p.predictor_name, {})
-                   .setdefault(p.predictor_version, {})[p.allele]) = p
-        return nested
 
     def kinds(self) -> tuple:
         """Sorted tuple of distinct ``kind`` values in this context.
         Empty when the context has no predictions (e.g. a
         ``nearest_self`` comparator that's just a sequence with no
         binding probe yet)."""
-        return tuple(sorted({p.kind for p in self.predictions}))
+        return tuple(sorted(self.predictions))
 
-    def predictors_for_kind(self, kind: str) -> tuple:
+    def predictors_for(self, kind: str) -> tuple:
         """Predictors that emitted ``kind`` for this peptide.
-        Drives multi-predictor disambiguation in ``best``. Accepts
-        kind aliases (``'ba'`` / ``'el'`` / …)."""
+        Drives multi-predictor disambiguation in ``best`` and
+        ``predictions_for``. Accepts kind aliases (``'ba'`` /
+        ``'el'`` / …)."""
         canonical = _resolve_kind(kind)
-        return tuple(sorted({
-            p.predictor_name for p in self.predictions
-            if p.kind == canonical}))
+        return tuple(sorted(self.predictions.get(canonical, {})))
 
     def versions_for(self, kind: str, predictor: str) -> tuple:
         """Versions of ``predictor`` that emitted ``kind``, sorted
-        oldest → newest by PEP 440. When multiple coexist, ``best``
-        picks the last entry by default; this accessor exposes the
-        full set for callers that want to walk every version.
-
-        Unparseable strings (legacy / pre-#261) sort before parseable
-        ones — so ``versions[-1]`` still yields the most recent valid
-        version when both styles coexist.
-        """
+        oldest → newest by PEP 440. When multiple coexist, the
+        leaf accessors default to the last entry; this method
+        exposes the full set for callers that want to walk every
+        version. Unparseable / legacy strings sort before
+        parseable ones."""
         canonical = _resolve_kind(kind)
-        versions = {
-            p.predictor_version for p in self.predictions
-            if p.kind == canonical and p.predictor_name == predictor}
-        parsed, fallback = _split_versions(versions)
+        by_version = self.predictions.get(canonical, {}).get(predictor, {})
+        parsed, fallback = _split_versions(by_version)
         return tuple(fallback + parsed)
 
-    def alleles_for(self, kind: str, predictor: str) -> tuple:
-        """Alleles a given (kind, predictor) covers. Used by
+    def alleles_for(self, kind: str, *,
+                    predictor: Optional[str] = None,
+                    version: Optional[str] = None) -> tuple:
+        """Alleles attested in the leaf tuple for
+        ``(kind, predictor, version)``. Filters out empty-string
+        alleles (processing kinds emit ``allele=""``). Used by
         coverage / report code that walks per-allele evidence
-        without forcing a single 'best' allele."""
-        canonical = _resolve_kind(kind)
-        return tuple(sorted({
-            p.allele for p in self.predictions
-            if p.kind == canonical and p.predictor_name == predictor
-            and p.allele}))
+        without forcing a single 'best' allele.
+
+        Same disambiguation contract as ``best``: raises when
+        multiple predictors emitted ``kind`` and ``predictor`` is
+        unset; auto-resolves to most recent when multiple versions
+        coexist and ``version`` is unset.
+        """
+        records = self.predictions_for(
+            kind, predictor=predictor, version=version)
+        return tuple(sorted({p.allele for p in records if p.allele}))
 
     # ------------------------------------------------------------------
-    # Best-of accessors — kind-named, predictor-aware.
+    # Leaf access + best-of.
     # ------------------------------------------------------------------
 
-    def best(self, kind: str, *,
-             predictor: Optional[str] = None,
-             version: Optional[str] = None,
-             score_key: Optional[Callable] = None):
-        """Best prediction for ``kind`` across alleles. Returns the
-        ``mhctools.Prediction`` (carries allele, score, value,
-        percentile_rank, …) or ``None`` when no record matches.
-
-        ``kind`` accepts aliases (case-insensitive): ``'ba'`` /
-        ``'affinity'`` / ``'binding'`` → ``pMHC_affinity``;
-        ``'el'`` / ``'presentation'`` / ``'elution'`` →
-        ``pMHC_presentation``; ``'stability'``;
-        ``'immunogenicity'``; ``'cleavage'`` / ``'proteasome'`` →
-        ``proteasome_cleavage``; ``'processing'`` / ``'ap'`` →
-        ``antigen_processing``; ``'tap'``; ``'erap'``. Canonical
-        ``pMHC_*`` strings also work.
+    def predictions_for(self, kind: str, *,
+                        predictor: Optional[str] = None,
+                        version: Optional[str] = None
+                        ) -> tuple["Prediction", ...]:
+        """All ``Prediction`` records for ``(kind, predictor,
+        version)``. Empty tuple when nothing matches.
 
         Predictor disambiguation:
         - One predictor emitted ``kind`` → ``predictor`` may be
           omitted.
         - Multiple predictors emitted ``kind`` → ``predictor`` is
-          required (cross-predictor ranking is meaningless under
-          *any* score key, since each predictor's score scale is its
-          own). Raises ``ValueError`` otherwise.
+          required; raises ``ValueError`` otherwise.
 
         Version disambiguation:
-        - One ``predictor_version`` on file → unambiguous.
         - Multiple versions on file → defaults to the most recent
-          (PEP 440 ordering). Pass ``version=`` to pin explicitly.
-          Versions auto-resolve (vs. predictor's hard-raise) because
-          the score scale is comparable across versions of the same
-          predictor — just freshness differs.
+          (PEP 440 ordering). Pass ``version=`` to pin.
 
-        Score selection:
-        - ``score_key`` is a callable ``Prediction -> float`` (higher
-          return value wins). Default is :func:`default_score_key`,
-          which uses ``Prediction.score`` (mhctools' normalized,
-          higher-is-better axis). Pass a custom key when you want
-          per-call ranking on a different axis — e.g.
-          ``score_key=lambda p: -p.percentile_rank`` for
-          "lowest %-rank wins". Higher-level pipelines use the
-          topiary DSL (``EpitopeConfig.score_expr``) on a row-frame
-          of predictions; ``best()`` is the per-record primitive.
+        Use this to rank predictions on a non-default axis (e.g.
+        ``min(ctx.predictions_for('affinity'), key=lambda p:
+        p.percentile_rank)``) — ``best`` does the common case
+        (``max`` over normalized ``score``) but isn't parametric.
         """
         canonical = _resolve_kind(kind)
-        candidates = [p for p in self.predictions if p.kind == canonical]
-        if not candidates:
-            return None
-        predictor_set = {p.predictor_name for p in candidates}
+        by_predictor = self.predictions.get(canonical, {})
+        if not by_predictor:
+            return ()
         if predictor is None:
-            if len(predictor_set) > 1:
+            if len(by_predictor) > 1:
                 raise ValueError(
                     "%s has predictions from multiple predictors "
                     "(%s); pass predictor= to disambiguate. "
                     "Each predictor's score scale is its own — "
-                    "cross-predictor ranking is meaningless under "
-                    "any score_key."
-                    % (canonical, sorted(predictor_set)))
-            # Single predictor → unambiguous.
-        else:
-            candidates = [
-                p for p in candidates if p.predictor_name == predictor]
-            if not candidates:
-                return None
-        version_set = {p.predictor_version for p in candidates}
+                    "cross-predictor ranking is not meaningful."
+                    % (canonical, sorted(by_predictor)))
+            predictor = next(iter(by_predictor))
+        by_version = by_predictor.get(predictor, {})
+        if not by_version:
+            return ()
         if version is None:
-            if len(version_set) > 1:
-                latest = _most_recent_version(version_set)
-                candidates = [
-                    p for p in candidates if p.predictor_version == latest]
-        else:
-            candidates = [
-                p for p in candidates if p.predictor_version == version]
-            if not candidates:
-                return None
-        if score_key is None:
-            score_key = default_score_key
-        return max(candidates, key=score_key)
+            if len(by_version) > 1:
+                version = _most_recent_version(by_version)
+            else:
+                version = next(iter(by_version))
+        return by_version.get(version, ())
 
-    # Kind-specific helpers. Each forwards to ``best`` with the same
-    # disambiguation contract — predictor required when ambiguous,
-    # version auto-resolves to most recent, ``score_key`` overridable
-    # for per-call ranking customization.
+    def best(self, kind: str, *,
+             predictor: Optional[str] = None,
+             version: Optional[str] = None
+             ) -> Optional["Prediction"]:
+        """Best ``Prediction`` for ``(kind, predictor, version)``
+        across alleles, ranked by ``Prediction.score``. Returns
+        ``None`` when no record matches.
+
+        ``kind`` accepts topiary's aliases (``'ba'`` / ``'el'`` /
+        ``'aff'`` / ``'ic50'`` / ``'presentation'`` / …).
+
+        For a different ranking axis (e.g. lowest IC50, lowest
+        %-rank), call ``predictions_for(...)`` and rank the leaf
+        tuple yourself — ``best`` is deliberately the common-case
+        primitive only.
+
+        CONTRACT: relies on mhctools normalizing
+        ``Prediction.score`` so higher = better *within one
+        predictor*. mhctools enforces this on producers; vaxrank
+        consumes ``score`` directly. Cross-predictor max is *not*
+        meaningful — handled by the ``predictor`` disambiguation
+        in ``predictions_for``.
+        """
+        candidates = self.predictions_for(
+            kind, predictor=predictor, version=version)
+        if not candidates:
+            return None
+        return max(candidates, key=lambda p: p.score)
+
+    # Kind-specific helpers. Each forwards to ``best`` with the
+    # same disambiguation contract.
     def best_affinity(self, *, predictor: Optional[str] = None,
-                      version: Optional[str] = None,
-                      score_key: Optional[Callable] = None):
+                      version: Optional[str] = None):
         return self.best(
-            'pMHC_affinity', predictor=predictor, version=version,
-            score_key=score_key)
+            'pMHC_affinity', predictor=predictor, version=version)
 
     def best_presentation(self, *, predictor: Optional[str] = None,
-                          version: Optional[str] = None,
-                          score_key: Optional[Callable] = None):
+                          version: Optional[str] = None):
         return self.best(
-            'pMHC_presentation', predictor=predictor, version=version,
-            score_key=score_key)
+            'pMHC_presentation', predictor=predictor, version=version)
 
     def best_stability(self, *, predictor: Optional[str] = None,
-                       version: Optional[str] = None,
-                       score_key: Optional[Callable] = None):
+                       version: Optional[str] = None):
         return self.best(
-            'pMHC_stability', predictor=predictor, version=version,
-            score_key=score_key)
+            'pMHC_stability', predictor=predictor, version=version)
 
     def best_immunogenicity(self, *, predictor: Optional[str] = None,
-                            version: Optional[str] = None,
-                            score_key: Optional[Callable] = None):
+                            version: Optional[str] = None):
         return self.best(
-            'immunogenicity', predictor=predictor, version=version,
-            score_key=score_key)
+            'immunogenicity', predictor=predictor, version=version)
 
     def best_cleavage(self, *, predictor: Optional[str] = None,
-                      version: Optional[str] = None,
-                      score_key: Optional[Callable] = None):
+                      version: Optional[str] = None):
         return self.best(
-            'proteasome_cleavage', predictor=predictor, version=version,
-            score_key=score_key)
+            'proteasome_cleavage', predictor=predictor, version=version)
 
     def best_antigen_processing(self, *, predictor: Optional[str] = None,
-                                version: Optional[str] = None,
-                                score_key: Optional[Callable] = None):
+                                version: Optional[str] = None):
         return self.best(
-            'antigen_processing', predictor=predictor, version=version,
-            score_key=score_key)
+            'antigen_processing', predictor=predictor, version=version)
+
+    # ------------------------------------------------------------------
+    # Flatten — for serialization / iteration when you don't care
+    # about the nesting.
+    # ------------------------------------------------------------------
+
+    def predictions_flat(self) -> tuple:
+        """Flatten the nested store back to a tuple of
+        ``Prediction`` records. Useful for serialization round-trips
+        and any code that just wants to iterate every prediction
+        without caring about the kind/predictor/version structure."""
+        return tuple(
+            p
+            for by_predictor in self.predictions.values()
+            for by_version in by_predictor.values()
+            for records in by_version.values()
+            for p in records)
 
 
 @dataclass(frozen=True)

--- a/vaxrank/peptide_context.py
+++ b/vaxrank/peptide_context.py
@@ -34,11 +34,25 @@ holds them.
 mhctools' ``Prediction.score`` is normalized so higher = better
 *within one predictor*. Cross-predictor ``max(score)`` is
 meaningless — mhcflurry's score scale and netmhcpan's score scale
-are independent transforms. So ``best_for_kind(kind)`` raises
-when there's no unambiguous answer and the caller hasn't passed
+are independent transforms. So ``best(kind)`` raises when multiple
+predictors emitted ``kind`` and the caller hasn't passed
 ``predictor=``. Callers that legitimately want a per-predictor
 loop iterate ``predictors_for_kind(kind)`` and call
-``best_for_kind(kind, predictor=…)`` per predictor.
+``best(kind, predictor=…)`` per predictor.
+
+Versions, however, *do* auto-resolve: when one predictor has
+multiple ``predictor_version`` strings on file (e.g. mhcflurry
+2.1.0 and 2.1.1 both ran), ``best`` defaults to the most recent
+version (PEP 440 ordering). Pass ``version=`` to pin to a specific
+version explicitly.
+
+## Kind aliases
+
+mhcflurry / netmhcpan / pVACseq / LENS use shorthand for the same
+underlying kinds (``BA`` / ``EL`` / etc). ``best`` and friends
+accept those aliases (case-insensitive) so callers don't have to
+remember which canonical string vaxrank stores. The canonical
+``pMHC_*`` strings keep working unchanged.
 
 Issue: openvax/vaxrank#282 (replaces).
 """
@@ -47,6 +61,69 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Optional
+
+from packaging.version import InvalidVersion, Version
+
+
+# Lowercase alias → canonical mhctools.Prediction.kind. The canonical
+# strings also resolve through this map (since ``str.lower`` is
+# applied first), so callers can pass either form.
+_KIND_ALIASES = {
+    # pMHC_affinity — "BA" in mhcflurry / netmhcpan parlance.
+    'pmhc_affinity': 'pMHC_affinity',
+    'affinity': 'pMHC_affinity',
+    'ba': 'pMHC_affinity',
+    'binding': 'pMHC_affinity',
+    # pMHC_presentation — "EL" (elution likelihood) in mhcflurry-pres.
+    'pmhc_presentation': 'pMHC_presentation',
+    'presentation': 'pMHC_presentation',
+    'el': 'pMHC_presentation',
+    'elution': 'pMHC_presentation',
+    # pMHC_stability.
+    'pmhc_stability': 'pMHC_stability',
+    'stability': 'pMHC_stability',
+    # Single-word kinds — keep canonical and short alias both routed.
+    'immunogenicity': 'immunogenicity',
+    'antigen_processing': 'antigen_processing',
+    'processing': 'antigen_processing',
+    'ap': 'antigen_processing',
+    'proteasome_cleavage': 'proteasome_cleavage',
+    'cleavage': 'proteasome_cleavage',
+    'proteasome': 'proteasome_cleavage',
+    'tap_transport': 'tap_transport',
+    'tap': 'tap_transport',
+    'erap_trimming': 'erap_trimming',
+    'erap': 'erap_trimming',
+}
+
+
+def _resolve_kind(kind: str) -> str:
+    """Map an alias / case-variant onto the canonical
+    ``mhctools.Prediction.kind`` string. Unknown inputs pass through
+    unchanged (so future predictor kinds work without a registry
+    update — they just won't have short aliases until added)."""
+    return _KIND_ALIASES.get(kind.lower(), kind)
+
+
+def _most_recent_version(versions) -> str:
+    """Pick the most recent ``predictor_version`` from a set.
+
+    PEP 440 ordering via ``packaging.version.Version``. Strings that
+    don't parse (empty / non-semver / pre-#261 unset) sort below any
+    valid version — so when both styles coexist, valid wins; when
+    none parse, lexicographic ``max`` is the fallback. Returning a
+    single string lets callers filter ``candidates`` by exact match.
+    """
+    parsed = []
+    fallback = []
+    for v in versions:
+        try:
+            parsed.append((Version(v), v))
+        except (InvalidVersion, TypeError):
+            fallback.append(v)
+    if parsed:
+        return max(parsed, key=lambda x: x[0])[1]
+    return max(fallback)
 
 
 # Reserved comparator names. Open-ended — callers can add new ones —
@@ -117,42 +194,81 @@ class PeptideContext:
 
     def predictors_for_kind(self, kind: str) -> tuple:
         """Predictors that emitted ``kind`` for this peptide.
-        Drives multi-predictor disambiguation in
-        ``best_for_kind``."""
+        Drives multi-predictor disambiguation in ``best``. Accepts
+        kind aliases (``'ba'`` / ``'el'`` / …)."""
+        canonical = _resolve_kind(kind)
         return tuple(sorted({
             p.predictor_name for p in self.predictions
-            if p.kind == kind}))
+            if p.kind == canonical}))
+
+    def versions_for(self, kind: str, predictor: str) -> tuple:
+        """Versions of ``predictor`` that emitted ``kind``, sorted
+        oldest → newest by PEP 440. When multiple coexist, ``best``
+        picks the last entry by default; this accessor exposes the
+        full set for callers that want to walk every version."""
+        canonical = _resolve_kind(kind)
+        versions = {
+            p.predictor_version for p in self.predictions
+            if p.kind == canonical and p.predictor_name == predictor}
+        # Sort newest last so callers can do versions[-1] for "latest".
+        parsed = []
+        fallback = []
+        for v in versions:
+            try:
+                parsed.append((Version(v), v))
+            except (InvalidVersion, TypeError):
+                fallback.append(v)
+        return tuple(sorted(fallback) +
+                     [v for _, v in sorted(parsed, key=lambda x: x[0])])
 
     def alleles_for(self, kind: str, predictor: str) -> tuple:
         """Alleles a given (kind, predictor) covers. Used by
         coverage / report code that walks per-allele evidence
         without forcing a single 'best' allele."""
+        canonical = _resolve_kind(kind)
         return tuple(sorted({
             p.allele for p in self.predictions
-            if p.kind == kind and p.predictor_name == predictor
+            if p.kind == canonical and p.predictor_name == predictor
             and p.allele}))
 
     # ------------------------------------------------------------------
     # Best-of accessors — kind-named, predictor-aware.
     # ------------------------------------------------------------------
 
-    def best_for_kind(self, kind: str, *,
-                       predictor: Optional[str] = None):
-        """Best prediction for ``kind`` across alleles for one
-        predictor. Returns the ``mhctools.Prediction`` (carries
-        allele, score, value, percentile_rank, …) or ``None`` when
-        no record matches.
+    def best(self, kind: str, *,
+             predictor: Optional[str] = None,
+             version: Optional[str] = None):
+        """Best prediction for ``kind`` across alleles. Returns the
+        ``mhctools.Prediction`` (carries allele, score, value,
+        percentile_rank, …) or ``None`` when no record matches.
 
-        Disambiguation:
-        - If only one predictor emitted ``kind`` for this peptide,
-          ``predictor`` may be omitted.
-        - If multiple predictors emitted ``kind``, ``predictor`` is
-          required — cross-predictor ``max(score)`` is meaningless
-          since each predictor's score scale is its own.
+        ``kind`` accepts aliases (case-insensitive): ``'ba'`` /
+        ``'affinity'`` / ``'binding'`` → ``pMHC_affinity``;
+        ``'el'`` / ``'presentation'`` / ``'elution'`` →
+        ``pMHC_presentation``; ``'stability'``;
+        ``'immunogenicity'``; ``'cleavage'`` / ``'proteasome'`` →
+        ``proteasome_cleavage``; ``'processing'`` / ``'ap'`` →
+        ``antigen_processing``; ``'tap'``; ``'erap'``. Canonical
+        ``pMHC_*`` strings also work.
 
-        Raises ``ValueError`` when the call is ambiguous.
+        Predictor disambiguation:
+        - One predictor emitted ``kind`` → ``predictor`` may be
+          omitted.
+        - Multiple predictors emitted ``kind`` → ``predictor`` is
+          required (cross-predictor ``max(score)`` is meaningless;
+          each predictor's score scale is its own). Raises
+          ``ValueError`` otherwise.
+
+        Version disambiguation:
+        - One ``predictor_version`` on file → unambiguous.
+        - Multiple versions on file → defaults to the most recent
+          (PEP 440 ordering). Pass ``version=`` to pin explicitly.
+          Versions auto-resolve (vs. predictor's hard-raise) because
+          the score scale is comparable across versions of the same
+          predictor — just freshness differs.
         """
-        candidates = [p for p in self.predictions if p.kind == kind]
+        canonical = _resolve_kind(kind)
+        candidates = [p for p in self.predictions if p.kind == canonical]
         if not candidates:
             return None
         predictor_set = {p.predictor_name for p in candidates}
@@ -163,11 +279,22 @@ class PeptideContext:
                     "(%s); pass predictor= to disambiguate. "
                     "Each predictor's score scale is its own — "
                     "cross-predictor max() is meaningless."
-                    % (kind, sorted(predictor_set)))
+                    % (canonical, sorted(predictor_set)))
             # Single predictor → unambiguous.
         else:
             candidates = [
                 p for p in candidates if p.predictor_name == predictor]
+            if not candidates:
+                return None
+        version_set = {p.predictor_version for p in candidates}
+        if version is None:
+            if len(version_set) > 1:
+                latest = _most_recent_version(version_set)
+                candidates = [
+                    p for p in candidates if p.predictor_version == latest]
+        else:
+            candidates = [
+                p for p in candidates if p.predictor_version == version]
             if not candidates:
                 return None
         # mhctools normalizes ``score`` so higher = better within a
@@ -176,25 +303,38 @@ class PeptideContext:
         # Best-across-alleles is unambiguously max(score).
         return max(candidates, key=lambda p: p.score)
 
-    # Kind-specific helpers. Each forwards to ``best_for_kind``
-    # with the same disambiguation contract.
-    def best_affinity(self, *, predictor: Optional[str] = None):
-        return self.best_for_kind('pMHC_affinity', predictor=predictor)
+    # Kind-specific helpers. Each forwards to ``best`` with the same
+    # disambiguation contract — predictor required when ambiguous,
+    # version auto-resolves to most recent.
+    def best_affinity(self, *, predictor: Optional[str] = None,
+                      version: Optional[str] = None):
+        return self.best(
+            'pMHC_affinity', predictor=predictor, version=version)
 
-    def best_presentation(self, *, predictor: Optional[str] = None):
-        return self.best_for_kind('pMHC_presentation', predictor=predictor)
+    def best_presentation(self, *, predictor: Optional[str] = None,
+                          version: Optional[str] = None):
+        return self.best(
+            'pMHC_presentation', predictor=predictor, version=version)
 
-    def best_stability(self, *, predictor: Optional[str] = None):
-        return self.best_for_kind('pMHC_stability', predictor=predictor)
+    def best_stability(self, *, predictor: Optional[str] = None,
+                       version: Optional[str] = None):
+        return self.best(
+            'pMHC_stability', predictor=predictor, version=version)
 
-    def best_immunogenicity(self, *, predictor: Optional[str] = None):
-        return self.best_for_kind('immunogenicity', predictor=predictor)
+    def best_immunogenicity(self, *, predictor: Optional[str] = None,
+                            version: Optional[str] = None):
+        return self.best(
+            'immunogenicity', predictor=predictor, version=version)
 
-    def best_cleavage(self, *, predictor: Optional[str] = None):
-        return self.best_for_kind('proteasome_cleavage', predictor=predictor)
+    def best_cleavage(self, *, predictor: Optional[str] = None,
+                      version: Optional[str] = None):
+        return self.best(
+            'proteasome_cleavage', predictor=predictor, version=version)
 
-    def best_antigen_processing(self, *, predictor: Optional[str] = None):
-        return self.best_for_kind('antigen_processing', predictor=predictor)
+    def best_antigen_processing(self, *, predictor: Optional[str] = None,
+                                version: Optional[str] = None):
+        return self.best(
+            'antigen_processing', predictor=predictor, version=version)
 
 
 @dataclass(frozen=True)

--- a/vaxrank/peptide_context.py
+++ b/vaxrank/peptide_context.py
@@ -83,6 +83,7 @@ Issue: openvax/vaxrank#282 (replaces).
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
 
@@ -90,15 +91,9 @@ from packaging.version import InvalidVersion, Version
 
 if TYPE_CHECKING:
     from mhctools.pred import Prediction
-    # Nested storage shape: kind → predictor → version →
-    # tuple[Prediction]. ``frozen=True`` on the dataclass blocks
-    # field reassignment; the nested dicts themselves are mutable
-    # by Python convention — consumers go through the typed
-    # accessors (``best`` / ``predictions_for`` / …) and don't
-    # reach into the raw store.
-    PredictionStore = dict[str, dict[str, dict[str, tuple[Prediction, ...]]]]
 
 
+@functools.lru_cache(maxsize=1)
 def _load_kind_aliases():
     """Load topiary's canonical kind-alias table.
 
@@ -110,6 +105,12 @@ def _load_kind_aliases():
     Cross-package private-name dependencies are brittle; this
     wrapper is the seam for upgrading topiary's public surface
     without touching every call site here.
+
+    Cached: the table is module-constant once topiary is loaded;
+    ``_resolve_kind`` is on the per-record hot path of ``best`` /
+    ``predictions_for``, so we don't want to redo the ``getattr``
+    chain on every call. Tests that need to swap topiary's table
+    must call ``_load_kind_aliases.cache_clear()``.
     """
     try:
         import topiary.ranking as _r
@@ -121,7 +122,7 @@ def _load_kind_aliases():
     table = getattr(_r, 'KIND_ALIASES', None)
     if table is None:
         table = getattr(_r, '_KIND_ALIASES', None)
-    if table is None:  # pragma: no cover
+    if table is None:
         raise ImportError(
             "vaxrank.peptide_context expected topiary.ranking to "
             "expose KIND_ALIASES (or the legacy _KIND_ALIASES); "
@@ -139,34 +140,19 @@ def _resolve_kind(kind: str) -> str:
     return _load_kind_aliases().get(kind.lower(), kind)
 
 
-def _split_versions(versions) -> tuple:
-    """Split a set of ``predictor_version`` strings into PEP 440
-    parseable + fallback. Returns ``(parsed_oldest_to_newest,
-    fallback_lex_sorted)`` — both are lists of the original
-    strings."""
-    parsed = []
-    fallback = []
+def _sort_versions(versions) -> list:
+    """Sort ``predictor_version`` strings: legacy / unparseable
+    strings come first (lex-sorted), valid PEP 440 versions follow
+    oldest → newest. The last element is therefore the *most recent*
+    valid version when any are valid, else the last legacy string
+    lex-sorted — that's what the leaf accessors default to."""
+    parsed, fallback = [], []
     for v in versions:
         try:
             parsed.append((Version(v), v))
         except (InvalidVersion, TypeError):
             fallback.append(v)
-    return ([v for _, v in sorted(parsed, key=lambda x: x[0])],
-            sorted(fallback))
-
-
-def _most_recent_version(versions) -> str:
-    """Pick the most recent ``predictor_version`` from a set.
-
-    PEP 440 ordering via ``packaging.version.Version``. Strings that
-    don't parse (empty / non-semver / pre-#261 unset) sort below any
-    valid version — so when both styles coexist, valid wins; when
-    none parse, lexicographic ``max`` is the fallback.
-    """
-    parsed, fallback = _split_versions(versions)
-    if parsed:
-        return parsed[-1]
-    return fallback[-1]
+    return sorted(fallback) + [v for _, v in sorted(parsed)]
 
 
 def _group_predictions(predictions) -> dict:
@@ -222,18 +208,13 @@ class PeptideContext:
     source_sequence: str = ''
     source_name: str = ''         # gene / virus / "self_proteome" / …
     offset: int = 0
-    # Nested storage. Constructor accepts either this shape or a
-    # flat ``list``/``tuple`` of ``Prediction`` records (auto-grouped
-    # via ``__post_init__``). Field type is ``PredictionStore``
-    # (alias under ``TYPE_CHECKING`` — see module top) so mhctools
-    # stays off the runtime import path.
-    predictions: "PredictionStore" = field(default_factory=dict)
+    # Nested storage; flat ``list[Prediction]`` is auto-grouped on
+    # construction. Shape documented in the module docstring.
+    predictions: dict = field(default_factory=dict)
 
     def __post_init__(self):
-        # Flat ``Prediction`` sequence → nested dict (one-time work
-        # at construction so read accessors don't have to repeat it).
-        # ``object.__setattr__`` is the escape hatch for writing to a
-        # frozen-dataclass field — plain ``self.x = ...`` is blocked.
+        # ``object.__setattr__`` is the escape hatch for writing to
+        # a frozen-dataclass field.
         if isinstance(self.predictions, (list, tuple)):
             object.__setattr__(
                 self, 'predictions', _group_predictions(self.predictions))
@@ -268,8 +249,7 @@ class PeptideContext:
         """
         canonical = _resolve_kind(kind)
         by_version = self.predictions.get(canonical, {}).get(predictor, {})
-        parsed, fallback = _split_versions(by_version)
-        return tuple(fallback + parsed)
+        return tuple(_sort_versions(by_version))
 
     def alleles_for(self, kind: str, *,
                     predictor: Optional[str] = None,
@@ -322,20 +302,17 @@ class PeptideContext:
         if predictor is None:
             if len(by_predictor) > 1:
                 raise ValueError(
-                    "%s has predictions from multiple predictors "
-                    "(%s); pass predictor= to disambiguate. "
-                    "Each predictor's score scale is its own — "
-                    "cross-predictor ranking is not meaningful."
-                    % (canonical, sorted(by_predictor)))
+                    f"{canonical} has predictions from multiple "
+                    f"predictors ({sorted(by_predictor)}); pass "
+                    f"predictor= to disambiguate. Each predictor's "
+                    f"score scale is its own — cross-predictor "
+                    f"ranking is not meaningful.")
             predictor = next(iter(by_predictor))
         by_version = by_predictor.get(predictor, {})
         if not by_version:
             return ()
         if version is None:
-            if len(by_version) > 1:
-                version = _most_recent_version(by_version)
-            else:
-                version = next(iter(by_version))
+            version = _sort_versions(by_version)[-1]
         return by_version.get(version, ())
 
     def best(self, kind: str, *,
@@ -367,37 +344,14 @@ class PeptideContext:
             return None
         return max(candidates, key=lambda p: p.score)
 
-    # Kind-specific helpers. Each forwards to ``best`` with the
-    # same disambiguation contract.
-    def best_affinity(self, *, predictor: Optional[str] = None,
-                      version: Optional[str] = None):
-        return self.best(
-            'pMHC_affinity', predictor=predictor, version=version)
-
-    def best_presentation(self, *, predictor: Optional[str] = None,
-                          version: Optional[str] = None):
-        return self.best(
-            'pMHC_presentation', predictor=predictor, version=version)
-
-    def best_stability(self, *, predictor: Optional[str] = None,
-                       version: Optional[str] = None):
-        return self.best(
-            'pMHC_stability', predictor=predictor, version=version)
-
-    def best_immunogenicity(self, *, predictor: Optional[str] = None,
-                            version: Optional[str] = None):
-        return self.best(
-            'immunogenicity', predictor=predictor, version=version)
-
-    def best_cleavage(self, *, predictor: Optional[str] = None,
-                      version: Optional[str] = None):
-        return self.best(
-            'proteasome_cleavage', predictor=predictor, version=version)
-
-    def best_antigen_processing(self, *, predictor: Optional[str] = None,
-                                version: Optional[str] = None):
-        return self.best(
-            'antigen_processing', predictor=predictor, version=version)
+    # Kind-named sugar for the common ``best(kind)`` calls. For
+    # predictor / version pinning, use ``best`` directly.
+    def best_affinity(self): return self.best('pMHC_affinity')
+    def best_presentation(self): return self.best('pMHC_presentation')
+    def best_stability(self): return self.best('pMHC_stability')
+    def best_immunogenicity(self): return self.best('immunogenicity')
+    def best_cleavage(self): return self.best('proteasome_cleavage')
+    def best_antigen_processing(self): return self.best('antigen_processing')
 
     # ------------------------------------------------------------------
     # Flatten — for serialization / iteration when you don't care
@@ -447,9 +401,6 @@ class CandidateEpitope:
     """
 
     mutant: PeptideContext
-    # ``field(default_factory=dict)`` would normally be required
-    # for mutable defaults, but the class is frozen so callers
-    # construct dicts explicitly. Keeps the dataclass simple.
     comparators: dict = field(default_factory=dict)
 
     # Mutation-specific context. Lives at this level (not on

--- a/vaxrank/peptide_context.py
+++ b/vaxrank/peptide_context.py
@@ -71,17 +71,18 @@ deliberately simple.
 
 ## Kind aliases
 
-Defers to ``topiary.ranking._KIND_ALIASES`` for canonical
-resolution (``ba`` / ``el`` / ``aff`` / ``ic50`` / ``presentation``
-/ etc. → canonical ``pMHC_*``). vaxrank does not maintain its own
-alias table.
+Defers to topiary's kind-alias table for canonical resolution
+(``ba`` / ``el`` / ``aff`` / ``ic50`` / ``presentation`` / etc. →
+canonical ``pMHC_*``). vaxrank does not maintain its own alias
+table. We prefer topiary's public ``KIND_ALIASES`` when available
+and fall back to the ``_KIND_ALIASES`` private name for older
+topiary releases — see ``_load_kind_aliases``.
 
 Issue: openvax/vaxrank#282 (replaces).
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
 
@@ -89,16 +90,53 @@ from packaging.version import InvalidVersion, Version
 
 if TYPE_CHECKING:
     from mhctools.pred import Prediction
+    # Nested storage shape: kind → predictor → version →
+    # tuple[Prediction]. ``frozen=True`` on the dataclass blocks
+    # field reassignment; the nested dicts themselves are mutable
+    # by Python convention — consumers go through the typed
+    # accessors (``best`` / ``predictions_for`` / …) and don't
+    # reach into the raw store.
+    PredictionStore = dict[str, dict[str, dict[str, tuple[Prediction, ...]]]]
+
+
+def _load_kind_aliases():
+    """Load topiary's canonical kind-alias table.
+
+    Prefers the public ``KIND_ALIASES`` (added in topiary going
+    forward) and falls back to ``_KIND_ALIASES`` for older releases
+    that haven't promoted the name yet. If neither is exposed,
+    raises a clear ``ImportError`` instead of letting an opaque
+    ``AttributeError`` surface deep inside vaxrank construction.
+    Cross-package private-name dependencies are brittle; this
+    wrapper is the seam for upgrading topiary's public surface
+    without touching every call site here.
+    """
+    try:
+        import topiary.ranking as _r
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "vaxrank.peptide_context requires topiary's kind-alias "
+            "table; topiary itself failed to import."
+        ) from e
+    table = getattr(_r, 'KIND_ALIASES', None)
+    if table is None:
+        table = getattr(_r, '_KIND_ALIASES', None)
+    if table is None:  # pragma: no cover
+        raise ImportError(
+            "vaxrank.peptide_context expected topiary.ranking to "
+            "expose KIND_ALIASES (or the legacy _KIND_ALIASES); "
+            "neither name is present. topiary may have refactored "
+            "the alias table — open an issue on vaxrank."
+        )
+    return table
 
 
 def _resolve_kind(kind: str) -> str:
     """Map an alias / case-variant onto the canonical
     ``mhctools.Prediction.kind`` string. Defers to topiary's
-    ``_KIND_ALIASES`` so vaxrank doesn't fork the canonical list.
+    kind-alias table so vaxrank doesn't fork the canonical list.
     Unknown inputs pass through unchanged."""
-    # Imported lazily so this module stays import-light.
-    from topiary.ranking import _KIND_ALIASES
-    return _KIND_ALIASES.get(kind.lower(), kind)
+    return _load_kind_aliases().get(kind.lower(), kind)
 
 
 def _split_versions(versions) -> tuple:
@@ -184,18 +222,19 @@ class PeptideContext:
     source_sequence: str = ''
     source_name: str = ''         # gene / virus / "self_proteome" / …
     offset: int = 0
-    # Nested storage. Constructor accepts either this form or a
-    # flat ``Sequence[Prediction]`` (auto-grouped via
-    # ``__post_init__``). Annotated under ``TYPE_CHECKING`` to keep
-    # mhctools off the runtime import path.
-    predictions: dict = field(default_factory=dict)
+    # Nested storage. Constructor accepts either this shape or a
+    # flat ``list``/``tuple`` of ``Prediction`` records (auto-grouped
+    # via ``__post_init__``). Field type is ``PredictionStore``
+    # (alias under ``TYPE_CHECKING`` — see module top) so mhctools
+    # stays off the runtime import path.
+    predictions: "PredictionStore" = field(default_factory=dict)
 
     def __post_init__(self):
-        # Flat producer input → nested storage. Flat is the common
-        # case (mhctools / topiary hand back ``list[Prediction]``);
-        # converting at construction means read accessors don't
-        # have to repeat the work on every call.
-        if isinstance(self.predictions, Sequence):
+        # Flat ``Prediction`` sequence → nested dict (one-time work
+        # at construction so read accessors don't have to repeat it).
+        # ``object.__setattr__`` is the escape hatch for writing to a
+        # frozen-dataclass field — plain ``self.x = ...`` is blocked.
+        if isinstance(self.predictions, (list, tuple)):
             object.__setattr__(
                 self, 'predictions', _group_predictions(self.predictions))
 
@@ -219,12 +258,14 @@ class PeptideContext:
         return tuple(sorted(self.predictions.get(canonical, {})))
 
     def versions_for(self, kind: str, predictor: str) -> tuple:
-        """Versions of ``predictor`` that emitted ``kind``, sorted
-        oldest → newest by PEP 440. When multiple coexist, the
-        leaf accessors default to the last entry; this method
-        exposes the full set for callers that want to walk every
-        version. Unparseable / legacy strings sort before
-        parseable ones."""
+        """All versions of ``predictor`` that emitted ``kind``.
+
+        Ordering: legacy / unparseable strings (lex-sorted) come
+        first, followed by valid PEP 440 versions oldest → newest.
+        That matches ``best`` / ``predictions_for`` defaulting to
+        the *last* entry — i.e. the most-recent valid version when
+        any exist, with legacy strings falling below.
+        """
         canonical = _resolve_kind(kind)
         by_version = self.predictions.get(canonical, {}).get(predictor, {})
         parsed, fallback = _split_versions(by_version)

--- a/vaxrank/peptide_context.py
+++ b/vaxrank/peptide_context.py
@@ -251,20 +251,27 @@ class PeptideContext:
     def alleles_for(self, kind: str, *,
                     predictor: Optional[str] = None,
                     version: Optional[str] = None) -> tuple[str, ...]:
-        """Alleles attested in the leaf tuple for
-        ``(kind, predictor, version)``. Filters out empty-string
-        alleles (processing kinds emit ``allele=""``). Used by
-        coverage / report code that walks per-allele evidence
-        without forcing a single 'best' allele.
+        """Alleles attested for ``kind``, optionally restricted by
+        ``predictor`` and / or ``version``. Filters out empty
+        alleles (processing kinds emit ``allele=""``).
 
-        Same disambiguation contract as ``best``: raises when
-        multiple predictors emitted ``kind`` and ``predictor`` is
-        unset; auto-resolves to most recent when multiple versions
-        coexist and ``version`` is unset.
+        Predictor- and version-agnostic by default — alleles are a
+        set property, not predictor-specific, so when multiple
+        predictors emitted ``kind`` we union their alleles rather
+        than raise. This is unlike ``best`` / ``predictions_for``,
+        where score scales differ across predictors so ranking
+        requires explicit disambiguation.
         """
-        records = self.predictions_for(
-            kind, predictor=predictor, version=version)
-        return tuple(sorted({p.allele for p in records if p.allele}))
+        canonical = _resolve_kind(kind)
+        alleles: set[str] = set()
+        for pn, by_version in self.predictions.get(canonical, {}).items():
+            if predictor is not None and pn != predictor:
+                continue
+            for ver, records in by_version.items():
+                if version is not None and ver != version:
+                    continue
+                alleles.update(p.allele for p in records if p.allele)
+        return tuple(sorted(alleles))
 
     def predictions_for(self, kind: str, *,
                         predictor: Optional[str] = None,
@@ -348,15 +355,18 @@ class PeptideContext:
 
     def predictions_flat(self) -> tuple["Prediction", ...]:
         """Flatten the nested store back to a tuple of
-        ``Prediction`` records. Useful for serialization round-trips
-        and any code that just wants to iterate every prediction
-        without caring about the kind/predictor/version structure."""
-        return tuple(
+        ``Prediction`` records, sorted by ``(kind, predictor_name,
+        predictor_version, allele)``. Sorted output is deterministic
+        across runs and through serialization round-trips even when
+        the input arrived in producer-specific order."""
+        flat = (
             p
             for by_predictor in self.predictions.values()
             for by_version in by_predictor.values()
             for records in by_version.values()
             for p in records)
+        return tuple(sorted(flat, key=lambda p: (
+            p.kind, p.predictor_name, p.predictor_version, p.allele)))
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

Introduces `vaxrank/peptide_context.py` as the replacement shape for the flat `EpitopePrediction` — Phase 1 ships the new types + tests; **Phase 2 migration of existing call-sites is tracked in #284**.

Two layers:

- **`PeptideContext`** — one peptide sequence + flanks + provenance + a tuple of `mhctools.Prediction` records (kind / predictor / version / allele). Generic shape used for the antigenic candidate AND for any reference comparator.
- **`CandidateEpitope`** — one sliding-window position from a `VaccinePeptide`. Holds the mutant `PeptideContext` plus an open-ended `comparators` dict (`'wt'` today; `'nearest_self'` / `'nearest_vital_self'` / `'nearest_nonCTA'` / `'nearest_oncovirus'` reserved for #254 / #257 / #258).

## Why

The flat `EpitopePrediction` only carries one axis (affinity `percentile_rank`), which is exactly the gap #282 documents — the 2.25.0 coverage feature's "two-axis evidence" story is half-real because `presentation_percentile` has nowhere to land. Generalizing to mhctools' multi-kind `Prediction` record fixes that cleanly and gives us the shape we need for the upcoming safety / homology comparators.

## API: `best(kind, *, predictor=None, version=None, score_key=None)`

The per-record primitive for "best prediction across alleles." Three orthogonal disambiguation levers:

**Predictor disambiguation (hard-raise).** Multiple predictors emit `kind` and `predictor=` is unset → `ValueError`. Cross-predictor ranking is meaningless because each predictor's score scale is its own. Callers that want a per-predictor loop iterate `predictors_for_kind(kind)`.

**Version disambiguation (auto-resolve).** Multiple versions of the chosen predictor on file → defaults to most recent (PEP 440). Pass `version=` to pin. Auto-resolves rather than raising because score scales are comparable across versions of the same predictor — only freshness differs. Empty / non-PEP 440 strings sort below valid versions, so legacy data degrades cleanly.

**Score selection (parametric).** `score_key` is a `Prediction → float` callable (higher wins). Default is `default_score_key` (uses `Prediction.score`). Override per call: `score_key=lambda p: -p.percentile_rank` for "lowest %-rank wins". Higher-level pipelines drive ranking via the topiary DSL on row-frames (`EpitopeConfig.score_expr`); `best()` is the per-record primitive and stays simple.

## Kind aliases

`best` and the structured-view accessors (`predictors_for_kind` / `alleles_for` / `versions_for`) accept aliases (case-insensitive). mhcflurry / netmhcpan / pVACseq / LENS shorthand all resolve:

| alias | canonical |
| --- | --- |
| `ba` / `affinity` / `binding` | `pMHC_affinity` |
| `el` / `presentation` / `elution` | `pMHC_presentation` |
| `stability` | `pMHC_stability` |
| `cleavage` / `proteasome` | `proteasome_cleavage` |
| `processing` / `ap` | `antigen_processing` |
| `tap` | `tap_transport` |
| `erap` | `erap_trimming` |

Canonical `pMHC_*` strings still work unchanged.

## Scope of this PR

**In:** new module + 53 unit tests covering structured views (4-level nested, version-axis collision-free), kind/predictor/allele/version iteration, single-predictor best, multi-predictor disambiguation, version auto-resolve + explicit pin, kind aliases parametrized over all entries, kind-named helpers, parametric `score_key` override, asdict round-trip serialization, flank-field carry, comparator dict, frozen mutation context.

100% effective coverage on `vaxrank/peptide_context.py` (1 line uncovered: `if TYPE_CHECKING:` block — false at runtime by design).

**Out:** migration of `epitope_io.py` / `epitope_logic.py` / `coverage.py` / `report.py` / `ranking.py` / `vaccine_peptide.py` / `vaccine_library.py` / `mrna.py` / `processing.py` / `core_logic.py` / `external_input.py` / `epitope_dsl.py` call-sites off `EpitopePrediction`. **Tracked in #284 with a 5-stage staging plan** so each consumer can migrate independently.

## Test plan

- [x] `pytest tests/test_peptide_context.py` — 53 tests pass
- [x] `./lint.sh` — clean
- [x] `./test.sh` — 806 passed, no regressions

## Related

- Closes the type-design portion of #282 (the field-level fix follows once call-sites migrate per #284).
- #284 — Phase 2 migration tracking issue (5-stage plan).
- Reserves comparator names for #254 (nearest_self, nearest_vital_self), #257 (nearest_nonCTA), #258 (nearest_oncovirus).
- Builds on #261's multi-predictor work.
