### PR TITLE
Score expressions are the single source of truth (3.1.0)

### DIFF
--- a/tests/_legacy_score_reference.py
+++ b/tests/_legacy_score_reference.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""Pure-Python reference implementation of the legacy per-prediction
+epitope score, used only by tests as an independent oracle to verify
+the DSL-evaluated score in :mod:`vaxrank.epitope_dsl`. Not imported
+by any production code — production goes through the DSL exclusively.
+"""
+
+import numpy as np
+
+DEFAULT_LOGISTIC_EPITOPE_SCORE_MIDPOINT = 350.0
+DEFAULT_LOGISTIC_EPITOPE_SCORE_WIDTH = 150.0
+DEFAULT_BINDING_AFFINITY_CUTOFF = 5000.0
+DEFAULT_PERCENTILE_RANK_CUTOFF = 10.0
+
+
+def legacy_score_one(ic50, percentile_rank, *,
+                     midpoint=DEFAULT_LOGISTIC_EPITOPE_SCORE_MIDPOINT,
+                     width=DEFAULT_LOGISTIC_EPITOPE_SCORE_WIDTH,
+                     ic50_cutoff=DEFAULT_BINDING_AFFINITY_CUTOFF,
+                     scoring_mode="affinity",
+                     percentile_rank_cutoff=DEFAULT_PERCENTILE_RANK_CUTOFF):
+    """Reference scorer. Mirrors what the DSL's default ``score_expr``
+    produces row-by-row; parity is asserted in
+    ``tests/test_epitope_dsl.py::test_default_score_matches_legacy_*``.
+    """
+    if scoring_mode == "percentile_rank":
+        if percentile_rank is None:
+            return 0.0
+        rank = float(percentile_rank)
+        if rank >= percentile_rank_cutoff:
+            return 0.0
+        return max(0.0, 1.0 - rank / percentile_rank_cutoff)
+
+    if ic50 >= ic50_cutoff:
+        return 0.0
+    rescaled = (float(ic50) - midpoint) / width
+    logistic = 1.0 / (1.0 + np.exp(rescaled))
+    normalizer = 1.0 / (1.0 + np.exp(-midpoint / width))
+    return logistic / normalizer

--- a/tests/test_combined_score_dsl.py
+++ b/tests/test_combined_score_dsl.py
@@ -8,9 +8,10 @@
 
 Pins:
 - The grammar (allowed nodes / functions; rejected constructs).
-- Parity with the three legacy ``combined_score_mode`` enum values
-  expressed as DSL strings.
-- The DSL's precedence over ``combined_score_mode`` when both are set.
+- Parity between the documented default expression and the three
+  legacy pre-3.1 mode formulas, all expressed as DSL strings.
+- That a user-supplied expression is the only mechanism — the
+  default formula travels the same code path.
 """
 
 import math
