### PR TITLE
Improve LENS/pVACseq-import UX, logging, and vaccine naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Vaxrank is the neoantigen ranking component of the
 [OpenVax](https://www.openvax.org/) pipeline for designing personalized
 cancer vaccines.  Given either (a) a patient's somatic mutations + tumor
 RNA-seq + HLA type, or (b) a pre-computed neoepitope report from
-[LENS](https://github.com/openvax/lens) or pVACseq, Vaxrank selects and
+[LENS](https://github.com/openvax/lens) or
+[pVACseq](https://github.com/griffithlab/pVACtools), Vaxrank selects and
 ranks the mutant antigens most likely to elicit a T-cell response and
 emits them as the vaccine type(s) the user requests — peptide pools,
 mRNA constructs, or analysis reports for review.
@@ -96,7 +97,9 @@ peptide synthesiser:
    subsequences spanning the mutation) are scored for predicted binding
    to the patient's HLA class I molecules using
    [mhctools](https://github.com/openvax/mhctools), which wraps
-   predictors such as MHCflurry, NetMHCpan, and BigMHC.
+   predictors such as [MHCflurry](https://github.com/openvax/mhcflurry),
+   [NetMHCpan](https://services.healthtech.dtu.dk/services/NetMHCpan-4.1/),
+   and [BigMHC](https://github.com/KarchinLab/bigmhc).
 4. **Vaccine peptide selection** — Vaxrank assembles longer synthetic long
    peptides (SLPs, typically 25-mers) around the mutation, scores them by
    the number and strength of their predicted MHC-binding epitopes,
@@ -349,8 +352,8 @@ outputs work identically.
 
 | Flag | Input format |
 |---|---|
-| `--input-lens` | LENS report TSV |
-| `--input-pvacseq` | pVACseq TSV (`*all_epitopes.tsv` or `*all_epitopes.aggregated.tsv`) |
+| `--input-lens` | [LENS](https://github.com/openvax/lens) report TSV |
+| `--input-pvacseq` | [pVACseq](https://github.com/griffithlab/pVACtools) TSV (`*all_epitopes.tsv` or `*all_epitopes.aggregated.tsv`) |
 
 ### Manifest schema
 
@@ -515,7 +518,8 @@ vaccine_peptides:
 ### Custom filtering and scoring with the topiary DSL
 
 For anything beyond the scalar logistic / percentile-rank defaults, set
-`epitopes.filter_expr` and/or `epitopes.score_expr` to a topiary DSL
+`epitopes.filter_expr` and/or `epitopes.score_expr` to a
+[topiary](https://github.com/openvax/topiary) DSL
 string. Both accept the full topiary 5.0 expression grammar (kind
 accessors like `affinity` / `presentation`, arithmetic, `&` / `|`,
 `.logistic(...)` / `.clip(...)` transforms, `column(col_name)` for raw

--- a/tests/data/epitope_fixtures/lens_v1.9_mhcflurry_only.tsv
+++ b/tests/data/epitope_fixtures/lens_v1.9_mhcflurry_only.tsv
@@ -1,4 +1,4 @@
 peptide	allele	mhcflurry_2.1.1.aff	mhcflurry_2.1.1.aff_perc	mhcflurry_2.1.1.pres_score	mhcflurry_2.1.1.pres_perc	mhcflurry_agretopicity	antigen_source	mut_aa_pos	variant_coords	gene_name	tpm	pep_context	origin_descriptor	snv_ref_allele	snv_alt_allele	indel_ref_allele	indel_alt_allele
-TAEFYQRY	HLA-A01:01	254.15	0.34	0.3	0.48	0.92	ERV				10.87	MDKFLDIYTLPRLNQEEVEFLNRPITSSEIEAVINSL	Hsap38.chr1.168248172.168249089.-				
+TAEFYQRY	HLA-A01:01	254.15	0.34	0.3	0.48	0.92	ERV				10.87	MDKFLDITAEFYQRYRPITSSEIEAVINSL	Hsap38.chr1.168248172.168249089.-
 SLLPAITEY	HLA-A02:01	45.2	0.15	0.82	0.18	0.08	SNV	245.0	chr17:7675088:C:T	TP53	42.5	AASLLPAITEYGTR	chr17:7675088:C:T	C	[T]		
 APRTVALTA	HLA-B07:02	890.4	1.8	0.45	1.25	0.5	CTA			MAGEA3	5.2	MPLQLLPAPRTVALTAGHG	MAGEA3				

--- a/tests/test_design_matrix.py
+++ b/tests/test_design_matrix.py
@@ -176,8 +176,8 @@ def test_peptide_minimal_epitope():
     assert seqs == sorted(["KLQGHSAPV", "NVDEILGRW", "VVVGADGVG"])
     for c in constructs:
         assert c.components['antigen_content'] == "minimal_epitope"
-        # Antigen name disambiguator carries the _epitope suffix
-        assert c.antigen_names[0].endswith("_epitope")
+        # Antigen name carries the minimal-epitope tag in its parens
+        assert c.antigen_names[0].endswith(", epitope)")
 
 
 def test_peptide_concat_minimal_ligands():
@@ -220,10 +220,10 @@ def test_peptide_minimal_with_multiple_top_ligands():
         "NVDEILGRW", "VDEILGRWE",      # GENEB top-2
         "VVVGADGVG",                    # GENEC only has 1
     ])
-    # Names include the disambiguating suffix when >1 ligand from same VP
-    suffixes = sorted(c.antigen_names[0].split("_")[-1] for c in constructs)
-    assert "epitope1" in suffixes
-    assert "epitope2" in suffixes
+    # Names include the disambiguating tag when >1 ligand from same VP
+    names = " ".join(c.antigen_names[0] for c in constructs)
+    assert "epitope1" in names
+    assert "epitope2" in names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_entry_point_helpers.py
+++ b/tests/test_entry_point_helpers.py
@@ -415,3 +415,40 @@ def test_lens_antigen_source_breakdown_orders_snv_indel_first():
             "'(missing)' must land last; got order %r" % kinds_in_order
     if snv_idx >= 0 and indel_idx >= 0:
         assert snv_idx < indel_idx
+
+
+# -- output-dir overwrite confirmation --------------------------------
+
+
+def test_confirm_overwrite_noop_for_missing_or_empty_dir(tmp_path):
+    """Missing or empty --output-dir needs no confirmation (no exit)."""
+    from vaxrank.cli.entry_point import _confirm_output_dir_overwrite
+    # missing
+    _confirm_output_dir_overwrite(
+        SimpleNamespace(output_dir=str(tmp_path / "nope"), force_overwrite=False))
+    # empty
+    (tmp_path / "empty").mkdir()
+    _confirm_output_dir_overwrite(
+        SimpleNamespace(output_dir=str(tmp_path / "empty"), force_overwrite=False))
+
+
+def test_confirm_overwrite_force_proceeds(tmp_path, caplog):
+    """--force-overwrite proceeds into a non-empty dir without prompting."""
+    from vaxrank.cli.entry_point import _confirm_output_dir_overwrite
+    (tmp_path / "f.txt").write_text("x")
+    with caplog.at_level(logging.INFO):
+        _confirm_output_dir_overwrite(
+            SimpleNamespace(output_dir=str(tmp_path), force_overwrite=True))
+    assert any('force-overwrite' in r.getMessage() for r in caplog.records)
+
+
+def test_confirm_overwrite_non_interactive_warns_and_proceeds(
+        tmp_path, caplog, monkeypatch):
+    """Non-interactive (no TTY) runs warn and proceed rather than hang."""
+    from vaxrank.cli import entry_point
+    (tmp_path / "f.txt").write_text("x")
+    monkeypatch.setattr(entry_point.sys.stdin, 'isatty', lambda: False)
+    with caplog.at_level(logging.WARNING):
+        entry_point._confirm_output_dir_overwrite(
+            SimpleNamespace(output_dir=str(tmp_path), force_overwrite=False))
+    assert any('already exists' in r.getMessage() for r in caplog.records)

--- a/tests/test_entry_point_helpers.py
+++ b/tests/test_entry_point_helpers.py
@@ -337,11 +337,12 @@ def test_auto_populate_no_output_dir_is_a_noop():
 # -- LENS antigen-source breakdown ordering ---------------------------
 
 
-def test_lens_antigen_source_breakdown_logs_before_filters():
-    """The up-front ``LENS report contains N row(s); antigen_source
-    breakdown:`` log line must fire BEFORE the per-filter "skipped X
-    rows" lines so the operator sees the input composition before
-    the drop counts."""
+def test_lens_funnel_summarizes_input_composition():
+    """The consolidated ``LENS load funnel`` line replaces the old
+    scattered per-stage count lines. It must report the input row
+    count + antigen_source breakdown and the candidate-epitope count
+    in one block (so the operator isn't left correlating drop counts
+    across multiple lines)."""
     import os
     from vaxrank.epitope_io import load_lens
     from vaxrank.external_input import ranked_from_lens_predictions
@@ -355,23 +356,17 @@ def test_lens_antigen_source_breakdown_logs_before_filters():
     with _capture_logger('vaxrank.external_input', logging.INFO) as records:
         ranked_from_lens_predictions(predictions, lens_path)
 
-    breakdown_idx = [
-        i for i, r in enumerate(records)
-        if 'antigen_source breakdown' in r.getMessage()
-        and 'LENS report contains' in r.getMessage()
-    ]
-    skip_idx = [
-        i for i, r in enumerate(records)
-        if 'Skipped' in r.getMessage()
-        and 'variant_coords' in r.getMessage()
-    ]
-    if not breakdown_idx:
-        pytest.skip("Test fixture didn't trigger up-front breakdown line")
-    if skip_idx:
-        assert breakdown_idx[0] < skip_idx[0], (
-            "Up-front breakdown must log BEFORE filter messages; got "
-            "breakdown@%d, skipped@%d"
-            % (breakdown_idx[0], skip_idx[0]))
+    funnel = [r.getMessage() for r in records
+              if 'LENS load funnel' in r.getMessage()]
+    assert len(funnel) == 1, (
+        "Expected exactly one consolidated funnel line; got %d" % len(funnel))
+    msg = funnel[0]
+    assert 'rows in:' in msg
+    assert 'candidate epitopes scored' in msg
+    # The old per-stage lines must be gone (no double-counting).
+    assert not any('LENS report contains' in r.getMessage() for r in records)
+    assert not any(
+        'lack gene_name' in r.getMessage() for r in records)
 
 
 def test_lens_antigen_source_breakdown_orders_snv_indel_first():
@@ -395,13 +390,12 @@ def test_lens_antigen_source_breakdown_orders_snv_indel_first():
 
     msgs = [
         r.getMessage() for r in records
-        if 'LENS report contains' in r.getMessage()
-        and 'antigen_source breakdown' in r.getMessage()
+        if 'LENS load funnel' in r.getMessage()
     ]
     if not msgs:
-        pytest.skip("Test fixture didn't trigger up-front breakdown line")
+        pytest.skip("Test fixture didn't trigger the funnel line")
     line = msgs[0]
-    m = re.search(r'breakdown:\s*([^.]+)', line)
+    m = re.search(r'rows in:\s*([^\n]+)', line)
     assert m, "Couldn't parse breakdown segment from: %r" % line
     segments = [s.strip() for s in m.group(1).split(',')]
     kinds_in_order = [s.split('=')[0].strip() for s in segments]

--- a/tests/test_entry_point_helpers.py
+++ b/tests/test_entry_point_helpers.py
@@ -452,3 +452,39 @@ def test_confirm_overwrite_non_interactive_warns_and_proceeds(
         entry_point._confirm_output_dir_overwrite(
             SimpleNamespace(output_dir=str(tmp_path), force_overwrite=False))
     assert any('already exists' in r.getMessage() for r in caplog.records)
+
+
+def test_write_run_summary(tmp_path):
+    """The top-level run_summary.txt records inputs, the MHC alleles in
+    play (flagged inferred on the external path), antigen counts, and
+    where each output landed."""
+    from vaxrank.cli.entry_point import _write_run_summary
+    args = SimpleNamespace(
+        output_dir=str(tmp_path),
+        input_lens='patient.lens.tsv', input_pvacseq=None, vcf=None, bam=None,
+        _inferred_mhc_alleles_from_lens=['HLA-A*02:01', 'HLA-B*07:02'],
+        mhc_alleles=None, mhc_alleles_file=None,
+        output_csv=str(tmp_path / 'neoepitope_predictions.csv'),
+        output_ascii_report=str(tmp_path / 'vaccine_report.txt'),
+        output_pdf_report=str(tmp_path / 'vaccine_report.pdf'),
+        vaccine_type=['peptide', 'mrna'])
+    patient = SimpleNamespace(
+        num_somatic_variants=5, num_coding_effect_variants=5,
+        num_variants_with_rna_support=4, num_variants_with_vaccine_peptides=5)
+
+    _write_run_summary(args, patient, source='external')
+
+    text = (tmp_path / 'run_summary.txt').read_text()
+    assert 'LENS report' in text and 'patient.lens.tsv' in text
+    assert 'inferred from report' in text
+    assert 'HLA-A*02:01' in text
+    assert 'variants with antigens:' in text and '5' in text
+    assert 'peptide constructs:' in text and 'mrna constructs:' in text
+
+
+def test_write_run_summary_noop_without_output_dir(tmp_path):
+    """No --output-dir → no run summary written (ranking-only runs)."""
+    from vaxrank.cli.entry_point import _write_run_summary
+    args = SimpleNamespace(output_dir='', input_lens=None, input_pvacseq=None)
+    _write_run_summary(args, None, source='external')
+    assert not list(tmp_path.iterdir())

--- a/tests/test_entry_point_helpers.py
+++ b/tests/test_entry_point_helpers.py
@@ -479,7 +479,10 @@ def test_write_run_summary(tmp_path):
     assert 'inferred from report' in text
     assert 'HLA-A*02:01' in text
     assert 'variants with antigens:' in text and '5' in text
-    assert 'peptide constructs:' in text and 'mrna constructs:' in text
+    # Multi-type + reports requested → split layout, so each modality
+    # subdir holds constructs + its own report.
+    assert 'peptide/' in text and 'mrna/' in text
+    assert 'constructs + vaccine_report' in text
 
 
 def test_write_run_summary_noop_without_output_dir(tmp_path):

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -1511,3 +1511,26 @@ def test_lens_cli_errors_when_no_output_flag_set():
     lens_path = os.path.join(DATA_DIR, "lens_example.tsv")
     with pytest.raises(ValueError, match="No output path specified"):
         main(["--input-lens", lens_path])
+
+
+def test_neoepitope_core_row_shared_contract():
+    """The shared core-row builder used by all three input paths
+    (VCF pipeline, LENS, pVACseq): consistent columns + blank for
+    missing affinity, and Score only when provided."""
+    from vaxrank.epitope_io import neoepitope_core_row
+    # Missing affinities → blank, present → 'NN.NN nM'.
+    row = neoepitope_core_row(
+        allele="HLA-A*02:01", mutant_peptide="SIINFEKL",
+        mutant_affinity=123.456, wt_peptide="", wt_affinity=None,
+        gene_name="TP53", variant="17:7675088 C>T")
+    assert row["Allele"] == "HLA-A*02:01"
+    assert row["Predicted mutant pMHC affinity"] == "123.46 nM"
+    assert row["Predicted wildtype pMHC affinity"] == ""   # blank, not "No prediction"
+    assert "Score" not in row                              # omitted when None
+    # Score is inserted only when supplied (pipeline path).
+    scored = neoepitope_core_row(
+        allele="A", mutant_peptide="P", mutant_affinity=None,
+        wt_peptide="", wt_affinity=None, gene_name="G", variant="v",
+        score=0.5)
+    assert scored["Score"] == 0.5
+    assert scored["Predicted mutant pMHC affinity"] == ""

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -817,13 +817,14 @@ def test_emit_outputs_logs_active_and_fired_dispatch(caplog, tmp_path):
 
     out_dir = str(tmp_path / "out")
     args = _mrna_args(out_dir)
+    args.input_lens = path  # source-specific label derives from this
     with caplog.at_level(logging.INFO):
         _emit_outputs(args, ranked, source='external')
     dispatch = [r.message for r in caplog.records
                 if 'Vaccine-type dispatch' in r.message]
     assert len(dispatch) == 1
     line = dispatch[0]
-    assert "[external]" in line
+    assert "[LENS import]" in line
     assert "['mrna']" in line  # active types and fired list both ['mrna']
 
 

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -940,3 +940,28 @@ def test_emit_outputs_skips_writer_when_no_output_dir(tmp_path):
     _emit_outputs(args, ranked, source='external')
     assert not os.path.exists(out_dir), \
         "Without --output-dir, no writer should have fired"
+
+
+def test_variant_is_frameshift():
+    # varcode trims the shared prefix, so the helper compares the
+    # *normalized* allele lengths: e.g. CAT/C -> AT/'' (delta 2).
+    from varcode import Variant
+    from vaxrank.external_input import variant_is_frameshift
+    assert variant_is_frameshift(Variant('1', 100, 'C', 'T')) is False    # SNV, delta 0
+    assert variant_is_frameshift(Variant('1', 100, 'CA', 'C')) is True     # 1bp del, delta 1
+    assert variant_is_frameshift(Variant('1', 100, 'C', 'CG')) is True     # 1bp ins, delta 1
+    assert variant_is_frameshift(Variant('1', 100, 'CAT', 'C')) is True    # delta 2
+    assert variant_is_frameshift(Variant('1', 100, 'CATG', 'C')) is False  # delta 3, inframe
+    assert variant_is_frameshift(Variant('1', 100, 'CATGA', 'C')) is True  # delta 4
+
+
+def test_maximal_mutant_span_combines_rows_for_frameshift():
+    from vaxrank.external_input import maximal_mutant_span
+    ctx = "WTWTWTNOVELAAANOVELBBBNOVELCCC"  # 30 chars
+    # non-frameshift: representative span unchanged
+    assert maximal_mutant_span(6, 11, ["NOVELAAA"], ctx, False) == (6, 11)
+    # frameshift: start = earliest located neoepitope, end = len(ctx)
+    peptides = ["NOVELBBB", "NOVELAAA", "NOVELCCC"]
+    start, end = maximal_mutant_span(14, 22, peptides, ctx, True)
+    assert start == ctx.find("NOVELAAA")   # earliest
+    assert end == len(ctx)                 # extends to context end

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -965,3 +965,69 @@ def test_maximal_mutant_span_combines_rows_for_frameshift():
     start, end = maximal_mutant_span(14, 22, peptides, ctx, True)
     assert start == ctx.find("NOVELAAA")   # earliest
     assert end == len(ctx)                 # extends to context end
+
+
+def test_check_varcode_annotation_with_stubs():
+    """Pure comparison logic (no varcode/genome): gene + effect-class
+    agreement on the provider's transcript, None when uncomputable."""
+    from types import SimpleNamespace
+    from vaxrank.external_input import check_varcode_annotation
+
+    class FrameShift:
+        gene_name = 'FYN'
+
+    class Substitution:
+        gene_name = 'TPMT'
+
+    # No resolved transcript -> skip (None, None).
+    assert check_varcode_annotation(
+        SimpleNamespace(), None, 'FYN', True) == (None, None)
+    # Frameshift + gene agree.
+    v_fs = SimpleNamespace(effect_on_transcript=lambda t: FrameShift())
+    assert check_varcode_annotation(v_fs, object(), 'FYN', True) == (True, True)
+    # Gene mismatch.
+    assert check_varcode_annotation(
+        v_fs, object(), 'OTHER', True) == (False, True)
+    # Effect-class mismatch (provider says frameshift, varcode substitution).
+    v_sub = SimpleNamespace(effect_on_transcript=lambda t: Substitution())
+    assert check_varcode_annotation(
+        v_sub, object(), 'TPMT', True) == (True, False)
+
+    # Exception during effect computation -> skipped, not raised.
+    def _boom(_t):
+        raise RuntimeError("effect blew up")
+    assert check_varcode_annotation(
+        SimpleNamespace(effect_on_transcript=_boom),
+        object(), 'X', False) == (None, None)
+
+
+def test_log_varcode_agreement(caplog):
+    import logging
+    from vaxrank.external_input import log_varcode_agreement
+
+    # All agree -> single INFO; the None entry (uncomputable) is ignored.
+    with caplog.at_level(logging.INFO, logger='vaxrank.external_input'):
+        log_varcode_agreement(
+            [(True, True, 'v1'), (True, True, 'v2'), (None, None, 'v3')],
+            'LENS')
+    assert any('agrees with LENS on all 2 checked' in r.getMessage()
+               for r in caplog.records)
+
+    # Mismatches -> WARNING; headline counts DISTINCT bad variants (v1
+    # has both, v2 effect-only -> 2 distinct, not max(1,2)=2 by luck;
+    # use a case where it differs: v1 gene-only, v2 effect-only -> 2).
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger='vaxrank.external_input'):
+        log_varcode_agreement(
+            [(False, True, 'v1'), (True, False, 'v2'), (True, True, 'v3')],
+            'pVACseq')
+    msg = [r.getMessage() for r in caplog.records
+           if 'disagrees' in r.getMessage()][0]
+    assert 'disagrees with pVACseq on 2 / 3' in msg
+    assert '1 gene' in msg and '1 effect-class' in msg
+
+    # Nothing checked -> silent.
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger='vaxrank.external_input'):
+        log_varcode_agreement([(None, None, 'x')], 'LENS')
+    assert not any('varcode' in r.getMessage() for r in caplog.records)

--- a/tests/test_mrna.py
+++ b/tests/test_mrna.py
@@ -279,7 +279,7 @@ def test_assembly_basic_construct():
     constructs = assemble_mrna_constructs(pairs, options=options)
     assert len(constructs) == 1
     c = constructs[0]
-    assert c.antigen_names == ['GENEA_1_100_A_T', 'GENEB_2_200_A_T']
+    assert c.antigen_names == ['GENEA (SNV)', 'GENEB (SNV)']
     assert c.no_polya_nt.startswith(UTR_5P_HBB)
     assert c.no_polya_nt.endswith(UTR_3P_HBB)
     # full_nt has polyA tail beyond UTR_3P_HBB
@@ -418,7 +418,7 @@ def test_write_mrna_outputs_fasta_and_manifest():
         assert entry['modality'] == 'mrna'
         assert entry['length_unit'] == 'nt'
         assert entry['name'] == 'mrna_001'
-        assert entry['antigen_names'] == ['GENE_1_1000_A_T']
+        assert entry['antigen_names'] == ['GENE (SNV)']
         # New structured fields
         assert 'lengths' in entry
         assert 'cds' in entry
@@ -454,9 +454,9 @@ def test_mrna_fasta_uses_semicolon_antigen_separator():
             header = f.readline().rstrip()
     assert "antigens=" in header
     # Both antigens land in one description, separated by ';'.
-    assert "GENEA_1_100_A_T;GENEB_2_200_A_T" in header
+    assert "GENEA (SNV);GENEB (SNV)" in header
     # And the legacy comma-joined form must not survive.
-    assert "GENEA_1_100_A_T,GENEB_2_200_A_T" not in header
+    assert "GENEA (SNV),GENEB (SNV)" not in header
 
 
 def test_mrna_max_constructs_logs_topk_selection_at_info(caplog):

--- a/tests/test_neoepitope_report.py
+++ b/tests/test_neoepitope_report.py
@@ -90,4 +90,7 @@ def test_neoepitope_report_handles_missing_wt_ic50(tmp_path):
     )
 
     df = pd.read_excel(excel_path, engine="openpyxl")
-    assert df.iloc[0]["Predicted wildtype pMHC affinity"] == "No prediction"
+    # Missing WT affinity is blank (read back as NaN) — the same
+    # missing-value convention all three report paths now share via
+    # neoepitope_core_row / _format_nm.
+    assert pd.isna(df.iloc[0]["Predicted wildtype pMHC affinity"])

--- a/tests/test_peptide.py
+++ b/tests/test_peptide.py
@@ -67,7 +67,7 @@ def test_slp_mode_one_construct_per_peptide():
     assert len(constructs) == 2
     assert constructs[0].sequence == "KLQGHSAPVLDVIVN"
     assert constructs[0].name == "peptide_001"
-    assert constructs[0].antigen_names == ["GENEA_1_100_A_T"]
+    assert constructs[0].antigen_names == ["GENEA (SNV)"]
     assert constructs[1].sequence == "MNNVDEILGRWESPV"
     assert constructs[1].name == "peptide_002"
     assert constructs[0].components['mode'] == 'slp'
@@ -111,7 +111,7 @@ def test_minimal_epitope_uses_top_prediction():
     [c] = assemble_peptide_constructs(
         pairs, options=PeptideConstructConfig(mode='minimal_epitope'))
     assert c.sequence == "KLAGHSPVL"
-    assert c.antigen_names == ["GENEA_1_1000_A_T_epitope"]
+    assert c.antigen_names == ["GENEA (SNV, epitope)"]
 
 
 def test_minimal_epitope_skips_peptides_without_predictions():
@@ -312,7 +312,7 @@ def test_candidates_per_slot_emits_alternates():
     assert len(constructs) == 2
     assert constructs[0].sequence == "KLQGHSAPVLD"
     assert constructs[1].sequence == "LQGHSAPVLDV"
-    assert "_alt1" in constructs[1].antigen_names[0]
+    assert "alt1" in constructs[1].antigen_names[0]
 
 
 def test_candidates_per_slot_default_is_one():

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -584,13 +584,12 @@ def test_re_location_warns_on_large_offset_drift(caplog):
 
 
 def test_warns_when_peptide_not_in_pep_context(caplog):
-    """LENS rows occasionally carry a ``peptide`` that isn't a
-    substring of its ``pep_context`` (peptide and pep_context built
-    from different isoforms / annotation snapshots — see Pt02
-    analysis, 8/2113 rows). Vaxrank skips those rows rather than
-    fabricate an offset, and emits a single aggregate WARN at the
-    end of ``annotate_processing`` with one example so the user can
-    file an upstream LENS bug."""
+    """A peptide that isn't a substring of its source sequence is
+    skipped during pepsickle annotation rather than given a fabricated
+    offset, with a single aggregate WARN at the end of
+    ``annotate_processing``. LENS-import mismatches are now dropped
+    earlier (``epitope_io.load_lens``); this is the defensive net for
+    anything that still reaches processing (e.g. the pipeline path)."""
     import logging
     # ``KLMXPV`` is one residue off from ``KLMNPV`` so it can't be
     # located in the source by substring or close-match search.
@@ -602,7 +601,7 @@ def test_warns_when_peptide_not_in_pep_context(caplog):
             predictor=StubPepsickle({source: [0.5] * len(source)}))
     assert n == 0
     skipped = [r for r in caplog.records
-               if 'not a substring' in r.message]
+               if "isn't a substring" in r.message]
     assert len(skipped) == 1, (
         "Expected exactly one aggregate skip-WARN; got %d" % len(skipped))
     assert "'KLMXPV'" in skipped[0].message

--- a/tests/test_vaccine_library.py
+++ b/tests/test_vaccine_library.py
@@ -378,7 +378,9 @@ def test_iter_named_antigens_naming_format():
         mutant_protein_fragment=fragment, target_epitopes=[])
     pairs = [(Variant('1', 1000, 'A', 'T'), [peptide])]
     [(name, frag, pep)] = list(iter_named_antigens(pairs))
-    assert name == "GENE_1_1000_A_T"
+    # Gene up front, category parenthesized; no mutation spelled out
+    # because GENE contributes only one variant to this set.
+    assert name == "GENE (SNV)"
     assert frag is fragment
     assert pep is peptide
 
@@ -396,7 +398,41 @@ def test_iter_named_antigens_alt_suffix():
 
     pairs = [(Variant('1', 100, 'A', 'T'), [_peptide("ABC"), _peptide("DEF"), _peptide("GHI")])]
     names = [n for n, _, _ in iter_named_antigens(pairs, candidates_per_slot=3)]
-    assert names == ["G_1_100_A_T", "G_1_100_A_T_alt1", "G_1_100_A_T_alt2"]
+    assert names == ["G (SNV)", "G (SNV alt1)", "G (SNV alt2)"]
+
+
+def test_iter_named_antigens_disambiguates_multi_variant_gene():
+    """When a gene contributes 2+ variants, each gets the mutation
+    spelled out; a single-variant gene in the same set stays clean.
+    Empty indel alleles render as '-'."""
+    from types import SimpleNamespace
+    from varcode import Variant
+    from vaxrank.vaccine_library import iter_named_antigens
+
+    def _peptide(gene):
+        f = SimpleNamespace(
+            amino_acids="ABC", gene_name=gene,
+            mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=3)
+        return SimpleNamespace(mutant_protein_fragment=f)
+
+    pairs = [
+        (Variant('1', 100, 'A', 'T'), [_peptide('TP53')]),     # SNV
+        (Variant('1', 200, 'A', 'T'), [_peptide('TP53')]),     # 2nd TP53
+        (Variant('2', 300, 'C', 'G'), [_peptide('KRAS')]),     # lone gene
+    ]
+    names = [n for n, _, _ in iter_named_antigens(pairs)]
+    assert names == [
+        "TP53 (SNV @ 1:100 A>T)",
+        "TP53 (SNV @ 1:200 A>T)",
+        "KRAS (SNV)",
+    ]
+
+
+def test_gene_names_from_antigen_names():
+    from vaxrank.vaccine_library import gene_names_from_antigen_names
+    names = ["FYN (INDEL)", "TP53 (SNV @ 1:100 A>T)", "FYN (INDEL @ 6:1 G>-)"]
+    # order-preserving, de-duplicated
+    assert gene_names_from_antigen_names(names) == ["FYN", "TP53"]
 
 
 def test_iter_named_antigens_skips_empty_peptide_lists():
@@ -416,7 +452,7 @@ def test_iter_named_antigens_handles_missing_gene_name():
     peptide = SimpleNamespace(mutant_protein_fragment=fragment)
     pairs = [(Variant('1', 100, 'A', 'T'), [peptide])]
     [(name, _, _)] = list(iter_named_antigens(pairs))
-    assert name == "unknown_1_100_A_T"
+    assert name == "unknown (SNV)"
 
 
 def test_iter_named_antigens_caps_at_candidates_per_slot():

--- a/tests/test_varcode_effects.py
+++ b/tests/test_varcode_effects.py
@@ -148,3 +148,28 @@ def test_mutant_protein_fragment_predicted_effect_selects_outcome():
         outcome_selection=OUTCOME_SELECTION_MOST_LIKELY) is likely
     assert frag.predicted_effect(
         outcome_selection=OUTCOME_SELECTION_MULTI_OUTCOME) is outcomes
+
+
+def test_template_data_include_manufacturability_override():
+    """The split-report layout (#17) toggles manufacturability per
+    report via the include_manufacturability override: forced off for
+    the modality-agnostic core + mRNA reports, following the run's
+    --manufacturability resolution (None) for the peptide report."""
+    from types import SimpleNamespace
+    from vaxrank.report import TemplateDataCreator
+
+    args = {'manufacturability': True, 'wt_epitopes': True,
+            'vaccine_type': ['peptide', 'mrna']}
+    patient = SimpleNamespace(patient_id='p', mhc_alleles=[])
+
+    def make(**kw):
+        return TemplateDataCreator(
+            ranked_variants_with_vaccine_peptides=[], patient_info=patient,
+            final_review='', reviewers='', args_for_report=args,
+            input_json_file=None, **kw).template_data
+
+    assert make()['include_manufacturability'] is True          # follows args
+    assert make(include_manufacturability=None)[
+        'include_manufacturability'] is True                    # explicit follow
+    assert make(include_manufacturability=False)[
+        'include_manufacturability'] is False                   # forced off (core/mrna)

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -269,6 +269,14 @@ def add_output_args(arg_parser):
              "canonical filenames inside (vaccine.fasta / cds.fasta / "
              "manifest.json / order_form.csv / mrna-sequence-parts.csv).")
     output_args_group.add_argument(
+        "--force-overwrite",
+        dest="force_overwrite",
+        action="store_true",
+        default=False,
+        help="Skip the confirmation prompt and write into --output-dir "
+             "even if it already exists and is non-empty. Use in "
+             "non-interactive / batch runs.")
+    output_args_group.add_argument(
         "--mrna-csv-no-full-rows",
         dest="mrna_csv_full_rows",
         action="store_false",

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -1328,43 +1328,78 @@ def main(args_list=None):
                 'max_constructs': pep_options.max_constructs,
             }
 
-    # Back-compat: ``mrna_ranking_decisions`` is the legacy field
-    # name TemplateDataCreator already understands; we still pass
-    # it so older callers / tests keep working. New section is
-    # ``vaccine_constructions``.
-    mrna_ranking_decisions = vaccine_constructions.get('mrna')
 
-    template_data_creator = TemplateDataCreator(
-        ranked_variants_with_vaccine_peptides=ranked_variants_with_vaccine_peptides,
-        patient_info=patient_info,
-        final_review=getattr(args, 'output_final_review', '') or '',
-        reviewers=getattr(args, 'output_reviewed_by', '') or '',
-        args_for_report=args_for_report,
-        input_json_file=getattr(args, 'input_json_file', None),
-        cosmic_vcf_filename=getattr(args, 'cosmic_vcf_filename', ''),
-        dna_vaf_by_variant=data.get('dna_vaf_by_variant') or {},
-        processing_predictions_by_key=processing_predictions_by_key,
-        mrna_ranking_decisions=mrna_ranking_decisions,
-        vaccine_constructions=vaccine_constructions,
-        target_alleles=target_alleles)
+    def _template_data(vc_subset, include_manufacturability):
+        return TemplateDataCreator(
+            ranked_variants_with_vaccine_peptides=(
+                ranked_variants_with_vaccine_peptides),
+            patient_info=patient_info,
+            final_review=getattr(args, 'output_final_review', '') or '',
+            reviewers=getattr(args, 'output_reviewed_by', '') or '',
+            args_for_report=args_for_report,
+            input_json_file=getattr(args, 'input_json_file', None),
+            cosmic_vcf_filename=getattr(args, 'cosmic_vcf_filename', ''),
+            dna_vaf_by_variant=data.get('dna_vaf_by_variant') or {},
+            processing_predictions_by_key=processing_predictions_by_key,
+            mrna_ranking_decisions=vc_subset.get('mrna'),
+            vaccine_constructions=vc_subset,
+            target_alleles=target_alleles,
+            include_manufacturability=include_manufacturability,
+        ).compute_template_data()
 
-    template_data = template_data_creator.compute_template_data()
+    def _render(template_data, ascii_path, html_path, pdf_path):
+        if ascii_path:
+            make_ascii_report(
+                template_data=template_data, ascii_report_path=ascii_path)
+        if html_path:
+            make_html_report(
+                template_data=template_data, html_report_path=html_path)
+        if pdf_path:
+            make_pdf_report(
+                template_data=template_data, pdf_report_path=pdf_path,
+                backend=args.pdf_backend)
 
-    if args.output_ascii_report:
-        make_ascii_report(
-            template_data=template_data,
-            ascii_report_path=args.output_ascii_report)
-
-    if args.output_html_report:
-        make_html_report(
-            template_data=template_data,
-            html_report_path=args.output_html_report)
-
-    if args.output_pdf_report:
-        make_pdf_report(
-            template_data=template_data,
-            pdf_report_path=args.output_pdf_report,
-            backend=args.pdf_backend)
+    active_types = _resolve_vaccine_types(args)
+    report_output_dir = getattr(args, 'output_dir', '') or ''
+    if len(active_types) > 1 and report_output_dir:
+        # Split layout (#269): a modality-agnostic core report at the
+        # top level (antigen ranking + coverage, no construction blocks
+        # or manufacturability), plus a per-modality report in each
+        # subdir = core + that modality's construction detail
+        # (manufacturability follows --manufacturability for peptide,
+        # off for mRNA).
+        _render(
+            _template_data({}, include_manufacturability=False),
+            args.output_ascii_report, args.output_html_report,
+            args.output_pdf_report)
+        for vtype in active_types:
+            target_dir = _vaccine_target_dir(
+                report_output_dir, vtype, active_types)
+            if not target_dir:
+                continue
+            vc = vaccine_constructions.get(vtype)
+            subset = {vtype: vc} if vc else {}
+            td = _template_data(
+                subset,
+                include_manufacturability=(
+                    None if vtype == 'peptide' else False))
+            os.makedirs(target_dir, exist_ok=True)
+            _render(
+                td,
+                (os.path.join(target_dir, 'vaccine_report.txt')
+                    if args.output_ascii_report else ''),
+                (os.path.join(target_dir, 'vaccine_report.html')
+                    if args.output_html_report else ''),
+                (os.path.join(target_dir, 'vaccine_report.pdf')
+                    if args.output_pdf_report else ''))
+    else:
+        # Single modality (or no --output-dir): one combined report —
+        # core + the single modality + its manufacturability.
+        _render(
+            _template_data(
+                vaccine_constructions, include_manufacturability=None),
+            args.output_ascii_report, args.output_html_report,
+            args.output_pdf_report)
 
 
 def run_vaxrank_from_parsed_args(args):

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -868,22 +868,35 @@ def _emit_outputs(args, ranked, source):
             raise
         fired.append(vtype)
 
+    if source == 'external':
+        source_label = (
+            'LENS import' if getattr(args, 'input_lens', None)
+            else 'pVACseq import' if getattr(args, 'input_pvacseq', None)
+            else 'external import')
+    else:
+        source_label = 'full pipeline'
     logger.info(
         "Vaccine-type dispatch [%s]: types=%s wrote=%s",
-        source, vaccine_types, fired)
+        source_label, vaccine_types, fired)
 
 
 _AUTO_OUTPUT_FILENAMES = {
-    # Pipeline path → ranked-peptides CSV / JSON.
+    # Pipeline path → ranked-peptides CSV / JSON + the human-readable
+    # ASCII and PDF vaccine reports.
     'pipeline': {
         'output_csv': 'ranked_vaccine_peptides.csv',
         'output_json_file': 'ranked_vaccine_peptides.json',
+        'output_ascii_report': 'vaccine_report.txt',
+        'output_pdf_report': 'vaccine_report.pdf',
     },
-    # External path → per-(peptide, allele) neoepitope CSV; no
-    # JSON dump (the LENS / pVACseq path doesn't build the rich
-    # in-memory result that ``--output-json-file`` serializes).
+    # External path → per-(peptide, allele) neoepitope CSV plus the
+    # same ASCII + PDF reports. No JSON dump (the LENS / pVACseq path
+    # doesn't build the rich in-memory result that
+    # ``--output-json-file`` serializes).
     'external': {
         'output_csv': 'neoepitope_predictions.csv',
+        'output_ascii_report': 'vaccine_report.txt',
+        'output_pdf_report': 'vaccine_report.pdf',
     },
 }
 
@@ -1081,6 +1094,14 @@ def main(args_list=None):
                 a for a in (patient_info.mhc_alleles or [])
                 if a and a != LENS_PROVENANCE_MARKER
             ]
