### PR TITLE
Allow varcode 5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=2.0.0,<3.0.0
 pandas>=2.1.4,<3.0.0
 pyensembl>=2.6.4,<3.0.0
-varcode>=4.17.0,<5.0.0
+varcode>=4.17.0,<6.0.0
 isovar>=1.4.7,<2.0.0
 mhctools>=3.13.3,<4.0.0
 # 5.10.0 adds EvalContext(default_methods=...) and apply_filter(default_methods=...)

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.3"
+__version__ = "3.1.4"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

- widen the varcode dependency upper bound from `<5.0.0` to `<6.0.0`
- bump vaxrank to `3.1.4`

## Why

`openvax/varcode#383` shipped varcode `5.0.0`. vaxrank does not use the removed splice/multi-outcome APIs directly, and the full vaxrank suite passes with the local varcode 5.0.0 checkout on `PYTHONPATH`.

## Validation

- `./lint.sh`
- `./test.sh`: 838 passed, 7 warnings
- `PYTHONPATH=/Users/iskander/code/varcode ./test.sh`: 838 passed, 7 warnings