@@ -22,7 +23,6 @@ def _make_vp(
         n_overlapping_reads=20,
         target_epitope_score=2.5,
         n_alt_reads_supporting_protein_sequence=8,
-        combined_score_mode=None,
         combined_score_expr=None,
 ):
     """Minimal ``VaccinePeptide`` for scoring tests. Most knobs are
@@ -48,7 +48,6 @@ def _make_vp(
     vp = VaccinePeptide(
         mutant_protein_fragment=frag,
         epitopes=[],
-        combined_score_mode=combined_score_mode,
         combined_score_expr=combined_score_expr,
     )
     # Fake target_epitope_score directly — the real one comes from
@@ -57,49 +56,49 @@ def _make_vp(
     return vp
 
 
-def test_dsl_parity_with_legacy_modes():
-    """The three legacy ``combined_score_mode`` values are exactly
-    representable as DSL expressions. Pinning the equivalences keeps
-    a future enum-mode rewrite from drifting away from the DSL."""
+def test_dsl_legacy_formulas_round_trip_as_expressions():
+    """Each pre-3.1 ``combined_score_mode`` value has an exact DSL
+    expression equivalent. Pinning these numeric values guards
+    against regressions in either the bindings (``expression_score``,
+    ``n_alt_reads``) or the arithmetic semantics."""
     n_alt = 16
     epitope = 3.0
-    vp_legacy = _make_vp(
+    # sqrt_reads_times_epitope ≡ default (DEFAULT_COMBINED_SCORE_EXPR)
+    vp_default = _make_vp(
         n_alt_reads=n_alt, target_epitope_score=epitope,
-        combined_score_mode='sqrt_reads_times_epitope')
-    vp_expr = _make_vp(
+        combined_score_expr=None)
+    vp_explicit = _make_vp(
         n_alt_reads=n_alt, target_epitope_score=epitope,
-        combined_score_expr='expression_score * target_epitope_score')
-    assert vp_expr.combined_score == pytest.approx(vp_legacy.combined_score)
+        combined_score_expr='sqrt(n_alt_reads) * target_epitope_score')
+    assert vp_default.combined_score == pytest.approx(vp_explicit.combined_score)
     # Numeric value: sqrt(16) * 3 = 12
-    assert vp_expr.combined_score == pytest.approx(12.0)
+    assert vp_default.combined_score == pytest.approx(12.0)
 
-    vp_legacy_b = _make_vp(
-        n_alt_reads=n_alt, target_epitope_score=epitope,
-        combined_score_mode='reads_times_epitope')
-    vp_expr_b = _make_vp(
+    vp_reads = _make_vp(
         n_alt_reads=n_alt, target_epitope_score=epitope,
         combined_score_expr='n_alt_reads * target_epitope_score')
-    assert vp_expr_b.combined_score == pytest.approx(vp_legacy_b.combined_score)
-    assert vp_expr_b.combined_score == pytest.approx(48.0)
+    assert vp_reads.combined_score == pytest.approx(48.0)
 
-    vp_legacy_c = _make_vp(
-        n_alt_reads=n_alt, target_epitope_score=epitope,
-        combined_score_mode='epitope_only')
-    vp_expr_c = _make_vp(
+    vp_only = _make_vp(
         n_alt_reads=n_alt, target_epitope_score=epitope,
         combined_score_expr='target_epitope_score')
-    assert vp_expr_c.combined_score == pytest.approx(vp_legacy_c.combined_score)
-    assert vp_expr_c.combined_score == pytest.approx(3.0)
+    assert vp_only.combined_score == pytest.approx(3.0)
 
 
-def test_dsl_supersedes_combined_score_mode():
-    """When both are set, the DSL wins. Same precedence as
-    ``epitopes.score_expr`` over the scalar knobs."""
-    vp = _make_vp(
-        n_alt_reads=4, target_epitope_score=2.0,
-        combined_score_mode='reads_times_epitope',  # would give 8.0
-        combined_score_expr='target_epitope_score')  # gives 2.0
-    assert vp.combined_score == pytest.approx(2.0)
+def test_default_expression_is_canonical_legacy_formula():
+    """The default ``combined_score_expr`` resolves to the canonical
+    pre-3.1 ``sqrt_reads_times_epitope`` formula. Single source of
+    truth: ``DEFAULT_COMBINED_SCORE_EXPR`` is what every default
+    VaccinePeptide evaluates."""
+    from vaxrank.vaccine_config import DEFAULT_COMBINED_SCORE_EXPR
+    assert DEFAULT_COMBINED_SCORE_EXPR == (
+        "sqrt(n_alt_reads) * target_epitope_score")
+    vp = _make_vp(n_alt_reads=9, target_epitope_score=2.0,
+                  combined_score_expr=None)
+    # __post_init__ resolved the default
+    assert vp.combined_score_expr == DEFAULT_COMBINED_SCORE_EXPR
+    # And the score is sqrt(9) * 2 = 6
+    assert vp.combined_score == pytest.approx(6.0)
 
 
 def test_dsl_supports_math_functions():
@@ -179,11 +178,15 @@ def test_dsl_parsed_at_construction_time_not_scoring_time():
         _make_vp(combined_score_expr='import os')
 
 
-def test_dsl_default_methods_path_is_off_by_default():
-    """No ``combined_score_expr`` set → enum mode applies, behavior
-    unchanged from before this PR."""
-    vp = _make_vp(combined_score_mode='sqrt_reads_times_epitope')
-    assert vp._combined_score_expr_ast is None
+def test_default_expr_is_pre_parsed_at_construction():
+    """When the user doesn't pass ``combined_score_expr``,
+    ``__post_init__`` resolves to the default and pre-parses it. The
+    AST is the SAME single artifact ``combined_score`` evaluates —
+    no separate hardcoded Python branch for the default case."""
+    vp = _make_vp(combined_score_expr=None)
+    from vaxrank.vaccine_config import DEFAULT_COMBINED_SCORE_EXPR
+    assert vp.combined_score_expr == DEFAULT_COMBINED_SCORE_EXPR
+    assert vp._combined_score_expr_ast is not None
     assert vp.combined_score == pytest.approx(math.sqrt(10) * 2.5)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -761,14 +761,27 @@ def test_manufacturability_config_rejects_unknown_rule():
         ManufacturabilityConfig(rules=("bogus_rule",))
 
 
-def test_vaccine_config_combined_score_mode():
-    config = VaccineConfig(combined_score_mode="reads_times_epitope")
-    eq_(config.combined_score_mode, "reads_times_epitope")
+def test_vaccine_config_combined_score_expr_default_is_legacy_formula():
+    """The default must be the canonical legacy formula expressed as a
+    DSL string — single source of truth for the default combined score.
+    """
+    from vaxrank.vaccine_config import DEFAULT_COMBINED_SCORE_EXPR
+    config = VaccineConfig()
+    eq_(config.combined_score_expr, DEFAULT_COMBINED_SCORE_EXPR)
+    eq_(config.combined_score_expr, "sqrt(n_alt_reads) * target_epitope_score")
 
 
-def test_vaccine_config_rejects_bad_combined_score_mode():
-    with pytest.raises(ValueError, match="combined_score_mode"):
-        VaccineConfig(combined_score_mode="invalid_mode")
+def test_vaccine_config_combined_score_expr_accepts_legacy_equivalents():
+    """Each pre-3.1 enum mode is reachable as a one-line expression."""
+    eq_(VaccineConfig(combined_score_expr="target_epitope_score")
+        .combined_score_expr, "target_epitope_score")
+    eq_(VaccineConfig(combined_score_expr="n_alt_reads * target_epitope_score")
+        .combined_score_expr, "n_alt_reads * target_epitope_score")
+
+
+def test_vaccine_config_rejects_unparseable_combined_score_expr():
+    with pytest.raises(ValueError, match="combined_score_expr"):
+        VaccineConfig(combined_score_expr="garbage !! syntax error")
 
 
 def test_vaccine_config_rejects_min_greater_than_max():

--- a/tests/test_core_logic_config.py
+++ b/tests/test_core_logic_config.py
@@ -30,7 +30,7 @@ from mhctools.pred import Prediction
 
 from vaxrank.mutant_protein_fragment import MutantProteinFragment
 from vaxrank.candidate_epitope import COMPARATOR_WT, CandidateEpitope, Peptide
-from vaxrank.vaccine_peptide import VaccinePeptide, _legacy_score_one
+from vaxrank.vaccine_peptide import VaccinePeptide
 
 from .common import eq_, ok_, gt_
 
@@ -269,10 +269,8 @@ def test_vaccine_peptides_from_epitopes_score_fraction_of_best_from_config():
             mutant_protein_fragment,
             epitopes,
             num_target_epitopes_to_keep=None,
-            epitope_score_params=None,
             manufacturability_thresholds=None,
             manufacturability_rules=None,
-            combined_score_mode=None,
             combined_score_expr=None,
             ranking_rules=None,
         ):
@@ -325,12 +323,21 @@ def test_vaccine_peptides_from_epitopes_score_fraction_of_best_from_config():
     eq_(strict_result[0].combined_score, 10.0)
 
 
-def test_config_integration_epitope_config_affects_vaccine_peptide_scoring():
-    """Test that EpitopeConfig parameters affect VaccinePeptide scores"""
+def test_target_epitope_score_flows_from_per_allele_scores():
+    """``VaccinePeptide.target_epitope_score`` reads
+    ``epitope.per_allele_scores`` directly. The DSL populates that at
+    ``predict_epitopes`` time; ``vaccine_peptides_from_epitopes`` is a
+    pure aggregator and does NOT re-score (which would be the
+    parallel-default trap). Pin both ends: a known per_allele_scores
+    on a target epitope sums into ``target_epitope_score``."""
+    import dataclasses
+
     class DummyFragment:
         def __init__(self, amino_acids):
             self.amino_acids = amino_acids
             self.n_alt_reads = 4
+            self.n_ref_reads = 0
+            self.n_overlapping_reads = 4
             self.n_alt_reads_supporting_protein_sequence = 4
             self.n_mutant_amino_acids = 1
             self.mutation_distance_from_edge = 0
@@ -352,20 +359,8 @@ def test_config_integration_epitope_config_affects_vaccine_peptide_scoring():
 
     epitope = _make_epitope("ACDEFGHIK", ic50=100.0, wt_ic50=200.0,
                             source_sequence="ACDEFGHIK")
-
-    default_score = _legacy_score_one(100.0, 0.5)
-    epitope_config = EpitopeConfig(
-        logistic_epitope_score_midpoint=50.0,
-        logistic_epitope_score_width=10.0,
-        binding_affinity_cutoff=5000.0,
-    )
-    custom_score = _legacy_score_one(
-        100.0, 0.5,
-        midpoint=epitope_config.logistic_epitope_score_midpoint,
-        width=epitope_config.logistic_epitope_score_width,
-        ic50_cutoff=epitope_config.binding_affinity_cutoff,
-    )
-    ok_(custom_score != default_score)
+    epitope = dataclasses.replace(
+        epitope, per_allele_scores={"HLA-A*02:01": 0.7})
 
     peptides = vaccine_peptides_from_epitopes(
         variant=MagicMock(),
@@ -374,10 +369,9 @@ def test_config_integration_epitope_config_affects_vaccine_peptide_scoring():
         vaccine_peptide_length=len(fragment),
         max_vaccine_peptides_per_variant=1,
         num_target_epitopes_to_keep=10,
-        epitope_config=epitope_config,
     )
     eq_(len(peptides), 1)
-    eq_(peptides[0].target_epitope_score, custom_score)
+    eq_(peptides[0].target_epitope_score, 0.7)
 
 
 def test_config_defaults_match_historical_behavior():
@@ -499,6 +493,8 @@ def test_manufacturability_thresholds_flow_from_manufacturability_config():
         def __init__(self, amino_acids):
             self.amino_acids = amino_acids
             self.n_alt_reads = 4
+            self.n_ref_reads = 0
+            self.n_overlapping_reads = 4
             self.n_alt_reads_supporting_protein_sequence = 4
             self.n_mutant_amino_acids = 1
             self.mutation_distance_from_edge = 0

--- a/tests/test_epitope_dsl.py
+++ b/tests/test_epitope_dsl.py
@@ -27,8 +27,8 @@ from topiary.ranking import EvalContext, apply_filter
 
 from vaxrank.epitope_config import EpitopeConfig
 from vaxrank.epitope_dsl import build_filter_node, build_score_node
-from vaxrank.vaccine_peptide import _legacy_score_one
 
+from ._legacy_score_reference import legacy_score_one
 from .common import eq_
 
 
@@ -53,7 +53,7 @@ def _predictions_df(rows):
 
 
 def _legacy_score(ic50, percentile_rank, cfg):
-    return _legacy_score_one(
+    return legacy_score_one(
         ic50, percentile_rank,
         midpoint=cfg.logistic_epitope_score_midpoint,
         width=cfg.logistic_epitope_score_width,

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -1102,7 +1102,7 @@ def _assert_default_scores_match_legacy(cfg, path, tmp_path):
     legacy per-prediction logistic score on the canonical (mhcflurry)
     leaf records selected by default_methods."""
     from vaxrank.epitope_io import write_neoepitope_report
