### PR TITLE
Make CLI startup locale-safe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ numpy>=2.0.0,<3.0.0
 pandas>=2.1.4,<3.0.0
 pyensembl>=2.6.4,<3.0.0
 varcode>=5.0.0,<6.0.0
-isovar>=1.4.7,<2.0.0
+# 1.7.2 replaces the removed pkg_resources logging lookup.
+isovar>=1.7.2,<2.0.0
 # 3.33.5 makes bundled YAML loading independent of the host locale.
 mhcgnomes>=3.33.5,<4.0.0
 mhctools>=3.13.3,<4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ pandas>=2.1.4,<3.0.0
 pyensembl>=2.6.4,<3.0.0
 varcode>=5.0.0,<6.0.0
 isovar>=1.4.7,<2.0.0
+# 3.33.5 makes bundled YAML loading independent of the host locale.
+mhcgnomes>=3.33.5,<4.0.0
 mhctools>=3.13.3,<4.0.0
 # 5.10.0 adds EvalContext(default_methods=...) and apply_filter(default_methods=...)
 # which vaxrank uses to score multi-model inputs (e.g. LENS with mhcflurry +

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+target-version = "py310"
+
+[lint]
+select = ["E4", "E7", "E9", "F"]

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -18,6 +18,9 @@ See: https://github.com/openvax/vaxrank/issues/29
 """
 
 import logging
+import os
+import subprocess
+import sys
 from unittest.mock import MagicMock, patch
 
 from vaxrank.cli import make_vaxrank_arg_parser
@@ -25,6 +28,33 @@ from vaxrank.cli.entry_point import (
     _resolve_ensembl_release,
     configure_logging,
 )
+
+
+def test_help_succeeds_under_ascii_locale():
+    """CLI help must not depend on a UTF-8 terminal (issue #308)."""
+    env = os.environ.copy()
+    env.update({
+        "LANG": "C",
+        "LC_ALL": "C",
+        "PYTHONCOERCECLOCALE": "0",
+        "PYTHONUTF8": "0",
+    })
+    command = (
+        "from vaxrank.cli.entry_point import main; "
+        "main(['-h'])"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", command],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.startswith("usage: vaxrank")
+    assert result.stdout.isascii()
 
 
 # ---- --ensembl-release (#29) ------------------------------------------------

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -88,8 +88,8 @@ def make_vaxrank_arg_parser():
         default=None,
         help="Path to YAML config. May be repeated; later files deep-merge "
              "over earlier ones. Each file may contain any of the top-level "
-             "sections 'epitopes', 'vaccine_peptides', and 'manufacturability' "
-             "— split them across files or keep them together.")
+             "sections 'epitopes', 'vaccine_peptides', and 'manufacturability'; "
+             "split them across files or keep them together.")
     add_config_override_args(arg_parser)
 
     arg_parser.add_argument(
@@ -237,10 +237,10 @@ def add_output_args(arg_parser):
              "{peptide, mrna}. Default: 'peptide mrna' (both); pass "
              "a subset to design just one. Single-mode runs (one "
              "type) write directly into --output-dir. Multi-mode "
-             "runs (≥2) write into per-modality subdirs "
-             "(--output-dir/peptide/, --output-dir/mrna/, …) so the "
+             "runs (2 or more) write into per-modality subdirs "
+             "(--output-dir/peptide/, --output-dir/mrna/, etc.) so the "
              "same flag set works regardless of how many modalities "
-             "are active. Future modalities (DNA, …) plug in here.")
+             "are active. Future modalities (DNA, etc.) plug in here.")
 
     # Unified output directory. ``--output-dir`` is always a
     # directory; vaxrank chooses canonical filenames inside it.
@@ -263,7 +263,7 @@ def add_output_args(arg_parser):
         help="Destination directory for the assembled vaccine "
              "constructs. Single-mode runs (one --vaccine-type) write "
              "files directly into DIR; multi-mode runs write to "
-             "per-modality subdirs (DIR/peptide/, DIR/mrna/, …). "
+             "per-modality subdirs (DIR/peptide/, DIR/mrna/, etc.). "
              "Required when designing a vaccine; omit for "
              "ranking-only / report-only runs. Vaxrank picks "
              "canonical filenames inside (vaccine.fasta / cds.fasta / "
@@ -329,7 +329,7 @@ def add_output_args(arg_parser):
              "vaxrank/processing_prediction.py. Pepsickle runs in an "
              "isolated subprocess (issue #266) so torch's libomp "
              "doesn't clash with the parent's pandas / numpy / "
