### PR TITLE
Adopt topiary pVACseq loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ outputs work identically.
 | Flag | Input format |
 |---|---|
 | `--input-lens` | LENS report TSV |
-| `--input-pvacseq` | pVACseq aggregated TSV (`*all_epitopes.aggregated.tsv`) |
+| `--input-pvacseq` | pVACseq TSV (`*all_epitopes.tsv` or `*all_epitopes.aggregated.tsv`) |
 
 ### Manifest schema
 
@@ -673,10 +673,11 @@ HLA alleles — runs Isovar transcript assembly + MHC binding prediction
 upstream tool (e.g. [LENS](https://github.com/openvax/lens) or pVACseq)
 has already produced a per-(peptide, allele) neoepitope report, Vaxrank
 skips Isovar + MHC prediction and consumes the report directly. The
-per-row `pep_context` (LENS) or `Best Peptide` (pVACseq aggregate) is
-used as the SLP-style antigen window. Downstream dispatch — reports +
-peptide constructs + mRNA constructs — is identical to the full
-pipeline.
+per-row `pep_context` (LENS) or `Best Peptide` / `MT Epitope Seq`
+(pVACseq) is used as the SLP-style antigen window. Downstream dispatch
+— reports + peptide constructs + mRNA constructs — is identical to the
+full pipeline. pVACseq parsing is delegated to topiary, so both
+`all_epitopes.tsv` and `all_epitopes.aggregated.tsv` are accepted.
 
 ### Mutant transcript assembly (Isovar)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ mhctools>=3.13.3,<4.0.0
 # 5.10.0 adds EvalContext(default_methods=...) and apply_filter(default_methods=...)
 # which vaxrank uses to score multi-model inputs (e.g. LENS with mhcflurry +
 # netmhcpan) without pre-subsetting the frame.
-# 5.12.0 promotes KIND_ALIASES to the public surface so vaxrank's
-# peptide_context can drop its defensive private-name fallback.
-topiary>=5.12.0,<6.0.0
+# 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
+# categorical DSL helpers used by pVACseq external-input scoring.
+topiary>=5.16.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -191,8 +191,154 @@ def test_load_pvacseq_populates_per_allele_scores():
 def test_load_pvacseq_missing_columns(tmp_path):
     bad_file = tmp_path / "bad.tsv"
     bad_file.write_text("Gene\tAA Change\nTP53\tG245S\n")
-    with pytest.raises(ValueError, match="missing required columns"):
+    with pytest.raises(ValueError, match="Could not detect pVACseq format"):
         load_pvacseq(bad_file)
+
+
+def _write_pvacseq_all_epitopes_fixture(tmp_path):
+    path = tmp_path / "pvacseq_all_epitopes.tsv"
+    columns = [
+        "Chromosome", "Start", "Stop", "Reference", "Variant",
+        "Transcript", "Variant Type", "Mutation", "Gene Name", "HLA Allele",
+        "Mutation Position", "MT Epitope Seq", "WT Epitope Seq",
+        "Median MT IC50 Score", "Median WT IC50 Score",
+        "Median MT Percentile", "Median WT Percentile",
+        "NetMHCpan MT IC50 Score", "NetMHCpan WT IC50 Score",
+        "NetMHCpan MT Percentile", "NetMHCpan WT Percentile",
+        "MHCflurry MT IC50 Score", "MHCflurry WT IC50 Score",
+        "MHCflurry MT Percentile", "MHCflurry WT Percentile",
+        "Tumor DNA Depth", "Tumor DNA VAF", "Tumor RNA Depth",
+        "Tumor RNA VAF", "Gene Expression", "Transcript Expression",
+    ]
+    rows = [
+        [
+            "chr1", "154590262", "154590263", "T", "A",
+            "ENST00000368474.9", "missense", "E806V", "ADAR",
+            "HLA-B*45:01", "5", "AERMGFTVV", "AERMGFTEV",
+            "76.11", "61.80", "0.10", "0.12",
+            "20.16", "28.54", "0.02", "0.04",
+            "61.51", "58.48", "0.09", "0.07",
+            "1233", "0.302", "1233", "0.348", "131.832", "84.961",
+        ],
+        [
+            "chr1", "154590262", "154590263", "T", "A",
+            "ENST00000368474.9", "missense", "E806V", "ADAR",
+            "HLA-B*45:01", "6", "AERMGFTVVT", "AERMGFTEVT",
+            "81.43", "40.97", "0.37", "0.20",
+            "NA", "NA", "NA", "NA",
+            "81.43", "40.97", "0.37", "0.20",
+            "1233", "0.302", "1233", "0.348", "131.832", "84.961",
+        ],
+        [
+            "chr1", "154590262", "154590263", "T", "A",
+            "ENST00000368474.9", "missense", "E806V", "ADAR",
+            "HLA-A*29:02", "5", "AERMGFTVV", "AERMGFTEV",
+            "850.30", "900.10", "2.50", "2.80",
+            "840.0", "890.0", "2.4", "2.7",
+            "860.6", "910.2", "2.6", "2.9",
+            "1233", "0.302", "1233", "0.348", "131.832", "84.961",
+        ],
+    ]
+    lines = ["\t".join(columns)]
+    lines.extend("\t".join(row) for row in rows)
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def _write_pvacseq_duplicate_peptide_fixture(tmp_path):
+    path = tmp_path / "pvacseq_duplicate_peptide.tsv"
+    columns = [
+        "Chromosome", "Start", "Stop", "Reference", "Variant",
+        "Transcript", "Variant Type", "Mutation", "Gene Name", "HLA Allele",
+        "Mutation Position", "MT Epitope Seq", "WT Epitope Seq",
+        "Median MT IC50 Score", "Median WT IC50 Score",
+        "Median MT Percentile", "Median WT Percentile",
+        "Tumor DNA Depth", "Tumor DNA VAF", "Tumor RNA Depth",
+        "Tumor RNA VAF", "Gene Expression", "Transcript Expression",
+    ]
+    rows = [
+        [
+            "chr1", "154590262", "154590263", "T", "A",
+            "ENST00000368474.9", "missense", "E806V", "ADAR",
+            "HLA-B*45:01", "5", "AERMGFTVV", "AERMGFTEV",
+            "76.11", "61.80", "0.10", "0.12",
+            "1233", "0.80", "1233", "0.348", "131.832", "84.961",
+        ],
+        [
+            "chr2", "200000", "200001", "G", "C",
+            "ENST00000288602.6", "missense", "V600E", "BRAF",
+            "HLA-B*45:01", "5", "AERMGFTVV", "AERMGFTEV",
+            "410.00", "900.10", "2.50", "2.80",
+            "900", "0.20", "900", "0.100", "70.0", "42.0",
+        ],
+    ]
+    lines = ["\t".join(columns)]
+    lines.extend("\t".join(row) for row in rows)
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def test_load_pvacseq_all_epitopes_flavor(tmp_path):
+    path = _write_pvacseq_all_epitopes_fixture(tmp_path)
+    report_df, epitopes = load_pvacseq(path)
+
+    assert len(report_df) == 3
+    # Same source + peptide groups the two AERMGFTVV alleles together.
+    assert len(epitopes) == 2
+    multi_allele = next(e for e in epitopes if e.sequence == "AERMGFTVV")
+    assert {p.allele for p in multi_allele.predictions_flat()} == {
+        "HLA-A*29:02", "HLA-B*45:01"}
+    assert multi_allele.wt.sequence == "AERMGFTEV"
+    assert multi_allele.per_allele_scores
+
+    topiary_df = report_df.attrs["topiary_df"]
+    assert "pvacseq_mhcflurry_ic50_mt" in topiary_df.columns
+    assert "pvacseq_mhcflurry_ic50_mt" in report_df.columns
+    assert set(report_df["MHC class"]) == {"I"}
+
+
+def test_pvacseq_all_epitopes_per_algorithm_column_scores(tmp_path):
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import write_neoepitope_report
+    import pandas as pd
+
+    path = _write_pvacseq_all_epitopes_fixture(tmp_path)
+    report_df, epitopes = load_pvacseq(path)
+    csv_path = tmp_path / "scored.csv"
+    cfg = EpitopeConfig(score_expr="pvacseq_mhcflurry_ic50_mt")
+
+    write_neoepitope_report(
+        report_df, epitopes, csv_report_path=str(csv_path),
+        epitope_config=cfg)
+
+    result = pd.read_csv(csv_path)
+    scored = result[
+        (result["Mutant peptide sequence"] == "AERMGFTVV")
+        & (result["Allele"] == "HLA-B*45:01")
+    ].iloc[0]
+    assert scored["vaxrank_score"] == pytest.approx(61.51)
+
+
+def test_pvacseq_source_keyed_filtered_scores_do_not_broadcast(tmp_path):
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import write_neoepitope_report
+    import pandas as pd
+
+    path = _write_pvacseq_duplicate_peptide_fixture(tmp_path)
+    report_df, epitopes = load_pvacseq(path)
+    csv_path = tmp_path / "filtered.csv"
+    cfg = EpitopeConfig(
+        filter_expr="tumor_dna_vaf > 0.5",
+        score_expr="affinity.value")
+
+    write_neoepitope_report(
+        report_df, epitopes, csv_report_path=str(csv_path),
+        epitope_config=cfg)
+
+    result = pd.read_csv(csv_path)
+    by_source = result.set_index("Source sequence name")["vaxrank_score"]
+    assert by_source["chr1-154590262-T-A"] == pytest.approx(76.11)
+    assert by_source["chr2-200000-G-C"] == 0.0
 
 
 # ── LENS import ──────────────────────────────────────────────────────────────
@@ -1365,5 +1511,3 @@ def test_lens_cli_errors_when_no_output_flag_set():
     lens_path = os.path.join(DATA_DIR, "lens_example.tsv")
     with pytest.raises(ValueError, match="No output path specified"):
         main(["--input-lens", lens_path])
-
-

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -660,6 +660,51 @@ def test_pvacseq_drives_mrna_construct_assembly_end_to_end():
     assert c.cds_nt.endswith("TAA")
 
 
+def test_pvacseq_all_epitopes_to_ranked_vaccine_peptides(tmp_path):
+    """all_epitopes flavor uses MT Epitope Seq + chr/ref/alt columns."""
+    from tests.test_epitope_io import _write_pvacseq_all_epitopes_fixture
+    from vaxrank.epitope_io import load_pvacseq
+    from vaxrank.external_input import ranked_from_pvacseq_predictions
+
+    path = _write_pvacseq_all_epitopes_fixture(tmp_path)
+    _, predictions = load_pvacseq(path)
+    ranked, dna_vaf_by_variant = ranked_from_pvacseq_predictions(
+        predictions, path)
+
+    assert len(ranked) == 1
+    variant, vaccine_peptides = ranked[0]
+    assert (variant.contig, variant.start, variant.ref, variant.alt) == (
+        "1", 154590262, "T", "A")
+    assert vaccine_peptides[0].mutant_protein_fragment.gene_name == "ADAR"
+    assert len(vaccine_peptides[0].epitopes) == 2
+    assert dna_vaf_by_variant[variant] == pytest.approx(0.302)
+
+
+def test_pvacseq_duplicate_peptides_stay_variant_scoped(tmp_path):
+    """Identical peptides from different pVACseq variants must not mix."""
+    from tests.test_epitope_io import _write_pvacseq_duplicate_peptide_fixture
+    from vaxrank.epitope_io import load_pvacseq
+    from vaxrank.external_input import ranked_from_pvacseq_predictions
+
+    path = _write_pvacseq_duplicate_peptide_fixture(tmp_path)
+    _, predictions = load_pvacseq(path)
+    ranked, _dna_vaf_by_variant = ranked_from_pvacseq_predictions(
+        predictions, path)
+
+    assert len(ranked) == 2
+    expected_source_by_variant = {
+        ("1", 154590262, "T", "A"): "chr1-154590262-T-A",
+        ("2", 200000, "G", "C"): "chr2-200000-G-C",
+    }
+    for variant, vaccine_peptides in ranked:
+        key = (variant.contig, variant.start, variant.ref, variant.alt)
+        expected_source = expected_source_by_variant[key]
+        epitopes = vaccine_peptides[0].epitopes
+        assert len(epitopes) == 1
+        assert epitopes[0].sequence == "AERMGFTVV"
+        assert epitopes[0].source_sequence == expected_source
+
+
 # ---- LENS scoring-column edge cases --------------------------------------
 
 def test_lens_warns_when_no_affinity_columns_detected(tmp_path, caplog):

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -110,7 +110,8 @@ def make_vaxrank_arg_parser():
     arg_parser.add_argument(
         "--input-pvacseq",
         default=None,
-        help="Path to a pVACseq aggregated TSV file (all_epitopes.aggregated.tsv). "
+        help="Path to a pVACseq TSV file (all_epitopes.tsv or "
+             "all_epitopes.aggregated.tsv). "
              "When provided without --vcf/--bam, vaxrank scores and ranks the "
              "pVACseq predictions and writes the requested output reports.")
 

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -264,7 +264,7 @@ def score_predictions(epitopes, cfg, *, topiary_df=None):
     )
 
 
-def attach_per_allele_scores(epitopes, cfg=None):
+def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None):
     """Score ``epitopes`` via the configured DSL and return a new list of
     :class:`~vaxrank.candidate_epitope.CandidateEpitope` instances with
     each one's ``per_allele_scores`` populated.
@@ -280,6 +280,10 @@ def attach_per_allele_scores(epitopes, cfg=None):
     so the loader path's default scoring matches the legacy pre-3.1
     semantics exactly. Pass a custom config to override the threshold
     knobs or supply a user ``score_expr``.
+
+    ``topiary_df`` can be supplied by loaders that already have a
+    richer topiary frame than can be reconstructed from CandidateEpitope
+    objects alone, e.g. pVACseq passthrough annotation columns.
     """
     from dataclasses import replace
     from .epitope_config import EpitopeConfig