-    from vaxrank.vaccine_peptide import _legacy_score_one
+    from tests._legacy_score_reference import legacy_score_one as _legacy_score_one
 
     report_df, epitopes = load_lens(path)
     # Auto-picked default for pMHC_affinity is mhcflurry — that's what
@@ -1186,24 +1186,24 @@ def test_write_neoepitope_report_xlsx(tmp_path):
 # its scoring-mode contract directly against IC50 / percentile_rank.
 
 def test_scoring_mode_affinity():
-    from vaxrank.vaccine_peptide import _legacy_score_one
+    from tests._legacy_score_reference import legacy_score_one as _legacy_score_one
     assert _legacy_score_one(100.0, 0.5, scoring_mode="affinity") > 0.5
 
 
 def test_scoring_mode_percentile_rank():
-    from vaxrank.vaccine_peptide import _legacy_score_one
+    from tests._legacy_score_reference import legacy_score_one as _legacy_score_one
     score = _legacy_score_one(100.0, 0.5, scoring_mode="percentile_rank")
     assert score == pytest.approx(0.95)
 
 
 def test_scoring_mode_percentile_rank_weak():
-    from vaxrank.vaccine_peptide import _legacy_score_one
+    from tests._legacy_score_reference import legacy_score_one as _legacy_score_one
     score = _legacy_score_one(100.0, 10.0, scoring_mode="percentile_rank")
     assert score == 0.0
 
 
 def test_scoring_mode_percentile_rank_none():
-    from vaxrank.vaccine_peptide import _legacy_score_one
+    from tests._legacy_score_reference import legacy_score_one as _legacy_score_one
     score = _legacy_score_one(100.0, None, scoring_mode="percentile_rank")
     assert score == 0.0
 

--- a/tests/test_epitope_prediction.py
+++ b/tests/test_epitope_prediction.py
@@ -15,7 +15,8 @@ from varcode import Variant
 from vaxrank.epitope_config import EpitopeConfig
 from vaxrank.epitope_logic import predict_epitopes
 from vaxrank.mutant_protein_fragment import MutantProteinFragment
-from vaxrank.vaccine_peptide import VaccinePeptide, _legacy_score_one
+from vaxrank.vaccine_peptide import VaccinePeptide
+from tests._legacy_score_reference import legacy_score_one as _legacy_score_one
 
 from .common import eq_, ok_
 

--- a/tests/test_mutant_protein_sequence.py
+++ b/tests/test_mutant_protein_sequence.py
@@ -111,7 +111,7 @@ def test_keep_top_k_epitopes():
 
     ranked_list = results.ranked_vaccine_peptides
 
-    from vaxrank.vaccine_peptide import _legacy_score_one
+    from tests._legacy_score_reference import legacy_score_one as _legacy_score_one
     for variant, vaccine_peptides in ranked_list:
         vaccine_peptide = vaccine_peptides[0]
         eq_(keep_k_epitopes, len(vaccine_peptide.target_epitopes))

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -161,14 +161,15 @@ def test_vaccine_peptide_post_init_derives_epitope_lists():
     assert vp.self_epitopes == [wildtype]
 
 
-def test_vaccine_peptide_post_init_validates_combined_score_mode():
-    """__post_init__ now raises on unknown modes — the contract added in
-    2.5.0 carries through the dataclass migration."""
-    with pytest.raises(ValueError, match="combined_score_mode"):
+def test_vaccine_peptide_post_init_validates_combined_score_expr():
+    """__post_init__ pre-parses the expression so syntax errors surface at
+    construction time rather than during ranking. 3.1 single-mechanism
+    contract — the expression IS the validated input, no enum fallback."""
+    with pytest.raises(ValueError, match="combined_score_expr"):
         VaccinePeptide(
             mutant_protein_fragment=_FakeFragment(),
             epitopes=[],
-            combined_score_mode="garbage",
+            combined_score_expr="not !! valid",
         )
 
 
@@ -217,14 +218,14 @@ def test_vaccine_peptide_json_roundtrip_with_real_fragment():
         mutant_protein_fragment=_sample_fragment(),
         epitopes=[mutant, wildtype],
         manufacturability_rules=("cysteine_count", "cterm_hydropathy"),
-        combined_score_mode="epitope_only",
+        combined_score_expr="target_epitope_score",
     )
     restored = VaccinePeptide.from_json(vp.to_json())
 
     # Wire-level invariants
     assert restored.mutant_protein_fragment == vp.mutant_protein_fragment
     assert restored.manufacturability_rules == vp.manufacturability_rules
-    assert restored.combined_score_mode == vp.combined_score_mode
+    assert restored.combined_score_expr == vp.combined_score_expr
 
     # Derived state must match — __post_init__ re-ran on load
     assert restored.target_epitopes == vp.target_epitopes

--- a/tests/test_vaccine_peptide_config.py
+++ b/tests/test_vaccine_peptide_config.py
@@ -30,13 +30,23 @@ from vaxrank.vaccine_peptide import VaccinePeptide
 
 
 def _make_fragment(seq="A" * 25, n_alt_reads=9):
-    """Minimal duck-typed MutantProteinFragment for VaccinePeptide tests."""
+    """Minimal duck-typed MutantProteinFragment for VaccinePeptide tests.
+
+    Must expose every binding the combined_score DSL evaluator looks up
+    (``_bindings_from_vaccine_peptide``); the DSL is the single path
+    that produces ``combined_score`` after the 3.1 refactor, including
+    for the default expression.
+    """
     return SimpleNamespace(
         amino_acids=seq,
         n_alt_reads=n_alt_reads,
+        n_ref_reads=0,
+        n_overlapping_reads=n_alt_reads,
         n_alt_reads_supporting_protein_sequence=n_alt_reads,
         n_mutant_amino_acids=1,
         mutation_distance_from_edge=5,
+        mutant_amino_acid_start_offset=0,
+        mutant_amino_acid_end_offset=1,
     )
 
 
@@ -100,35 +110,37 @@ def test_combined_score_default_mode_is_legacy():
     assert vp.combined_score == pytest.approx(np.sqrt(9) * vp.target_epitope_score)
 
 
-def test_combined_score_reads_times_epitope_mode():
+def test_combined_score_reads_times_epitope_expr():
+    """Legacy 'reads_times_epitope' formula via the DSL."""
     fragment = _make_fragment(n_alt_reads=9)
     vp = VaccinePeptide(
         mutant_protein_fragment=fragment,
         epitopes=[_make_mutant_epitope()],
-        combined_score_mode="reads_times_epitope",
+        combined_score_expr="n_alt_reads * target_epitope_score",
     )
