### PR TITLE
[codex] Use varcode 5 outcome effects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=2.0.0,<3.0.0
 pandas>=2.1.4,<3.0.0
 pyensembl>=2.6.4,<3.0.0
-varcode>=4.17.0,<6.0.0
+varcode>=5.0.0,<6.0.0
 isovar>=1.4.7,<2.0.0
 mhctools>=3.13.3,<4.0.0
 # 5.10.0 adds EvalContext(default_methods=...) and apply_filter(default_methods=...)

--- a/tests/test_varcode_effects.py
+++ b/tests/test_varcode_effects.py
@@ -1,0 +1,150 @@
+from varcode import MultiOutcomeEffect
+from varcode.effect_candidates import EffectCandidate
+from varcode.effects.effect_classes import MutationEffect
+
+from vaxrank.mutant_protein_fragment import MutantProteinFragment
+from vaxrank.report import TemplateDataCreator
+from vaxrank.varcode_effects import (
+    OUTCOME_SELECTION_HIGHEST_PRIORITY,
+    OUTCOME_SELECTION_MOST_LIKELY,
+    OUTCOME_SELECTION_MULTI_OUTCOME,
+    select_varcode_effect_outcome,
+    summarize_varcode_effect_outcomes,
+)
+
+
+class _LikelyEffect(MutationEffect):
+    @property
+    def short_description(self):
+        return "likely"
+
+    @property
+    def transcript_name(self):
+        return "TX-LIKELY"
+
+    @property
+    def transcript_id(self):
+        return "ENST-LIKELY"
+
+
+class _PriorityEffect(MutationEffect):
+    @property
+    def short_description(self):
+        return "priority"
+
+    @property
+    def transcript_name(self):
+        return "TX-PRIORITY"
+
+    @property
+    def transcript_id(self):
+        return "ENST-PRIORITY"
+
+
+class _FakeOutcomeSet(MultiOutcomeEffect):
+    def __init__(self, likely_effect, priority_effect):
+        MultiOutcomeEffect.__init__(self, variant=None)
+        self._likely_effect = likely_effect
+        self._priority_effect = priority_effect
+        self._candidates = (
+            EffectCandidate(likely_effect, source="producer-order"),
+            EffectCandidate(priority_effect, source="priority-order"),
+        )
+
+    @property
+    def candidates(self):
+        return self._candidates
+
+    @property
+    def most_likely_effect(self):
+        return self._likely_effect
+
+    @property
+    def highest_priority_effect(self):
+        return self._priority_effect
+
+
+class _Transcript:
+    id = "ENST-TEST"
+
+
+class _Variant:
+    def __init__(self, effect):
+        self.effect = effect
+
+    def __str__(self):
+        return "VariantWithOutcomeSet"
+
+    def effect_on_transcript(self, transcript):
+        return self.effect
+
+
+def _outcome_set():
+    likely = _LikelyEffect(variant=None)
+    priority = _PriorityEffect(variant=None)
+    return _FakeOutcomeSet(likely, priority), likely, priority
+
+
+def test_select_varcode_effect_outcome_distinguishes_selection_modes():
+    outcomes, likely, priority = _outcome_set()
+
+    assert select_varcode_effect_outcome(
+        outcomes,
+        OUTCOME_SELECTION_MOST_LIKELY) is likely
+    assert select_varcode_effect_outcome(
+        outcomes,
+        OUTCOME_SELECTION_HIGHEST_PRIORITY) is priority
+    assert select_varcode_effect_outcome(
+        outcomes,
+        OUTCOME_SELECTION_MULTI_OUTCOME) is outcomes
+    assert select_varcode_effect_outcome(likely) is likely
+
+
+def test_varcode_effect_outcome_summary_includes_candidates():
+    outcomes, _likely, _priority = _outcome_set()
+
+    summary = summarize_varcode_effect_outcomes(outcomes)
+
+    assert summary["Outcome set type"] == "_FakeOutcomeSet"
+    assert summary["Most likely effect"] == "_LikelyEffect: likely"
+    assert summary["Highest priority effect"] == "_PriorityEffect: priority"
+    assert "_LikelyEffect: likely (producer-order)" in summary[
+        "Candidate effects"]
+    assert "_PriorityEffect: priority (priority-order)" in summary[
+        "Candidate effects"]
+
+
+def test_report_effect_data_uses_selected_effect_and_shows_outcomes():
+    outcomes, _likely, priority = _outcome_set()
+    creator = object.__new__(TemplateDataCreator)
+
+    effect_data = creator._effect_data(outcomes, selected_effect=priority)
+
+    assert effect_data["Effect type"] == "_PriorityEffect"
+    assert effect_data["Transcript name"] == "TX-PRIORITY"
+    assert effect_data["Transcript ID"] == "ENST-PRIORITY"
+    assert effect_data["Outcome set type"] == "_FakeOutcomeSet"
+    assert effect_data["Most likely effect"] == "_LikelyEffect: likely"
+    assert effect_data["Highest priority effect"] == "_PriorityEffect: priority"
+
+
+def test_mutant_protein_fragment_predicted_effect_selects_outcome():
+    outcomes, likely, priority = _outcome_set()
+    frag = MutantProteinFragment(
+        variant=_Variant(outcomes),
+        gene_name="TEST",
+        amino_acids="MTEST",
+        mutant_amino_acid_start_offset=0,
+        mutant_amino_acid_end_offset=1,
+        supporting_reference_transcripts=[_Transcript()],
+        n_overlapping_reads=0,
+        n_alt_reads=0,
+        n_ref_reads=0,
+        n_alt_reads_supporting_protein_sequence=0,
+    )
+
+    assert frag.predicted_effect() is priority
+    assert frag.predicted_effect(
+        outcome_selection=OUTCOME_SELECTION_MOST_LIKELY) is likely
+    assert frag.predicted_effect(
+        outcome_selection=OUTCOME_SELECTION_MULTI_OUTCOME) is outcomes