+            # Surface the inferred alleles once, up front — every
+            # downstream consumer (linker optimizer, coverage-aware
+            # antigen selection, report) reuses this same set.
+            if args._inferred_mhc_alleles_from_lens:
+                alleles = args._inferred_mhc_alleles_from_lens
+                logger.info(
+                    "Inferred %d MHC allele(s) from the report: %s",
+                    len(alleles), ", ".join(alleles))
         # Per-(peptide, allele) CSV / XLSX report is unique to the
         # external-input path; emit it before the shared dispatch.
         _emit_neoepitope_report_external(args, report_df, predictions)

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -939,6 +939,41 @@ def _auto_populate_output_paths_from_dir(args):
             ", ".join("%s -> %s" % (a, p) for a, p in filled))
 
 
+def _confirm_output_dir_overwrite(args):
+    """Confirm before writing into an existing, non-empty --output-dir.
+
+    Interactive (TTY) runs get a ``y/N`` prompt and abort on anything
+    but yes. Non-interactive / batch runs don't prompt (that would hang
+    a pipeline) — they proceed with a visible WARNING; pass
+    ``--force-overwrite`` to silence it. A missing or empty directory
+    needs no confirmation.
+    """
+    output_dir = getattr(args, 'output_dir', '') or ''
+    if not output_dir or not os.path.isdir(output_dir) or not os.listdir(
+            output_dir):
+        return
+    if getattr(args, 'force_overwrite', False):
+        logger.info(
+            "--output-dir %r exists and is non-empty; --force-overwrite "
+            "set, writing into it.", output_dir)
+        return
+    if not (sys.stdin.isatty() and sys.stderr.isatty()):
+        logger.warning(
+            "--output-dir %r already exists and is non-empty; writing "
+            "into it (non-interactive run — pass --force-overwrite to "
+            "silence this warning).", output_dir)
+        return
+    try:
+        reply = input(
+            "Output directory %r already exists and is non-empty. "
+            "Overwrite its contents? [y/N] " % output_dir)
+    except EOFError:
+        reply = ''
+    if reply.strip().lower() not in ('y', 'yes'):
+        logger.error("Aborted: --output-dir %r left untouched.", output_dir)
+        sys.exit(1)
+
+
 def configure_logging(args):
     logging.config.fileConfig(
         str(files('vaxrank').joinpath('logging.conf')),
@@ -1037,6 +1072,7 @@ def main(args_list=None):
     # --output-* flag, with no default destination). Applies to both
     # the VCF/BAM pipeline path and the external-input path.
     check_args(args)
+    _confirm_output_dir_overwrite(args)
 
     # Architecture (post-#252):
     #

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -939,6 +939,74 @@ def _auto_populate_output_paths_from_dir(args):
             ", ".join("%s -> %s" % (a, p) for a, p in filled))
 
 