-    # expression_score is an honest metric; mode only affects combined_score
+    # expression_score is an honest metric; the expression sets combined_score
     assert vp.expression_score == pytest.approx(np.sqrt(9))
     assert vp.combined_score == pytest.approx(9.0 * vp.target_epitope_score)
 
 
-def test_combined_score_epitope_only_mode():
+def test_combined_score_epitope_only_expr():
+    """Legacy 'epitope_only' formula via the DSL."""
     fragment = _make_fragment(n_alt_reads=9)
     vp = VaccinePeptide(
         mutant_protein_fragment=fragment,
         epitopes=[_make_mutant_epitope()],
-        combined_score_mode="epitope_only",
+        combined_score_expr="target_epitope_score",
     )
     assert vp.expression_score == pytest.approx(np.sqrt(9))
     assert vp.combined_score == pytest.approx(vp.target_epitope_score)
 
 
-def test_vaccine_peptide_rejects_unknown_combined_score_mode():
-    with pytest.raises(ValueError, match="combined_score_mode"):
+def test_vaccine_peptide_rejects_unparseable_combined_score_expr():
+    with pytest.raises(ValueError, match="combined_score_expr"):
         VaccinePeptide(
             mutant_protein_fragment=_make_fragment(),
             epitopes=[_make_mutant_epitope()],
-            combined_score_mode="garbage",
+            combined_score_expr="this is not valid syntax !!!",
         )
 
 
@@ -149,7 +161,7 @@ peptide:
       - cterm_hydropathy
       - aspartate_proline
 vaccine_peptides:
-  combined_score_mode: epitope_only
+  combined_score_expr: "target_epitope_score"
 """
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".yaml", delete=False
@@ -173,40 +185,40 @@ vaccine_peptides:
             "cysteine_count", "cterm_hydropathy", "aspartate_proline",
         )
         assert isinstance(mfg.rules, tuple)
-        assert vc.combined_score_mode == "epitope_only"
+        assert vc.combined_score_expr == "target_epitope_score"
 
         vp = VaccinePeptide(
             mutant_protein_fragment=_make_fragment(),
             epitopes=[_make_mutant_epitope()],
             manufacturability_rules=mfg.rules,
-            combined_score_mode=vc.combined_score_mode,
+            combined_score_expr=vc.combined_score_expr,
         )
         tup = vp.peptide_synthesis_difficulty_score_tuple(
             rules=vp.manufacturability_rules,
         )
         assert len(tup) == 3
-        # combined_score under epitope_only is just the epitope score
+        # combined_score under "target_epitope_score" is just the epitope score
         assert vp.combined_score == pytest.approx(vp.target_epitope_score)
     finally:
         os.unlink(config_path)
 
 
 def test_vaccine_peptide_roundtrip_preserves_custom_config():
-    """to_dict / from_dict preserves non-default rules + score mode."""
+    """to_dict / from_dict preserves non-default rules + score expression."""
     fragment = _make_fragment()
     vp = VaccinePeptide(
         mutant_protein_fragment=fragment,
         epitopes=[_make_mutant_epitope()],
         manufacturability_rules=["cysteine_count"],
-        combined_score_mode="epitope_only",
+        combined_score_expr="target_epitope_score",
     )
     d = vp.to_dict()
     assert d["manufacturability_rules"] == ["cysteine_count"]
-    assert d["combined_score_mode"] == "epitope_only"
+    assert d["combined_score_expr"] == "target_epitope_score"
 
 
 def test_vaccine_peptide_roundtrip_omits_defaults():
-    """to_dict doesn't include None/default rule + mode fields."""
+    """to_dict doesn't include None/default rule + expression fields."""
     fragment = _make_fragment()
     vp = VaccinePeptide(
         mutant_protein_fragment=fragment,
@@ -214,7 +226,7 @@ def test_vaccine_peptide_roundtrip_omits_defaults():
     )
     d = vp.to_dict()
     assert "manufacturability_rules" not in d
-    assert "combined_score_mode" not in d
+    assert "combined_score_expr" not in d
     assert "ranking_rules" not in d
 
 
@@ -415,7 +427,7 @@ def test_bundled_default_yaml_round_trips_to_default_configs(tmp_path):
         "preferred_peptide_length", "min_peptide_length",
         "max_peptide_length", "padding_around_mutation",
         "max_vaccine_peptides_per_variant", "num_target_epitopes_to_keep",
-        "score_fraction_of_best", "combined_score_mode",
+        "score_fraction_of_best", "combined_score_expr",
         "require_target_epitopes_in_variant",
     ):
         assert getattr(vc, field) == getattr(vc_defaults, field), (

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -516,6 +516,30 @@ class CandidateEpitope(Peptide):
     # reading this flag instead of the raw one.
     occurs_in_non_CTA_reference: bool = False
 
+    # Per-allele score for this epitope as computed by the configured
+    # :class:`~vaxrank.epitope_config.EpitopeConfig` ``score_expr``
+    # (see :mod:`vaxrank.epitope_dsl`). Keys are allele names exactly
+    # as they appear on the predictions; values are the DSL output
+    # summed over predictor leaves with the same (peptide, allele).
+    # Populated by :func:`~vaxrank.epitope_logic.predict_epitopes`
+    # (and equivalent loaders); empty when an epitope is loaded
+    # without scores yet attached. Downstream consumers MUST read
+    # from here and never recompute — the DSL is the single source
+    # of truth.
+    per_allele_scores: dict = field(default_factory=dict)
+
+    @property
+    def epitope_score(self) -> float:
+        """Per-epitope total score = sum of per-allele scores.
+
+        This is the binding fed to the combined-score DSL as
+        ``target_epitope_score`` (aggregated across an epitope set)
+        and the value used by the vaccine-peptide ranker. Defined
+        here exactly once; no parallel formula exists in the
+        codebase.
+        """
+        return float(sum(self.per_allele_scores.values()))
+
     def __hash__(self) -> int:
         # Inherited from Peptide in spirit, but ``@dataclass(frozen=True)``
         # regenerates ``__hash__`` on every subclass — and ours would
@@ -567,7 +591,8 @@ class CandidateEpitope(Peptide):
             source_class=self.source_class,
             overlaps_mutation=self.overlaps_mutation,
             occurs_in_reference=self.occurs_in_reference,
-            occurs_in_non_CTA_reference=self.occurs_in_non_CTA_reference)
+            occurs_in_non_CTA_reference=self.occurs_in_non_CTA_reference,
+            per_allele_scores=dict(self.per_allele_scores))
 
     @classmethod
     def from_peptide(cls, peptide: "Peptide",
@@ -651,6 +676,11 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
                 'overlaps_mutation': False,
                 'occurs_in_reference': False,
                 'occurs_in_non_CTA_reference': False,
+                # Accumulator for per-allele DSL scores. Same allele
+                # may appear in multiple rows (different predictors);
+                # all rows for one allele share the same score by
+                # construction of the DSL eval, so last-write-wins.
+                'per_allele_scores': {},
             }
             groups[key] = slot
         slot['mutant_preds'].append(row['mutant'])
@@ -658,6 +688,9 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
         slot['occurs_in_reference'] |= bool(row.get('occurs_in_reference', False))
         slot['occurs_in_non_CTA_reference'] |= bool(
             row.get('occurs_in_non_CTA_reference', False))
+        if 'allele_score' in row:
+            slot['per_allele_scores'][row['mutant'].allele] = float(
+                row['allele_score'])
         wt = row.get('wt')
         if wt is not None and wt.peptide and wt.peptide == peptide:
             # Self-WT: comparing the candidate against itself is meaningless.