--- a/vaxrank/gene_pathway_check.py
+++ b/vaxrank/gene_pathway_check.py
@@ -15,6 +15,8 @@ from os.path import join, dirname
 
 import pandas as pd
 
+from .varcode_effects import select_varcode_effect_outcome
+
 
 _ENSEMBL_GENE_ID_COLUMN_NAME = 'Ensembl Gene ID'
 _MUTATION_COLUMN_NAME = 'Mutation'
@@ -109,7 +111,9 @@ class GenePathwayCheck(object):
             Variant object to evaluate
         """
         try:
-            effect_description = variant.effects().top_priority_effect().short_description
+            effect = variant.effects(splice_outcomes=True).top_priority_effect()
+            effect = select_varcode_effect_outcome(effect)
+            effect_description = effect.short_description
             overlapping_gene_ids = variant.gene_ids
         except ValueError:
             # Variant is on a contig not in the reference genome

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -18,6 +18,13 @@ from typing import Any
 from serializable import DataclassSerializable
 from varcode.effects import top_priority_effect
 
+from .varcode_effects import (
+    OUTCOME_SELECTION_HIGHEST_PRIORITY,
+    OUTCOME_SELECTION_MOST_LIKELY,
+    OUTCOME_SELECTION_MULTI_OUTCOME,
+    select_varcode_effect_outcome,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -193,9 +200,10 @@ class MutantProteinFragment(DataclassSerializable):
         using varcode's MutantTranscript.  Used as an opt-in fallback when
         isovar has no RNA support for a variant.
 
-        Transcript selection: among protein-modifying effects, pick the one
-        with the longest mutant protein, breaking ties by lex-sorted
-        transcript ID.  (Effects are already priority-sorted by varcode.)
+        Transcript selection: ask varcode 5 for splice outcome sets, collapse
+        each to its highest-priority concrete outcome, then choose the most
+        protein-disruptive effect. Within that tier, pick the longest mutant
+        protein, breaking ties by lex-sorted transcript ID.
 
         Parameters
         ----------
@@ -207,12 +215,20 @@ class MutantProteinFragment(DataclassSerializable):
         -------
         MutantProteinFragment or None
         """