@@ -288,10 +292,12 @@ def attach_per_allele_scores(epitopes, cfg=None):
         return epitopes
     if cfg is None:
         cfg = EpitopeConfig()
-    score_series = score_predictions(epitopes, cfg)
-    # score_series is keyed by (source_sequence_name, peptide, offset, allele)
-    # where source_sequence_name mirrors ``epitopes_to_topiary_df`` —
-    # epitope.source_sequence or (falling back to) epitope.sequence.
+    score_series = score_predictions(epitopes, cfg, topiary_df=topiary_df)
+    # score_series is keyed by topiary's group columns. For the rebuilt
+    # vaxrank frame the first key mirrors ``epitopes_to_topiary_df``;
+    # for a supplied loader frame (pVACseq) it matches that loader's
+    # source/variant grouping. ``CandidateEpitope.source_sequence`` is
+    # set to the same key by those loaders.
     by_position: dict[tuple, dict[str, float]] = {}
     for idx, val in score_series.items():
         src_name, peptide, offset, allele = idx
@@ -319,7 +325,7 @@ def collect_dsl_references(node):
     already validated by topiary's ``apply_filter``; vaxrank only uses
     this to drive :func:`validate_dsl_against_predictions`.
     """
-    from topiary.ranking.nodes import Column, Field
+    from topiary.ranking.nodes import Field
 
     columns = set()
     kinds = set()
@@ -328,9 +334,10 @@ def collect_dsl_references(node):
         n = stack.pop()
         if n is None:
             continue
-        if isinstance(n, Column):
-            columns.add(n.col_name)
-        elif isinstance(n, Field):
+        col_name = getattr(n, "col_name", None)
+        if isinstance(col_name, str):
+            columns.add(col_name)
+        if isinstance(n, Field):
             kinds.add((n.kind, n.method, n.version))
         child_iter = getattr(n, "child_nodes", None)
         if callable(child_iter):

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -192,12 +192,133 @@ def load_predictions(path):
 
 # ── pVACseq import ───────────────────────────────────────────────────────────
 
+def _is_missing(val):
+    """True for scalar missing values from pandas / pVACseq TSVs."""
+    if val is None:
+        return True
+    try:
+        return bool(pd.isna(val))
+    except (TypeError, ValueError):
+        return False
+
+
+def _format_nm(value):
+    value = _safe_float(value)
+    return '%.2f nM' % value if value is not None else 'No prediction'
+
+
+def _first_float(*values):
+    for value in values:
+        coerced = _safe_float(value)
+        if coerced is not None:
+            return coerced
+    return None
+
+
+def _topiary_group_source(row):
+    """Source key matching topiary.ranking.EvalContext grouping."""
+    return (
+        _safe_str(row.get("variant"))
+        or _safe_str(row.get("source_sequence_name"))
+        or _safe_str(row.get("peptide"))
+    )
+
+
+def _topiary_pvacseq_to_epitope_rows(df):
+    """Convert topiary.read_pvacseq long-form rows to CandidateEpitope rows."""
+    epitope_rows = []
+    n_rows = 0
+    for _, row in df.iterrows():
+        peptide = _safe_str(row.get("peptide"))
+        allele = _safe_str(row.get("allele"))
+        value = _safe_float(row.get("value"))
+        if not peptide or not allele or value is None:
+            continue
+
+        method = _safe_str(row.get("prediction_method_name")) or "pvacseq"
+        version = _safe_str(row.get("predictor_version"))
+        kind = _safe_str(row.get("kind")) or _kind_for_method(method)
+        percentile_rank = _safe_float(row.get("percentile_rank"))
+        score = _safe_float(row.get("score"))
+        mutant = Prediction(
+            kind=kind, predictor_name=method, predictor_version=version,
+            allele=allele, peptide=peptide, value=value,
+            score=score if score is not None else 0.0,
+            percentile_rank=percentile_rank,
+        )
+
+        wt = None
+        wt_value = _safe_float(row.get("wt_value"))
+        if wt_value is not None:
+            wt_method = _safe_str(row.get("wt_prediction_method_name")) or method
+            wt_version = _safe_str(row.get("wt_predictor_version")) or version
+            wt = Prediction(
+                kind=kind, predictor_name=wt_method,
+                predictor_version=wt_version, allele=allele,
+                peptide=_safe_str(row.get("wt_peptide")),
+                value=wt_value, score=0.0,
+                percentile_rank=_safe_float(row.get("wt_percentile_rank")),
+            )
+
+        epitope_rows.append({
+            'peptide': peptide,
+            'source': _topiary_group_source(row),
+            'offset': int(_safe_float(row.get("peptide_offset")) or 0),
+            'mutant': mutant,
+            'wt': wt,
+            'source_class': SOURCE_CLASS_MUTATION,
+            'overlaps_mutation': _safe_bool(
+                row.get("contains_mutant_residues"), default=True),
+            'occurs_in_reference': _safe_bool(row.get("pvacseq_ref_match")),
+            'occurs_in_non_CTA_reference': _safe_bool(
+                row.get("pvacseq_ref_match")),
+        })
+        n_rows += 1
+    return epitope_rows, n_rows
+
+
+def _build_pvacseq_report_row(row):
+    """Build one user-facing report row from a topiary pVACseq row."""
+    rna_expr = _first_float(
+        row.get("rna_transcript_expression"),
+        row.get("transcript_expression"),
+        row.get("gene_expression"))
+    rna_vaf = _first_float(row.get("rna_vaf"), row.get("tumor_rna_vaf"))
+    dna_vaf = _first_float(row.get("dna_vaf"), row.get("tumor_dna_vaf"))
+    out = {
+        'Allele': _safe_str(row.get("allele")),
+        'Mutant peptide sequence': _safe_str(row.get("peptide")),
+        'Predicted mutant pMHC affinity': _format_nm(row.get("value")),
+        'Wildtype sequence': _safe_str(row.get("wt_peptide")),
+        'Predicted wildtype pMHC affinity': _format_nm(row.get("wt_value")),
+        'Gene name': _safe_str(row.get("gene")),
+        'Genomic variant': _safe_str(row.get("variant")),
+        'Tier': _safe_str(row.get("pvacseq_tier")),
+        'Ref Match': _safe_bool(row.get("pvacseq_ref_match")),
+        'RNA Expr': rna_expr,
+        'RNA VAF': rna_vaf,
+        'DNA VAF': dna_vaf,
+        '%ile MT': _safe_float(row.get("percentile_rank")),
+        'Source sequence name': _topiary_group_source(row),
+        'Peptide offset': int(_safe_float(row.get("peptide_offset")) or 0),
+        'MHC class': _safe_str(row.get("mhc_class")),
+        'Contains mutant residues': _safe_bool(
+            row.get("contains_mutant_residues"), default=True),
+    }
+    for col, value in row.items():
+        if col.startswith("pvacseq_") and col not in {
+                "pvacseq_ref_match", "pvacseq_tier"}:
+            out[col] = _safe_float(value)
+    return out
+
+
 def load_pvacseq(path):
     """