@@ -687,5 +720,6 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
             overlaps_mutation=slot['overlaps_mutation'],
             occurs_in_reference=slot['occurs_in_reference'],
             occurs_in_non_CTA_reference=slot['occurs_in_non_CTA_reference'],
+            per_allele_scores=dict(slot['per_allele_scores']),
         ))
     return out

--- a/vaxrank/config/default.yaml
+++ b/vaxrank/config/default.yaml
@@ -20,8 +20,8 @@
 #
 #   vaccine_peptides   (modality-agnostic) Per-variant antigen-window
 #                      selection + the *ranking* of those windows:
-#                      length, padding, ``combined_score_mode`` /
-#                      ``combined_score_expr``, ``ranking_rules``,
+#                      length, padding, ``combined_score_expr``,
+#                      ``ranking_rules``,
 #                      ``score_fraction_of_best``, and the
 #                      antigen-design knobs that apply to every
 #                      modality (``antigen_content``,
@@ -154,20 +154,18 @@ vaccine_peptides:
   per_mutation: 1
 
   # ---- Score / ranking ----
-  # 'sqrt_reads_times_epitope' (default) | 'reads_times_epitope' | 'epitope_only'.
-  combined_score_mode: sqrt_reads_times_epitope
-
-  # Optional DSL expression evaluated per VaccinePeptide; supersedes
-  # combined_score_mode when set. Bindings: target_epitope_score,
-  # self_epitope_score, expression_score, n_alt_reads,
-  # n_ref_reads, n_overlapping_reads,
+  # DSL expression evaluated per VaccinePeptide to produce
+  # combined_score (used to rank variants).
+  # Bindings: target_epitope_score, self_epitope_score,
+  # expression_score, n_alt_reads, n_ref_reads, n_overlapping_reads,
   # n_alt_reads_supporting_protein_sequence, n_mutant_amino_acids.
   # Functions: sqrt, log, log1p, exp, min, max, abs, pow.
-  # The three legacy modes are equivalent to:
-  #   epitope_only             ≡ "target_epitope_score"
-  #   reads_times_epitope      ≡ "n_alt_reads * target_epitope_score"
-  #   sqrt_reads_times_epitope ≡ "expression_score * target_epitope_score"
-  # combined_score_expr: "log1p(n_alt_reads) * target_epitope_score"
+  # The default below IS the canonical formula — there is no
+  # separate mode enum. Sample alternatives:
+  #   "target_epitope_score"                        (epitope-only)
+  #   "n_alt_reads * target_epitope_score"          (linear in reads)
+  #   "log1p(n_alt_reads) * target_epitope_score"   (log-compressed)
+  combined_score_expr: "sqrt(n_alt_reads) * target_epitope_score"
   # Keep candidates whose score is at least this fraction of the best
   # before lexicographic tie-breaking.
   score_fraction_of_best: 0.99