-             "pyarrow OpenMP runtime. Doesn't change vaccine ranking — "
+             "pyarrow OpenMP runtime. Doesn't change vaccine ranking; "
              "adds info for review.")
     output_args_group.add_argument(
         "--no-processing-aware-annotation",
@@ -372,7 +372,7 @@ def add_output_args(arg_parser):
     output_args_group.add_argument(
         "--output-ascii-report",
         default="",
-        help="Path to ASCII summary report — ranked antigens with "
+        help="Path to ASCII summary report: ranked antigens with "
              "their predicted MHC ligands, manufacturability metrics "
              "(peptide-mode only by default), and processing-credibility "
              "scores. Antigen-centric: content adapts to --vaccine-type "
@@ -519,7 +519,7 @@ def add_mrna_output_args(group):
     group.add_argument(
         "--mrna-3p-utr",
         default="HBB_FI",
-        help="3' UTR name (one of: %s). Default: HBB_FI (tandem 2× HBB / "
+        help="3' UTR name (one of: %s). Default: HBB_FI (tandem 2x HBB / "
              "FI element, BioNTech FixVac canonical)."
              % ", ".join(sorted(UTRS_3P)))
     group.add_argument(
@@ -620,7 +620,7 @@ def add_mrna_output_args(group):
         help="Override --antigen-content for mRNA. 'mutation_spanning' "
              "(default if --antigen-content unset) emits 25-aa SLP-style "
              "windows; 'minimal_epitope' emits top MHC ligands as "
-             "antigens — concatenated minimal-epitope mRNA "
+             "antigens; concatenated minimal-epitope mRNA "
              "(\"string of beads\") is a first-class design.")
     group.add_argument(
         "--mrna-epitopes-per-antigen",
@@ -633,7 +633,7 @@ def add_mrna_output_args(group):
         default=2,
         type=int,
         help="Maximum number of mRNA constructs in the vaccine. "
-             "Default: 2 (BioNTech FixVac canonical: 2× pentatope, "
+             "Default: 2 (BioNTech FixVac canonical: 2x pentatope, "
              "10 antigens at 5/construct, Sahin 2017). Set to 1 for "
              "a single construct; raise for broader coverage.")
     group.add_argument(
@@ -694,7 +694,7 @@ def add_peptide_output_args(group):
         default="G4Sx3",
         type=_linker_arg,
         help="Linker used in --peptide-mode=multi_epitope (case-insensitive). "
-             "Accepts named entries (P2A, AAY, EAAAK, …), compositional "
+             "Accepts named entries (P2A, AAY, EAAAK, etc.), compositional "
              "forms ((BASE)N or BASExN for repeats, GnSm for n-glycines + "
              "m-serines literal, AnY for n-alanines + Y), and aliases. "
              "Shared with mRNA mode. Default: G4Sx3 = (G4S)3 = "

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.8"
+__version__ = "3.1.9"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

- require `mhcgnomes>=3.33.5` so bundled MHC YAML data is decoded explicitly as UTF-8
- require `isovar>=1.7.2` so CLI startup no longer depends on the removed `pkg_resources` API
- keep argparse help text ASCII-safe so `vaxrank -h` works on non-UTF-8 terminals
- add an end-to-end C/ASCII-locale regression for CLI help
- make the repository's historical Ruff rule baseline explicit after Ruff 0.16 broadened its defaults
- bump vaxrank to 3.1.9

## Root cause and impact

Vaxrank 3.1.8 could fail at three points during `vaxrank -h` on current or non-UTF-8 environments:

1. `mhcgnomes` relied on the platform default when loading UTF-8 package data; version 3.33.5 fixes that upstream.
2. `isovar` imported `pkg_resources`, which current Setuptools has removed; version 1.7.2 uses `importlib.resources`.
3. Argparse help contained punctuation that Latin-1 or ASCII stdout could not encode.

The CI lint command also depended on Ruff's changing default rule selection. Ruff 0.16 enabled a much broader default set, causing 500 failures on the unchanged codebase. The new minimal `ruff.toml` preserves the rule families the project previously enforced.

## User impact

After installation, `vaxrank -h` starts without the `pkg_resources` warning and prints successfully under UTF-8, Latin-1, and C/ASCII locales. Existing UTF-8 users see only equivalent ASCII punctuation in help text.

## Validation

- `./lint.sh`
- `./test.sh` — 859 passed
- `LC_ALL=C LANG=C PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 vaxrank -h`
- verified installed `mhcgnomes 3.33.5` and `isovar 1.7.2`

Fixes #308
Fixes #309

Upstream fixes: pirl-unc/mhcgnomes#97, openvax/isovar#191