-    Import a pVACseq aggregated TSV (``*all_epitopes.aggregated.tsv``)
-    and return a neoepitope report DataFrame ready for output.
+    Import a pVACseq TSV and return a neoepitope report DataFrame ready
+    for output.
 
-    Each row is one variant's best epitope.
+    Both pVACseq output flavors are accepted:
+    ``*all_epitopes.aggregated.tsv`` and ``*all_epitopes.tsv``.
 
     Parameters
     ----------
@@ -212,117 +333,27 @@ def load_pvacseq(path):
         vaxrank_score
     list of CandidateEpitope
         One ``vaxrank.candidate_epitope.CandidateEpitope`` per unique
-        ``(peptide, source_sequence, offset)`` group; pVACseq rows
-        typically map 1:1 since each row carries its own allele.
+        ``(peptide, source_sequence, offset)`` group.
     """
-    df = pd.read_csv(path, sep="\t")
-    required = {"Best Peptide", "Allele", "IC50 MT"}
-    missing = required - set(df.columns)
-    if missing:
-        raise ValueError(
-            f"pVACseq file {path} missing required columns: {missing}")
+    from topiary import read_pvacseq
 
-    epitope_rows = []
-    report_rows = []
-    n_rows = 0
-    for _, row in df.iterrows():
-        peptide = row.get("Best Peptide", "")
-        if not peptide or pd.isna(peptide):
-            continue
-
-        allele = row.get("Allele", "")
-        if pd.isna(allele):
-            continue
-
-        ic50_mt = row.get("IC50 MT")
-        if pd.isna(ic50_mt):
-            continue
-        ic50_mt = float(ic50_mt)
-
-        ic50_wt = row.get("IC50 WT")
-        wt_ic50 = float(ic50_wt) if not pd.isna(ic50_wt) else None
-
-        percentile = row.get("%ile MT")
-        percentile_rank = float(percentile) if not pd.isna(percentile) else None
-
-        wt_peptide = row.get("WT Epitope Seq", "")
-        if pd.isna(wt_peptide):
-            wt_peptide = ""
-
-        ref_match = row.get("Ref Match", False)
-        if isinstance(ref_match, str):
-            occurs_in_reference = ref_match.strip().lower() == "true"
-        else:
-            occurs_in_reference = bool(ref_match) if not pd.isna(ref_match) else False
-
-        method = row.get("Best MT IC50 Score Method", "pvacseq")
-        if pd.isna(method):
-            method = "pvacseq"
-
-        gene = row.get("Gene", "")
-        if pd.isna(gene):
-            gene = ""
-        variant_id = row.get("ID", "")
-        if pd.isna(variant_id):
-            variant_id = ""
-        tier = row.get("Tier", "")
-        if pd.isna(tier):
-            tier = ""
-
-        kind = _kind_for_method(str(method))
-        mutant = Prediction(
-            kind=kind, predictor_name=str(method), predictor_version="",
-            allele=str(allele), peptide=str(peptide), value=ic50_mt,
-            score=0.0, percentile_rank=percentile_rank,
-        )
-        wt = None
-        if wt_ic50 is not None:
-            wt = Prediction(
-                kind=kind, predictor_name=str(method), predictor_version="",
-                allele=str(allele), peptide=str(wt_peptide),
-                value=wt_ic50, score=0.0, percentile_rank=None,
-            )
-        epitope_rows.append({
-            'peptide': str(peptide), 'source': "", 'offset': 0,
-            'mutant': mutant, 'wt': wt,
-            'source_class': SOURCE_CLASS_MUTATION,
-            'overlaps_mutation': True,
-            'occurs_in_reference': occurs_in_reference,
-            'occurs_in_non_CTA_reference': occurs_in_reference,
-        })
-        n_rows += 1
-
-        # Build report row preserving pVACseq metadata
-        wt_ic50_str = '%.2f nM' % wt_ic50 if wt_ic50 is not None else 'No prediction'
-        report_rows.append({
-            'Allele': str(allele),
-            'Mutant peptide sequence': str(peptide),
-            'Predicted mutant pMHC affinity': '%.2f nM' % ic50_mt,
-            'Wildtype sequence': str(wt_peptide),
-            'Predicted wildtype pMHC affinity': wt_ic50_str,
-            'Gene name': str(gene),
-            'Genomic variant': str(variant_id),
-            'Tier': str(tier),
-            'Ref Match': occurs_in_reference,
-            'RNA Expr': _safe_float(row.get("RNA Expr")),
-            'RNA VAF': _safe_float(row.get("RNA VAF")),
-            'DNA VAF': _safe_float(row.get("DNA VAF")),
-            '%ile MT': percentile_rank,
-        })
+    result = read_pvacseq(path)
+    topiary_df = result.df
+    epitope_rows, n_rows = _topiary_pvacseq_to_epitope_rows(topiary_df)
+    report_rows = [
+        _build_pvacseq_report_row(row)
+        for _, row in topiary_df.iterrows()
+        if _safe_str(row.get("peptide")) and _safe_str(row.get("allele"))
+    ]
 
     report_df = pd.DataFrame(report_rows) if report_rows else pd.DataFrame()
+    report_df.attrs["topiary_df"] = topiary_df
     epitopes = candidate_epitopes_from_rows(epitope_rows)
-    # Loader path mirrors ``predict_epitopes``: populate
-    # ``per_allele_scores`` via the DSL so downstream consumers
-    # (VaccinePeptide.target_epitope_score, ranking, reports) see the
-    # same shape as upstream-path epitopes. Without this, every loaded
-    # epitope has ``epitope_score=0`` and the variant gets dropped as
-    # "no epitopes" during ranking.
     from .epitope_dsl import attach_per_allele_scores
-    epitopes = attach_per_allele_scores(epitopes)
+    epitopes = attach_per_allele_scores(epitopes, topiary_df=topiary_df)
     logger.info(
-        "Loaded %d epitope(s) (%d row(s)) from pVACseq file %s",
-        len(epitopes), n_rows, path)
+        "Loaded %d epitope(s) (%d row(s), %s flavor) from pVACseq file %s",
+        len(epitopes), n_rows, result.extra.get("pvacseq_format"), path)
     return report_df, epitopes
 
 
@@ -330,9 +361,7 @@ def load_pvacseq(path):
 
 def _safe_str(val):
     """Coerce a cell to str, mapping NaN/None/'NA' to empty string."""
-    if val is None:
-        return ""
-    if isinstance(val, float) and pd.isna(val):
+    if _is_missing(val):
         return ""
     s = str(val)
     if s == "NA":
@@ -342,12 +371,26 @@ def _safe_str(val):
 
 def _safe_float(val):
     """Convert to float, returning None for NaN/missing."""
-    if val is None or (isinstance(val, float) and pd.isna(val)):
+    if _is_missing(val):
         return None
     try:
         return float(val)
     except (ValueError, TypeError):
         return None
+
+
+def _safe_bool(val, default=False):
+    """Coerce common TSV boolean spellings; missing values use *default*."""
+    if _is_missing(val):
+        return default
+    if isinstance(val, str):
+        lowered = val.strip().lower()
+        if lowered in {"true", "t", "yes", "y", "1"}:
+            return True
+        if lowered in {"false", "f", "no", "n", "0"}:
+            return False
+        return default
+    return bool(val)
 
 
 # ── LENS import ──────────────────────────────────────────────────────────────
@@ -690,7 +733,8 @@ def _build_lens_report_row(row, allele, peptide, detected, display_pred,
 # ── Shared report writer ─────────────────────────────────────────────────────
 
 def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
-                            csv_report_path=None, epitope_config=None):
+                            csv_report_path=None, epitope_config=None,
+                            topiary_df=None):
     """
     Score epitopes and write a neoepitope report from imported data.
 