+        from varcode.effects.effect_ordering import effect_priority
         from varcode.mutant_transcript import apply_variant_to_transcript
 
-        effects = variant.effects()
+        effects = variant.effects(splice_outcomes=True)
         coding_effects = [
-            e for e in effects
-            if hasattr(e, 'transcript') and e.modifies_protein_sequence
+            select_varcode_effect_outcome(e, OUTCOME_SELECTION_HIGHEST_PRIORITY)
+            for e in effects
+        ]
+        coding_effects = [
+            e for e in coding_effects
+            if (
+                e is not None and
+                hasattr(e, 'transcript') and
+                e.modifies_protein_sequence)
         ]
         if not coding_effects:
             logger.debug(
@@ -220,26 +236,37 @@ class MutantProteinFragment(DataclassSerializable):
                 variant.short_description)
             return None
 
-        # Among same-type effects (same priority tier), prefer longest protein
-        # then lex-sorted transcript ID.  variant.effects() is already sorted
-        # by priority, so the first element's type defines the top tier.
-        best_type = type(coding_effects[0])
-        same_tier = [e for e in coding_effects if type(e) is best_type]
+        # Prefer the most protein-disruptive concrete outcome, then choose
+        # the longest protein / lex-sorted transcript within that tier.
+        best_priority = max(effect_priority(e) for e in coding_effects)
+        same_tier = [
+            e for e in coding_effects
+            if effect_priority(e) == best_priority
+        ]
         same_tier.sort(key=lambda e: (
-            -len(e.transcript.protein_sequence or ''),
+            -len(
+                getattr(e, 'mutant_protein_sequence', None) or
+                e.transcript.protein_sequence or ''),
             e.transcript.id,
         ))
         best_effect = same_tier[0]
         transcript = best_effect.transcript
 
-        mt = apply_variant_to_transcript(variant, transcript)
-        if mt is None or mt.mutant_protein_sequence is None:
+        mut_protein = getattr(best_effect, 'mutant_protein_sequence', None)
+        if mut_protein is None:
+            mt = getattr(best_effect, 'mutant_transcript', None)
+            if mt is not None:
+                mut_protein = mt.mutant_protein_sequence
+        if mut_protein is None:
+            mt = apply_variant_to_transcript(variant, transcript)
+            if mt is not None:
+                mut_protein = mt.mutant_protein_sequence
+        if mut_protein is None:
             logger.debug(
                 "MutantTranscript construction failed for %s on %s",
                 variant.short_description, transcript.id)
             return None
 
-        mut_protein = mt.mutant_protein_sequence
         ref_protein = transcript.protein_sequence
         if not ref_protein:
             return None
@@ -385,8 +412,16 @@ class MutantProteinFragment(DataclassSerializable):
             subsequences = subsequences[:limit]
         return subsequences
 
-    def predicted_effect(self):
+    def predicted_effect(
+            self,
+            outcome_selection=OUTCOME_SELECTION_HIGHEST_PRIORITY):
         """Top-priority varcode effect across the supporting transcripts.
+
+        Varcode 5 can represent splice-disrupting variants as multi-outcome
+        sets. By default vaxrank collapses those sets to the highest-priority
+        concrete outcome so peptide mechanics keep working with a single
+        protein effect. Use ``outcome_selection="most_likely"`` for producer
+        order, or ``outcome_selection="multi_outcome"`` for report metadata.
 
         Returns ``None`` when no Transcript objects are available —
         common on external-input paths (LENS / pVACseq) where a
@@ -405,15 +440,27 @@ class MutantProteinFragment(DataclassSerializable):
         invalid transcript data (``ValueError``, ``KeyError``); other
         exceptions propagate so genuine bugs aren't swallowed.
         """
