### PR TITLE
Fix LENS / pVACseq path: populate per_allele_scores at load time

### DIFF
--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -163,6 +163,31 @@ def test_load_pvacseq():
     assert any(ep.occurs_in_reference for ep in epitopes)
 
 
+def test_load_pvacseq_populates_per_allele_scores():
+    """Regression: the 3.1.0 single-mechanism refactor moved
+    per-(peptide, allele) scoring to the DSL and stored the result on
+    ``CandidateEpitope.per_allele_scores``. The pVACseq loader path
+    must populate it too — otherwise every loaded epitope has
+    ``epitope_score=0`` and every variant gets dropped during
+    ranking as 'no epitopes for peptide'. Pin both ends: scores are
+    non-empty and (for binding-affinity rows) non-zero."""
+    path = os.path.join(DATA_DIR, "pvacseq_example.tsv")
+    _, epitopes = load_pvacseq(path)
+    assert epitopes
+    # Every epitope has scores keyed by its actual allele(s).
+    for e in epitopes:
+        assert e.per_allele_scores, (
+            f"Epitope {e.sequence!r} loaded with empty per_allele_scores"
+        )
+        for p in e.predictions_flat():
+            assert p.allele in e.per_allele_scores
+    # The strong binder in the fixture (SVVGSSSSS, IC50≈76 nM) must
+    # produce a non-zero score under the default logistic.
+    e_strong = next(
+        ep for ep in epitopes if ep.sequence == "SVVGSSSSS")
+    assert e_strong.epitope_score > 0.0
+
+
 def test_load_pvacseq_missing_columns(tmp_path):
     bad_file = tmp_path / "bad.tsv"
     bad_file.write_text("Gene\tAA Change\nTP53\tG245S\n")
@@ -213,6 +238,19 @@ def test_load_lens_emits_one_epitope_per_position_with_multi_predictor_leaves():
     assert wt_mhcf.value == pytest.approx(95.4 / 0.020)
     assert e.overlaps_mutation is True
     assert e.source_sequence == "AASVVGSSSSSGTR"
+
+
+def test_load_lens_populates_per_allele_scores():
+    """Parallel of ``test_load_pvacseq_populates_per_allele_scores`` —
+    the LENS loader must populate per_allele_scores so downstream
+    ranking doesn't drop every variant as zero-scoring."""
+    path = os.path.join(DATA_DIR, "lens_example.tsv")
+    _, epitopes = load_lens(path)
+    assert epitopes
+    for e in epitopes:
+        assert e.per_allele_scores, (
+            f"Epitope {e.sequence!r} loaded with empty per_allele_scores"
+        )
 
 
 def test_load_lens_report_display_uses_canonical_predictor():

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -264,6 +264,48 @@ def score_predictions(epitopes, cfg, *, topiary_df=None):
     )
 
 