@@ -716,6 +760,11 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
     excel_report_path : str, optional
     csv_report_path : str, optional
     epitope_config : EpitopeConfig, optional
+    topiary_df : pandas.DataFrame, optional
+        Pre-built topiary long-form rows to use for DSL validation and
+        scoring. ``load_pvacseq`` stores this on ``report_df.attrs`` so
+        pVACseq annotation columns remain available to custom DSL
+        expressions.
     """
     from .epitope_config import EpitopeConfig
     from .epitope_dsl import (
@@ -750,10 +799,14 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
                 "preserved by the other columns.", dup_count)
 
     # Build the topiary DataFrame once and share it between validator and
-    # scorer — these two pass over the same ~N rows and rebuilding is the
-    # dominant cost on large LENS files. ``default_methods`` typos are
-    # caught inside :func:`score_predictions` before eval.
-    topiary_df = epitopes_to_topiary_df(epitopes)
+    # scorer. pVACseq import keeps the loader-produced frame in
+    # ``report_df.attrs`` so passthrough columns such as
+    # ``pvacseq_mhcflurry_ic50_mt`` remain DSL-addressable; LENS and
+    # vaxrank-native callers fall back to rebuilding from CandidateEpitope.
+    if topiary_df is None:
+        topiary_df = report_df.attrs.get("topiary_df")
+    if topiary_df is None:
+        topiary_df = epitopes_to_topiary_df(epitopes)
 
     validate_dsl_against_predictions(
         epitope_config, epitopes, topiary_df=topiary_df)
@@ -761,20 +814,38 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
     score_series = score_predictions(
         epitopes, epitope_config, topiary_df=topiary_df)
 
-    # score_series is indexed by (source_sequence_name, peptide,
-    # peptide_offset, allele). We built the topiary DF with
-    # source_sequence_name = peptide, peptide_offset = 0, so the effective
-    # group key is (peptide, allele) — align back onto report_df using that.
+    # score_series is indexed by topiary's group key
+    # (source/variant, peptide, peptide_offset, allele). pVACseq reports
+    # carry that source key through for precise alignment. If an exact
+    # source-keyed row is absent, it was filtered out and must stay at 0.
+    # Older LENS-shaped reports lack source/offset columns and keep the
+    # legacy (peptide, allele) broadcast.
     scores_by_key = {}
+    scores_by_pair = {}
     for idx_tuple, score in score_series.items():
-        _, peptide, _, allele = idx_tuple
-        scores_by_key[(peptide, allele)] = score
+        source_name, peptide, offset, allele = idx_tuple
+        scores_by_key[(source_name, peptide, int(offset), allele)] = score
+        scores_by_pair[(peptide, allele)] = score
 
     report_df = report_df.copy()
-    scores = [
-        round(float(scores_by_key.get((row[peptide_col], row[allele_col]), 0.0)), 6)
-        for _, row in report_df.iterrows()
-    ]
+    source_col = 'Source sequence name'
+    offset_col = 'Peptide offset'
+    has_source_keys = (
+        source_col in report_df.columns and offset_col in report_df.columns)
+    scores = []
+    for _, row in report_df.iterrows():
+        score = None
+        if has_source_keys:
+            offset = _safe_float(row.get(offset_col))
+            if offset is not None:
+                score = scores_by_key.get((
+                    row.get(source_col), row[peptide_col], int(offset),
+                    row[allele_col]))
+            if score is None:
+                score = 0.0
+        else:
+            score = scores_by_pair.get((row[peptide_col], row[allele_col]), 0.0)
+        scores.append(round(float(score), 6))
     report_df.insert(2, 'vaxrank_score', scores)
 
     report_df = report_df.sort_values('vaxrank_score', ascending=False)

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -50,10 +50,16 @@ from .vaccine_library import (
 )
 from .vaccine_peptide import VaccinePeptide
 
-# pVACseq aggregate-report scoring column priority. Sniffed against
-# the row dict; the first column present + non-NaN wins.
-_PVACSEQ_IC50_COLS = ('IC50 MT', 'Best IC50 Score MT')
-_PVACSEQ_RANK_COLS = ('%ile MT', 'Best Percentile MT')
+# pVACseq scoring column priority. Sniffed against the row dict; the first
+# column present + non-NaN wins. Covers both aggregate and all_epitopes TSVs.
+_PVACSEQ_IC50_COLS = (
+    'IC50 MT', 'Best IC50 Score MT',
+    'Median MT IC50 Score', 'Best MT IC50 Score',
+)
+_PVACSEQ_RANK_COLS = (
+    '%ile MT', 'Best Percentile MT',
+    'Median MT Percentile', 'Best MT Percentile',
+)
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +69,28 @@ logger = logging.getLogger(__name__)
 # alleles inferred from a LENS / pVACseq report. Shared with
 # ``vaxrank.cli.entry_point`` so producer + consumer can't drift.
 LENS_PROVENANCE_MARKER = '(inferred from report)'
+
+
+def _missing_cell(value):
+    if value is None:
+        return True
+    try:
+        return bool(pd.isna(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def _first_cell(row, *names):
+    for name in names:
+        value = row.get(name)
+        if not _missing_cell(value):
+            return value
+    return None
+
+
+def _first_str(row, *names):
+    value = _first_cell(row, *names)
+    return str(value) if value is not None else ""
 
 
 def _parse_variant_coords(coords):
@@ -919,17 +947,85 @@ def _parse_pvacseq_id(vid, genome=None):
     return v, True
 
 
+def _pvacseq_variant_key(row):
+    """Variant key for aggregated or all_epitopes pVACseq rows."""
+    existing = _first_cell(row, 'ID')
+    if existing is not None:
+        return existing
+    chrom = _first_cell(row, 'Chromosome')
+    start = _first_cell(row, 'Start')
+    ref = _first_cell(row, 'Reference')
+    alt = _first_cell(row, 'Variant')
+    if None in (chrom, start, ref, alt):
+        index = _first_cell(row, 'Index')
+        return index
+    stop = _first_cell(row, 'Stop')
+    if stop is not None:
+        return f"{chrom}-{start}-{stop}-{ref}-{alt}"
+    return f"{chrom}-{start}-{ref}-{alt}"
+
+
+def _pvacseq_source_key(row):
+    """Source key matching load_pvacseq's CandidateEpitope source."""
+    existing = _first_cell(row, 'ID')
+    if existing is not None:
+        return str(existing)
+    index = _first_cell(row, 'Index')
+    if index is not None:
+        return str(index)
+    chrom = _first_cell(row, 'Chromosome')
+    start = _first_cell(row, 'Start')
+    ref = _first_cell(row, 'Reference')
+    alt = _first_cell(row, 'Variant')
+    if None in (chrom, start, ref, alt):
+        return ""
+    return f"{chrom}-{start}-{ref}-{alt}"
+
+
+def _pvacseq_peptide(row):
+    return _first_str(row, 'Best Peptide', 'MT Epitope Seq', 'peptide')
+
+
+def _pvacseq_gene(row):
+    return _first_str(row, 'Gene', 'Gene Name', 'gene')
+
+
+def _pvacseq_transcript_ids(row):
+    transcript = _first_str(row, 'Best Transcript', 'Transcript', 'transcript')
+    return [transcript] if transcript else []
+
+
+def _pvacseq_rna_depth(row):
+    return _coerce_int(_first_cell(row, 'RNA Depth', 'Tumor RNA Depth'), default=0)
+
+
+def _pvacseq_rna_vaf(row):
+    raw = _first_cell(row, 'RNA VAF', 'Tumor RNA VAF')
+    try:
+        return float(raw) if raw is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _pvacseq_dna_vaf(row):
+    raw = _first_cell(row, 'DNA VAF', 'Tumor DNA VAF')
+    try:
+        return float(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
 def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
                                     genome=None,
                                     num_target_epitopes_to_keep=None):
     """pVACseq variant of :func:`ranked_from_lens_predictions`.
 
-    Re-reads the raw aggregate TSV (the per-(peptide, allele)
+    Re-reads the raw pVACseq TSV (the per-(peptide, allele)
     ``report_df`` returned by ``load_pvacseq`` carries display columns
-    rather than the original ``ID`` / ``Best Peptide`` / ``IC50 MT``).
+    rather than every original aggregate / all_epitopes column).
 
-    Uses ``Best Peptide`` as the antigen sequence and treats the
-    peptide itself as the mutation span (no SLP-context column).
+    Uses ``Best Peptide`` / ``MT Epitope Seq`` as the antigen sequence
+    and treats the peptide itself as the mutation span (no SLP-context column).
     mRNA construct generation from pVACseq input therefore produces
     shorter antigen windows than the LENS path.
     """