+def _write_run_summary(args, patient_info, source):
+    """Write a top-level ``run_summary.txt`` in --output-dir.
+
+    In multi-vaccine-type runs the constructs live in per-modality
+    subdirs (peptide/, mrna/), but this summary — plus the neoepitope
+    table and ASCII/PDF reports — sits at the top level as the shared
+    context both branches were built from: the inputs, the MHC alleles
+    in play, the antigen counts, and where each output landed. The
+    detailed LENS load funnel is in the run log."""
+    output_dir = getattr(args, 'output_dir', '') or ''
+    if not output_dir:
+        return
+    lines = ["Vaxrank run summary", "=" * 19, ""]
+    if getattr(args, 'input_lens', None):
+        lines.append("Input: LENS report — %s" % args.input_lens)
+    elif getattr(args, 'input_pvacseq', None):
+        lines.append("Input: pVACseq report — %s" % args.input_pvacseq)
+    else:
+        lines.append("Input: full pipeline")
+        for label, attr in (("vcf", "vcf"), ("bam", "bam")):
+            if getattr(args, attr, None):
+                lines.append("  %s: %s" % (label, getattr(args, attr)))
+
+    alleles = _resolve_target_alleles(args)
+    if alleles:
+        inferred = getattr(args, '_inferred_mhc_alleles_from_lens', None)
+        note = " (inferred from report)" if (
+            source == 'external' and inferred) else ""
+        lines += ["", "MHC alleles%s: %s" % (note, ", ".join(alleles))]
+
+    if patient_info is not None:
+        lines += [
+            "",
+            "Antigen counts:",
+            "  variants with antigens:    %d" % (
+                patient_info.num_somatic_variants or 0),
+            "  with resolved transcript:  %d" % (
+                patient_info.num_coding_effect_variants or 0),
+            "  with RNA support:          %d" % (
+                patient_info.num_variants_with_rna_support or 0),
+            "  with vaccine peptide(s):   %d" % (
+                patient_info.num_variants_with_vaccine_peptides or 0),
+        ]
+
+    lines += ["", "Outputs (relative to this directory):"]
+    for label, attr in (
+            ("neoepitope table", "output_csv"),
+            ("ASCII report", "output_ascii_report"),
+            ("PDF report", "output_pdf_report")):
+        path = getattr(args, attr, '') or ''
+        if path:
+            lines.append("  %-18s %s" % (
+                label + ":", os.path.relpath(path, output_dir)))
+    vaccine_types = _resolve_vaccine_types(args)
+    for vtype in vaccine_types:
+        target_dir = _vaccine_target_dir(output_dir, vtype, vaccine_types)
+        if target_dir:
+            lines.append("  %-18s %s/" % (
+                vtype + " constructs:",
+                os.path.relpath(target_dir, output_dir)))
+
+    os.makedirs(output_dir, exist_ok=True)
+    summary_path = os.path.join(output_dir, "run_summary.txt")
+    with open(summary_path, 'w') as f:
+        f.write("\n".join(lines) + "\n")
+    logger.info("Wrote run summary to %s", summary_path)
+
+
 def _confirm_output_dir_overwrite(args):
     """Confirm before writing into an existing, non-empty --output-dir.
 
@@ -1166,6 +1234,7 @@ def main(args_list=None):
             threshold=getattr(args, 'pepsickle_threshold', 0.5))
 
     _emit_outputs(args, ranked_variants_with_vaccine_peptides, source)
+    _write_run_summary(args, patient_info, source)
 
     ########################
     # Template-based reports (PDF / HTML / ASCII)

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -993,12 +993,20 @@ def _write_run_summary(args, patient_info, source):
             lines.append("  %-18s %s" % (
                 label + ":", os.path.relpath(path, output_dir)))
     vaccine_types = _resolve_vaccine_types(args)
+    # In the split-report layout (multi-type + reports requested) each
+    # modality subdir also holds its own vaccine_report; say so.
+    split_reports = len(vaccine_types) > 1 and any(
+        getattr(args, a, '') for a in (
+            'output_ascii_report', 'output_html_report', 'output_pdf_report'))
     for vtype in vaccine_types:
         target_dir = _vaccine_target_dir(output_dir, vtype, vaccine_types)
         if target_dir:
-            lines.append("  %-18s %s/" % (
-                vtype + " constructs:",
-                os.path.relpath(target_dir, output_dir)))
+            contents = (
+                "constructs + vaccine_report" if split_reports
+                else "constructs")
+            lines.append("  %-18s %s/  (%s)" % (
+                vtype + ":", os.path.relpath(target_dir, output_dir),
+                contents))
 
     os.makedirs(output_dir, exist_ok=True)
     summary_path = os.path.join(output_dir, "run_summary.txt")

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -1034,7 +1034,9 @@ def _confirm_output_dir_overwrite(args):
     try:
         reply = input(
             "Output directory %r already exists and is non-empty. "
-            "Overwrite its contents? [y/N] " % output_dir)
+            "Vaxrank will write into it, overwriting any files with the "
+            "same names (other files are left in place). Continue? "
+            "[y/N] " % output_dir)
     except EOFError:
         reply = ''
     if reply.strip().lower() not in ('y', 'yes'):

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -27,6 +27,7 @@ objects at the end.
 """
 
 import logging
+import os
 import re
 from dataclasses import dataclass
 
@@ -733,6 +734,19 @@ def _build_lens_report_row(row, allele, peptide, detected, display_pred,
 
 # ── Shared report writer ─────────────────────────────────────────────────────
 
+def _ensure_parent_dir(path):
+    """Create the parent directory of an output file if it's missing.
+
+    pandas' ``to_csv`` / ``to_excel`` refuse to write into a
+    non-existent directory; mirror the vaccine writers, which already
+    ``os.makedirs`` their target dir, so ``--output-csv foo/bar.csv``
+    works without the user pre-creating ``foo/``.
+    """
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+
 def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
                             csv_report_path=None, epitope_config=None,
                             topiary_df=None):
@@ -853,10 +867,12 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
     report_df.insert(0, 'rank', range(1, len(report_df) + 1))
 
     if csv_report_path:
+        _ensure_parent_dir(csv_report_path)
         report_df.to_csv(csv_report_path, index=False)
         logger.info('Wrote CSV neoepitope report to %s', csv_report_path)
 
     if excel_report_path:
+        _ensure_parent_dir(excel_report_path)
         writer = pd.ExcelWriter(excel_report_path, engine='openpyxl')
         report_df.to_excel(writer, sheet_name='Neoepitopes', index=False)
         worksheet = writer.sheets['Neoepitopes']

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -204,8 +204,12 @@ def _is_missing(val):
 
 
 def _format_nm(value):
+    # Missing affinity → blank, consistent with every other missing
+    # value in the neoepitope CSVs (see _build_lens_report_row). A
+    # blank cell in a "Predicted … affinity" column reads as "not
+    # predicted" without mixing a string sentinel into numeric data.
     value = _safe_float(value)
-    return '%.2f nM' % value if value is not None else 'No prediction'
+    return '%.2f nM' % value if value is not None else ''
 
 
 def _first_float(*values):
@@ -729,11 +733,19 @@ def _build_lens_report_row(row, allele, peptide, detected, display_pred,
     out = {
         'Allele': allele,
         'Mutant peptide sequence': str(peptide),
+        # Missing values are left blank everywhere in this CSV (the
+        # numeric columns below — %ile rank / Agretopicity / TPM —
+        # already do this). A blank cell in a "Predicted … affinity"
+        # column reads unambiguously as "not predicted", and keeps the
+        # file clean for pandas / Excel rather than mixing a
+        # "No prediction" string into otherwise-numeric data. The
+        # human-readable ASCII / PDF reports still spell out
+        # "No prediction" where that reads better.
         'Predicted mutant pMHC affinity': (
-            '%.2f nM' % display_value if display_value is not None
-            else 'No prediction'),
+            '%.2f nM' % display_value if display_value is not None else ''),
         'Wildtype sequence': '',
-        'Predicted wildtype pMHC affinity': 'No prediction',
+        # WT affinity isn't predicted on the import path → always blank.
+        'Predicted wildtype pMHC affinity': '',
         'Gene name': gene,
         'Genomic variant': variant_pos,
         'Antigen source': antigen_source,

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -212,6 +212,43 @@ def _format_nm(value):
     return '%.2f nM' % value if value is not None else ''
 
 
+# Canonical core of the per-(peptide, allele) neoepitope table. All
+# three input paths (VCF pipeline, LENS, pVACseq) build their report
+# rows on top of this so the shared columns — and the missing-value
+# convention — are produced by one piece of code and can't drift
+# (this is where the old "No prediction" vs blank inconsistency came
+# from: three hand-rolled row dicts). Affinity args are raw nM floats
+# (or None → blank). Callers append their source-specific columns.
+NEOEPITOPE_CORE_COLUMNS = (
+    'Allele', 'Mutant peptide sequence', 'Score',
+    'Predicted mutant pMHC affinity', 'Wildtype sequence',
+    'Predicted wildtype pMHC affinity', 'Gene name', 'Genomic variant')
+
+
+def neoepitope_core_row(allele, mutant_peptide, mutant_affinity,
+                        wt_peptide, wt_affinity, gene_name, variant,
+                        score=None):
+    """Build the shared core columns of one neoepitope-report row.
+
+    ``score`` is included only when provided (the pipeline path
+    surfaces it inline; the import paths add ``vaxrank_score`` in
+    :func:`write_neoepitope_report`). Affinities are raw nM floats or
+    None; formatting + the missing-value rule live in ``_format_nm``.
+    """
+    row = {
+        'Allele': allele or '',
+        'Mutant peptide sequence': mutant_peptide or '',
+    }
+    if score is not None:
+        row['Score'] = score
+    row['Predicted mutant pMHC affinity'] = _format_nm(mutant_affinity)
+    row['Wildtype sequence'] = wt_peptide or ''
+    row['Predicted wildtype pMHC affinity'] = _format_nm(wt_affinity)
+    row['Gene name'] = gene_name or ''
+    row['Genomic variant'] = variant or ''
+    return row
+
+
 def _first_float(*values):
     for value in values:
         coerced = _safe_float(value)
@@ -290,14 +327,15 @@ def _build_pvacseq_report_row(row):
         row.get("gene_expression"))
     rna_vaf = _first_float(row.get("rna_vaf"), row.get("tumor_rna_vaf"))
     dna_vaf = _first_float(row.get("dna_vaf"), row.get("tumor_dna_vaf"))
-    out = {
-        'Allele': _safe_str(row.get("allele")),
-        'Mutant peptide sequence': _safe_str(row.get("peptide")),
-        'Predicted mutant pMHC affinity': _format_nm(row.get("value")),
-        'Wildtype sequence': _safe_str(row.get("wt_peptide")),
-        'Predicted wildtype pMHC affinity': _format_nm(row.get("wt_value")),
-        'Gene name': _safe_str(row.get("gene")),
-        'Genomic variant': _safe_str(row.get("variant")),
+    out = neoepitope_core_row(
+        allele=_safe_str(row.get("allele")),
+        mutant_peptide=_safe_str(row.get("peptide")),
+        mutant_affinity=row.get("value"),
+        wt_peptide=_safe_str(row.get("wt_peptide")),
+        wt_affinity=row.get("wt_value"),
+        gene_name=_safe_str(row.get("gene")),
+        variant=_safe_str(row.get("variant")))
+    out.update({
         'Tier': _safe_str(row.get("pvacseq_tier")),
         'Ref Match': _safe_bool(row.get("pvacseq_ref_match")),
         'RNA Expr': rna_expr,
@@ -309,7 +347,7 @@ def _build_pvacseq_report_row(row):
         'MHC class': _safe_str(row.get("mhc_class")),
         'Contains mutant residues': _safe_bool(
             row.get("contains_mutant_residues"), default=True),
-    }
+    })
     for col, value in row.items():
         if col.startswith("pvacseq_") and col not in {
                 "pvacseq_ref_match", "pvacseq_tier"}:
@@ -730,30 +768,19 @@ def _build_lens_report_row(row, allele, peptide, detected, display_pred,
         _safe_float(row.get(display_pred.agretopicity_col))
         if display_pred and display_pred.agretopicity_col else None)
 
-    out = {
-        'Allele': allele,
-        'Mutant peptide sequence': str(peptide),
-        # Missing values are left blank everywhere in this CSV (the
-        # numeric columns below — %ile rank / Agretopicity / TPM —
-        # already do this). A blank cell in a "Predicted … affinity"
-        # column reads unambiguously as "not predicted", and keeps the
-        # file clean for pandas / Excel rather than mixing a
-        # "No prediction" string into otherwise-numeric data. The
-        # human-readable ASCII / PDF reports still spell out
-        # "No prediction" where that reads better.
-        'Predicted mutant pMHC affinity': (
-            '%.2f nM' % display_value if display_value is not None else ''),
-        'Wildtype sequence': '',
-        # WT affinity isn't predicted on the import path → always blank.
-        'Predicted wildtype pMHC affinity': '',
-        'Gene name': gene,
-        'Genomic variant': variant_pos,
+    # Shared core columns (WT affinity isn't predicted on the import
+    # path → None → blank); then LENS-specific extras.
+    out = neoepitope_core_row(
+        allele=allele, mutant_peptide=str(peptide),
+        mutant_affinity=display_value, wt_peptide='', wt_affinity=None,
+        gene_name=gene, variant=variant_pos)
+    out.update({
         'Antigen source': antigen_source,
         'Predictors used': ','.join(chosen_tools),
         '%ile rank': display_percentile,
         'Agretopicity': display_agretopicity,
         'TPM': _safe_float(row.get("tpm")),
-    }
+    })
     # Every detected predictor gets a raw-value column so users can see
     # per-tool signals side-by-side in the report, even if not chosen
     # for DSL scoring.

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -576,6 +576,12 @@ def load_lens(path):
 
     epitope_rows = []
     report_rows = []
+    # Rows whose peptide isn't a substring of a non-empty pep_context —
+    # peptide and pep_context came from different isoforms / annotation
+    # snapshots upstream. Dropped here (not carried into the report,
+    # constructs, or pepsickle); summarized once after the loop.
+    n_dropped_peptide_context_mismatch = 0
+    mismatch_examples = []
     for _, row in df.iterrows():
         peptide = row.get("peptide", "")
         if not peptide or pd.isna(peptide):
@@ -593,6 +599,23 @@ def load_lens(path):
         # LENS doesn't emit a WT IC50 column directly. Computed
         # once per row (shared across detected predictors).
         agretopicity = _safe_float(row.get("mhcflurry_agretopicity"))
+        # Locate the neoepitope inside its surrounding context once per
+        # row (pep_context is a row-level column, not per-predictor).
+        # LENS centers the peptide within pep_context but doesn't emit
+        # the offset directly; substring search recovers it. When
+        # pep_context is non-empty but doesn't contain the peptide, the
+        # two were built from different isoforms / annotation snapshots
+        # (an upstream LENS issue) — drop the row here rather than carry
+        # a fabricated offset downstream into the report, constructs,
+        # and pepsickle. An empty pep_context is a different case (no
+        # SLP window at all): keep it, offset 0, bare-neoepitope fallback.
+        pep_context = _safe_str(row.get("pep_context"))
+        if pep_context and str(peptide) not in pep_context:
+            n_dropped_peptide_context_mismatch += 1
+            if len(mismatch_examples) < 1:
+                mismatch_examples.append((str(peptide), pep_context))
+            continue
+        offset = pep_context.find(str(peptide)) if pep_context else 0
         row_added = False
         for d in chosen:
             value = _safe_float(row.get(d.value_col))
@@ -601,18 +624,6 @@ def load_lens(path):
             percentile_rank = (
                 _safe_float(row.get(d.percentile_col))
                 if d.percentile_col else None)
-            pep_context = _safe_str(row.get("pep_context"))
-            # Locate the neoepitope inside its surrounding context.
-            # LENS centers the peptide within pep_context but doesn't
-            # emit the offset directly; substring search recovers it.
-            # When the peptide isn't a substring (e.g. the row's
-            # pep_context is empty), offset stays at 0 — downstream
-            # code (vaxrank.processing) re-locates by substring search
-            # too and reports drift, so this is recoverable.
-            offset = (
-                pep_context.find(str(peptide))
-                if pep_context and str(peptide) in pep_context
-                else 0)
             # Derive WT IC50 from agretopicity, only for the
             # mhcflurry-affinity predictor (the value matches that
             # tool's IC50 scale). Other predictors leave wt_ic50=None.
@@ -665,6 +676,16 @@ def load_lens(path):
             display_pred=display_pred,
             chosen_tools=[d.tool for d in chosen],
         ))