+        if outcome_selection not in {
+                OUTCOME_SELECTION_HIGHEST_PRIORITY,
+                OUTCOME_SELECTION_MOST_LIKELY,
+                OUTCOME_SELECTION_MULTI_OUTCOME}:
+            select_varcode_effect_outcome(None, outcome_selection)
         if not self.supporting_reference_transcripts:
             return None
         # Imported here to keep the module-load cost down and avoid a
         # circular-ish import (varcode is heavy).
         from varcode.errors import ReferenceMismatchError
+        from varcode.splice_outcomes import enumerate_splice_outcomes
         effects = []
         for t in self.supporting_reference_transcripts:
             try:
-                effects.append(self.variant.effect_on_transcript(t))
+                effect = self.variant.effect_on_transcript(t)
+                effect = enumerate_splice_outcomes(effect)
+                effect = select_varcode_effect_outcome(
+                    effect,
+                    outcome_selection=outcome_selection)
+                if effect is not None:
+                    effects.append(effect)
             except (ReferenceMismatchError, ValueError, KeyError) as e:
                 logger.debug(
                     "varcode.effect_on_transcript failed for %s on %s: "

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -26,6 +26,11 @@ from varcode import load_vcf_fast
 from .cancer_hotspots import get_hotspot_url
 from .manufacturability import ManufacturabilityScores
 from .processing import PEPSICKLE_PREDICTOR_NAME
+from .varcode_effects import (
+    OUTCOME_SELECTION_MULTI_OUTCOME,
+    is_multi_outcome_effect,
+    summarize_varcode_effect_outcomes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +194,7 @@ class TemplateDataCreator(object):
         ])
         return variant_data
 
-    def _effect_data(self, predicted_effect):
+    def _effect_data(self, predicted_effect, selected_effect=None):
         """OrderedDict with info about the given varcode effect.
 
         ``predicted_effect`` may be ``None`` on external-input paths
@@ -198,19 +203,24 @@ class TemplateDataCreator(object):
         Render those rows with ``"—"`` placeholders rather than
         crash.
         """
-        if predicted_effect is None:
+        display_effect = selected_effect or predicted_effect
+        if display_effect is None:
             return OrderedDict([
                 ('Effect type', '—'),
                 ('Transcript name', '—'),
                 ('Transcript ID', '—'),
                 ('Effect description', '—'),
             ])