@@ -939,15 +1035,15 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
     if df.empty:
         return []
 
-    by_peptide: dict[str, list] = {}
+    by_source_peptide: dict[tuple[str, str], list] = {}
     for e in epitopes:
-        by_peptide.setdefault(e.sequence, []).append(e)
+        by_source_peptide.setdefault((e.source_sequence, e.sequence), []).append(e)
 
     rows = df.to_dict('records')
     groups = {}
     for r in rows:
-        key = r.get('ID') or r.get('Index')
-        if key is None or pd.isna(key):
+        key = _pvacseq_variant_key(r)
+        if _missing_cell(key):
             continue
         groups.setdefault(key, []).append(r)
 
@@ -963,14 +1059,10 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
     for vid, group_rows in groups.items():
         rep = _pick_representative(
             group_rows, _PVACSEQ_IC50_COLS, _PVACSEQ_RANK_COLS)
-        best_pep = rep.get('Best Peptide') or rep.get('peptide') or ""
+        best_pep = _pvacseq_peptide(rep)
         # Preserve pVACseq's own gene name; empty string when missing
         # (codebase convention for "not known"). No 'unknown' invention.
-        gene_raw = rep.get('Gene')
-        gene = (
-            str(gene_raw) if gene_raw and not (
-                isinstance(gene_raw, float) and pd.isna(gene_raw))
-            else "")
+        gene = _pvacseq_gene(rep)
 
         variant, alleles_real = _parse_pvacseq_id(vid, genome=genome)
         if variant is None:
@@ -980,18 +1072,14 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
                 vid)
             continue
 
-        # Real RNA-read counts from pVACseq aggregate columns.
-        # ``RNA Depth`` = total coverage at the variant position.
-        # ``RNA VAF`` = variant allele frequency (alt / total).
+        # Real RNA-read counts from pVACseq columns.
+        # ``RNA Depth`` / ``Tumor RNA Depth`` = total coverage at the
+        # variant position. ``RNA VAF`` / ``Tumor RNA VAF`` = variant
+        # allele frequency (alt / total).
         # n_alt_reads = round(depth × vaf); ref = depth − alt. Missing
         # values yield 0 — honest "no read signal," never fabricated.
-        n_total = _coerce_int(rep.get('RNA Depth'), default=0)
-        rna_vaf = rep.get('RNA VAF')
-        try:
-            vaf = float(rna_vaf) if rna_vaf is not None and not (
-                isinstance(rna_vaf, float) and pd.isna(rna_vaf)) else 0.0
-        except (TypeError, ValueError):
-            vaf = 0.0
+        n_total = _pvacseq_rna_depth(rep)
+        vaf = _pvacseq_rna_vaf(rep)
         n_alt_reads = int(round(n_total * vaf)) if n_total > 0 else 0
         n_ref_reads = max(0, n_total - n_alt_reads)
 