+
+    if n_dropped_peptide_context_mismatch:
+        ex_peptide, ex_context = mismatch_examples[0]
+        logger.warning(
+            "Dropped %d LENS row(s) whose peptide isn't a substring of "
+            "its (non-empty) pep_context — peptide and pep_context were "
+            "built from different isoforms / annotation snapshots "
+            "upstream. These are excluded from the report and "
+            "constructs. Example: peptide=%r not in pep_context=%r.",
+            n_dropped_peptide_context_mismatch, ex_peptide, ex_context)
 
     report_df = pd.DataFrame(report_rows) if report_rows else pd.DataFrame()
     epitopes = candidate_epitopes_from_rows(epitope_rows)

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -104,6 +104,13 @@ def check_varcode_annotation(variant, transcript, provided_gene,
     try:
         effect = variant.effect_on_transcript(transcript)
     except Exception:
+        # A sanity check must never crash the load; skip this variant.
+        # Logged at DEBUG so a genuine effect-computation bug is still
+        # diagnosable rather than silently swallowed.
+        logger.debug(
+            "varcode could not compute an effect for %s on %s; skipping "
+            "the annotation cross-check.", variant, transcript,
+            exc_info=True)
         return None, None
     gene_ok = (not provided_gene or not effect.gene_name
                or provided_gene == effect.gene_name)
@@ -126,13 +133,16 @@ def log_varcode_agreement(results, source_name):
     gene_bad = [lbl for g, e, lbl in checked if not g]
     effect_bad = [lbl for g, e, lbl in checked if not e]
     if gene_bad or effect_bad:
+        # Distinct variants with any mismatch (a variant can be in both
+        # lists), so the headline count is truthful.
+        n_bad = len(set(gene_bad) | set(effect_bad))
         example = (gene_bad or effect_bad)[0]
         logger.warning(
             "varcode disagrees with %s on %d / %d checked variant(s): "
             "%d gene, %d effect-class mismatch(es) (e.g. %s). %s values "
             "are kept; check that the pyensembl release matches the build "
             "%s used.",
-            source_name, max(len(gene_bad), len(effect_bad)), len(checked),
+            source_name, n_bad, len(checked),
             len(gene_bad), len(effect_bad), example, source_name, source_name)
     else:
         logger.info(
@@ -172,6 +182,11 @@ def maximal_mutant_span(rep_start, rep_end, peptides, context,
     since for a frameshift everything from the onset to the new stop
     (= the end of the translated context) is novel — even residues no
     single neoepitope happened to cover.
+
+    Precondition: ``context`` is the mutant protein translation ending
+    at the (new) stop codon, with no trailing wild-type sequence — true
+    for LENS / pVACseq ``pep_context``. If a provider ever appended
+    post-stop sequence, the extend-to-end step would over-mark it.
     """
     if not is_frameshift:
         return rep_start, rep_end

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -112,53 +112,32 @@ def check_varcode_annotation(variant, transcript, provided_gene,
     return gene_ok, effect_ok
 
 
-class AnnotationCheck:
-    """Accumulates the varcode-vs-provider sanity check across a load.
-
-    Shared by every external loader (LENS, pVACseq, …) so the
-    comparison and the summary log live in one place rather than being
-    re-implemented per modality. ``record`` cross-checks one variant;
-    ``log`` emits a single per-load summary.
+def log_varcode_agreement(results, source_name):
+    """Summarize a varcode-vs-provider annotation cross-check in one log
+    line. ``results`` is a list of ``(gene_ok, effect_ok, label)``
+    tuples from :func:`check_varcode_annotation` (entries with
+    ``gene_ok is None`` — varcode couldn't compute — are ignored).
+    Shared by every external loader so the summary isn't re-implemented
+    per modality.
     """
-
-    def __init__(self):
-        self.checked = 0
-        self.gene_mismatch = 0
-        self.effect_mismatch = 0
-        self.examples = []
-
-    def record(self, variant, transcript, provided_gene,
-               provided_is_frameshift, label=''):
-        gene_ok, effect_ok = check_varcode_annotation(
-            variant, transcript, provided_gene, provided_is_frameshift)
-        if gene_ok is None:
-            return
-        self.checked += 1
-        if not gene_ok:
-            self.gene_mismatch += 1
-        if not effect_ok:
-            self.effect_mismatch += 1
-        if (not gene_ok or not effect_ok) and len(self.examples) < 1:
-            self.examples.append((label, provided_gene))
-
-    def log(self, source_name):
-        if not self.checked:
-            return
-        if self.gene_mismatch or self.effect_mismatch:
-            ex = self.examples[0] if self.examples else None
-            logger.warning(
-                "varcode disagrees with %s on %d / %d checked variant(s): "
-                "%d gene, %d effect-class mismatch(es)%s. The %s values "
-                "are kept; check that the pyensembl release matches the "
-                "build %s used.",
-                source_name, max(self.gene_mismatch, self.effect_mismatch),
-                self.checked, self.gene_mismatch, self.effect_mismatch,
-                (" (e.g. %s gene=%s)" % ex) if ex else "",
-                source_name, source_name)
-        else:
-            logger.info(
-                "varcode agrees with %s on all %d checked variant(s) "
-                "(gene + effect class).", source_name, self.checked)
+    checked = [(g, e, lbl) for g, e, lbl in results if g is not None]
+    if not checked:
+        return
+    gene_bad = [lbl for g, e, lbl in checked if not g]
+    effect_bad = [lbl for g, e, lbl in checked if not e]
+    if gene_bad or effect_bad:
+        example = (gene_bad or effect_bad)[0]
+        logger.warning(
+            "varcode disagrees with %s on %d / %d checked variant(s): "
+            "%d gene, %d effect-class mismatch(es) (e.g. %s). %s values "
+            "are kept; check that the pyensembl release matches the build "
+            "%s used.",
+            source_name, max(len(gene_bad), len(effect_bad)), len(checked),
+            len(gene_bad), len(effect_bad), example, source_name, source_name)
+    else:
+        logger.info(
+            "varcode agrees with %s on all %d checked variant(s) "
+            "(gene + effect class).", source_name, len(checked))
 
 
 def variant_is_frameshift(variant):
@@ -713,9 +692,9 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
     # Transcript. The gap is almost always a release mismatch.
     n_with_ids = 0
     n_resolved = 0
-    # Sanity-check varcode against LENS's own annotation (shared
-    # accumulator; see AnnotationCheck).
-    annotation_check = AnnotationCheck()
+    # Sanity-check varcode against LENS's own annotation. Collected
+    # per variant, summarized once by log_varcode_agreement.
+    annotation_results = []
     # ``vaf`` column carries DNA VAF in LENS v1.9 (sits between
     # ``mhcflurry_agretopicity`` and ``totcopynum`` / ``multiplicity``
     # / ``ccf`` — all DNA-clonal annotations; values track DNA VAF
@@ -843,9 +822,10 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
         # Sanity-check LENS's annotation against varcode on LENS's own
         # transcript (validation only — we keep LENS's values either
         # way; this just surfaces real disagreements).
-        annotation_check.record(
+        gene_ok, effect_ok = check_varcode_annotation(
             variant, transcripts[0] if transcripts else None,
-            gene_name, lens_is_frameshift, label=str(coords))
+            gene_name, lens_is_frameshift)
+        annotation_results.append((gene_ok, effect_ok, str(coords)))
 
         fragment = MutantProteinFragment(
             variant=variant,
@@ -992,7 +972,7 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
             "is a release mismatch — pass --ensembl-release N to match "
             "the build LENS used.", n_unresolved, n_with_ids)
 
-    annotation_check.log("LENS")
+    log_varcode_agreement(annotation_results, "LENS")
 
     # ── Load funnel summary ──────────────────────────────────────────
     # One consolidated view of where the LENS rows went, replacing the
@@ -1209,7 +1189,7 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
     # Aggregate transcript-resolution stats (see LENS path for rationale).
     n_with_ids = 0
     n_resolved = 0
-    annotation_check = AnnotationCheck()
+    annotation_results = []
     # pVACseq carries an explicit ``DNA VAF`` column (separate from
     # the ``RNA VAF`` we already consume for read counts). Plumb it
     # through to the report's DNA-VAF field.
@@ -1264,10 +1244,12 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
         # frameshift comes from the variant's own ref/alt (provider
         # data) — this still cross-checks that varcode's effect class
         # is consistent with the genomic alleles, and that the gene
-        # agrees. Shared with the LENS path via AnnotationCheck.
-        annotation_check.record(
+        # agrees. Shared with the LENS path via check_varcode_annotation
+        # + log_varcode_agreement.
+        gene_ok, effect_ok = check_varcode_annotation(
             variant, transcripts[0] if transcripts else None,
-            gene, variant_is_frameshift(variant), label=str(vid))
+            gene, variant_is_frameshift(variant))
+        annotation_results.append((gene_ok, effect_ok, str(vid)))
         fragment = MutantProteinFragment(
             variant=variant, gene_name=gene,
             amino_acids=str(best_pep),
@@ -1323,7 +1305,7 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
             "N to match the build pVACseq used.",
             n_unresolved, n_with_ids)
 
-    annotation_check.log("pVACseq")
+    log_varcode_agreement(annotation_results, "pVACseq")
 
     ranked.sort(
         key=lambda pair: (

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -1208,11 +1208,21 @@ def _patient_info_from_external(ranked, source_path, patient_id,
     mhc_alleles = []
     if predictions:
         seen = set()
-        for p in predictions:
-            allele = getattr(p, 'allele', '') or ''
-            if allele and allele not in seen:
-                seen.add(allele)
-                mhc_alleles.append(allele)
+        for ep in predictions:
+            # ``predictions`` here is a list of CandidateEpitope, which
+            # has no ``.allele`` — its alleles are the keys of
+            # ``per_allele_scores`` (populated by the DSL at load).
+            # Fall back to the raw Prediction.allele list for any loader
+            # that doesn't populate per_allele_scores.
+            alleles = list((getattr(ep, 'per_allele_scores', None) or {}))
+            if not alleles:
+                alleles = [
+                    getattr(p, 'allele', '')
+                    for p in (getattr(ep, 'predictions', None) or [])]
+            for allele in alleles:
+                if allele and allele not in seen:
+                    seen.add(allele)
+                    mhc_alleles.append(allele)
         if mhc_alleles:
             mhc_alleles = sorted(mhc_alleles) + [LENS_PROVENANCE_MARKER]
     return PatientInfo(

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -72,6 +72,19 @@ logger = logging.getLogger(__name__)
 LENS_PROVENANCE_MARKER = '(inferred from report)'
 
 
+def _antigen_kind_sort_key(kind, count):
+    """Stable antigen_source ordering — SNV / INDEL first, then by
+    descending count, ``(missing)`` last. Shared by the input
+    breakdown and the funnel's coord breakdown so both read the same.
+    """
+    priority = {'SNV': 0, 'INDEL': 1}
+    if kind.upper() in priority:
+        return (priority[kind.upper()], 0, kind)
+    if kind == '(missing)':
+        return (3, 0, kind)
+    return (2, -count, kind)
+
+
 def _missing_cell(value):
     if value is None:
         return True
@@ -462,10 +475,10 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
     list[(varcode.Variant, list[VaccinePeptide])]
     """
     if not lens_tsv_path:
-        return []
+        return [], {}
     df = pd.read_csv(lens_tsv_path, sep="\t", low_memory=False)
     if df.empty:
-        return []
+        return [], {}
 
     # Auto-detect which LENS predictor columns are present so the
     # representative-row pick reads real values. Without this, every
@@ -517,17 +530,9 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
                     isinstance(kind, float) and pd.isna(kind))
                 else '(missing)')
             full_kinds[kind_key] = full_kinds.get(kind_key, 0) + 1
-        # Stable order: SNV / INDEL up-front (the variant-coord paths),
-        # then everything else by descending count, with (missing) last.
-        priority = {'SNV': 0, 'INDEL': 1}
-        def _bucket_order(item):
-            k, count = item
-            if k.upper() in priority:
-                return (priority[k.upper()], 0, k)
-            if k == '(missing)':
-                return (3, 0, k)
-            return (2, -count, k)
-        ordered = sorted(full_kinds.items(), key=_bucket_order)
+        ordered = sorted(
+            full_kinds.items(),
+            key=lambda kv: _antigen_kind_sort_key(kv[0], kv[1]))
         breakdown = ', '.join("%s=%d" % (k, v) for k, v in ordered)
     else:
         full_kinds = {}
@@ -859,7 +864,7 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
         k: full_kinds.get(k, 0) - skipped_kinds.get(k, 0) for k in full_kinds}
     coord_breakdown = ', '.join(
         "%s=%d" % (k, kept_kinds[k]) for k in sorted(
-            kept_kinds, key=lambda x: (x.upper() not in ('SNV', 'INDEL'), x))
+            kept_kinds, key=lambda k: _antigen_kind_sort_key(k, kept_kinds[k]))
         if kept_kinds[k] > 0) or '(none)'
     if n_snv_indel_no_gene or n_snv_indel_no_transcript or n_snv_indel_no_reads:
         note = (
@@ -1036,10 +1041,10 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
     shorter antigen windows than the LENS path.
     """
     if not pvacseq_tsv_path:
-        return []
+        return [], {}
     df = pd.read_csv(pvacseq_tsv_path, sep="\t", low_memory=False)
     if df.empty:
-        return []
+        return [], {}
 
     by_source_peptide: dict[tuple[str, str], list] = {}
     for e in epitopes:

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -200,6 +200,47 @@ def maximal_mutant_span(rep_start, rep_end, peptides, context,
     return start, len(context)
 
 
+def log_transcript_resolution(n_with_ids, n_resolved, source_name,
+                              id_label="transcript IDs"):
+    """Warn once when some variants' transcript IDs didn't resolve
+    against the configured pyensembl release (almost always a release
+    mismatch). Shared by every external loader."""
+    if n_with_ids and n_resolved < n_with_ids:
+        logger.warning(
+            "%d / %d variant(s) had %s that didn't resolve against the "
+            "configured pyensembl release. Most often this is a release "
+            "mismatch — pass --ensembl-release N to match the build %s "
+            "used.", n_with_ids - n_resolved, n_with_ids, id_label,
+            source_name)
+
+
+def ranked_sorted_by_target_score(ranked):
+    """Order ``(variant, [VaccinePeptide])`` entries by descending
+    target-epitope score, ties broken by variant string for
+    determinism. Shared by every external loader so the ranking order
+    is defined in one place."""
+    return sorted(
+        ranked,
+        key=lambda pair: (
+            -pair[1][0].target_epitope_score if pair[1] else 0.0,
+            str(pair[0])))
+
+
+@dataclasses.dataclass
+class _ExternalVariantEntry:
+    """One variant's contribution to an external loader's output,
+    plus the per-variant stats the loader aggregates. Lets the
+    per-variant build live in a helper while the loader stays a thin
+    accumulate-and-summarize loop."""
+    variant: object = None
+    vaccine_peptide: object = None
+    had_transcript_ids: bool = False
+    resolved_transcript: bool = False
+    annotation: object = None       # (gene_ok, effect_ok, label) or None
+    dna_vaf: object = None          # float or None
+    unparseable: bool = False
+
+
 def _missing_cell(value):
     if value is None:
         return True
@@ -560,6 +601,163 @@ def _read_counts_from_lens_row(row):
     return n_total, n_alt_reads, n_ref_reads, n_alt_supporting_protein
 
 
+def _lens_ranked_entry(coords, group_rows, by_peptide, genome,
+                       vaccine_peptide_length, affinity_cols, rank_cols,
+                       num_target_epitopes_to_keep):
+    """Build one variant's :class:`_ExternalVariantEntry` from a LENS
+    row group. Returns the entry (with ``unparseable`` / ``vaccine_peptide``
+    None for rows that can't be turned into an antigen); the caller
+    aggregates the stats and the ranked list."""
+    rep = _pick_representative(group_rows, affinity_cols, rank_cols)
+    # Build the Variant from REAL ref/alt columns (snv_*_allele /
+    # indel_*_allele depending on antigen_source). variant_coords gives
+    # only chr:pos in LENS v1.9; the alleles live in dedicated columns.
+    variant = _variant_from_lens_row(rep, genome=genome)
+    if variant is None:
+        logger.debug(
+            "Could not build Variant from LENS row at coords=%r "
+            "(antigen_source=%r); skipping.", coords,
+            rep.get('antigen_source'))
+        return _ExternalVariantEntry(unparseable=True)
+
+    peptide = rep.get('peptide') or ""
+    pep_context = rep.get('pep_context') or ""
+    if not pep_context:
+        # No SLP window available — fall back to the neoepitope itself
+        # as the antigen. The construct will be short but valid.
+        pep_context = peptide
+    # Translation halts at the first stop codon — anything after ``*``
+    # doesn't exist as protein. Truncate so manufacturability /
+    # hydropathy / codon-optimization see only real residues.
+    pep_context = truncate_at_stop_codon(str(pep_context))
+    peptide = truncate_at_stop_codon(str(peptide))
+    if not pep_context or not peptide:
+        logger.debug(
+            "Dropped LENS row for variant %r: peptide / pep_context "
+            "empty after stop-codon truncation.", coords)
+        return _ExternalVariantEntry()
+    # Some LENS files emit non-standard residues (U / O / X / B / Z / J);
+    # vaxrank's manufacturability / hydropathy code is keyed off the 20
+    # canonical AAs, so drop the row rather than crash.
+    if not has_only_standard_amino_acids(pep_context):
+        logger.warning(
+            "Dropped LENS row for variant %r: pep_context %r contains "
+            "non-standard residues (allowed: 20 canonical AAs).",
+            coords, pep_context)
+        return _ExternalVariantEntry()
+    # Preserve LENS's own gene name; fall back to empty string (the
+    # codebase convention for "not known").
+    gene_name_raw = rep.get('gene_name')
+    gene_name = (
+        str(gene_name_raw) if gene_name_raw and not (
+            isinstance(gene_name_raw, float) and pd.isna(gene_name_raw))
+        else "")
+
+    start_off, end_off = _mut_offsets_in_context(peptide, pep_context)
+    if start_off is None:
+        logger.debug(
+            "Could not locate peptide %r in pep_context %r for variant "
+            "%r; skipping (mutation span unknown).",
+            peptide, pep_context, coords)
+        return _ExternalVariantEntry()
+
+    # Frameshift → the whole downstream tail is novel; combine the
+    # variant's neoepitope rows into the maximal mutant span. Frameshift
+    # is derived from the variant's own ref/alt (general); LENS's own
+    # frameshift annotation is kept separately only to sanity-check
+    # varcode.
+    start_off, end_off = maximal_mutant_span(
+        start_off, end_off, [r.get('peptide') for r in group_rows],
+        pep_context, variant_is_frameshift(variant))
+    lens_is_frameshift = (
+        str(rep.get('indel_type') or '').strip().lower() == 'frameshift'
+        or 'fs' in str(rep.get('variant_effect') or '').lower())
+
+    # Window pep_context to the canonical SLP fragment size; the same
+    # operation the pipeline path's Isovar fragments satisfy by
+    # construction (see MutantProteinFragment.slp_window_around_mutation).
+    pep_context, start_off, end_off = (
+        MutantProteinFragment.slp_window_around_mutation(
+            pep_context, start_off, end_off, vaccine_peptide_length))
+
+    # Real RNA-read counts from LENS columns. Missing → 0 (honest "no
+    # signal"); never fabricated from TPM.
+    (n_total, n_alt_reads, n_ref_reads,
+     n_alt_supporting_protein) = _read_counts_from_lens_row(rep)
+
+    # Real transcript IDs → pyensembl Transcript objects so template
+    # reports have varcode context; shrinks to [] when unresolvable.
+    tid = rep.get('transcript_id')
+    all_tids = rep.get('all_transcript_ids_encoding_peptide')
+    transcript_ids = []
+    if tid and not (isinstance(tid, float) and pd.isna(tid)):
+        transcript_ids.append(str(tid))
+    if all_tids and isinstance(all_tids, str) and all_tids.lower() != 'nan':
+        for t in all_tids.split(','):
+            t = t.strip()
+            if t and t not in transcript_ids:
+                transcript_ids.append(t)
+    transcripts = _resolve_transcripts(transcript_ids, genome)
+
+    entry = _ExternalVariantEntry(
+        variant=variant,
+        had_transcript_ids=bool(transcript_ids),
+        resolved_transcript=bool(transcripts),
+        # Sanity-check LENS's annotation against varcode on LENS's own
+        # transcript (validation only — LENS's values are kept).
+        annotation=(check_varcode_annotation(
+            variant, transcripts[0] if transcripts else None,
+            gene_name, lens_is_frameshift) + (str(coords),)))
+
+    fragment = MutantProteinFragment(
+        variant=variant, gene_name=gene_name, amino_acids=str(pep_context),
+        mutant_amino_acid_start_offset=start_off,
+        mutant_amino_acid_end_offset=end_off,
+        supporting_reference_transcripts=transcripts,
+        n_overlapping_reads=n_total, n_alt_reads=n_alt_reads,
+        n_ref_reads=n_ref_reads,
+        n_alt_reads_supporting_protein_sequence=n_alt_supporting_protein,
+        # Real ref/alt columns → real genotype, not a placeholder.
+        placeholder_alleles=False)
+
+    # Collect the variant's CandidateEpitopes (deduped on identity); LENS
+    # rows are mutant-derived, so every one overlaps the mutation.
+    seen_peptides = set()
+    seen_epitope_ids = set()
+    variant_epitopes = []
+    for r in group_rows:
+        pep = r.get('peptide') or ""
+        if not pep or pep in seen_peptides:
+            continue
+        seen_peptides.add(pep)
+        for e in by_peptide.get(pep, []):
+            if id(e) in seen_epitope_ids:
+                continue
+            seen_epitope_ids.add(id(e))
+            if not e.overlaps_mutation:
+                e = dataclasses.replace(e, overlaps_mutation=True)
+            variant_epitopes.append(e)
+    if not variant_epitopes:
+        # Transcript stats + annotation already recorded above; just no
+        # vaccine peptide for this variant.
+        return entry
+
+    entry.vaccine_peptide = VaccinePeptide(
+        mutant_protein_fragment=fragment,
+        epitopes=variant_epitopes,
+        num_target_epitopes_to_keep=num_target_epitopes_to_keep)
+
+    # DNA VAF for the report (representative row; LENS dedupes by variant).
+    vaf_raw = rep.get('vaf')
+    if vaf_raw is not None and not (
+            isinstance(vaf_raw, float) and pd.isna(vaf_raw)):
+        try:
+            entry.dna_vaf = float(vaf_raw)
+        except (TypeError, ValueError):
+            pass
+    return entry
+
+
 def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
                                  num_target_epitopes_to_keep=None,
                                  vaccine_peptide_length=25):
@@ -718,193 +916,22 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
     # the report's "DNA VAF" field gets populated instead of "n/a".
     dna_vaf_by_variant = {}
     for coords, group_rows in groups.items():
-        rep = _pick_representative(group_rows, affinity_cols, rank_cols)
-        # Build the Variant from REAL ref/alt columns
-        # (snv_ref_allele/snv_alt_allele or indel_ref_allele/indel_alt_allele
-        # depending on antigen_source). variant_coords gives only chr:pos in
-        # LENS v1.9; the alleles live in dedicated columns.
-        variant = _variant_from_lens_row(rep, genome=genome)
-        if variant is None:
+        entry = _lens_ranked_entry(
+            coords, group_rows, by_peptide, genome, vaccine_peptide_length,
+            affinity_cols, rank_cols, num_target_epitopes_to_keep)
+        if entry.unparseable:
             n_unparseable += 1
-            logger.debug(
-                "Could not build Variant from LENS row at coords=%r "
-                "(antigen_source=%r); skipping.",
-                coords, rep.get('antigen_source'))
             continue
-        peptide = rep.get('peptide') or ""
-        pep_context = rep.get('pep_context') or ""
-        if not pep_context:
-            # No SLP window available — fall back to using the
-            # neoepitope itself as the antigen. The construct will be
-            # short but valid.
-            pep_context = peptide
-        # Translation halts at the first stop codon — anything after
-        # ``*`` doesn't exist as protein. Truncate so manufacturability
-        # / hydropathy / codon-optimization see only real residues.
-        pep_context = truncate_at_stop_codon(str(pep_context))
-        peptide = truncate_at_stop_codon(str(peptide))
-        # If the neoepitope itself was past the stop, we can't make a
-        # vaccine peptide out of it — drop the row.
-        if not pep_context or not peptide:
-            n_skipped_post_stop = locals().get('n_skipped_post_stop', 0) + 1
-            logger.debug(
-                "Dropped LENS row for variant %r: peptide / pep_context "
-                "empty after stop-codon truncation.", coords)
-            continue
-        # Some LENS files emit non-standard residues (selenocysteine
-        # 'U', pyrrolysine 'O', ambiguous 'X' / 'B' / 'Z' / 'J').
-        # Vaxrank's manufacturability / hydropathy code is keyed off
-        # the 20 canonical AAs, so drop the row rather than crash.
-        if not has_only_standard_amino_acids(pep_context):
-            logger.warning(
-                "Dropped LENS row for variant %r: pep_context %r "
-                "contains non-standard residues (allowed: 20 canonical "
-                "AAs).", coords, pep_context)
-            continue
-        # Preserve LENS's own gene name; fall back to empty string
-        # (the codebase convention for "not known") rather than
-        # invent "unknown". Empty propagates through
-        # iter_named_antigens which already handles it.
-        gene_name_raw = rep.get('gene_name')
-        gene_name = (
-            str(gene_name_raw) if gene_name_raw and not (
-                isinstance(gene_name_raw, float) and pd.isna(gene_name_raw))
-            else "")
-
-        start_off, end_off = _mut_offsets_in_context(peptide, pep_context)
-        if start_off is None:
-            logger.debug(
-                "Could not locate peptide %r in pep_context %r for "
-                "variant %r; skipping (mutation span unknown).",
-                peptide, pep_context, coords)
-            continue
-
-        # Frameshift → the whole downstream tail is novel; combine the
-        # variant's neoepitope rows into the maximal mutant span.
-        # Frameshift is derived from the variant's own ref/alt (general,
-        # not a LENS-specific column). ``lens_is_frameshift`` (LENS's
-        # annotation) is kept separately only to sanity-check varcode.
-        start_off, end_off = maximal_mutant_span(
-            start_off, end_off,
-            [r.get('peptide') for r in group_rows],
-            pep_context, variant_is_frameshift(variant))
-        lens_is_frameshift = (
-            str(rep.get('indel_type') or '').strip().lower() == 'frameshift'
-            or 'fs' in str(rep.get('variant_effect') or '').lower())
-
-        # Window pep_context down to the canonical SLP fragment size
-        # (--vaccine-peptide-length, default 25). LENS sometimes
-        # emits the entire protein prefix here, which would render
-        # as a 100+aa "vaccine peptide" — not what
-        # ``MutantProteinFragment`` represents elsewhere in vaxrank.
-        # The pipeline path gets correctly-sized fragments from
-        # Isovar by construction; the same operation lives on
-        # ``MutantProteinFragment.slp_window_around_mutation`` so
-        # both paths share one definition of "an SLP-windowed
-        # protein fragment around a mutation."
-        pep_context, start_off, end_off = (
-            MutantProteinFragment.slp_window_around_mutation(
-                pep_context, start_off, end_off, vaccine_peptide_length))
-
-        # Real RNA-read counts from LENS columns. Missing → 0
-        # (honest "no signal"); never fabricate from TPM.
-        (n_total, n_alt_reads, n_ref_reads,
-         n_alt_supporting_protein) = _read_counts_from_lens_row(rep)
-
-        # Pull real transcript IDs when available, then resolve to
-        # pyensembl ``Transcript`` objects so downstream
-        # ``predicted_effect()`` (used by template reports) has real
-        # varcode context. When ``genome`` is None or an ID can't be
-        # resolved, the resolved list shrinks accordingly — the
-        # report renderer tolerates the empty case.
-        tid = rep.get('transcript_id')
-        all_tids = rep.get('all_transcript_ids_encoding_peptide')
-        transcript_ids = []
-        if tid and not (isinstance(tid, float) and pd.isna(tid)):
-            transcript_ids.append(str(tid))
-        if (all_tids and isinstance(all_tids, str)
-                and all_tids.lower() != 'nan'):
-            for t in all_tids.split(','):
-                t = t.strip()
-                if t and t not in transcript_ids:
-                    transcript_ids.append(t)
-        transcripts = _resolve_transcripts(transcript_ids, genome)
-        if transcript_ids:
+        if entry.annotation is not None:
+            annotation_results.append(entry.annotation)
+        if entry.had_transcript_ids:
             n_with_ids += 1
-            if transcripts:
+            if entry.resolved_transcript:
                 n_resolved += 1
-
-        # Sanity-check LENS's annotation against varcode on LENS's own
-        # transcript (validation only — we keep LENS's values either
-        # way; this just surfaces real disagreements).
-        gene_ok, effect_ok = check_varcode_annotation(
-            variant, transcripts[0] if transcripts else None,
-            gene_name, lens_is_frameshift)
-        annotation_results.append((gene_ok, effect_ok, str(coords)))
-
-        fragment = MutantProteinFragment(
-            variant=variant,
-            gene_name=gene_name,
-            amino_acids=str(pep_context),
-            mutant_amino_acid_start_offset=start_off,
-            mutant_amino_acid_end_offset=end_off,
-            supporting_reference_transcripts=transcripts,
-            n_overlapping_reads=n_total,
-            n_alt_reads=n_alt_reads,
-            n_ref_reads=n_ref_reads,
-            n_alt_reads_supporting_protein_sequence=n_alt_supporting_protein,
-            # Real LENS ref/alt columns are consulted directly, so
-            # the synthesized Variant carries a real biological
-            # genotype — placeholder_alleles is False.
-            placeholder_alleles=False,
-        )
-
-        # Collect all Epitopes whose mutant peptide appears in any of
-        # this variant's rows. The load_lens adapter has already
-        # grouped all per-(allele, predictor) Prediction records into
-        # one CandidateEpitope per (peptide, source, offset), so dedup is on
-        # CandidateEpitope identity — typically yields one CandidateEpitope per unique
-        # peptide in the variant's row group.
-        seen_peptides = set()
-        seen_epitope_ids = set()
-        variant_epitopes = []
-        for r in group_rows:
-            pep = r.get('peptide') or ""
-            if not pep or pep in seen_peptides:
-                continue
-            seen_peptides.add(pep)
-            for e in by_peptide.get(pep, []):
-                if id(e) in seen_epitope_ids:
-                    continue
-                seen_epitope_ids.add(id(e))
-                # CandidateEpitope is frozen — flag mutation-overlap via
-                # dataclasses.replace. LENS rows are mutant-derived
-                # by construction, so every CandidateEpitope reached this way
-                # overlaps the mutation.
-                if not e.overlaps_mutation:
-                    e = dataclasses.replace(e, overlaps_mutation=True)
-                variant_epitopes.append(e)
-
-        if not variant_epitopes:
-            continue
-
-        vp = VaccinePeptide(
-            mutant_protein_fragment=fragment,
-            epitopes=variant_epitopes,
-            num_target_epitopes_to_keep=num_target_epitopes_to_keep,
-        )
-        ranked.append((variant, [vp]))
-
-        # Capture DNA VAF for the report's "DNA VAF" field. Take from
-        # the representative row; LENS dedupes by variant so the
-        # value is consistent across the group.
-        vaf_raw = rep.get('vaf')
-        if vaf_raw is not None and not (
-                isinstance(vaf_raw, float) and pd.isna(vaf_raw)):
-            try:
-                dna_vaf_by_variant[variant] = float(vaf_raw)
-            except (TypeError, ValueError):
-                pass
+        if entry.dna_vaf is not None:
+            dna_vaf_by_variant[entry.variant] = entry.dna_vaf
+        if entry.vaccine_peptide is not None:
+            ranked.append((entry.variant, [entry.vaccine_peptide]))
 
     if n_unparseable:
         logger.warning(
@@ -979,14 +1006,7 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
     # acceptable (e.g., a CSV-only run — no transcript effects
     # rendered anywhere). Only the release-mismatch case is worth
     # logging here.
-    if n_with_ids and n_resolved < n_with_ids:
-        n_unresolved = n_with_ids - n_resolved
-        logger.warning(
-            "%d / %d variant(s) had transcript IDs that didn't resolve "
-            "against the configured pyensembl release. Most often this "
-            "is a release mismatch — pass --ensembl-release N to match "
-            "the build LENS used.", n_unresolved, n_with_ids)
-
+    log_transcript_resolution(n_with_ids, n_resolved, "LENS")
     log_varcode_agreement(annotation_results, "LENS")
 
     # ── Load funnel summary ──────────────────────────────────────────
@@ -1032,15 +1052,9 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
     funnel.append("  note (SNV/INDEL anomalies): %s" % note)
     logger.info("\n".join(funnel))
 
-    # Order by target_epitope_score descending so the top candidates
-    # win greedy bin-packing in the construct assemblers. Ties broken
-    # alphabetically by variant coordinates for determinism.
-    ranked.sort(
-        key=lambda pair: (
-            -pair[1][0].target_epitope_score if pair[1] else 0.0,
-            str(pair[0]),
-        ))
-    return ranked, dna_vaf_by_variant
+    # Top candidates first so they win greedy bin-packing in the
+    # construct assemblers (shared ordering helper).
+    return ranked_sorted_by_target_score(ranked), dna_vaf_by_variant
 
 
 def _parse_pvacseq_id(vid, genome=None):
@@ -1308,26 +1322,10 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
             "Skipped %d pVACseq row group(s) with unparseable IDs; "
             "see DEBUG log for details.", n_skipped)
 
-    # The "no genome configured" case is now caught pre-flight in
-    # ``arg_parser.check_args`` for runs that request template
-    # reports; only the release-mismatch case is worth logging here.
-    if n_with_ids and n_resolved < n_with_ids:
-        n_unresolved = n_with_ids - n_resolved
-        logger.warning(
-            "%d / %d variant(s) had Best Transcript IDs that didn't "
-            "resolve against the configured pyensembl release. Most "
-            "often this is a release mismatch — pass --ensembl-release "
-            "N to match the build pVACseq used.",
-            n_unresolved, n_with_ids)
-
+    log_transcript_resolution(
+        n_with_ids, n_resolved, "pVACseq", id_label="Best Transcript IDs")
     log_varcode_agreement(annotation_results, "pVACseq")
-
-    ranked.sort(
-        key=lambda pair: (
-            -pair[1][0].target_epitope_score if pair[1] else 0.0,
-            str(pair[0]),
-        ))
-    return ranked, dna_vaf_by_variant
+    return ranked_sorted_by_target_score(ranked), dna_vaf_by_variant
 
 
 def _patient_info_from_external(ranked, source_path, patient_id,

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -39,6 +39,7 @@ Limitations:
 
 import dataclasses
 import logging
+import os
 
 import pandas as pd
 
@@ -528,9 +529,9 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
             return (2, -count, k)
         ordered = sorted(full_kinds.items(), key=_bucket_order)
         breakdown = ', '.join("%s=%d" % (k, v) for k, v in ordered)
-        logger.info(
-            "LENS report contains %d row(s); antigen_source "
-            "breakdown: %s.", len(rows), breakdown)
+    else:
+        full_kinds = {}
+        breakdown = ''
 
     groups = {}
     n_skipped_empty_coords = 0
@@ -555,17 +556,17 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
             skipped_kinds[kind_key] = skipped_kinds.get(kind_key, 0) + 1
             continue
         groups.setdefault(coords, []).append(r)
+    skipped_breakdown = ', '.join(
+        "%s=%d" % (k, v) for k, v in sorted(
+            skipped_kinds.items(), key=lambda kv: -kv[1]))
     if n_skipped_empty_coords:
-        breakdown = ', '.join(
-            "%s=%d" % (k, v) for k, v in sorted(
-                skipped_kinds.items(), key=lambda kv: -kv[1]))
-        logger.info(
-            "Skipped %d LENS row(s) with empty variant_coords; "
-            "antigen_source breakdown: %s.",
-            n_skipped_empty_coords, breakdown)
         # SNV / INDEL rows are *expected* to carry coords; flag them
         # separately so the user can chase upstream rather than assume
-        # "typical".
+        # "typical". (The non-coord rows aren't dropped from the run —
+        # they're still scored as candidate epitopes for the neoepitope
+        # report; they just can't be placed on the genome for the
+        # variant-based vaccine-construct ranking. The funnel below
+        # spells this out.)
         unexpected = {k: v for k, v in skipped_kinds.items()
                       if k.upper() in ('SNV', 'INDEL')}
         if unexpected:
@@ -785,85 +786,47 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
         k = r.get('antigen_source')
         return ('(missing)' if _is_missing(k) else str(k).strip())
 
-    def _kind_breakdown(rows_subset):
-        b = {}
-        for r in rows_subset:
-            k = _kind(r)
-            b[k] = b.get(k, 0) + 1
-        return ', '.join(
-            "%s=%d" % (k, v) for k, v in sorted(
-                b.items(), key=lambda kv: -kv[1]))
-
     rows_no_gene_name = [r for r in rows if _is_missing(r.get('gene_name'))]
     rows_no_transcript = [r for r in rows if _is_missing(r.get('transcript_id'))]
-    n_no_gene_name = len(rows_no_gene_name)
-    n_no_transcript = len(rows_no_transcript)
-    n_no_reads = sum(
-        1 for r in rows
-        if _is_missing(r.get('rna_reads_covering_genomic_origin')))
     if n_no_pep_context:
         logger.warning(
             "%d / %d LENS row(s) lack pep_context — antigens for those "
             "rows degenerate to the bare neoepitope (no SLP context). "
             "Vaccine windows will be ~9 aa instead of ~25 aa.",
             n_no_pep_context, len(rows))
-    # ``gene_name`` and ``transcript_id`` are expected to be empty for
-    # ERV / CTA-SELF / SPLICE / FUSION antigens (no canonical gene model
-    # to point at). Show the actual antigen_source breakdown rather
-    # than asserting "typical for X" — and warn separately if any SNV
-    # / INDEL rows lack these (which would be an upstream bug).
+    # ``gene_name`` / ``transcript_id`` / ``rna_reads`` are *expected*
+    # to be empty for ERV / CTA-SELF / SPLICE / FUSION antigens (no
+    # canonical gene model / genome-coord origin). So we don't log the
+    # full breakdown here (that just re-counts the same non-coord rows
+    # the funnel already accounts for) — we only warn about SNV / INDEL
+    # rows missing these, which would be a genuine upstream bug. The
+    # counts feed the funnel's "note:" line.
     _SNV_OR_INDEL_KINDS = {'SNV', 'INDEL'}
-    if n_no_gene_name:
-        logger.info(
-            "%d / %d LENS row(s) lack gene_name; antigen_source "
-            "breakdown: %s.",
-            n_no_gene_name, len(rows), _kind_breakdown(rows_no_gene_name))
-        anomalous = [r for r in rows_no_gene_name
-                     if _kind(r).upper() in _SNV_OR_INDEL_KINDS]
-        if anomalous:
-            logger.warning(
-                "%d SNV / INDEL row(s) lack gene_name — those antigen "
-                "kinds are expected to carry one. Likely upstream "
-                "LENS bug.", len(anomalous))
-    if n_no_transcript:
-        logger.info(
-            "%d / %d LENS row(s) lack transcript_id; antigen_source "
-            "breakdown: %s. Downstream varcode-effect annotation won't "
-            "have a transcript context for these.",
-            n_no_transcript, len(rows), _kind_breakdown(rows_no_transcript))
-        anomalous = [r for r in rows_no_transcript
-                     if _kind(r).upper() in _SNV_OR_INDEL_KINDS]
-        if anomalous:
-            logger.warning(
-                "%d SNV / INDEL row(s) lack transcript_id — those "
-                "antigen kinds are expected to carry one. Likely "
-                "upstream LENS bug.", len(anomalous))
-    if n_no_reads:
-        rows_no_reads = [
-            r for r in rows
-            if _is_missing(r.get('rna_reads_covering_genomic_origin'))
-        ]
-        # Antigen kinds where ``rna_reads_covering_genomic_origin`` is
-        # legitimately missing: ERV / SPLICE / FUSION don't have a
-        # genome-coord origin in the same sense as SNV / INDEL —
-        # those rows are RNA-evidenced via different LENS columns
-        # (e.g. ERV expression). Surface SNV / INDEL gaps as the
-        # noteworthy anomaly and treat the rest as informational.
-        anomalous_no_reads = [
-            r for r in rows_no_reads
-            if _kind(r).upper() in _SNV_OR_INDEL_KINDS
-        ]
-        logger.info(
-            "%d / %d LENS row(s) lack rna_reads_covering_genomic_origin; "
-            "antigen_source breakdown: %s. Those rows score with "
-            "n_alt_reads=0 — combined-score ranking falls back to the "
-            "epitope-only branch for them.",
-            n_no_reads, len(rows), _kind_breakdown(rows_no_reads))
-        if anomalous_no_reads:
-            logger.warning(
-                "%d SNV / INDEL row(s) lack rna_reads_covering_genomic_origin "
-                "— those kinds are expected to carry RNA-read counts.",
-                len(anomalous_no_reads))
+    rows_no_reads = [
+        r for r in rows
+        if _is_missing(r.get('rna_reads_covering_genomic_origin'))]
+    n_snv_indel_no_gene = sum(
+        1 for r in rows_no_gene_name if _kind(r).upper() in _SNV_OR_INDEL_KINDS)
+    n_snv_indel_no_transcript = sum(
+        1 for r in rows_no_transcript
+        if _kind(r).upper() in _SNV_OR_INDEL_KINDS)
+    n_snv_indel_no_reads = sum(
+        1 for r in rows_no_reads if _kind(r).upper() in _SNV_OR_INDEL_KINDS)
+    if n_snv_indel_no_gene:
+        logger.warning(
+            "%d SNV / INDEL row(s) lack gene_name — those antigen kinds "
+            "are expected to carry one. Likely upstream LENS bug.",
+            n_snv_indel_no_gene)
+    if n_snv_indel_no_transcript:
+        logger.warning(
+            "%d SNV / INDEL row(s) lack transcript_id — those antigen "
+            "kinds are expected to carry one. Likely upstream LENS bug.",
+            n_snv_indel_no_transcript)
+    if n_snv_indel_no_reads:
+        logger.warning(
+            "%d SNV / INDEL row(s) lack rna_reads_covering_genomic_origin "
+            "— those kinds are expected to carry RNA-read counts.",
+            n_snv_indel_no_reads)
 
     # Transcript-resolution summary. The "no genome configured" case
     # is now caught pre-flight in ``arg_parser.check_args`` for any
@@ -879,6 +842,49 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
             "against the configured pyensembl release. Most often this "
             "is a release mismatch — pass --ensembl-release N to match "
             "the build LENS used.", n_unresolved, n_with_ids)
+
+    # ── Load funnel summary ──────────────────────────────────────────
+    # One consolidated view of where the LENS rows went, replacing the
+    # per-stage count lines that double-counted (the non-coord rows
+    # "skipped" from variant ranking were the same rows re-counted as
+    # "lack gene_name / transcript_id"). The rows feed two independent
+    # uses: (1) every row minus mismatches is scored as a candidate
+    # epitope for the neoepitope report; (2) only rows with genomic
+    # variant_coords can be placed on the genome for variant-based
+    # vaccine-construct ranking. Spelling that out here is what makes
+    # the "skipped, then counted again" confusion go away.
+    n_coord_rows = len(rows) - n_skipped_empty_coords
+    n_variants_ranked = sum(1 for _v, vps in ranked if vps)
+    kept_kinds = {
+        k: full_kinds.get(k, 0) - skipped_kinds.get(k, 0) for k in full_kinds}
+    coord_breakdown = ', '.join(
+        "%s=%d" % (k, kept_kinds[k]) for k in sorted(
+            kept_kinds, key=lambda x: (x.upper() not in ('SNV', 'INDEL'), x))
+        if kept_kinds[k] > 0) or '(none)'
+    if n_snv_indel_no_gene or n_snv_indel_no_transcript or n_snv_indel_no_reads:
+        note = (
+            "%d missing gene_name, %d missing transcript_id, "
+            "%d missing rna_reads" % (
+                n_snv_indel_no_gene, n_snv_indel_no_transcript,
+                n_snv_indel_no_reads))
+    else:
+        note = "all carry gene_name / transcript_id / rna_reads"
+    funnel = [
+        "LENS load funnel: %s" % os.path.basename(lens_tsv_path),
+        "  %d rows in: %s" % (len(rows), breakdown or '(none)'),
+        "  → %d candidate epitopes scored for the neoepitope report "
+        "(all antigen sources)" % len(epitopes),
+        "  → %d row(s) with genomic variant_coords (%s) → %d unique "
+        "variant(s) → %d ranked with vaccine peptide(s) for constructs" % (
+            n_coord_rows, coord_breakdown, len(groups), n_variants_ranked),
+    ]
+    if n_skipped_empty_coords:
+        funnel.append(
+            "  → %d non-coord row(s) (%s) are report-only — no genome "
+            "placement, so excluded from construct ranking" % (
+                n_skipped_empty_coords, skipped_breakdown))
+    funnel.append("  note (SNV/INDEL anomalies): %s" % note)
+    logger.info("\n".join(funnel))
 
     # Order by target_epitope_score descending so the top candidates
     # win greedy bin-packing in the construct assemblers. Ties broken

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -85,6 +85,127 @@ def _antigen_kind_sort_key(kind, count):
     return (2, -count, kind)
 
 
+def check_varcode_annotation(variant, transcript, provided_gene,
+                             provided_is_frameshift):
+    """Cross-check varcode against an external tool's own annotation.
+
+    Shared by every external loader (LENS, pVACseq, …) — varcode is
+    used here only to *validate* and interpret the columns the provider
+    already gave us, never to supply information the provider lacks.
+
+    Compares on the provider's own transcript (different isoforms
+    renumber residues, so we check gene + effect *class*, never raw
+    positions). Returns ``(gene_ok, effect_ok)``, or ``(None, None)``
+    when varcode can't compute an effect (no resolved transcript) so
+    the caller can skip the check rather than fabricate a verdict.
+    """
+    if transcript is None:
+        return None, None
+    try:
+        effect = variant.effect_on_transcript(transcript)
+    except Exception:
+        return None, None
+    gene_ok = (not provided_gene or not effect.gene_name
+               or provided_gene == effect.gene_name)
+    effect_ok = (
+        bool(provided_is_frameshift) == (type(effect).__name__ == 'FrameShift'))
+    return gene_ok, effect_ok
+
+
+class AnnotationCheck:
+    """Accumulates the varcode-vs-provider sanity check across a load.
+
+    Shared by every external loader (LENS, pVACseq, …) so the
+    comparison and the summary log live in one place rather than being
+    re-implemented per modality. ``record`` cross-checks one variant;
+    ``log`` emits a single per-load summary.
+    """
+
+    def __init__(self):
+        self.checked = 0
+        self.gene_mismatch = 0
+        self.effect_mismatch = 0
+        self.examples = []
+
+    def record(self, variant, transcript, provided_gene,
+               provided_is_frameshift, label=''):
+        gene_ok, effect_ok = check_varcode_annotation(
+            variant, transcript, provided_gene, provided_is_frameshift)
+        if gene_ok is None:
+            return
+        self.checked += 1
+        if not gene_ok:
+            self.gene_mismatch += 1
+        if not effect_ok:
+            self.effect_mismatch += 1
+        if (not gene_ok or not effect_ok) and len(self.examples) < 1:
+            self.examples.append((label, provided_gene))
+
+    def log(self, source_name):
+        if not self.checked:
+            return
+        if self.gene_mismatch or self.effect_mismatch:
+            ex = self.examples[0] if self.examples else None
+            logger.warning(
+                "varcode disagrees with %s on %d / %d checked variant(s): "
+                "%d gene, %d effect-class mismatch(es)%s. The %s values "
+                "are kept; check that the pyensembl release matches the "
+                "build %s used.",
+                source_name, max(self.gene_mismatch, self.effect_mismatch),
+                self.checked, self.gene_mismatch, self.effect_mismatch,
+                (" (e.g. %s gene=%s)" % ex) if ex else "",
+                source_name, source_name)
+        else:
+            logger.info(
+                "varcode agrees with %s on all %d checked variant(s) "
+                "(gene + effect class).", source_name, self.checked)
+
+
+def variant_is_frameshift(variant):
+    """True if the variant's genomic ref/alt imply a frameshift.
+
+    Modality-agnostic — derived from the provider's own ref/alt
+    nucleotides (LENS, pVACseq, VCF all build a varcode ``Variant`` the
+    same way), not from a tool-specific annotation column. A frameshift
+    indel changes coding length by a non-multiple of 3.
+    """
+    ref = variant.ref or ''
+    alt = variant.alt or ''
+    return abs(len(ref) - len(alt)) % 3 != 0
+
+
+def maximal_mutant_span(rep_start, rep_end, peptides, context,
+                        is_frameshift):
+    """Mutant-residue span within ``context`` for an external antigen.
+
+    Shared by every external loader so LENS and pVACseq mark mutations
+    identically. For a **frameshift** the whole downstream sequence (to
+    the new stop) is novel, but a single representative neoepitope only
+    covers part of it — so we combine *every* neoepitope the provider
+    listed for the variant: the union of their located spans tiles the
+    novel tail and recovers the maximal mutant region. Non-frameshift
+    variants keep the representative span (the mutation is local; a
+    union would over-extend into wild-type flanks).
+
+    Uses only provider-supplied peptides (no varcode-derived sequence).
+    The start comes from combining rows (the earliest located neoepitope
+    ≈ the frameshift onset); the end extends to the end of ``context``,
+    since for a frameshift everything from the onset to the new stop
+    (= the end of the translated context) is novel — even residues no
+    single neoepitope happened to cover.
+    """
+    if not is_frameshift:
+        return rep_start, rep_end
+    start = rep_start
+    for peptide in peptides:
+        if not peptide:
+            continue
+        idx = context.find(peptide)
+        if idx >= 0:
+            start = min(start, idx)
+    return start, len(context)
+
+
 def _missing_cell(value):
     if value is None:
         return True
@@ -592,6 +713,9 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
     # Transcript. The gap is almost always a release mismatch.
     n_with_ids = 0
     n_resolved = 0
+    # Sanity-check varcode against LENS's own annotation (shared
+    # accumulator; see AnnotationCheck).
+    annotation_check = AnnotationCheck()
     # ``vaf`` column carries DNA VAF in LENS v1.9 (sits between
     # ``mhcflurry_agretopicity`` and ``totcopynum`` / ``multiplicity``
     # / ``ccf`` — all DNA-clonal annotations; values track DNA VAF
@@ -661,6 +785,19 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
                 peptide, pep_context, coords)
             continue
 
+        # Frameshift → the whole downstream tail is novel; combine the
+        # variant's neoepitope rows into the maximal mutant span.
+        # Frameshift is derived from the variant's own ref/alt (general,
+        # not a LENS-specific column). ``lens_is_frameshift`` (LENS's
+        # annotation) is kept separately only to sanity-check varcode.
+        start_off, end_off = maximal_mutant_span(
+            start_off, end_off,
+            [r.get('peptide') for r in group_rows],
+            pep_context, variant_is_frameshift(variant))
+        lens_is_frameshift = (
+            str(rep.get('indel_type') or '').strip().lower() == 'frameshift'
+            or 'fs' in str(rep.get('variant_effect') or '').lower())
+
         # Window pep_context down to the canonical SLP fragment size
         # (--vaccine-peptide-length, default 25). LENS sometimes
         # emits the entire protein prefix here, which would render
@@ -702,6 +839,13 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
             n_with_ids += 1
             if transcripts:
                 n_resolved += 1
+
+        # Sanity-check LENS's annotation against varcode on LENS's own
+        # transcript (validation only — we keep LENS's values either
+        # way; this just surfaces real disagreements).
+        annotation_check.record(
+            variant, transcripts[0] if transcripts else None,
+            gene_name, lens_is_frameshift, label=str(coords))
 
         fragment = MutantProteinFragment(
             variant=variant,
@@ -847,6 +991,8 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
             "against the configured pyensembl release. Most often this "
             "is a release mismatch — pass --ensembl-release N to match "
             "the build LENS used.", n_unresolved, n_with_ids)
+
+    annotation_check.log("LENS")
 
     # ── Load funnel summary ──────────────────────────────────────────
     # One consolidated view of where the LENS rows went, replacing the
@@ -1063,6 +1209,7 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
     # Aggregate transcript-resolution stats (see LENS path for rationale).
     n_with_ids = 0
     n_resolved = 0
+    annotation_check = AnnotationCheck()
     # pVACseq carries an explicit ``DNA VAF`` column (separate from
     # the ``RNA VAF`` we already consume for read counts). Plumb it
     # through to the report's DNA-VAF field.
@@ -1112,6 +1259,15 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
             n_with_ids += 1
             if transcripts:
                 n_resolved += 1
+        # Sanity-check varcode against the variant. pVACseq's aggregate
+        # carries no explicit effect annotation, so the "provided"
+        # frameshift comes from the variant's own ref/alt (provider
+        # data) — this still cross-checks that varcode's effect class
+        # is consistent with the genomic alleles, and that the gene
+        # agrees. Shared with the LENS path via AnnotationCheck.
+        annotation_check.record(
+            variant, transcripts[0] if transcripts else None,
+            gene, variant_is_frameshift(variant), label=str(vid))
         fragment = MutantProteinFragment(
             variant=variant, gene_name=gene,
             amino_acids=str(best_pep),
@@ -1166,6 +1322,8 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
             "often this is a release mismatch — pass --ensembl-release "
             "N to match the build pVACseq used.",
             n_unresolved, n_with_ids)
+
+    annotation_check.log("pVACseq")
 
     ranked.sort(
         key=lambda pair: (

--- a/vaxrank/mrna.py
+++ b/vaxrank/mrna.py
@@ -54,6 +54,7 @@ from .mrna_library import (
     UTRS_5P,
 )
 from .vaccine_library import (
+    gene_names_from_antigen_names,
     get_linker,
     iter_named_antigens,
     select_antigen_window,
@@ -1048,8 +1049,10 @@ def write_mrna_outputs(constructs, output_dir, manifest_path=None,
                 # avoids the trap where downstream tools split the
                 # FASTA description on ',' (treating each antigen
                 # name as a separate token).
-                f.write(">%s antigens=%s length=%d\n" % (
-                    c.name, ';'.join(c.antigen_names), len(seq)))
+                genes = gene_names_from_antigen_names(c.antigen_names)
+                f.write(">%s antigens=%s length=%d genes=%s\n" % (
+                    c.name, ';'.join(c.antigen_names), len(seq),
+                    ';'.join(genes)))
                 f.write(_wrap_fasta(seq))
                 f.write("\n")
 

--- a/vaxrank/peptide.py
+++ b/vaxrank/peptide.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass, field
 
 from .manufacturability import ManufacturabilityScores
 from .vaccine_library import (
+    gene_names_from_antigen_names,
     get_linker,
     iter_named_antigens,
     select_antigen_window,
@@ -180,10 +181,16 @@ def _antigen_records(ranked_vaccine_peptides, antigen_content,
                     "epitope predictions available.", base_name)
                 continue
             for k, ep in enumerate(tops):
-                # When epitopes_per_antigen=1 keep the legacy
-                # ``<name>_epitope`` suffix; for >1 disambiguate.
-                suffix = "_epitope" if len(tops) == 1 else "_epitope%d" % (k + 1)
-                yield base_name + suffix, ep.sequence
+                # Tag the minimal-epitope antigen inside the category
+                # parens so the gene stays cleanly parseable:
+                # "GENE (SNV)" → "GENE (SNV, epitope)". For >1 per
+                # antigen, number them.
+                tag = "epitope" if len(tops) == 1 else "epitope%d" % (k + 1)
+                if base_name.endswith(")"):
+                    name = "%s, %s)" % (base_name[:-1], tag)
+                else:
+                    name = "%s (%s)" % (base_name, tag)
+                yield name, ep.sequence
         else:
             # mutation_spanning: pick a mutation-centered window
             yield base_name, select_antigen_window(
@@ -386,8 +393,10 @@ def write_peptide_outputs(constructs, fasta_path, manifest_path=None,
 
     with open(fasta_path, 'w') as f:
         for c in constructs:
-            f.write(">%s antigens=%s length=%d\n" % (
-                c.name, ','.join(c.antigen_names), len(c.sequence)))
+            genes = gene_names_from_antigen_names(c.antigen_names)
+            f.write(">%s antigens=%s length=%d genes=%s\n" % (
+                c.name, ','.join(c.antigen_names), len(c.sequence),
+                ','.join(genes)))
             for i in range(0, len(c.sequence), 80):
                 f.write(c.sequence[i:i + 80] + "\n")
 

--- a/vaxrank/processing.py
+++ b/vaxrank/processing.py
@@ -324,18 +324,19 @@ def annotate_processing(epitopes, predictor=None,
 
     if n_annotated:
         logger.info(
-            "Pepsickle credibility tagging: annotated %d / %d "
+            "Pepsickle proteasomal-cleavage annotation: annotated %d / %d "
             "CandidateEpitope(s) across %d unique source sequence(s).",
             n_annotated, len(epitopes_list), len(by_source))
     if n_skipped_peptide_not_in_context:
+        # LENS-import mismatches are already dropped at load
+        # (epitope_io.load_lens); reaching here means a pipeline-path
+        # peptide wasn't locatable in its source, which is unexpected.
         ex_peptide, ex_source = skipped_examples[0]
         logger.warning(
-            "Pepsickle credibility tagging: skipped %d / %d "
-            "CandidateEpitope(s) because the peptide is not a substring "
-            "of its pep_context source — peptide and pep_context "
-            "were built from different isoforms / annotation "
-            "snapshots. Example: peptide=%r not found in "
-            "pep_context=%r.",
+            "Pepsickle proteasomal-cleavage annotation: skipped %d / %d "
+            "CandidateEpitope(s) whose peptide isn't a substring of its "
+            "source sequence. Example: peptide=%r not found in "
+            "source=%r.",
             n_skipped_peptide_not_in_context, len(epitopes_list),
             ex_peptide, ex_source)
     return n_annotated, processing_predictions

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -96,9 +96,25 @@ class TemplateDataCreator(object):
             raw_types = [raw_types]
         self.vaccine_type = ', '.join(raw_types)
 
-        # filter output-related command-line args: we want to display everything else
+        # Show the *effective* run parameters, not the raw argparse
+        # Namespace. We drop: output-path args (covered by the Inputs /
+        # file listing), the argparse ``version`` SUPPRESS sentinel,
+        # internal config-plumbing keys, and any value that is unset
+        # (None / ''). A None here means "not set / inherits a default"
+        # — noise in a record of what actually ran, and the source of
+        # the confusing ``manufacturability: None`` / ``version:
+        # ==SUPPRESS==`` lines.
+        _internal_keys = {
+            'version', 'config', 'config_set_overrides',
+            'config_expr_overrides',
+        }
         args_to_display_in_report = {
-            k: v for k, v in args_for_report.items() if not k.startswith("output")
+            k: v for k, v in args_for_report.items()
+            if not k.startswith("output")
+            and k not in _internal_keys
+            and v is not None
+            and v != ''
+            and v != '==SUPPRESS=='
         }
 
         self.template_data = {

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -768,24 +768,24 @@ def make_minimal_neoepitope_report(
                                     and wt_p.value is not None):
                                 wt_ic50 = wt_p.value
                                 break
-                    wt_ic50_str = (
-                        '%.2f nM' % wt_ic50 if wt_ic50 is not None
-                        else 'No prediction')
-                    row = OrderedDict([
-                        ('Allele', p.allele),
-                        ('Mutant peptide sequence',
-                            epitope.sequence),
-                        ('Score', vaccine_peptide.target_epitope_score),
-                        ('Predicted mutant pMHC affinity',
-                            '%.2f nM' % p.value),
-                        ('Variant allele RNA read count',
-                            vaccine_peptide.mutant_protein_fragment.n_alt_reads),
-                        ('Wildtype sequence', wt_peptide_sequence),
-                        ('Predicted wildtype pMHC affinity', wt_ic50_str),
-                        ('Gene name',
+                    # Build the shared core columns via the same helper
+                    # the LENS / pVACseq report builders use, so all
+                    # three input paths emit identical core columns and
+                    # the same missing-value convention. The RNA-read
+                    # count is this path's only source-specific column.
+                    from .epitope_io import neoepitope_core_row
+                    row = neoepitope_core_row(
+                        allele=p.allele,
+                        mutant_peptide=epitope.sequence,
+                        mutant_affinity=p.value,
+                        wt_peptide=wt_peptide_sequence,
+                        wt_affinity=wt_ic50,
+                        gene_name=(
                             vaccine_peptide.mutant_protein_fragment.gene_name),
-                        ('Genomic variant', variant.short_description),
-                    ])
+                        variant=variant.short_description,
+                        score=vaccine_peptide.target_epitope_score)
+                    row['Variant allele RNA read count'] = (
+                        vaccine_peptide.mutant_protein_fragment.n_alt_reads)
                     rows.append(row)
 
     if len(rows) > 0:

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -58,7 +58,8 @@ class TemplateDataCreator(object):
             processing_predictions_by_key=None,
             mrna_ranking_decisions=None,
             vaccine_constructions=None,
-            target_alleles=None):
+            target_alleles=None,
+            include_manufacturability=None):
         """
         Construct a TemplateDataCreator object, from the output of the vaxrank pipeline.
 
@@ -122,8 +123,15 @@ class TemplateDataCreator(object):
             'reviewers': reviewers.split(',') if reviewers else [],
             'final_review': final_review,
             'input_json_file': input_json_file,
-            # these report sections are optional
-            'include_manufacturability': args_for_report['manufacturability'],
+            # these report sections are optional. ``include_manufacturability``
+            # can be overridden per report (the split-report layout turns it
+            # off for the modality-agnostic core report and the mRNA report,
+            # on for the peptide report); when None it follows the run's
+            # ``--manufacturability`` resolution.
+            'include_manufacturability': (
+                args_for_report['manufacturability']
+                if include_manufacturability is None
+                else include_manufacturability),
             'include_wt_epitopes': args_for_report['wt_epitopes'],
         }
 

--- a/vaxrank/templates/template.txt
+++ b/vaxrank/templates/template.txt
@@ -12,8 +12,8 @@ Package version info
 === Antigen ranking ===
 Per-variant ranked antigen windows by combined_score. Modality-agnostic;
 modality-specific decisions (which antigens land in the vaccine, the
-manufacturability tuple, allele coverage) are in the "Vaccine construction"
-sections below.
+manufacturability tuple, allele coverage) are in the
+{% if vaccine_constructions %}"Vaccine construction" sections below.{% else %}per-modality reports (peptide/, mrna/).{% endif %}
 
 {% for v in variants %}
 {{ v.num }}) {{ v.short_description }} ({{ v.variant_data['Gene name'] }})

--- a/vaxrank/vaccine_library.py
+++ b/vaxrank/vaccine_library.py
@@ -537,37 +537,84 @@ def get_linker(name):
             name, ', '.join(all_linker_names())))
 
 
+def _variant_category(variant):
+    """Coarse antigen category for naming — ``SNV`` / ``INDEL`` (the
+    LENS ``antigen_source`` vocabulary), derived from the variant
+    itself so it's identical on the pipeline and LENS / pVACseq paths.
+    """
+    if getattr(variant, 'is_snv', False):
+        return 'SNV'
+    if (getattr(variant, 'is_insertion', False)
+            or getattr(variant, 'is_deletion', False)
+            or getattr(variant, 'is_indel', False)):
+        return 'INDEL'
+    return 'variant'
+
+
+def gene_names_from_antigen_names(antigen_names):
+    """Distinct gene names (order-preserving) parsed from antigen names
+    produced by :func:`iter_named_antigens`. The gene is the text
+    before the parenthesized category, so ``"FYN (INDEL)"`` → ``FYN``.
+    Used by the FASTA writers to list the construct's gene(s) in the
+    header."""
+    genes = []
+    for name in antigen_names:
+        gene = name.split(" (")[0]
+        if gene and gene not in genes:
+            genes.append(gene)
+    return genes
+
+
 def iter_named_antigens(ranked_vaccine_peptides, candidates_per_slot=1):
     """Yield ``(name, fragment, vaccine_peptide)`` per ranked candidate.
 
     Both peptide and mRNA assembly walk the same ranked list and need
-    the same per-candidate name (``gene_chr_pos_ref_alt`` with an
-    ``_alt<k>`` suffix on alternates). Centralizing the loop here keeps
-    that naming consistent across modalities.
+    the same per-candidate name. The name reads ``GENE (CATEGORY)`` —
+    e.g. ``FYN (INDEL)`` — keeping the gene up front and the antigen
+    category (SNV / INDEL) parenthesized. The specific mutation is
+    appended *only* when a gene contributes more than one variant to
+    this construct set, so a single-variant gene stays clean while
+    collisions disambiguate: ``FYN (INDEL @ 6:111674599 G>-)``. Empty
+    indel alleles render as ``-`` (clearer than varcode's normalized
+    empty string). Alternate candidates per variant get an ``altK``
+    tag. The gene is always ``name.split(" (")[0]``.
 
     Parameters
     ----------
     ranked_vaccine_peptides : list[(varcode.Variant, list[VaccinePeptide])]
     candidates_per_slot : int
-        How many ranked alternates to walk per variant. The first
-        candidate gets the bare name; subsequent candidates get
-        ``_alt1``, ``_alt2``, etc.
+        How many ranked alternates to walk per variant.
     """
+    def _gene_of(variant, peptides):
+        return (getattr(peptides[0].mutant_protein_fragment, 'gene_name', None)
+                or 'unknown')
+
+    # Pre-pass: which genes contribute 2+ distinct variants? Those
+    # need the mutation spelled out to tell their antigens apart.
+    variants_per_gene = {}
     for variant, peptides in ranked_vaccine_peptides:
         if not peptides:
             continue
+        gene = _gene_of(variant, peptides)
+        variants_per_gene.setdefault(gene, set()).add(
+            (variant.contig, variant.start, variant.ref, variant.alt))
+    ambiguous_genes = {
+        g for g, keys in variants_per_gene.items() if len(keys) > 1}
+
+    for variant, peptides in ranked_vaccine_peptides:
+        if not peptides:
+            continue
+        gene = _gene_of(variant, peptides)
         for idx, peptide in enumerate(peptides[:max(1, candidates_per_slot)]):
             fragment = peptide.mutant_protein_fragment
-            base_name = "%s_%s_%s_%s_%s" % (
-                getattr(fragment, 'gene_name', None) or 'unknown',
-                variant.contig,
-                variant.start,
-                variant.ref or '.',
-                variant.alt or '.',
-            )
+            detail = _variant_category(variant)
+            if gene in ambiguous_genes:
+                detail = "%s @ %s:%s %s>%s" % (
+                    detail, variant.contig, variant.start,
+                    variant.ref or '-', variant.alt or '-')
             if idx > 0:
-                base_name = "%s_alt%d" % (base_name, idx)
-            yield base_name, fragment, peptide
+                detail = "%s alt%d" % (detail, idx)
+            yield "%s (%s)" % (gene, detail), fragment, peptide
 
 
 def select_antigen_window(fragment, base_name, max_length_aa):


### PR DESCRIPTION
Started as the parent-dir fix and broadened (per request) into a pass over the LENS/pVACseq-import experience.

## Changes

**Output / reports**
- Create the parent directory for neoepitope report outputs (the original crash: `Cannot save file into a non-existent directory`).
- `--output-dir` now auto-populates the **ASCII text + PDF reports** too, not just the CSV.
- Write a top-level **`run_summary.txt`** (inputs, MHC alleles in play, antigen counts, output map) so multi-type runs have shared run context at the top level alongside the neoepitope table and reports; per-modality constructs stay in subdirs.
- Prompt before overwriting an existing non-empty `--output-dir` (interactive only; batch runs warn and proceed). New `--force-overwrite`.

**Logging**
- Replace the scattered LENS-load count lines (which double-counted the same non-coord rows across two passes) with a single **load funnel** that makes the two row uses explicit: every row is scored as a candidate epitope for the neoepitope report, while only genomic-coord rows are placed on the genome for construct ranking.
- Source-specific dispatch label: `[LENS import]` / `[pVACseq import]` / `[full pipeline]` instead of `[external]`.
- Rename "Pepsickle credibility tagging" -> "proteasomal-cleavage annotation".

**Correctness**
- Fix inferred-MHC-allele aggregation: read alleles from `CandidateEpitope.per_allele_scores` (it has no `.allele`), so the per-junction linker optimizer + mhcflurry default actually engage on the external path. Surface the alleles once, up front.
- Drop peptide-not-in-`pep_context` rows at load (excluded from report + constructs, warned once) instead of late inside pepsickle.

**Naming / display**
- Redesign vaccine antigen naming: `GENE (CATEGORY)` (e.g. `FYN (INDEL)`), with the specific mutation appended only to disambiguate when a gene contributes 2+ variants (`TP53 (SNV @ 1:100 A>T)`). Empty indel alleles render as `-` rather than varcode's `.`. FASTA headers gain a trailing `genes=` field.
- Neoepitope CSVs use blank uniformly for missing values (was a mix of "No prediction" strings and blanks).

**Docs**
- README links pVACseq, BigMHC, topiary, and the input-format tools.

All 847 tests pass; tests updated for the intentional format changes.
