### PR TITLE
test.sh: memory-aware pytest-xdist worker count

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ fi
 
 # Use pytest-xdist with a memory-aware worker count. Each worker loads
 # its own pyensembl / mhctools / topiary state (~3 GB resident), so
-# naive ``-n auto`` on an 8-core box can balloon to ~24 GB — and gets
+# naive `-n auto` on an 8-core box can balloon to ~24 GB — and gets
 # even worse when sibling pytest suites (hitlist, trufflepig) are
 # running concurrently. We pick the smaller of (cores, available_RAM
 # / per_worker_gb), and drop to 1 worker when the machine is already
@@ -23,33 +23,33 @@ readonly PER_WORKER_GB=3.0
 # macOS available-RAM heuristic: free + inactive + speculative pages
 # are reclaimable on demand, so they count as headroom.
 macos_available_bytes() {
-    local page_size pages
-    page_size=$(sysctl -n hw.pagesize)
-    pages=$(vm_stat | awk '
-        /Pages free/        { gsub(/\./, "", $3); free     = $3 }
-        /Pages inactive/    { gsub(/\./, "", $3); inactive = $3 }
-        /Pages speculative/ { gsub(/\./, "", $3); spec     = $3 }
-        END                 { print free + inactive + spec }
-    ')
-    echo $(( pages * page_size ))
+  local page_size pages
+  page_size=$(sysctl -n hw.pagesize)
+  pages=$(vm_stat | awk '
+    /Pages free/        { gsub(/\./, "", $3); free     = $3 }
+    /Pages inactive/    { gsub(/\./, "", $3); inactive = $3 }
+    /Pages speculative/ { gsub(/\./, "", $3); spec     = $3 }
+    END                 { print free + inactive + spec }
+  ')
+  echo $(( pages * page_size ))
 }
 
 # Pick a pytest -n value that respects both CPU and available RAM.
 pytest_workers() {
-    local cpus avail_bytes
-    cpus=$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.logicalcpu)
-    if [[ "$(uname)" == "Darwin" ]]; then
-        avail_bytes=$(macos_available_bytes)
-    else
-        avail_bytes=$(awk '/MemAvailable/ { print $2 * 1024 }' /proc/meminfo)
-    fi
-    awk -v cpus="$cpus" -v bytes="$avail_bytes" -v budget="$PER_WORKER_GB" '
-        BEGIN {
-            by_memory = int(bytes / 1024^3 / budget)
-            n = (cpus < by_memory ? cpus : by_memory)
-            print (n < 1 ? 1 : n)
-        }
-    '
+  local cpus avail_bytes
+  cpus=$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.logicalcpu)
+  if [[ "$(uname)" == "Darwin" ]]; then
+    avail_bytes=$(macos_available_bytes)
+  else
+    avail_bytes=$(awk '/MemAvailable/ { print $2 * 1024 }' /proc/meminfo)
+  fi
+  awk -v cpus="$cpus" -v bytes="$avail_bytes" -v budget="$PER_WORKER_GB" '
+    BEGIN {
+      by_memory = int(bytes / 1024^3 / budget)
+      n = (cpus < by_memory ? cpus : by_memory)
+      print (n < 1 ? 1 : n)
+    }
+  '
 }
 
 XDIST_FLAG=""

--- a/test.sh
+++ b/test.sh
@@ -9,14 +9,53 @@ if [[ "$(uname)" == "Darwin" && -d /opt/homebrew/lib \
   export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 fi
 
-# Use pytest-xdist with 2 workers when available. Each worker loads
+# Use pytest-xdist with a memory-aware worker count. Each worker loads
 # its own pyensembl / mhctools / topiary state (~3 GB resident), so
-# naive `-n auto` on an 8-core box can balloon to ~24 GB. Two
-# workers is a sweet spot: meaningful parallelism without the memory
-# blowup. xdist is not a required dependency, so fall back to serial
-# pytest when it isn't installed (e.g., CI).
+# naive ``-n auto`` on an 8-core box can balloon to ~24 GB — and gets
+# even worse when sibling pytest suites (hitlist, trufflepig) are
+# running concurrently. We pick the smaller of (cores, available_RAM
+# / per_worker_gb), and drop to 1 worker when the machine is already
+# under strain. xdist is not a required dependency, so fall back to
+# serial pytest when it isn't installed (e.g., CI).
+
+readonly PER_WORKER_GB=3.0
+
+# macOS available-RAM heuristic: free + inactive + speculative pages
+# are reclaimable on demand, so they count as headroom.
+macos_available_bytes() {
+    local page_size pages
+    page_size=$(sysctl -n hw.pagesize)
+    pages=$(vm_stat | awk '
+        /Pages free/        { gsub(/\./, "", $3); free     = $3 }
+        /Pages inactive/    { gsub(/\./, "", $3); inactive = $3 }
+        /Pages speculative/ { gsub(/\./, "", $3); spec     = $3 }
+        END                 { print free + inactive + spec }
+    ')
+    echo $(( pages * page_size ))
+}
+
+# Pick a pytest -n value that respects both CPU and available RAM.
+pytest_workers() {
+    local cpus avail_bytes
+    cpus=$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.logicalcpu)
+    if [[ "$(uname)" == "Darwin" ]]; then
+        avail_bytes=$(macos_available_bytes)
+    else
+        avail_bytes=$(awk '/MemAvailable/ { print $2 * 1024 }' /proc/meminfo)
+    fi
+    awk -v cpus="$cpus" -v bytes="$avail_bytes" -v budget="$PER_WORKER_GB" '
+        BEGIN {
+            by_memory = int(bytes / 1024^3 / budget)
+            n = (cpus < by_memory ? cpus : by_memory)
+            print (n < 1 ? 1 : n)
+        }
+    '
+}
+
 XDIST_FLAG=""
 if python -c "import xdist" 2>/dev/null; then
-  XDIST_FLAG="-n 2"
+  workers=$(pytest_workers)
+  XDIST_FLAG="-n $workers"
+  echo "Running pytest with -n ${workers} (per-worker budget ≈ ${PER_WORKER_GB} GB)"
 fi
 pytest ${XDIST_FLAG} --cov=vaxrank/ --cov-report=term-missing tests


### PR DESCRIPTION
## Summary

Replaces the hardcoded ``-n 2`` in ``test.sh`` with a worker count that respects both CPU and available RAM. Each pytest worker carries ~3 GB resident (pyensembl + mhctools + topiary), so the right ceiling is ``min(cores, available_RAM / 3GB)``.

- Linux: ``/proc/meminfo`` ``MemAvailable``
- macOS: ``vm_stat`` (free + inactive + speculative pages — all reclaimable on demand)

Falls back to 1 worker on a constrained machine. CI without ``pytest-xdist`` still runs serial as before. Motivation: sibling pytest suites on the same host (hitlist, trufflepig) were pushing the box into swap when each picked ``-n 2``.

## Test plan
- [ ] Run ``./test.sh`` locally on macOS; confirm it prints ``Running pytest with -n N`` and N reflects available RAM
- [ ] Confirm CI (no xdist) still runs serial pytest