@@ -1007,11 +1095,7 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
         # Resolve to a pyensembl ``Transcript`` so template reports
         # have real effect context; falls back to [] when the genome
         # isn't plumbed through or the ID can't be resolved.
-        best_tid = rep.get('Best Transcript')
-        transcript_ids = (
-            [str(best_tid)]
-            if best_tid and not (isinstance(best_tid, float) and pd.isna(best_tid))
-            else [])
+        transcript_ids = _pvacseq_transcript_ids(rep)
         transcripts = _resolve_transcripts(transcript_ids, genome)
         if transcript_ids:
             n_with_ids += 1
@@ -1031,11 +1115,12 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
         seen_epitope_ids = set()
         variant_epitopes = []
         for r in group_rows:
-            pep = r.get('Best Peptide') or r.get('peptide') or ""
+            pep = _pvacseq_peptide(r)
             if not pep or pep in seen_peptides:
                 continue
             seen_peptides.add(pep)
-            for e in by_peptide.get(pep, []):
+            source_key = _pvacseq_source_key(r)
+            for e in by_source_peptide.get((source_key, pep), []):
                 if id(e) in seen_epitope_ids:
                     continue
                 seen_epitope_ids.add(id(e))
@@ -1050,13 +1135,9 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
             num_target_epitopes_to_keep=num_target_epitopes_to_keep,
         )]))
 
