### PR TITLE
README: drop the Features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,47 +19,19 @@ mRNA constructs, or analysis reports for review.
 
 ## Contents
 
-- [Features](#features)
 - [Quick Start](#quick-start)
 - [Overview](#overview)
-- [Vaccine designs](#vaccine-designs) — 8 design points across two modalities
-- [Vaccine types and output modes](#vaccine-types-and-output-modes) —
-  reports, peptide constructs, mRNA constructs, external inputs
+- [Vaccine designs](#vaccine-designs)
+- [Vaccine types and output modes](#vaccine-types-and-output-modes)
 - [Clinical Use](#clinical-use)
 - [Installation](#installation)
-- [Configuration](#configuration) — YAML config + topiary DSL
+- [Configuration](#configuration)
 - [MHC Binding Predictors](#mhc-binding-predictors)
-- [How It Works](#how-it-works) — pipeline internals + data model
+- [How It Works](#how-it-works)
 - [Papers & Citations](#papers--citations)
 - [Dependencies](#dependencies)
 - [Legacy flags](#legacy-flags)
 - [Development](#development)
-
-## Features
-
-- **Two input paths.** Full pipeline from a tumor VCF + RNA-seq BAM,
-  or drive ranking from a pre-computed neoepitope report produced by
-  [LENS](https://github.com/openvax/lens) or pVACseq via
-  `--input-lens` / `--input-pvacseq`.
-- **Multiple vaccine types from one run.** `--vaccine-type` is
-  multi-valued: pass `peptide`, `mrna`, or both. The same ranked
-  candidates render to peptide-pool FASTAs, mRNA constructs, or both
-  in parallel.
-- **Eight vaccine designs across two modalities.** Two orthogonal
-  axes — `--antigen-content` (mutation-spanning SLP vs minimal MHC
-  ligand) × `--antigens-per-construct` (1 vs N) — give four designs
-  per modality, including canonical SLPs (PGV-001) and BioNTech-style
-  multi-antigen mRNA (FixVac / iNeST).
-- **Analysis reports** in CSV, XLSX, ASCII, HTML, PDF, and JSON, plus
-  a per-(peptide, allele) neoepitope report. Reports run independently
-  of vaccine-type dispatch.
-- **MHC predictor integration** via [mhctools](https://github.com/openvax/mhctools):
-  MHCflurry, NetMHCpan family, BigMHC, NetMHCIIpan, Pepsickle, and IEDB
-  web predictors.
-- **Shared linker library** with primary-source citations and a
-  compositional grammar — `(G4S)2`, `AAY`, 2A self-cleaving peptides,
-  furin motifs — usable interchangeably across peptide and mRNA
-  designs.
 
 ## Quick Start
 


### PR DESCRIPTION
The intro paragraph at the top of the README already states honestly what vaxrank does: ranks neoantigens from variants + RNA-seq + HLA (or from a LENS / pVACseq report) and emits them as peptide pools, mRNA constructs, or analysis reports.

The Features section below it duplicated that in marketing-shaped bullets. Most items were either CLI flag listings ("``--vaccine-type`` is multi-valued"), output format lists ("CSV, XLSX, ASCII, HTML, PDF, and JSON"), or dependency mentions ("MHC predictor integration via mhctools") presented as differentiators. The "Eight vaccine designs across two modalities" framing puffed a 2x2 axis matrix into a bigger-sounding number.

This PR cuts that section entirely. The matching marketing suffixes in the table of contents (``— 8 design points across two modalities``, ``— YAML config + topiary DSL``, etc.) are removed for the same reason.

## Test plan
- [ ] Reviewer reads the (now shorter) README and confirms nothing load-bearing was lost — the intro paragraph plus Quick Start cover the same ground

🤖 Generated with [Claude Code](https://claude.com/claude-code)