### PR TITLE
CI: make test.sh xdist-conditional

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -9,9 +9,14 @@ if [[ "$(uname)" == "Darwin" && -d /opt/homebrew/lib \
   export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 fi
 
-# -n 2 caps pytest-xdist at 2 workers. Each worker is its own Python
-# process and loads its own pyensembl / mhctools / topiary state
-# (~3 GB resident), so naive `-n auto` on an 8-core box can balloon
-# to ~24 GB. Two workers is a sweet spot: meaningful parallelism
-# without the memory blowup.
-pytest -n 2 --cov=vaxrank/ --cov-report=term-missing tests
+# Use pytest-xdist with 2 workers when available. Each worker loads
+# its own pyensembl / mhctools / topiary state (~3 GB resident), so
+# naive `-n auto` on an 8-core box can balloon to ~24 GB. Two
+# workers is a sweet spot: meaningful parallelism without the memory
+# blowup. xdist is not a required dependency, so fall back to serial
+# pytest when it isn't installed (e.g., CI).
+XDIST_FLAG=""
+if python -c "import xdist" 2>/dev/null; then
+  XDIST_FLAG="-n 2"
+fi
+pytest ${XDIST_FLAG} --cov=vaxrank/ --cov-report=term-missing tests


### PR DESCRIPTION
## Summary

`test.sh` calls `pytest -n 2`, which fails on CI with `unrecognized arguments: -n` because pytest-xdist isn't in `requirements.txt`. Detect xdist at runtime and only pass `-n 2` when it's importable; otherwise fall back to serial pytest. Local dev (xdist installed) keeps parallel workers; CI gets serial.

## Background

This fix was committed on the `candidate-epitope-migration` branch (340bbdb) but the squash merge of #286 missed it — `gh pr merge --auto` ran immediately at the time it was queued (no required-checks gate on the repo), merging at the earlier `d85aee9` HEAD before this fix was pushed. So `main` shipped with the broken `pytest -n 2` and the next CI run on any PR would fail until this lands.

## Test plan

- [x] Local `./test.sh` passes (xdist available; `-n 2` resolved)
- [ ] CI passes serially (xdist not installed; `XDIST_FLAG` empty)