### PR TITLE
[codex] Handle missing IC50 values

### DIFF
--- a/tests/test_design_matrix.py
+++ b/tests/test_design_matrix.py
@@ -74,7 +74,7 @@ def _make_vaccine_peptide(
                     kind='pMHC_affinity', predictor_name='stub',
                     predictor_version='', allele='HLA-A*02:01',
                     peptide=seq, value=ic50, score=0.0,
-                    percentile_rank=ic50 / 100.0),)),
+                    percentile_rank=0.5),)),
             overlaps_mutation=True, occurs_in_reference=False)
         for seq, ic50 in epitope_seqs_with_ic50
     ]

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -37,7 +37,7 @@ from vaxrank.processing import (
 
 
 def _ep(peptide, source, offset, ic50=100.0, allele="HLA-A*02:01",
-        predictor="stub"):
+        predictor="stub", percentile_rank=0.5):
     """Build a minimal ``CandidateEpitope`` for tests — one mutant
     pMHC_affinity ``Prediction`` plus the (peptide, source, offset)
     layout the processing annotator joins on."""
@@ -49,7 +49,7 @@ def _ep(peptide, source, offset, ic50=100.0, allele="HLA-A*02:01",
         peptide=peptide,
         value=ic50,
         score=0.0,
-        percentile_rank=ic50 / 100.0,
+        percentile_rank=percentile_rank,
     )
     return CandidateEpitope.from_peptide(
         Peptide(
@@ -375,6 +375,22 @@ def test_epitope_data_renders_one_row_per_predictor_for_same_pep_allele():
     # column order is stable across rows.
     assert all(isinstance(r, OrderedDict) for r in rows)
     assert list(rows[0].keys()) == list(rows[1].keys())
+
+
+def test_epitope_data_renders_missing_mutant_ic50_placeholder():
+    """Rows with no affinity value should render instead of crashing."""
+    from vaxrank.report import TemplateDataCreator
+
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = {}
+    for missing_value in (None, float('nan')):
+        epitope = _ep(
+            "SIINFEKL", "SSIINFEKL", offset=1, ic50=missing_value,
+            percentile_rank=None)
+
+        row = creator._epitope_data(epitope, epitope.best_affinity())
+
+        assert row['IC50'] == 'No prediction'
 
 
 def test_epitope_data_surfaces_processing_columns_when_annotated():

--- a/tests/test_vaccine_peptide_config.py
+++ b/tests/test_vaccine_peptide_config.py
@@ -76,6 +76,33 @@ def _make_mutant_epitope(ic50=10.0, peptide="A" * 9, source="A" * 25,
     )
 
 
+def _make_mutant_epitope_with_affinities(
+        ic50s, peptide="A" * 9, source="A" * 25, offset=0):
+    preds = tuple(
+        Prediction(
+            kind='pMHC_affinity',
+            predictor_name='test',
+            predictor_version='',
+            allele=f'HLA-A*{i + 1:02d}:01',
+            peptide=peptide,
+            value=ic50,
+            score=0.0,
+            percentile_rank=0.5,
+        )
+        for i, ic50 in enumerate(ic50s)
+    )
+    return CandidateEpitope.from_peptide(
+        Peptide(
+            sequence=peptide,
+            source_sequence=source,
+            offset=offset,
+            predictions=preds,
+        ),
+        overlaps_mutation=True,
+        occurs_in_reference=False,
+    )
+
+
 def test_default_manufacturability_tuple_length():
     """Default sort tuple length = 10 (legacy behavior, unchanged)."""
     vp = VaccinePeptide(
@@ -85,6 +112,23 @@ def test_default_manufacturability_tuple_length():
     tup = vp.peptide_synthesis_difficulty_score_tuple()
     assert len(tup) == 10
     assert len(DEFAULT_MANUFACTURABILITY_RULES) == 10
+
+
+def test_vaccine_peptide_sort_ignores_missing_ic50_values():
+    """IC50 sorting should use finite affinity values and send
+    missing-only epitopes to the end."""
+    mixed_missing = _make_mutant_epitope_with_affinities(
+        [None, np.nan, 10.0], peptide="A" * 9)
+    finite = _make_mutant_epitope(ic50=50.0, peptide="C" * 9)
+    missing_only = _make_mutant_epitope(ic50=np.nan, peptide="D" * 9)
+
+    vp = VaccinePeptide(
+        mutant_protein_fragment=_make_fragment(),
+        epitopes=[missing_only, finite, mixed_missing],
+        sort_epitopes_by="ic50",
+    )
+
+    assert vp.target_epitopes == [mixed_missing, finite, missing_only]
 
 
 def test_custom_rules_shorten_tuple():

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -395,8 +395,8 @@ class TemplateDataCreator(object):
         """
         wt_ic50 = self._wt_ic50_for_allele(
             epitope, prediction.allele, predictor=prediction.predictor_name)
-        wt_ic50_str = (
-            '%.2f nM' % wt_ic50 if wt_ic50 is not None else 'No prediction')
+        wt_ic50_str = _format_ic50(wt_ic50)
+        ic50_str = _format_ic50(prediction.value)
         wt_peptide_sequence = (
             epitope.wt.sequence if epitope.wt is not None else '')
         epitope_data = OrderedDict([
@@ -409,7 +409,7 @@ class TemplateDataCreator(object):
             # netmhcpan), so making the source explicit per row is
             # the only honest answer.
             ('Predictor', prediction.predictor_name or '—'),
-            ('IC50', '%.2f nM' % prediction.value),
+            ('IC50', ic50_str),
             # ``Score`` is the per-allele DSL score for this epitope
             # as computed at predict time by the configured
             # ``EpitopeConfig.score_expr`` (default: logistic of
@@ -739,6 +739,14 @@ def _sanitize(val):
         return int(val)
     else:
         return _str_sig_figs(val, 5)
+
+def _format_ic50(value):
+    try:
+        if pd.isna(value):
+            return 'No prediction'
+    except (TypeError, ValueError):
+        pass
+    return '%.2f nM' % value
 
 def resize_columns(worksheet, amino_acids_col, pos_col):
     """

--- a/vaxrank/vaccine_peptide.py
+++ b/vaxrank/vaccine_peptide.py
@@ -140,6 +140,20 @@ class VaccinePeptide(DataclassSerializable):
         # sort to the end via +inf.
         sort_by = self.sort_epitopes_by
 
+        def _usable_prediction_values(predictions, attr):
+            values = []
+            for p in predictions:
+                value = getattr(p, attr)
+                if value is None:
+                    continue
+                try:
+                    if np.isnan(value):
+                        continue
+                except TypeError:
+                    pass
+                values.append(value)
+            return values
+
         def _epitope_sort_key(e):
             affinity_leaves = [
                 p for p in e.predictions_flat()
@@ -147,13 +161,11 @@ class VaccinePeptide(DataclassSerializable):
             if not affinity_leaves:
                 return float("inf")
             if sort_by == "percentile_rank":
-                ranks = [
-                    p.percentile_rank for p in affinity_leaves
-                    if p.percentile_rank is not None
-                    and not (isinstance(p.percentile_rank, float)
-                             and np.isnan(p.percentile_rank))]
+                ranks = _usable_prediction_values(
+                    affinity_leaves, "percentile_rank")
                 return min(ranks) if ranks else float("inf")
-            return min(p.value for p in affinity_leaves)
+            ic50s = _usable_prediction_values(affinity_leaves, "value")
+            return min(ic50s) if ic50s else float("inf")
 
         # Universal target/self split — source-agnostic. An epitope
         # whose exact sequence appears in the patient's reference

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.7"
+__version__ = "3.1.8"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Fixes #306.

This PR makes missing affinity IC50 values non-fatal in the two places that assumed every pMHC_affinity row had a numeric Prediction.value:

- VaccinePeptide target-epitope sorting now ignores missing/NaN IC50 or percentile-rank values and sends missing-only epitopes to the end.
- Template report rows render missing/NaN mutant IC50 as No prediction, matching the existing WT IC50 placeholder behavior.
- Test fixtures no longer derive fake percentile ranks from IC50 values.
- Bumps vaxrank.__version__ to 3.1.8 for the PR.

## Root Cause

The IC50 sort path used min(p.value for p in affinity_leaves) directly, unlike the percentile-rank path which already filtered missing values. The report path then formatted mutant IC50 with %.2f nM unconditionally.

## Validation

- ./lint.sh
- ./test.sh (858 passed, 8 warnings)