-        dna_vaf_raw = rep.get('DNA VAF')
-        if dna_vaf_raw is not None and not (
-                isinstance(dna_vaf_raw, float) and pd.isna(dna_vaf_raw)):
-            try:
-                dna_vaf_by_variant[variant] = float(dna_vaf_raw)
-            except (TypeError, ValueError):
-                pass
+        dna_vaf = _pvacseq_dna_vaf(rep)
+        if dna_vaf is not None:
+            dna_vaf_by_variant[variant] = dna_vaf
 
     if n_skipped:
         logger.warning(

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.2"
+__version__ = "3.1.3"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

- Replace vaxrank's duplicate pVACseq TSV parser with a thin adapter over `topiary.read_pvacseq`.
- Accept both pVACseq `all_epitopes.tsv` and `all_epitopes.aggregated.tsv` flavors for `--input-pvacseq`.
- Preserve topiary/pVACseq passthrough columns for DSL scoring, including per-algorithm pVACseq columns.
- Keep pVACseq ranking and report scoring source-aware so duplicate peptide sequences from different variants do not mix.
- Bump vaxrank version to `3.1.3` and require `topiary>=5.16.0,<6.0.0`.

## Root Cause

Vaxrank had its own aggregated-only pVACseq parser. That parser drifted from topiary's canonical pVACseq interpretation, could not read unaggregated `all_epitopes.tsv`, and did not retain all pVACseq annotation columns for custom DSL expressions.

## Validation

- `./lint.sh`
- `./test.sh` (`838 passed`)
- `python -m pip index versions topiary` confirms topiary `5.16.1` is now available on PyPI.

Fixes #297.