### PR TITLE
Drop defensive _load_kind_aliases; require topiary>=5.12.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,9 @@ mhctools>=3.13.3,<4.0.0
 # 5.10.0 adds EvalContext(default_methods=...) and apply_filter(default_methods=...)
 # which vaxrank uses to score multi-model inputs (e.g. LENS with mhcflurry +
 # netmhcpan) without pre-subsetting the frame.
-topiary>=5.10.0,<6.0.0
+# 5.12.0 promotes KIND_ALIASES to the public surface so vaxrank's
+# peptide_context can drop its defensive private-name fallback.
+topiary>=5.12.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_peptide_context.py
+++ b/tests/test_peptide_context.py
@@ -402,7 +402,7 @@ def test_alleles_for_unions_across_versions():
 ])
 def test_best_resolves_kind_aliases_via_topiary(alias, canonical):
     """vaxrank doesn't maintain its own alias table — defers to
-    topiary's ``_KIND_ALIASES``. Pin the entries vaxrank cares
+    topiary's ``KIND_ALIASES``. Pin the entries vaxrank cares
     about so a topiary change shows up here."""
     ctx = PeptideContext(
         peptide_sequence='SIINFEKL',
@@ -421,75 +421,6 @@ def test_predictors_for_accepts_aliases():
         ))
     assert ctx.predictors_for('el') == ('bigmhc', 'mhcflurry')
     assert ctx.predictors_for('presentation') == ('bigmhc', 'mhcflurry')
-
-
-# ---- _load_kind_aliases: defensive topiary import ----------------------
-
-
-def test_load_kind_aliases_prefers_public_name(monkeypatch):
-    """When topiary publishes a public ``KIND_ALIASES``, vaxrank
-    prefers it over the legacy private ``_KIND_ALIASES``. Pins the
-    upgrade path so when topiary promotes the name, vaxrank picks
-    it up without code changes. The result is wrapped in a
-    read-only view so vaxrank can't mutate topiary's table."""
-    from types import MappingProxyType
-    import topiary.ranking
-    from vaxrank import peptide_context as pc
-
-    sentinel = {'sentinel_alias': 'pMHC_affinity'}
-    pc._load_kind_aliases.cache_clear()
-    monkeypatch.setattr(
-        topiary.ranking, 'KIND_ALIASES', sentinel, raising=False)
-    try:
-        result = pc._load_kind_aliases()
-        assert isinstance(result, MappingProxyType)
-        assert dict(result) == sentinel  # content equal
-        assert result is not sentinel    # but wrapped, not aliased
-    finally:
-        pc._load_kind_aliases.cache_clear()
-
-
-def test_load_kind_aliases_raises_when_neither_present(monkeypatch):
-    """If a future topiary refactor removes both names, vaxrank
-    raises ``ImportError`` with a clear diagnostic instead of
-    letting an opaque ``AttributeError`` surface from inside
-    PeptideContext construction. Proves the safety net actually
-    fires + the message is well-formed."""
-    import topiary.ranking
-    from vaxrank import peptide_context as pc
-
-    pc._load_kind_aliases.cache_clear()
-    monkeypatch.delattr(topiary.ranking, 'KIND_ALIASES', raising=False)
-    monkeypatch.delattr(topiary.ranking, '_KIND_ALIASES', raising=False)
-    try:
-        with pytest.raises(ImportError, match='KIND_ALIASES'):
-            pc._load_kind_aliases()
-    finally:
-        pc._load_kind_aliases.cache_clear()
-
-
-def test_load_kind_aliases_is_cached(monkeypatch):
-    """``_load_kind_aliases`` is on the per-record hot path of
-    ``best`` / ``predictions_for``; the result is module-constant
-    so we cache it (``functools.lru_cache``) instead of redoing
-    the ``getattr`` chain on every call."""
-    import topiary.ranking
-    from vaxrank import peptide_context as pc
-
-    pc._load_kind_aliases.cache_clear()
-    first = pc._load_kind_aliases()
-    # Swap the underlying table; cached call should NOT see the swap.
-    sentinel = {'sentinel_alias': 'pMHC_affinity'}
-    monkeypatch.setattr(
-        topiary.ranking, 'KIND_ALIASES', sentinel, raising=False)
-    try:
-        assert pc._load_kind_aliases() is first  # cached
-        # After cache_clear, the new attr wins (still wrapped).
-        pc._load_kind_aliases.cache_clear()
-        result = pc._load_kind_aliases()
-        assert dict(result) == sentinel
-    finally:
-        pc._load_kind_aliases.cache_clear()
 
 
 # ---- predictions_for: leaf access + disambiguation ---------------------

--- a/vaxrank/peptide_context.py
+++ b/vaxrank/peptide_context.py
@@ -72,69 +72,25 @@ deliberately simple.
 
 ## Kind aliases
 
-Defers to topiary's kind-alias table for canonical resolution
+Defers to ``topiary.ranking.KIND_ALIASES`` for canonical resolution
 (``ba`` / ``el`` / ``aff`` / ``ic50`` / ``presentation`` / etc. →
 canonical ``pMHC_*``). vaxrank does not maintain its own alias