+def attach_per_allele_scores(epitopes, cfg=None):
+    """Score ``epitopes`` via the configured DSL and return a new list of
+    :class:`~vaxrank.candidate_epitope.CandidateEpitope` instances with
+    each one's ``per_allele_scores`` populated.
+
+    External-input loaders (``load_pvacseq`` / ``load_lens``) build
+    unscored CandidateEpitopes from a TSV. The upstream pipeline path
+    populates ``per_allele_scores`` inside ``predict_epitopes`` from the
+    DSL eval; this helper is the equivalent step for the loader path so
+    downstream consumers (``VaccinePeptide.target_epitope_score`` etc.)
+    see the same shape regardless of where the epitopes came from.
+
+    ``cfg`` defaults to a fresh :class:`~vaxrank.epitope_config.EpitopeConfig`
+    so the loader path's default scoring matches the legacy pre-3.1
+    semantics exactly. Pass a custom config to override the threshold
+    knobs or supply a user ``score_expr``.
+    """
+    from dataclasses import replace
+    from .epitope_config import EpitopeConfig
+
+    if not epitopes:
+        return epitopes
+    if cfg is None:
+        cfg = EpitopeConfig()
+    score_series = score_predictions(epitopes, cfg)
+    # score_series is keyed by (source_sequence_name, peptide, offset, allele)
+    # where source_sequence_name mirrors ``epitopes_to_topiary_df`` —
+    # epitope.source_sequence or (falling back to) epitope.sequence.
+    by_position: dict[tuple, dict[str, float]] = {}
+    for idx, val in score_series.items():
+        src_name, peptide, offset, allele = idx
+        by_position.setdefault((src_name, peptide, offset), {})[allele] = float(val)
+    return [
+        replace(
+            e,
+            per_allele_scores=by_position.get(
+                (e.source_sequence or e.sequence, e.sequence, e.offset),
+                {}))
+        for e in epitopes
+    ]
+
+
 def collect_dsl_references(node):
     """Walk a parsed DSL node and collect its external-data references.
 

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -312,6 +312,14 @@ def load_pvacseq(path):
 
     report_df = pd.DataFrame(report_rows) if report_rows else pd.DataFrame()
     epitopes = candidate_epitopes_from_rows(epitope_rows)
+    # Loader path mirrors ``predict_epitopes``: populate
+    # ``per_allele_scores`` via the DSL so downstream consumers
+    # (VaccinePeptide.target_epitope_score, ranking, reports) see the
+    # same shape as upstream-path epitopes. Without this, every loaded
+    # epitope has ``epitope_score=0`` and the variant gets dropped as
+    # "no epitopes" during ranking.
+    from .epitope_dsl import attach_per_allele_scores
+    epitopes = attach_per_allele_scores(epitopes)
     logger.info(
         "Loaded %d epitope(s) (%d row(s)) from pVACseq file %s",
         len(epitopes), n_rows, path)
@@ -615,6 +623,12 @@ def load_lens(path):
 
     report_df = pd.DataFrame(report_rows) if report_rows else pd.DataFrame()
     epitopes = candidate_epitopes_from_rows(epitope_rows)
+    # See load_pvacseq for the parallel rationale: the 3.1 refactor moved
+    # per-(peptide, allele) scoring to the DSL and stored the result on
+    # CandidateEpitope.per_allele_scores. Loaders must populate it or
+    # downstream ranking sees zero-scored epitopes and drops everything.
+    from .epitope_dsl import attach_per_allele_scores
+    epitopes = attach_per_allele_scores(epitopes)
     logger.info(
         "Loaded %d epitope(s) (%d row(s) × %d predictor(s)) from %s",
         len(epitopes), len(report_df), len(chosen), path)


### PR DESCRIPTION
## What broke

The 3.1.0 single-mechanism refactor (#291) moved per-(peptide, allele) scoring to the DSL and stored the result on ``CandidateEpitope.per_allele_scores``. ``predict_epitopes`` was updated to populate it; the external-input loaders (``load_lens`` / ``load_pvacseq``) were not. The upstream path was tested in #291; the external-input path was not.

Result: every externally-loaded epitope had ``epitope_score == 0`` (no per-allele entries to sum), so ``target_epitope_score == 0``, ``combined_score == 0``, and the ranker dropped every variant as ``"No epitopes for peptide"``. ``vaxrank --input-pvacseq`` and ``--input-lens`` produced empty reports.

## How it surfaced

Tried to close the loop by running vaxrank against the WashU/Griffith Lab HCC1395 example pVACseq TSV in cAIrn:

```
vaxrank --input-pvacseq HCC1395_TUMOR_DNA.MHC_I.all_epitopes.aggregated.tsv \
        --ensembl-release 109 \
        --output-ascii-report pvacseq.txt
```

317 pVACseq rows in, 0 ranked variants out, hundreds of "No epitopes for peptide" log lines.

## Fix

- New ``epitope_dsl.attach_per_allele_scores(epitopes, cfg=None)`` runs the same DSL pipeline the upstream path uses on already-loaded epitopes and stamps each one's ``per_allele_scores`` dict.
- Called at the end of both ``load_pvacseq`` and ``load_lens``.
- Defaults to a fresh ``EpitopeConfig()`` so the loader path's default scoring matches pre-3.1 semantics exactly.

## Verification

- 832 tests pass (830 prior + 2 new regressions, one per loader).
- Lint clean.
- Re-running on the same HCC1395 pVACseq TSV: 23 ranked variants out with sensible scores (ADAR 19.6, MSH6 10.4, ZNF548 6.7, ADPRHL1 4.7, DBN1 3.0, FAM217B 2.3, SOX13 1.4, ...).

## Test plan
- [x] ``test_load_pvacseq_populates_per_allele_scores`` pins non-empty scores per epitope and non-zero ``epitope_score`` for the strong-binder fixture row
- [x] ``test_load_lens_populates_per_allele_scores`` pins the same for the LENS loader
- [x] End-to-end smoke against cAIrn HCC1395 pVACseq TSV produces a non-empty rank table

🤖 Generated with [Claude Code](https://claude.com/claude-code)