### PR TITLE
WT prediction: use predict_from_named_peptides, name by mutant peptide

### DIFF
--- a/tests/test_epitope_prediction.py
+++ b/tests/test_epitope_prediction.py
@@ -142,6 +142,89 @@ def test_predict_epitopes_returns_one_row_per_predictor_for_multimodel(mouse_gen
         assert per_method == {'mhcflurry', 'netmhcpan'}
 
 
+def test_wt_prediction_uses_named_peptides_keyed_by_mutant(mouse_genome):
+    """WT comparator path: ``predict_from_named_peptides`` is called with
+    each entry named after its mutant peptide, and the resulting row's
+    own ``peptide`` column populates the CandidateEpitope's WT — not a
+    side dict. Locks in the one-hop lookup invariant."""
+    from unittest.mock import patch
+    import pandas as pd
+    from topiary import TopiaryPredictor
+
+    wdr13_transcript = mouse_genome.transcripts_by_name("Wdr13-201")[0]
+    protein_fragment = MutantProteinFragment(
+        variant=Variant('X', '8125624', 'C', 'A'),
+        gene_name='Wdr13',
+        amino_acids='KLQGHSAPVLDVIVNCDESLLASSD',
+        mutant_amino_acid_start_offset=12,
+        mutant_amino_acid_end_offset=13,
+        n_overlapping_reads=71, n_alt_reads=25, n_ref_reads=46,
+        n_alt_reads_supporting_protein_sequence=2,
+        supporting_reference_transcripts=[wdr13_transcript])
+
+    # 9-mer at offset 8 covers [8, 17) — overlaps mutation at [12, 13).
+    mutant_peptide = protein_fragment.amino_acids[8:17]
+    mutant_df = pd.DataFrame([{
+        'peptide': mutant_peptide, 'peptide_length': 9,
+        'peptide_offset': 8, 'allele': 'H-2-Kb',
+        'affinity': 100.0, 'percentile_rank': 0.5,
+        'value': 100.0, 'prediction_method_name': 'mhcflurry',
+        'source_sequence_name': 'Wdr13', 'kind': 'pMHC_affinity',
+        'predictor_version': '', 'score': 0.5,
+    }])
+
+    # Distinct WT string so we can verify the consumer reads it from
+    # the row, not from a side dict.
+    stub_wt_sequence = 'WTSEQUENC'
+    captured_calls = []
+
+    def _stub_predict_wt(name_to_peptide):
+        captured_calls.append(dict(name_to_peptide))
+        return pd.DataFrame([{
+            'source_sequence_name': name, 'peptide': stub_wt_sequence,
+            'peptide_length': 9, 'peptide_offset': 0,
+            'allele': 'H-2-Kb', 'affinity': 1000.0,
+            'percentile_rank': 5.0, 'value': 1000.0,
+            'prediction_method_name': 'mhcflurry',
+            'predictor_version': '', 'score': 0.1,
+            'kind': 'pMHC_affinity',
+        } for name in name_to_peptide])
+
+    class _StubTopiary(TopiaryPredictor):
+        def __init__(self):
+            pass
+
+        def predict_from_named_sequences(self, _named_sequences):
+            return mutant_df
+
+        def predict_from_named_peptides(self, name_to_peptide):
+            return _stub_predict_wt(name_to_peptide)
+
+    cfg = EpitopeConfig(
+        min_epitope_score=0,
+        default_methods={'pMHC_affinity': 'mhcflurry'})
+    with patch('vaxrank.epitope_logic.ReferenceProteome'):
+        epitopes = predict_epitopes(
+            mhc_predictor=_StubTopiary(),
+            protein_fragment=protein_fragment,
+            epitope_config=cfg,
+            genome=mouse_genome)
+
+    # WT call happened exactly once, named by the mutant peptide.
+    assert len(captured_calls) == 1
+    assert list(captured_calls[0].keys()) == [mutant_peptide]
+
+    # The CandidateEpitope's WT peptide came from the row's
+    # ``peptide`` column, not from any side dict.
+    assert len(epitopes) == 1
+    wt = epitopes[0].wt
+    assert wt is not None
+    assert wt.sequence == stub_wt_sequence
+    wt_leaves = wt.predictions_flat()
+    assert len(wt_leaves) == 1
+    assert wt_leaves[0].value == 1000.0
+
+
 def test_mhc_predictor_error(mouse_genome):
     wdr13_transcript = mouse_genome.transcripts_by_name("Wdr13-201")[0]
 

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -88,6 +88,25 @@ def _kind_for_method(method_name):
     return _METHOD_KIND_MAP.get(str(method_name).lower(), "pMHC_affinity")
 
 
+def drop_empty_sample_name(df):
+    """Drop ``sample_name`` when topiary emits it with no real values.
+
+    Topiary 5.16.2+ prepends ``sample_name`` to the group index whenever
+    the column is present with any non-NaN value — and topiary's
+    ``predict_*`` methods now always emit the column filled with empty
+    strings, which count as non-NaN. Vaxrank is single-sample and would
+    rather keep the group key 4-wide than carry a placeholder level
+    through every downstream lookup.
+    """
+    if "sample_name" not in df.columns:
+        return df
+    has_real_value = (
+        df["sample_name"].dropna().astype(str).str.strip().ne("").any())
+    if has_real_value:
+        return df
+    return df.drop(columns=["sample_name"])
+
+
 def epitopes_to_topiary_df(epitopes):
     """Convert a list of :class:`vaxrank.candidate_epitope.CandidateEpitope` into the
     topiary long-format DataFrame consumed by
@@ -115,7 +134,6 @@ def epitopes_to_topiary_df(epitopes):
         source_name = ctx.source_sequence or ctx.sequence
         for p in ctx.predictions_flat():
             rows.append({
-                "sample_name": "",
                 "source_sequence_name": source_name,
                 "peptide": p.peptide,
                 "peptide_offset": ctx.offset,

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -337,8 +337,9 @@ def load_pvacseq(path):
     """
     from topiary import read_pvacseq
 
+    from .epitope_dsl import drop_empty_sample_name
     result = read_pvacseq(path)
-    topiary_df = result.df
+    topiary_df = drop_empty_sample_name(result.df)
     epitope_rows, n_rows = _topiary_pvacseq_to_epitope_rows(topiary_df)
     report_rows = [
         _build_pvacseq_report_row(row)

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -170,12 +170,9 @@ def predict_epitopes(
                 global_epitope_start_pos:global_epitope_start_pos + peptide_length]
             wt_peptides[peptide] = wt_peptide
 
-    # Predict binding for WT peptides. Each WT entry is named after the
-    # mutant peptide it pairs with, so the resulting frame can be looked
-    # up directly by the mutant peptide string at consumer time —
-    # ``predict_from_named_peptides`` scores the exact peptide given
-    # (no k-mer sliding) so ``source_sequence_name`` uniquely identifies
-    # each row.
+    # Name each WT entry after its mutant peptide so the prediction
+    # frame keys cleanly by mutant peptide. ``predict_from_named_peptides``
+    # scores the exact peptide given (no k-mer sliding).
     wt_predictions_grouped = {}
     min_peptide_length = min(predictions_df["peptide_length"]) if len(predictions_df) > 0 else DEFAULT_MIN_KMER_LENGTH
     valid_wt_peptides = {

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -23,7 +23,7 @@ from topiary.ranking import EvalContext, apply_filter
 
 from .config.defaults import DEFAULT_MIN_KMER_LENGTH
 from .epitope_config import EpitopeConfig
-from .epitope_dsl import build_filter_node, build_score_node
+from .epitope_dsl import build_filter_node, build_score_node, drop_empty_sample_name
 from .mutant_protein_fragment import MutantProteinFragment
 from .candidate_epitope import (
     CandidateEpitope, SOURCE_CLASS_MUTATION,
@@ -122,6 +122,7 @@ def predict_epitopes(
 
     if predictions_df.empty:
         return []
+    predictions_df = drop_empty_sample_name(predictions_df)
 
     # ``default_methods`` (per-kind ``prediction_method_name`` defaults
     # for unqualified DSL refs) is required when multi-predictor data
@@ -183,6 +184,7 @@ def predict_epitopes(
     if valid_wt_peptides:
         try:
             wt_df = topiary_predictor.predict_from_named_peptides(valid_wt_peptides)
+            wt_df = drop_empty_sample_name(wt_df)
             for _, row in wt_df.iterrows():
                 key = (row["source_sequence_name"], row["allele"])
                 wt_predictions_grouped[key] = row

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -170,20 +170,24 @@ def predict_epitopes(
                 global_epitope_start_pos:global_epitope_start_pos + peptide_length]
             wt_peptides[peptide] = wt_peptide
 
-    # Predict binding for WT peptides via Topiary
+    # Predict binding for WT peptides. Each WT entry is named after the
+    # mutant peptide it pairs with, so the resulting frame can be looked
+    # up directly by the mutant peptide string at consumer time —
+    # ``predict_from_named_peptides`` scores the exact peptide given
+    # (no k-mer sliding) so ``source_sequence_name`` uniquely identifies
+    # each row.
     wt_predictions_grouped = {}
     min_peptide_length = min(predictions_df["peptide_length"]) if len(predictions_df) > 0 else DEFAULT_MIN_KMER_LENGTH
     valid_wt_peptides = {
-        f"wt_{i}": seq
-        for i, seq in enumerate(set(wt_peptides.values()))
-        if len(seq) >= min_peptide_length
+        mutant_pep: wt_pep
+        for mutant_pep, wt_pep in wt_peptides.items()
+        if len(wt_pep) >= min_peptide_length
     }
     if valid_wt_peptides:
         try:
-            wt_df = topiary_predictor.predict_from_named_sequences(valid_wt_peptides)
-            # Index WT predictions by (peptide, allele)
+            wt_df = topiary_predictor.predict_from_named_peptides(valid_wt_peptides)
             for _, row in wt_df.iterrows():
-                key = (row["peptide"], row["allele"])
+                key = (row["source_sequence_name"], row["allele"])
                 wt_predictions_grouped[key] = row
         except Exception:
             logger.error(
@@ -243,9 +247,9 @@ def predict_epitopes(
         # don't get a meaningful WT pair.
         wt_pred = None
         if overlaps_mutation:
-            wt_peptide = wt_peptides[peptide]
-            wt_row = wt_predictions_grouped.get((wt_peptide, row["allele"]))
+            wt_row = wt_predictions_grouped.get((peptide, row["allele"]))
             if wt_row is None:
+                wt_peptide = wt_peptides[peptide]
                 if len(wt_peptide) < min_peptide_length:
                     logger.info(
                         'No prediction for too-short WT epitope %s: possible stop-loss variant',
@@ -260,7 +264,7 @@ def predict_epitopes(
                     predictor_name=tool,
                     predictor_version=row.get("predictor_version", "") or "",
                     allele=row["allele"],
-                    peptide=wt_peptide,
+                    peptide=wt_row["peptide"],
                     value=wt_ic50,
                     score=0.0,
                     percentile_rank=None,


### PR DESCRIPTION
## Summary

- Replaces the WT prediction call in `epitope_logic.predict_epitopes` from `predict_from_named_sequences` to `predict_from_named_peptides`, which scores the exact peptide given (no k-mer sliding).
- Names each WT entry after the **mutant peptide it pairs with** (was: synthetic `wt_0`, `wt_1`, ...). The resulting frame is then indexed by `(source_sequence_name, allele) == (mutant_peptide, allele)`, which is exactly the key the consumer site needs.
- The per-mutant-row lookup collapses from a two-hop (`wt_peptides[peptide]` → `wt_predictions_grouped[(wt_peptide, allele)]`) to a one-hop (`wt_predictions_grouped[(peptide, allele)]`). The WT amino acid sequence is now read off the prediction row (`wt_row[\"peptide\"]`) instead of a side dict.

## Why

`predict_from_named_sequences` is built for "scan a protein, emit all valid k-mers per name." Passing it isolated peptides risked emitting multiple k-mer rows under the same `source_sequence_name`, which is why the prior code couldn't use the name as a key and had to dedup by WT-peptide string plus look up by `(peptide, allele)`. The new method scores each peptide as a single row, so naming-by-mutant-peptide becomes a sound lookup key.

The `wt_peptides` map is kept (still needed at construction time to know *which* WT sequence to predict per mutant); it just no longer participates in the consumer-side lookup.

## Test plan

- [x] `tests/test_epitope_prediction.py`, `tests/test_nan_robustness.py`, `tests/test_epitope_dsl.py` — all WT-comparator-touching tests pass.
- [x] Full suite: 842 passed.