-        return OrderedDict([
-            ('Effect type', predicted_effect.__class__.__name__),
-            ('Transcript name', predicted_effect.transcript_name),
-            ('Transcript ID', predicted_effect.transcript_id),
-            ('Effect description', predicted_effect.short_description),
+        effect_data = OrderedDict([
+            ('Effect type', display_effect.__class__.__name__),
+            ('Transcript name', display_effect.transcript_name or '—'),
+            ('Transcript ID', display_effect.transcript_id or '—'),
+            ('Effect description', display_effect.short_description),
         ])
+        if is_multi_outcome_effect(predicted_effect):
+            effect_data.update(summarize_varcode_effect_outcomes(
+                predicted_effect))
+        return effect_data
 
     def _peptide_header_display_data(self, vaccine_peptide, rank):
         """
@@ -474,11 +484,16 @@ class TemplateDataCreator(object):
 
             top_peptide = vaccine_peptides[0]
             variant_data = self._variant_data(variant, top_peptide)
-            predicted_effect = top_peptide.mutant_protein_fragment.predicted_effect()
-            effect_data = self._effect_data(predicted_effect)
+            mutant_protein_fragment = top_peptide.mutant_protein_fragment
+            predicted_effect = mutant_protein_fragment.predicted_effect()
+            predicted_effect_outcomes = mutant_protein_fragment.predicted_effect(
+                outcome_selection=OUTCOME_SELECTION_MULTI_OUTCOME)
+            effect_data = self._effect_data(
+                predicted_effect_outcomes,
+                selected_effect=predicted_effect)
 
             databases = self._databases(
-                variant, predicted_effect, top_peptide.mutant_protein_fragment.gene_name)
+                variant, predicted_effect, mutant_protein_fragment.gene_name)
 
             peptides = []
             for j, vaccine_peptide in enumerate(vaccine_peptides):

--- a/vaxrank/varcode_effects.py
+++ b/vaxrank/varcode_effects.py
@@ -1,0 +1,75 @@
+from collections import OrderedDict
+
+from varcode import MultiOutcomeEffect
+
+
+OUTCOME_SELECTION_HIGHEST_PRIORITY = "highest_priority"
+OUTCOME_SELECTION_MOST_LIKELY = "most_likely"
+OUTCOME_SELECTION_MULTI_OUTCOME = "multi_outcome"
+
+OUTCOME_SELECTIONS = {
+    OUTCOME_SELECTION_HIGHEST_PRIORITY,
+    OUTCOME_SELECTION_MOST_LIKELY,
+    OUTCOME_SELECTION_MULTI_OUTCOME,
+}
+
+
+def is_multi_outcome_effect(effect):
+    return isinstance(effect, MultiOutcomeEffect)
+
+
+def select_varcode_effect_outcome(
+        effect,
+        outcome_selection=OUTCOME_SELECTION_HIGHEST_PRIORITY):
+    """Collapse a varcode 5 multi-outcome effect to one concrete effect.
+
+    ``most_likely_effect`` is producer-order-first; ``highest_priority_effect``
+    is varcode's most protein-disruptive candidate. Vaxrank's peptide
+    mechanics usually need a single concrete effect, so callers should choose
+    the collapse that matches the question rather than relying on varcode's
+    compatibility shims.
+    """
+    if outcome_selection not in OUTCOME_SELECTIONS:
+        raise ValueError(
+            "Unknown varcode outcome selection %r. Expected one of %s" % (
+                outcome_selection,
+                ", ".join(sorted(OUTCOME_SELECTIONS))))
+    if effect is None:
+        return None
+    if outcome_selection == OUTCOME_SELECTION_MULTI_OUTCOME:
+        return effect
+    if not is_multi_outcome_effect(effect):
+        return effect
+    if outcome_selection == OUTCOME_SELECTION_MOST_LIKELY:
+        return effect.most_likely_effect
+    return effect.highest_priority_effect
+
+
+def format_varcode_effect(effect):
+    if effect is None:
+        return "n/a"
+    description = getattr(effect, "short_description", None) or "n/a"
+    return "%s: %s" % (effect.__class__.__name__, description)
+
+
+def format_varcode_candidate(candidate):
+    text = format_varcode_effect(candidate.effect)
+    source = getattr(candidate, "source", None)
+    if source:
+        text = "%s (%s)" % (text, source)
+    return text
+
+
+def summarize_varcode_effect_outcomes(effect):
+    """Report rows for varcode 5 multi-outcome effects."""
+    if not is_multi_outcome_effect(effect):
+        return OrderedDict()
+    return OrderedDict([
+        ("Outcome set type", effect.__class__.__name__),
+        ("Most likely effect", format_varcode_effect(effect.most_likely_effect)),
+        ("Highest priority effect", format_varcode_effect(
+            effect.highest_priority_effect)),
+        ("Candidate effects", "; ".join(
+            format_varcode_candidate(c)
+            for c in effect.candidates)),
+    ])

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.4"
+__version__ = "3.1.5"
 
 
 def print_version():


### PR DESCRIPTION
## Summary
- require `varcode>=5.0.0,<6.0.0` and bump vaxrank to `3.1.5`
- add a small varcode 5 outcome-selection helper that distinguishes `most_likely_effect`, `highest_priority_effect`, and the original multi-outcome wrapper
- request `splice_outcomes=True` in DNA fallback/pathway annotation and collapse to highest-priority concrete outcomes for peptide mechanics
- include varcode multi-outcome summaries in reports so most-likely and highest-priority candidates are visible when they differ

## Validation
- `python -m pytest tests/test_varcode_effects.py`
- `./lint.sh`
- `./test.sh`