--- a/vaxrank/config/loader.py
+++ b/vaxrank/config/loader.py
@@ -326,7 +326,6 @@ _VACCINE_CONFIG_MAPPING: list[tuple[str, str]] = [
     ("vaccine_peptides.padding_around_mutation", "padding_around_mutation"),
     ("vaccine_peptides.per_mutation", "max_vaccine_peptides_per_variant"),
     ("vaccine_peptides.score_fraction_of_best", "score_fraction_of_best"),
-    ("vaccine_peptides.combined_score_mode", "combined_score_mode"),
     ("vaccine_peptides.combined_score_expr", "combined_score_expr"),
     ("vaccine_peptides.ranking_rules", "ranking_rules"),
     ("vaccine_peptides.require_target_epitopes_in_variant",

--- a/vaxrank/config/schema.py
+++ b/vaxrank/config/schema.py
@@ -91,7 +91,6 @@ class VaccinePeptidesConfigSchema(
     per_mutation: Optional[int] = None
     max_epitopes_per_candidate: Optional[int] = None
     score_fraction_of_best: Optional[float] = None
-    combined_score_mode: Optional[str] = None
     combined_score_expr: Optional[str] = None
     ranking_rules: Optional[list[str]] = None
     require_target_epitopes_in_variant: Optional[bool] = None

--- a/vaxrank/core_logic.py
+++ b/vaxrank/core_logic.py
@@ -295,13 +295,6 @@ def vaccine_peptides_from_epitopes(
     if epitope_config is None:
         epitope_config = EpitopeConfig()
 
-    epitope_score_params = {
-        "midpoint": epitope_config.logistic_epitope_score_midpoint,
-        "width": epitope_config.logistic_epitope_score_width,
-        "ic50_cutoff": epitope_config.binding_affinity_cutoff,
-        "scoring_mode": epitope_config.scoring_mode,
-        "percentile_rank_cutoff": epitope_config.percentile_rank_cutoff,
-    }
     if vaccine_config is None:
         vaccine_config = VaccineConfig(
             preferred_peptide_length=vaccine_peptide_length,
@@ -360,10 +353,8 @@ def vaccine_peptides_from_epitopes(
             mutant_protein_fragment=candidate_fragment,
             epitopes=subsequence_epitopes,
             num_target_epitopes_to_keep=vaccine_config.num_target_epitopes_to_keep,
-            epitope_score_params=epitope_score_params,
             manufacturability_thresholds=mfg.thresholds_dict(),
             manufacturability_rules=mfg.rules,
-            combined_score_mode=vaccine_config.combined_score_mode,
             combined_score_expr=vaccine_config.combined_score_expr,
             ranking_rules=vaccine_config.ranking_rules,
         )

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -361,22 +361,42 @@ def validate_dsl_against_predictions(cfg, epitopes, *, topiary_df=None):
                 )
 
 
-def _default_score_node(cfg):
-    from topiary.ranking import Affinity, Column, Const
+# Default per-prediction score expressions. These string templates are
+# the SINGLE source of truth for what the default scoring formula looks
+# like — there is no parallel Python builder. When an EpitopeConfig has
+# ``score_expr=None`` the relevant template is formatted with the
+# config's scalar threshold knobs and then parsed by the topiary DSL,
+# exactly as a user-supplied ``score_expr`` would be. Format placeholders
+# correspond to EpitopeConfig fields; keep them in sync.
+DEFAULT_AFFINITY_SCORE_EXPR_TEMPLATE = (
+    "(affinity.value < {binding_affinity_cutoff}) * "
+    "affinity.value.logistic_normalized("
+    "{logistic_epitope_score_midpoint}, {logistic_epitope_score_width})"
+)
+DEFAULT_PERCENTILE_SCORE_EXPR_TEMPLATE = (
+    "(percentile_rank < {percentile_rank_cutoff}) * "
+    "(1.0 - percentile_rank / {percentile_rank_cutoff}).clip(0.0, none)"
+)
 
+
+def default_score_expr(cfg):
+    """Return the default per-prediction score expression for ``cfg``.
+
+    Formats :data:`DEFAULT_AFFINITY_SCORE_EXPR_TEMPLATE` or
+    :data:`DEFAULT_PERCENTILE_SCORE_EXPR_TEMPLATE` against the
+    config's scalar threshold fields. This is the string a user would
+    write to reproduce the default — it is also exactly the string
+    that gets parsed when ``cfg.score_expr`` is unset, so the default
+    behavior travels through the same DSL pipeline as any override.
+    """
     if cfg.scoring_mode == "percentile_rank":
-        cutoff = cfg.percentile_rank_cutoff
-        rank = Column("percentile_rank")
-        # Match `max(0, 1 - rank / cutoff)` with the `rank >= cutoff → 0` gate.
-        # The mask is strict `<`, so the DSL drops NaN (→ False) and ≥-cutoff
-        # rows to 0 exactly as the legacy scorer does.
-        linear = Const(1.0) - rank / cutoff
-        return (rank < cutoff) * linear.clip(lo=0.0, hi=None)
-
-    midpoint = cfg.logistic_epitope_score_midpoint
-    width = cfg.logistic_epitope_score_width
-    cutoff_mask = Affinity < cfg.binding_affinity_cutoff
-    return cutoff_mask * Affinity.logistic_normalized(midpoint, width)
+        return DEFAULT_PERCENTILE_SCORE_EXPR_TEMPLATE.format(
+            percentile_rank_cutoff=cfg.percentile_rank_cutoff)
+    return DEFAULT_AFFINITY_SCORE_EXPR_TEMPLATE.format(
+        binding_affinity_cutoff=cfg.binding_affinity_cutoff,
+        logistic_epitope_score_midpoint=cfg.logistic_epitope_score_midpoint,
+        logistic_epitope_score_width=cfg.logistic_epitope_score_width,
+    )
 
 
 def build_filter_node(cfg):
@@ -393,7 +413,14 @@ def build_filter_node(cfg):
 
 
 def build_score_node(cfg):
-    """Return the ``DSLNode`` that computes the per-epitope score."""
-    if cfg.score_expr is not None:
-        return _parse(cfg.score_expr)
-    return _default_score_node(cfg)
+    """Return the ``DSLNode`` that computes the per-(peptide, allele) score.
+
+    Single code path: parse the resolved expression string. When
+    ``cfg.score_expr`` is set the user's string is used; otherwise
+    :func:`default_score_expr` returns the canonical default formatted
+    against the config's scalar threshold knobs. The default is not a
+    different mechanism — it is the same DSL machinery applied to a
+    well-known formula.
+    """
+    return _parse(cfg.score_expr if cfg.score_expr is not None
+                  else default_score_expr(cfg))

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -291,6 +291,12 @@ def predict_epitopes(
             # is populated (via pirlygenes), this branch will diverge
             # for CTA-matching peptides.
             'occurs_in_non_CTA_reference': occurs_in_reference,
+            # Per-(peptide, allele) DSL score; threaded onto the
+            # CandidateEpitope as ``per_allele_scores[allele]`` by
+            # ``candidate_epitopes_from_rows``. Single source of
+            # truth — VaccinePeptide reads it directly and never
+            # recomputes from ic50 / percentile_rank.
+            'allele_score': epitope_score,
         })
 
     logger.info(

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -26,7 +26,6 @@ from varcode import load_vcf_fast
 from .cancer_hotspots import get_hotspot_url
 from .manufacturability import ManufacturabilityScores
 from .processing import PEPSICKLE_PREDICTOR_NAME
-from .vaccine_peptide import _legacy_score_one
 
 logger = logging.getLogger(__name__)
 
@@ -377,14 +376,15 @@ class TemplateDataCreator(object):
             # the only honest answer.
             ('Predictor', prediction.predictor_name or '—'),
             ('IC50', '%.2f nM' % prediction.value),
-            # ``Score`` is the logistic transform of IC50 (range
-            # [0, 1]; higher = stronger predicted binder). It is NOT
-            # mhcflurry's presentation_score / EL — vaxrank derives
-            # it locally so the column is comparable across
-            # predictors.
-            ('Score (affinity, logistic IC50)',
-                _sanitize(_legacy_score_one(
-                    prediction.value, prediction.percentile_rank))),
+            # ``Score`` is the per-allele DSL score for this epitope
+            # as computed at predict time by the configured
+            # ``EpitopeConfig.score_expr`` (default: logistic of
+            # IC50, range [0, 1]; higher = stronger). Read directly
+            # from ``epitope.per_allele_scores`` — the single source
+            # of truth — rather than recomputing from the raw IC50.
+            ('Score',
+                _sanitize(epitope.per_allele_scores.get(
+                    prediction.allele, 0.0))),
             ('Allele', prediction.allele.replace('HLA-', '')),
             ('WT sequence', wt_peptide_sequence),
             ('WT IC50', wt_ic50_str),

--- a/vaxrank/vaccine_config.py
+++ b/vaxrank/vaccine_config.py
@@ -29,6 +29,7 @@ from typing import Optional
 
 import msgspec
 
+from .combined_score_dsl import parse_combined_score_expr
 from .config.defaults import (
     DEFAULT_MAX_PEPTIDE_LENGTH,
     DEFAULT_MAX_VACCINE_PEPTIDES_PER_VARIANT,
@@ -41,12 +42,10 @@ from .config.defaults import (
 from .ranking import RANKING_RULE_REGISTRY
 
 
-COMBINED_SCORE_MODES = (
-    "sqrt_reads_times_epitope",
-    "reads_times_epitope",
-    "epitope_only",
-)
-DEFAULT_COMBINED_SCORE_MODE = "sqrt_reads_times_epitope"
+# Single source of truth for the default vaccine-peptide combined score.
+# Everything that computes ``combined_score`` reads this constant (or a
+# user-supplied override) via the DSL — no parallel hardcoded branch.
+DEFAULT_COMBINED_SCORE_EXPR = "sqrt(n_alt_reads) * target_epitope_score"
 
 
 class VaccineConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
@@ -125,11 +124,14 @@ class VaccineConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     max_vaccine_peptides_per_variant: int = DEFAULT_MAX_VACCINE_PEPTIDES_PER_VARIANT
     num_target_epitopes_to_keep: int = DEFAULT_NUM_MUTANT_EPITOPES_TO_KEEP
     score_fraction_of_best: float = DEFAULT_VACCINE_PEPTIDE_SCORE_FRACTION_OF_BEST
-    combined_score_mode: str = DEFAULT_COMBINED_SCORE_MODE
-    # Optional DSL expression that supersedes ``combined_score_mode``
-    # when set. See :mod:`vaxrank.combined_score_dsl` for grammar +
-    # bindings. ``None`` keeps the enum-mode behavior.
-    combined_score_expr: Optional[str] = None
+    # DSL expression evaluated to produce each vaccine peptide's
+    # ``combined_score``. See :mod:`vaxrank.combined_score_dsl` for
+    # grammar + bindings (``target_epitope_score``, ``n_alt_reads``,
+    # ``expression_score``, etc.). The default is
+    # :data:`DEFAULT_COMBINED_SCORE_EXPR` — the legacy
+    # ``sqrt(n_alt_reads) * target_epitope_score`` formula. There is
+    # no separate mode enum: the expression IS the mechanism.
+    combined_score_expr: str = DEFAULT_COMBINED_SCORE_EXPR
     ranking_rules: Optional[tuple[str, ...]] = None
     # When True (default, legacy behavior), variants whose vaccine peptides
     # contain no mutant-overlapping epitopes are dropped from the report
@@ -188,11 +190,11 @@ class VaccineConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
                 f"score_fraction_of_best must be in (0, 1], "
                 f"got {self.score_fraction_of_best}"
             )
-        if self.combined_score_mode not in COMBINED_SCORE_MODES:
-            raise ValueError(
-                f"combined_score_mode must be one of {COMBINED_SCORE_MODES}, "
-                f"got '{self.combined_score_mode}'"
-            )
+        # Validate the expression at config construction so a malformed
+        # YAML / CLI override fails fast, not on first vaccine peptide.
+        # ``parse_combined_score_expr`` performs the same AST-allowlist
+        # check used at evaluation time.
+        parse_combined_score_expr(self.combined_score_expr)
         if self.ranking_rules is not None:
             for rule_name in self.ranking_rules:
                 if rule_name not in RANKING_RULE_REGISTRY:

--- a/vaxrank/vaccine_peptide.py
+++ b/vaxrank/vaccine_peptide.py
@@ -16,50 +16,16 @@ from typing import Any, Optional
 import numpy as np
 from serializable import DataclassSerializable
 
-from .config.defaults import (
-    DEFAULT_BINDING_AFFINITY_CUTOFF,
-    DEFAULT_LOGISTIC_EPITOPE_SCORE_MIDPOINT,
-    DEFAULT_LOGISTIC_EPITOPE_SCORE_WIDTH,
-    DEFAULT_PERCENTILE_RANK_CUTOFF,
+from .combined_score_dsl import (
+    evaluate_combined_score,
+    parse_combined_score_expr,
 )
 from .manufacturability import (
     ManufacturabilityScores,
     compute_manufacturability_tuple,
 )
 from .ranking import compute_ranking_tuple
-from .vaccine_config import COMBINED_SCORE_MODES, DEFAULT_COMBINED_SCORE_MODE
-
-
-def _legacy_score_one(ic50, percentile_rank, *,
-                      midpoint=DEFAULT_LOGISTIC_EPITOPE_SCORE_MIDPOINT,
-                      width=DEFAULT_LOGISTIC_EPITOPE_SCORE_WIDTH,
-                      ic50_cutoff=DEFAULT_BINDING_AFFINITY_CUTOFF,
-                      scoring_mode="affinity",
-                      percentile_rank_cutoff=DEFAULT_PERCENTILE_RANK_CUTOFF):
-    """Per-prediction logistic score used by ``VaccinePeptide`` to sum
-    scores across the leaf ``mhctools.Prediction`` records inside
-    each ``CandidateEpitope``.
-
-    Kept as a free function so the math stays in one place. The
-    topiary DSL's default ``score_expr`` produces byte-identical
-    output (pinned by ``test_default_score_matches_legacy_*``); a
-    follow-up will route ``VaccinePeptide``'s score aggregation
-    through ``score_predictions`` directly and this helper goes away.
-    """
-    if scoring_mode == "percentile_rank":
-        if percentile_rank is None:
-            return 0.0
-        rank = float(percentile_rank)
-        if rank >= percentile_rank_cutoff:
-            return 0.0
-        return max(0.0, 1.0 - rank / percentile_rank_cutoff)
-
-    if ic50 >= ic50_cutoff:
-        return 0.0
-    rescaled = (float(ic50) - midpoint) / width
-    logistic = 1.0 / (1.0 + np.exp(rescaled))
-    normalizer = 1.0 / (1.0 + np.exp(-midpoint / width))
-    return logistic / normalizer
+from .vaccine_config import DEFAULT_COMBINED_SCORE_EXPR
 
 
 @dataclass
@@ -104,12 +70,15 @@ class VaccinePeptide(DataclassSerializable):
         10-rule default order is used (byte-identical with prior
         releases).
 
-    combined_score_mode : str or None
-        How to fold expression into the final ``combined_score``. One
-        of ``sqrt_reads_times_epitope`` (default, legacy),
-        ``reads_times_epitope``, or ``epitope_only``. Does not affect
-        the ``expression_score`` property, which always reports
-        ``sqrt(n_alt_reads)``.
+    combined_score_expr : str or None
+        DSL expression evaluated against this VaccinePeptide to
+        produce ``combined_score``. See
+        :mod:`vaxrank.combined_score_dsl` for grammar and bindings
+        (``target_epitope_score``, ``n_alt_reads``,
+        ``expression_score``, ...). ``None`` resolves to
+        :data:`vaxrank.vaccine_config.DEFAULT_COMBINED_SCORE_EXPR`.
+        There is no separate mode enum — the expression IS the
+        mechanism.
 
     ranking_rules : sequence of str or None
         Ordered list of ranking rule names driving the lexicographic
@@ -123,15 +92,12 @@ class VaccinePeptide(DataclassSerializable):
     mutant_protein_fragment: Any
     epitopes: list = field(default_factory=list)
     num_target_epitopes_to_keep: Optional[int] = None
-    epitope_score_params: Optional[dict] = None
     sort_epitopes_by: str = "ic50"
     manufacturability_thresholds: Optional[dict] = None
     manufacturability_rules: Optional[tuple] = None
-    combined_score_mode: Optional[str] = None
-    # When set, supersedes ``combined_score_mode``. A string DSL
-    # expression evaluated per-VP at scoring time — see
-    # :mod:`vaxrank.combined_score_dsl` for the grammar and
-    # bindings. ``None`` keeps the enum-mode behavior.
+    # DSL expression that produces this peptide's ``combined_score``.
+    # ``None`` resolves to :data:`DEFAULT_COMBINED_SCORE_EXPR`. There
+    # is no fallback mode enum — this string is the single mechanism.
     combined_score_expr: Optional[str] = None
     ranking_rules: Optional[tuple] = None
 
@@ -147,33 +113,21 @@ class VaccinePeptide(DataclassSerializable):
 
     def __post_init__(self):
         # Normalize the optional collection/tuple fields.
-        self.epitope_score_params = self.epitope_score_params or {}
         self.manufacturability_thresholds = self.manufacturability_thresholds or {}
         if self.manufacturability_rules is not None:
             self.manufacturability_rules = tuple(self.manufacturability_rules)
         if self.ranking_rules is not None:
             self.ranking_rules = tuple(self.ranking_rules)
 
-        # Validate combined_score_mode; resolve None to the legacy default.
-        resolved_mode = self.combined_score_mode or DEFAULT_COMBINED_SCORE_MODE
-        if resolved_mode not in COMBINED_SCORE_MODES:
-            raise ValueError(
-                f"combined_score_mode must be one of {COMBINED_SCORE_MODES}, "
-                f"got '{resolved_mode}'"
-            )
-        self.combined_score_mode = resolved_mode
-
-        # Pre-parse + validate the optional DSL expression once at
-        # construction time so syntax errors surface early (not at
-        # ranking time, after we've already done all the loading
-        # work). The parsed AST is stashed on the instance for
-        # ``combined_score`` to evaluate per call.
-        if self.combined_score_expr is not None:
-            from .combined_score_dsl import parse_combined_score_expr
-            self._combined_score_expr_ast = parse_combined_score_expr(
-                self.combined_score_expr)
-        else:
-            self._combined_score_expr_ast = None
+        # Resolve the score expression: user-supplied or the canonical
+        # default. Pre-parse once so syntax errors surface at config /
+        # construction time, not after a full ranking run. The AST is
+        # the single artifact ``combined_score`` evaluates against —
+        # there is no fallback Python branch for the default formula.
+        if self.combined_score_expr is None:
+            self.combined_score_expr = DEFAULT_COMBINED_SCORE_EXPR
+        self._combined_score_expr_ast = parse_combined_score_expr(
+            self.combined_score_expr)
 
         # Sort key over CandidateEpitope: pick the strongest pMHC_affinity
         # record across all predictors / alleles inside the CandidateEpitope.
@@ -226,26 +180,18 @@ class VaccinePeptide(DataclassSerializable):
             key=_epitope_sort_key,
         )
 
-        # Score each CandidateEpitope by summing the per-prediction logistic
-        # score across all of its mutant affinity records. Iterates
-        # ``predictions_flat()`` + kind-filters rather than
-        # ``predictions_for(kind=...)`` so multi-predictor data
-        # doesn't trip the predictor-disambiguation check.
-        params = self.epitope_score_params
-
-        def _epitope_total_score(e):
-            return sum(
-                _legacy_score_one(
-                    ic50=p.value,
-                    percentile_rank=p.percentile_rank,
-                    **params)
-                for p in e.predictions_flat()
-                if p.kind == 'pMHC_affinity')
-
+        # The per-epitope total score lives on ``CandidateEpitope`` as
+        # ``epitope_score`` (sum of its ``per_allele_scores`` populated
+        # at predict time by the configured ``EpitopeConfig.score_expr``
+        # — see :mod:`vaxrank.epitope_dsl`). VaccinePeptide is downstream
+        # of scoring; it never recomputes from ic50 / percentile_rank.
+        # This is what makes the DSL the single source of truth: change
+        # the per-prediction formula in one place and the change flows
+        # all the way through to ``combined_score``.
         self.self_epitope_score = sum(
-            _epitope_total_score(e) for e in self.self_epitopes)
+            e.epitope_score for e in self.self_epitopes)
         self.target_epitope_score = sum(
-            _epitope_total_score(e) for e in self.target_epitopes)
+            e.epitope_score for e in self.target_epitopes)
 
         self.manufacturability_scores = ManufacturabilityScores.from_amino_acids(
             self.mutant_protein_fragment.amino_acids
@@ -307,28 +253,21 @@ class VaccinePeptide(DataclassSerializable):
 
     @property
     def expression_score(self):
-        # Honest expression metric regardless of combined_score_mode — this
-        # is what reports display as "Expression score". The mode changes
-        # how expression folds into `combined_score`, not the metric itself.
+        # Honest expression metric. ``sqrt(n_alt_reads)`` is a binding
+        # the default combined-score expression uses; if the user
+        # writes a different ``combined_score_expr`` that doesn't
+        # reference it, this property is still queryable for reports.
         return np.sqrt(self.mutant_protein_fragment.n_alt_reads)
 
     @property
     def combined_score(self):
-        # When the DSL expression is set, it supersedes the enum
-        # mode entirely — same precedence relationship as
-        # ``epitopes.score_expr`` overriding the scalar logistic
-        # knobs in :mod:`vaxrank.epitope_dsl`.
-        if self._combined_score_expr_ast is not None:
-            from .combined_score_dsl import evaluate_combined_score
-            return evaluate_combined_score(
-                self._combined_score_expr_ast, self)
-        epitope = self.target_epitope_score
-        if self.combined_score_mode == "reads_times_epitope":
-            return float(self.mutant_protein_fragment.n_alt_reads) * epitope
-        if self.combined_score_mode == "epitope_only":
-            return epitope
-        # Default: sqrt_reads_times_epitope (legacy)
-        return self.expression_score * epitope
+        # Single code path: evaluate the (pre-parsed) DSL expression.
+        # When the user didn't override, ``combined_score_expr`` was
+        # resolved to ``DEFAULT_COMBINED_SCORE_EXPR`` in
+        # ``__post_init__`` — the default formula is *evaluated*
+        # through the DSL, not branched around.
+        return evaluate_combined_score(
+            self._combined_score_expr_ast, self)
 
     def to_dict(self):
         # The persisted form combines the filtered target + self lists
@@ -340,15 +279,14 @@ class VaccinePeptide(DataclassSerializable):
             "mutant_protein_fragment": self.mutant_protein_fragment,
             "epitopes": epitopes,
             "num_target_epitopes_to_keep": self.num_target_epitopes_to_keep,
-            "epitope_score_params": self.epitope_score_params,
             "sort_epitopes_by": self.sort_epitopes_by,
         }
         if self.manufacturability_thresholds:
             d["manufacturability_thresholds"] = self.manufacturability_thresholds
         if self.manufacturability_rules is not None:
             d["manufacturability_rules"] = list(self.manufacturability_rules)
-        if self.combined_score_mode != DEFAULT_COMBINED_SCORE_MODE:
-            d["combined_score_mode"] = self.combined_score_mode
+        if self.combined_score_expr != DEFAULT_COMBINED_SCORE_EXPR:
+            d["combined_score_expr"] = self.combined_score_expr
         if self.ranking_rules is not None:
             d["ranking_rules"] = list(self.ranking_rules)
         return d

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.2"
+__version__ = "3.1.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Collapses three nested layers of "default formula lives in two places" into a single mechanism — DSL string expressions — per layer. After this PR, there is no production code path that runs a hardcoded Python score formula while a user-supplied expression governs elsewhere.

### Layer 3 — Combined score (vaccine peptide)
- Deletes the ``combined_score_mode`` enum (``sqrt_reads_times_epitope`` / ``reads_times_epitope`` / ``epitope_only``).
- ``VaccineConfig.combined_score_expr: str`` now defaults to ``DEFAULT_COMBINED_SCORE_EXPR = \"sqrt(n_alt_reads) * target_epitope_score\"`` — the canonical legacy formula, expressed once as a DSL string.
- ``VaccinePeptide.__post_init__`` resolves ``None`` to that default and pre-parses; ``combined_score`` always evaluates the AST. **No mode branch, no Python fallback.**

### Layer 2 — Per-epitope total
- New ``CandidateEpitope.per_allele_scores: dict[str, float]`` populated at predict time. ``epitope_score`` is a property summing it.
- ``VaccinePeptide.target_epitope_score`` / ``self_epitope_score`` now read ``e.epitope_score`` directly — no recomputation from raw IC50.
- ``_legacy_score_one`` is removed from production. A test-only oracle lives at ``tests/_legacy_score_reference.py`` and is only consumed by parity assertions.

### Layer 1 — Per-(peptide, allele) score
- Deletes ``_default_score_node`` (the imperative DSLNode builder).
- Adds ``DEFAULT_AFFINITY_SCORE_EXPR_TEMPLATE`` / ``DEFAULT_PERCENTILE_SCORE_EXPR_TEMPLATE`` — string templates that ``default_score_expr(cfg)`` formats against ``EpitopeConfig``'s scalar threshold fields.
- ``build_score_node(cfg)`` always parses a string (user expression or formatted default). Default and override travel the **same** code path.

## Breaking config change
YAML files setting ``vaccine_peptides.combined_score_mode`` no longer parse. Migration:

| Old mode value              | New ``combined_score_expr``                       |
|----------------------------|----------------------------------------------------|
| ``epitope_only``            | ``\"target_epitope_score\"``                      |
| ``reads_times_epitope``     | ``\"n_alt_reads * target_epitope_score\"``        |
| ``sqrt_reads_times_epitope`` | ``\"sqrt(n_alt_reads) * target_epitope_score\"`` (this is the new default — omit to use it) |

## Verification

- **830 tests pass**, lint clean.
- Existing parity tests ``test_default_score_matches_legacy_*`` pass against the new templated default (formula is mathematically identical).
- HCC1395 smoke run produces a **byte-identical** rank table vs 3.0.2:
  - STX12 #1 = 76.773 (was 76.773)
  - MACF1 #2 = 13.090 (was 13.090)
  - SZT2 #3 = 4.200 (was 4.200)
  - ...all 7 ranked variants identical.

## Test plan
- [x] Full pytest suite green (830 passed, 1 skipped)
- [x] Lint clean
- [x] HCC1395 end-to-end smoke matches 3.0.2 output byte-for-byte
- [ ] Reviewer confirms migration table is enough for users with ``combined_score_mode`` in their YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)