### PR TITLE
Fix #289: NaN-tolerant Prediction construction + JSON writer

### DIFF
--- a/tests/test_nan_robustness.py
+++ b/tests/test_nan_robustness.py
@@ -1,0 +1,208 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""Regression tests for #289.
+
+Two layered guarantees:
+
+1. ``epitope_logic._finite_or_none`` coerces NaN / Inf to ``None`` so
+   ``Prediction.value`` never carries NaN coming out of the topiary
+   frame. The topiary frame legitimately emits NaN in the ``value``
+   column for non-affinity kinds (``pMHC_presentation`` carries its
+   probability in ``score``, not ``value``); the producer must
+   normalize these on the way in or every downstream consumer pays.
+
+2. ``cli.entry_point._to_json_nan_tolerant`` renders NaN / Inf as
+   JSON ``null`` rather than crashing the writer. Defense in depth:
+   even if a future producer leaks a NaN, the whole report doesn't
+   get lost on the last step.
+"""
+import json
+import math
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+
+# ---- _finite_or_none ----------------------------------------------------
+
+
+def test_finite_or_none_passes_through_finite():
+    from vaxrank.epitope_logic import _finite_or_none
+
+    assert _finite_or_none(0.0) == 0.0
+    assert _finite_or_none(123.456) == 123.456
+    assert _finite_or_none(-1e9) == -1e9
+
+
+def test_finite_or_none_coerces_nan_and_inf():
+    from vaxrank.epitope_logic import _finite_or_none
+
+    assert _finite_or_none(float('nan')) is None
+    assert _finite_or_none(float('inf')) is None
+    assert _finite_or_none(float('-inf')) is None
+
+
+def test_finite_or_none_passes_none():
+    from vaxrank.epitope_logic import _finite_or_none
+
+    assert _finite_or_none(None) is None
+
+
+def test_finite_or_none_passes_ints():
+    """Ints are well-defined; should pass through."""
+    from vaxrank.epitope_logic import _finite_or_none
+
+    assert _finite_or_none(0) == 0
+    assert _finite_or_none(42) == 42
+
+
+# ---- predict_epitopes: presentation rows don't leak NaN ----------------
+
+
+def _stub_topiary_predictions_df():
+    """Build a minimal topiary-shaped frame with both affinity (real
+    IC50 in ``value``) and presentation (``value=NaN``) rows for the
+    same peptide × allele. Mirrors what mhctools.MHCflurry emits via
+    TopiaryPredictor on real input."""
+    rows = []
+    # Affinity row — has IC50 in 'value' and 'affinity'
+    rows.append({
+        'peptide': 'KLQGHSAPV', 'peptide_length': 9,
+        'peptide_offset': 0, 'allele': 'HLA-A*02:01',
+        'kind': 'pMHC_affinity',
+        'value': 50.0, 'affinity': 50.0,
+        'score': 0.5, 'percentile_rank': 0.5,
+        'prediction_method_name': 'mhcflurry',
+        'predictor_version': '2.1.1',
+        'source_sequence_name': 'gene',
+    })
+    # Presentation row — value/affinity NaN; score carries the signal
+    rows.append({
+        'peptide': 'KLQGHSAPV', 'peptide_length': 9,
+        'peptide_offset': 0, 'allele': 'HLA-A*02:01',
+        'kind': 'pMHC_presentation',
+        'value': float('nan'), 'affinity': float('nan'),
+        'score': 0.42, 'percentile_rank': 1.7,
+        'prediction_method_name': 'mhcflurry',
+        'predictor_version': '2.1.1',
+        'source_sequence_name': 'gene',
+    })
+    return pd.DataFrame(rows)
+
+
+def test_predict_epitopes_does_not_emit_nan_value_for_presentation():
+    """Regression for #289: a topiary frame with NaN in ``value``
+    for ``pMHC_presentation`` rows must yield ``Prediction.value=None``,
+    not ``Prediction.value=NaN``."""
+    from topiary import TopiaryPredictor
+    from varcode import Variant
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_logic import predict_epitopes
+    from vaxrank.mutant_protein_fragment import MutantProteinFragment
+
+    fake_df = _stub_topiary_predictions_df()
+
+    class _StubTopiary(TopiaryPredictor):
+        def __init__(self):
+            pass
+
+        def predict_from_named_sequences(self, _named_sequences):
+            return fake_df
+
+    fragment = MutantProteinFragment(
+        variant=Variant('X', '1000', 'C', 'A', ensembl=None),
+        gene_name='gene',
+        amino_acids='KLQGHSAPVLDVIVNCDESLLASSD',
+        mutant_amino_acid_start_offset=12,
+        mutant_amino_acid_end_offset=13,
+        n_overlapping_reads=10, n_alt_reads=5, n_ref_reads=5,
+        n_alt_reads_supporting_protein_sequence=5,
+        supporting_reference_transcripts=[])
+
+    cfg = EpitopeConfig(
+        min_epitope_score=0,
+        default_methods={'pMHC_affinity': 'mhcflurry'})
+    with patch('vaxrank.epitope_logic.ReferenceProteome'):
+        epitopes = predict_epitopes(
+            mhc_predictor=_StubTopiary(),
+            protein_fragment=fragment,
+            epitope_config=cfg,
+            genome=None)
+
+    # Every leaf Prediction must have a finite or None ``value`` —
+    # never NaN.
+    nan_records = []
+    for e in epitopes:
+        for p in e.predictions_flat():
+            if isinstance(p.value, float) and math.isnan(p.value):
+                nan_records.append(p)
+    assert nan_records == [], (
+        f'Expected no NaN in Prediction.value; found {len(nan_records)}: '
+        f'{nan_records[:3]}')
+
+    # And the presentation prediction must come through as None (we
+    # dropped the NaN, we didn't replace it with the affinity value).
+    presentation_preds = [
+        p for e in epitopes for p in e.predictions_flat()
+        if p.kind == 'pMHC_presentation']
+    assert presentation_preds, "expected pMHC_presentation leaf in output"
+    assert all(p.value is None for p in presentation_preds), (
+        "pMHC_presentation rows should have value=None, not NaN")
+
+
+# ---- _to_json_nan_tolerant ---------------------------------------------
+
+
+def test_json_writer_renders_nan_as_null():
+    """Defense-in-depth: if a NaN slips past the producer guards, the
+    JSON writer renders it as ``null`` rather than crashing."""
+    from vaxrank.cli.entry_point import _to_json_nan_tolerant
+
+    payload = {'finite': 1.5, 'nan': float('nan'),
+               'inf': float('inf'), 'neg_inf': float('-inf'),
+               'nested': {'also_nan': float('nan')}}
+    out = _to_json_nan_tolerant(payload)
+    parsed = json.loads(out)
+    assert parsed['finite'] == 1.5
+    assert parsed['nan'] is None
+    assert parsed['inf'] is None
+    assert parsed['neg_inf'] is None
+    assert parsed['nested']['also_nan'] is None
+
+
+def test_json_writer_handles_list_of_floats():
+    """Lists of floats with embedded NaN also serialize cleanly."""
+    from vaxrank.cli.entry_point import _to_json_nan_tolerant
+
+    payload = {'values': [1.0, float('nan'), 2.0, float('inf')]}
+    parsed = json.loads(_to_json_nan_tolerant(payload))
+    assert parsed['values'] == [1.0, None, 2.0, None]
+
+
+def test_json_writer_round_trips_real_payload():
+    """A finite payload that doesn't trigger the NaN path should
+    survive the writer with the same content."""
+    from vaxrank.cli.entry_point import _to_json_nan_tolerant
+
+    payload = {'a': 1, 'b': 'string', 'c': [1, 2, 3], 'd': {'e': 4.5}}
+    parsed = json.loads(_to_json_nan_tolerant(payload))
+    assert parsed == payload
+
+
+# ---- stdlib json baseline (for documentation; not a real test) ---------
+
+
+def test_simplejson_default_rejects_nan_as_documented():
+    """Sanity: confirms the bug premise. The stdlib + simplejson
+    *default* path rejects NaN — which is why we wrapped with
+    ``ignore_nan=True``. This test fails the day simplejson changes
+    its default; if it ever does, we can remove the wrapper."""
+    import simplejson
+    with pytest.raises(ValueError, match='Out of range'):
+        simplejson.dumps({'x': float('nan')})

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -71,6 +71,17 @@ from ..vaf import extract_dna_vaf_by_variant
 logger = logging.getLogger(__name__)
 
 
+def _to_json_nan_tolerant(obj):
+    """Serialize ``obj`` to a JSON string, rendering NaN/Inf as
+    ``null`` rather than raising. Defense-in-depth wrapper around
+    ``serializable.to_json``; producers should already be coercing
+    NaN to None, but a writer-side safety net prevents the whole
+    report from being lost on a single rogue float (#289)."""
+    import simplejson
+    from serializable.helpers import to_serializable_repr
+    return simplejson.dumps(to_serializable_repr(obj), ignore_nan=True)
+
+
 def _filter_unannotatable_variants(variants):
     """
     Filter out variants whose contigs cannot be resolved by varcode/pyensembl.
@@ -1420,7 +1431,15 @@ def ranked_vaccine_peptides_with_metadata_from_parsed_args(args):
     # be useful to save the data to be able to iterate just on the formatting
     if args.output_json_file:
         with open(args.output_json_file, 'w') as f:
-            f.write(serializable.to_json(data))
+            # ``ignore_nan=True`` is defense in depth — producers should
+            # be coercing NaN/Inf to None before reaching the writer
+            # (see vaxrank.epitope_logic._finite_or_none), but if any
+            # slips through (e.g. a future predictor adapter, or a
+            # custom score expression), render it as JSON null instead
+            # of crashing the whole report. Note: strict JSON doesn't
+            # have a NaN literal — simplejson's default behavior is to
+            # raise; we explicitly opt into the null representation.
+            f.write(_to_json_nan_tolerant(data))
             logger.info('Wrote JSON report data to %s', args.output_json_file)
 
     return data

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -11,11 +11,11 @@
 # limitations under the License.
 
 
+import math
 import traceback
 import logging
 from typing import Optional
 
-import numpy as np
 from mhctools.pred import Prediction
 from pyensembl import Genome
 from topiary import TopiaryPredictor
@@ -32,6 +32,24 @@ from .candidate_epitope import (
 from .reference_proteome import ReferenceProteome
 
 logger = logging.getLogger(__name__)
+
+
+def _finite_or_none(x):
+    """Coerce ``None`` / NaN / Inf floats to ``None``.
+
+    Topiary frames legitimately carry NaN in the ``value`` column for
+    non-affinity kinds (``pMHC_presentation`` carries its probability
+    in ``score``, not ``value``). Pass-through writes NaN into
+    ``Prediction.value`` which then poisons every downstream consumer
+    — sorting, scoring, and especially JSON serialization (simplejson
+    rejects NaN / Inf for strict compliance). Producers should emit
+    ``None`` to mean "no IC50 for this kind", not ``NaN``.
+    """
+    if x is None:
+        return None
+    if isinstance(x, float) and (math.isnan(x) or math.isinf(x)):
+        return None
+    return x
 
 
 def slice_epitopes(epitopes, start_offset, end_offset):
@@ -209,14 +227,16 @@ def predict_epitopes(
             num_low_scoring += 1
             continue
 
-        # IC50 value: use the "affinity" column if available, otherwise "value"
-        ic50 = row.get("affinity")
-        if ic50 is None or (isinstance(ic50, float) and np.isnan(ic50)):
-            ic50 = row["value"]
+        # IC50 value: use the "affinity" column when present (affinity
+        # rows), otherwise fall back to "value". For non-affinity kinds
+        # (e.g. pMHC_presentation), both columns are legitimately NaN
+        # in the topiary frame — coerce to None so the Prediction
+        # carries an honest "no IC50" instead of a NaN poison pill.
+        ic50 = _finite_or_none(row.get("affinity"))
+        if ic50 is None:
+            ic50 = _finite_or_none(row.get("value"))
 
-        percentile_rank = row.get("percentile_rank")
-        if percentile_rank is not None and isinstance(percentile_rank, float) and np.isnan(percentile_rank):
-            percentile_rank = None
+        percentile_rank = _finite_or_none(row.get("percentile_rank"))
 
         # Resolve WT comparator only when the peptide overlaps the
         # mutation — non-overlapping peptides aren't neoepitopes and
@@ -231,11 +251,9 @@ def predict_epitopes(
                         'No prediction for too-short WT epitope %s: possible stop-loss variant',
                         wt_peptide)
             else:
-                wt_affinity = wt_row.get("affinity")
-                if wt_affinity is not None and not (isinstance(wt_affinity, float) and np.isnan(wt_affinity)):
-                    wt_ic50 = wt_affinity
-                else:
-                    wt_ic50 = wt_row["value"]
+                wt_ic50 = _finite_or_none(wt_row.get("affinity"))
+                if wt_ic50 is None:
+                    wt_ic50 = _finite_or_none(wt_row.get("value"))
                 tool = row.get("prediction_method_name", "")
                 wt_pred = Prediction(
                     kind=row.get("kind") or "pMHC_affinity",


### PR DESCRIPTION
## Summary

Two layered fixes for #289 — JSON output crashed on real HCC1395 data with \`ValueError: Out of range float values are not JSON compliant\`.

### Root cause

The topiary frame returned by \`mhctools.MHCflurry\` + \`TopiaryPredictor\` carries NaN in the \`value\` column for \`pMHC_presentation\` rows by design — presentation is a probability (the \`score\` column), not an IC50. \`epitope_logic.predict_epitopes\` fell back from \`affinity\` (NaN) to \`value\` (also NaN) and wrote NaN straight into \`Prediction.value\`, which then poisoned every downstream consumer — including \`simplejson\` (strict mode rejects NaN/Inf).

### Producer fix

New \`_finite_or_none\` helper coerces NaN / Inf / None → None at the point where \`Prediction.value\` and \`percentile_rank\` get populated. \`Prediction.value\` now honestly carries either an IC50 (finite) or \`None\` (no IC50 for this kind) — never NaN. Same fix applied to the WT comparator construction.

### Writer hardening

New \`_to_json_nan_tolerant\` wraps \`serializable.to_json\` with \`simplejson(..., ignore_nan=True)\` so any NaN that slips past producer guards renders as JSON \`null\` instead of crashing the whole report. Defense in depth for future predictor adapters or custom score expressions.

### Tests

\`tests/test_nan_robustness.py\` (9 tests, all passing) pins both layers:
- \`_finite_or_none\` semantics (NaN/Inf/None → None; finite passes through)
- \`predict_epitopes\` on a topiary frame with NaN-valued presentation rows produces \`Prediction.value=None\` for presentation, never NaN — direct regression for #289
- \`_to_json_nan_tolerant\` round-trips NaN/Inf as \`null\` in dicts, nested dicts, and lists
- Sanity baseline that \`simplejson\` *default* rejects NaN (documents why the wrapper exists)

## Verified

- ✅ 829 tests pass (820 previous + 9 new)
- ✅ Real-data smoke: HCC1395 (25 PASS somatic variants, 6 HLA-I alleles, mhcflurry default predictor) — JSON + ASCII output both written cleanly where the run previously crashed
- ✅ Lint clean

## Closes

#289