-table. We prefer topiary's public ``KIND_ALIASES`` when available
-and fall back to the ``_KIND_ALIASES`` private name for older
-topiary releases — see ``_load_kind_aliases``.
+table. Requires topiary >= 5.12.0 (public name).
 
 Issue: openvax/vaxrank#282 (replaces).
 """
 
 from __future__ import annotations
 
-import functools
 import math
 from dataclasses import dataclass, field
-from types import MappingProxyType
 from typing import TYPE_CHECKING, Optional
 
 from packaging.version import InvalidVersion, Version
+from topiary.ranking import KIND_ALIASES as _KIND_ALIASES
 
 if TYPE_CHECKING:
     from mhctools.pred import Prediction
-
-
-@functools.lru_cache(maxsize=1)
-def _load_kind_aliases():
-    """Load topiary's canonical kind-alias table.
-
-    Prefers the public ``KIND_ALIASES`` (added in topiary going
-    forward) and falls back to ``_KIND_ALIASES`` for older releases
-    that haven't promoted the name yet. If neither is exposed,
-    raises a clear ``ImportError`` instead of letting an opaque
-    ``AttributeError`` surface deep inside vaxrank construction.
-    Cross-package private-name dependencies are brittle; this
-    wrapper is the seam for upgrading topiary's public surface
-    without touching every call site here.
-
-    Cached: the table is module-constant once topiary is loaded;
-    ``_resolve_kind`` is on the per-record hot path of ``best`` /
-    ``predictions_for``, so we don't want to redo the ``getattr``
-    chain on every call. Tests that need to swap topiary's table
-    must call ``_load_kind_aliases.cache_clear()``.
-    """
-    try:
-        import topiary.ranking as _r
-    except ImportError as e:  # pragma: no cover
-        raise ImportError(
-            "vaxrank.peptide_context requires topiary's kind-alias "
-            "table; topiary itself failed to import."
-        ) from e
-    table = getattr(_r, 'KIND_ALIASES', None)
-    if table is None:
-        table = getattr(_r, '_KIND_ALIASES', None)
-    if table is None:
-        raise ImportError(
-            "vaxrank.peptide_context expected topiary.ranking to "
-            "expose KIND_ALIASES (or the legacy _KIND_ALIASES); "
-            "neither name is present. topiary may have refactored "
-            "the alias table — open an issue on vaxrank."
-        )
-    # Wrap as a read-only view so a misbehaving caller can't
-    # mutate topiary's alias table for the rest of the session.
-    return MappingProxyType(table)
 
 
 def _resolve_kind(kind: str) -> str:
@@ -142,7 +98,7 @@ def _resolve_kind(kind: str) -> str:
     ``mhctools.Prediction.kind`` string. Defers to topiary's
     kind-alias table so vaxrank doesn't fork the canonical list.
     Unknown inputs pass through unchanged."""
-    return _load_kind_aliases().get(kind.lower(), kind)
+    return _KIND_ALIASES.get(kind.lower(), kind)
 
 
 def _nan_safe(x: float) -> tuple[bool, float]:


### PR DESCRIPTION
## Summary

topiary 5.12.0 promotes `KIND_ALIASES` to the public surface ([openvax/topiary#162](https://github.com/openvax/topiary/pull/162)), which kills the cross-package private-name dance vaxrank's `peptide_context` was carrying.

## What goes away

- **`_load_kind_aliases`** — 30-line defensive loader that preferred public `KIND_ALIASES`, fell back to private `_KIND_ALIASES`, raised a clear `ImportError` if neither was present, and cached via `functools.lru_cache`. All of that is now a 1-line module import.
- **`MappingProxyType` wrap** — was guarding against callers mutating topiary's alias table. With the function gone there's no public surface to mutate; the private module constant is fine.
- **`functools` and `MappingProxyType` imports**.
- **Three tests** — `test_load_kind_aliases_prefers_public_name` / `_raises_when_neither_present` / `_is_cached`. They were pinning the defensive seam that no longer exists.

## What changes for callers

Nothing. `_resolve_kind` keeps the same signature and behavior. The user-facing API surface (`PeptideContext.best`, `predictions_for`, etc.) is unchanged.

## Requirements bump

`topiary>=5.10.0,<6.0.0` → `topiary>=5.12.0,<6.0.0`. Comment in `requirements.txt` explains the floor.

## Net delta

- `vaxrank/peptide_context.py`: -52 / +5 lines
- `tests/test_peptide_context.py`: -71 / 0 lines
- `requirements.txt`: +2 / -1 lines

## Test plan

- [x] `pytest tests/test_peptide_context.py` — 54 pass (was 57; dropped 3 defensive-import tests)
- [x] `pytest tests/` — 806 pass, 1 skipped, no regressions
- [x] `./lint.sh` — clean
- [x] Verified `from topiary.ranking import KIND_ALIASES` works in topiary 5.12.0

## Related

- Builds on [openvax/topiary#162](https://github.com/openvax/topiary/pull/162) — public `KIND_ALIASES`
- Unblocks vaxrank#284 Phase 2 migration: subsequent PRs no longer have to dance around the temporary defensive seam