### PR TITLE
Use oncoref for CTA-aware self references

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,9 @@ platformdirs
 msgspec>=0.18.6,<1.0.0
 dnachisel>=3.2.0,<4.0.0
 serializable>=1.1.0,<2.0.0
+# 1.8.174 is the direct authority for HPA-backed CTA identity and the full
+# candidate CTA universe used by antigen-specific self references.
+oncoref==1.8.174
 # vaxrank.peptide_context imports packaging.version for PEP 440 ordering
 # of predictor_version strings. Always pulled in transitively via setuptools
 # / pip, but pinned explicitly so minimal / --no-deps installs don't break

--- a/tests/test_epitope_prediction.py
+++ b/tests/test_epitope_prediction.py
@@ -74,6 +74,41 @@ def test_reference_peptide_logic(mouse_genome):
     eq_(_legacy_score_one(p_not_in_ref.value, p_not_in_ref.percentile_rank),
         vaccine_peptide.target_epitope_score)
 
+
+def test_predict_epitopes_records_distinct_non_cta_reference_flag(mouse_genome):
+    """The CTA-aware flag must come from its own reference index."""
+    from unittest.mock import patch
+
+    wdr13_transcript = mouse_genome.transcripts_by_name("Wdr13-201")[0]
+    protein_fragment = MutantProteinFragment(
+        variant=Variant("X", "8125624", "C", "A"),
+        gene_name="Wdr13",
+        amino_acids="KLQGHSAPVLDVIVNCDESLLASSD",
+        mutant_amino_acid_start_offset=12,
+        mutant_amino_acid_end_offset=13,
+        n_overlapping_reads=71,
+        n_alt_reads=25,
+        n_ref_reads=46,
+        n_alt_reads_supporting_protein_sequence=2,
+        supporting_reference_transcripts=[wdr13_transcript],
+    )
+
+    with patch("vaxrank.epitope_logic.ReferenceProteome") as reference_cls:
+        reference_cls.return_value.contains.return_value = True
+        reference_cls.from_genome.return_value.contains.return_value = False
+        epitopes = predict_epitopes(
+            mhc_predictor=RandomBindingPredictor(["H-2-Kb"]),
+            protein_fragment=protein_fragment,
+            epitope_config=EpitopeConfig(min_epitope_score=0),
+            genome=mouse_genome,
+        )
+
+    assert epitopes
+    assert all(epitope.occurs_in_reference for epitope in epitopes)
+    assert all(not epitope.occurs_in_non_CTA_reference for epitope in epitopes)
+    reference_cls.from_genome.assert_called_once_with(
+        mouse_genome, exclude_cta_genes=True)
+
 def test_predict_epitopes_returns_one_row_per_predictor_for_multimodel(mouse_genome):
     """Multi-model TopiaryPredictor (post-2.24, #261) keeps each
     predictor's view of every (peptide, allele) pair. In the new

--- a/tests/test_reference_proteome.py
+++ b/tests/test_reference_proteome.py
@@ -30,7 +30,10 @@ from vaxrank.reference_proteome import (
     get_cache_dir,
     DEFAULT_MIN_KMER_LENGTH,
     DEFAULT_MAX_KMER_LENGTH,
+    _filtered_kmer_set_cache,
     _kmer_set_cache,
+    cta_source_gene_ids_for_genome,
+    oncoref_cta_source_gene_ids,
 )
 
 from .common import eq_, ok_
@@ -522,8 +525,6 @@ def test_genome_protein_dict_excludes_gene_ids():
     t2 = create_mock_transcript("T2", "GHIJKL", gene_id="G2")
     t3 = create_mock_transcript("T3", "MNOPQR", gene_id="G1")
     genome = create_mock_genome([t1, t2, t3])
-    genome.transcript_ids_of_gene_id.return_value = ["T1", "T3"]
-
     proteins = genome_protein_dict(genome, exclude_gene_ids={"G1"})
     assert "T1" not in proteins
     assert "T3" not in proteins
@@ -540,13 +541,21 @@ def test_genome_protein_dict_skips_non_coding():
 
 
 def test_genome_protein_dict_exclude_unknown_gene_id():
-    """Excluding a gene ID not in the genome should warn, not crash."""
+    """Excluding a gene ID not in the genome should be a harmless no-op."""
     t1 = create_mock_transcript("T1", "ABCDEF", gene_id="G1")
     genome = create_mock_genome([t1])
-    genome.transcript_ids_of_gene_id.side_effect = ValueError("not found")
 
     proteins = genome_protein_dict(genome, exclude_gene_ids={"NONEXISTENT"})
     assert "T1" in proteins
+
+
+def test_genome_protein_dict_normalizes_versioned_gene_ids():
+    t1 = create_mock_transcript("T1", "ABCDEF", gene_id="G1.7")
+    genome = create_mock_genome([t1])
+
+    proteins = genome_protein_dict(genome, exclude_gene_ids={"G1"})
+
+    assert proteins == {}
 
 
 # =============================================================================
@@ -610,8 +619,6 @@ def test_from_genome_with_exclude_gene_ids():
     t1 = create_mock_transcript("T1", "ABCDEFGHIJ", gene_id="G1")
     t2 = create_mock_transcript("T2", "KLMNOPQRST", gene_id="G2")
     genome = create_mock_genome([t1, t2])
-    genome.transcript_ids_of_gene_id.return_value = ["T1"]
-
     ref = ReferenceProteome.from_genome(
         genome, exclude_gene_ids={"G1"}, min_kmer_length=8, max_kmer_length=8)
     assert not ref.contains("ABCDEFGH")  # G1 excluded
@@ -619,17 +626,64 @@ def test_from_genome_with_exclude_gene_ids():
 
 
 def test_from_genome_with_exclude_cta_genes():
-    t1 = create_mock_transcript("T1", "ABCDEFGHIJ", gene_id="ENSG00000006047")
+    prame_gene_id = "ENSG00000185686"
+    t1 = create_mock_transcript("T1", "ABCDEFGHIJ", gene_id=prame_gene_id)
     t2 = create_mock_transcript("T2", "KLMNOPQRST", gene_id="ENSG00000099999")
-    genome = create_mock_genome([t1, t2])
-    genome.transcript_ids_of_gene_id.return_value = ["T1"]
-
-    ref = ReferenceProteome.from_genome(
-        genome, exclude_cta_genes=True,
-        min_kmer_length=8, max_kmer_length=8)
+    genome = create_mock_genome([t1, t2], species_name="Homo sapiens")
+    with patch(
+            "vaxrank.reference_proteome.oncoref_cta_source_gene_ids",
+            return_value=frozenset({prame_gene_id})):
+        ref = ReferenceProteome.from_genome(
+            genome, exclude_cta_genes=True,
+            min_kmer_length=8, max_kmer_length=8)
 
     assert not ref.contains("ABCDEFGH")  # CTA gene excluded
     assert ref.contains("KLMNOPQR")
+    assert ref.excluded_gene_ids == frozenset({prame_gene_id})
+
+
+def test_oncoref_cta_source_universe_includes_prame():
+    """PRAME must never re-enter the negative self source set."""
+    assert "ENSG00000185686" in oncoref_cta_source_gene_ids()
+
+
+def test_cta_source_exclusion_is_human_only():
+    genome = create_mock_genome([], species_name="Mus musculus")
+    with patch("vaxrank.reference_proteome.oncoref_cta_source_gene_ids") as load_ctas:
+        assert cta_source_gene_ids_for_genome(genome) == frozenset()
+    load_ctas.assert_not_called()
+
+
+def test_cta_shared_sequence_remains_self_through_non_cta_gene():
+    """Removing a CTA source gene must not remove a shared non-CTA peptide."""
+    prame_gene_id = "ENSG00000185686"
+    shared = "ABCDEFGHIJ"
+    cta = create_mock_transcript("CTA_TX", shared, gene_id=prame_gene_id)
+    non_cta = create_mock_transcript("SELF_TX", shared, gene_id="ENSG_NON_CTA")
+    genome = create_mock_genome(
+        [cta, non_cta], species_name="Homo sapiens", release=111)
+    with patch(
+            "vaxrank.reference_proteome.oncoref_cta_source_gene_ids",
+            return_value=frozenset({prame_gene_id})):
+        ref = ReferenceProteome.from_genome(
+            genome, exclude_cta_genes=True,
+            min_kmer_length=8, max_kmer_length=8)
+
+    assert ref.contains("ABCDEFGH")
+
+
+def test_filtered_reference_proteome_is_cached_per_genome_and_policy():
+    _filtered_kmer_set_cache.clear()
+    t1 = create_mock_transcript("T1", "ABCDEFGHIJ", gene_id="G1")
+    t2 = create_mock_transcript("T2", "KLMNOPQRST", gene_id="G2")
+    genome = create_mock_genome([t1, t2], release=112)
+    first = ReferenceProteome.from_genome(
+        genome, exclude_gene_ids={"G1"}, min_kmer_length=8, max_kmer_length=8)
+    second = ReferenceProteome.from_genome(
+        genome, exclude_gene_ids={"G1"}, min_kmer_length=8, max_kmer_length=8)
+
+    assert first._kmer_set is second._kmer_set
+    assert genome.transcripts.call_count == 1
 
 
 def test_from_genome_with_exclude_fasta(tmp_path):
@@ -664,8 +718,6 @@ def test_from_genome_combined_exclusions(tmp_path):
     t2 = create_mock_transcript("T2", "KLMNOPQRST", gene_id="G2")
     t3 = create_mock_transcript("T3", "UVWXYZABCD", gene_id="G3")
     genome = create_mock_genome([t1, t2, t3])
-    genome.transcript_ids_of_gene_id.return_value = ["T1"]
-
     ref = ReferenceProteome.from_genome(
         genome,
         exclude_gene_ids={"G1"},

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -508,12 +508,11 @@ class CandidateEpitope(Peptide):
     # them is intended.
     occurs_in_reference: bool = False
 
-    # CTA-aware safety signal: same as ``occurs_in_reference`` but
-    # with CTA genes excluded from the reference set. Equals
-    # ``occurs_in_reference`` until a CTA database is configured
-    # (today the CTA set is empty, so producers populate the two
-    # flags identically). Consumers opt into CTA-friendly policy by
-    # reading this flag instead of the raw one.
+    # CTA-aware safety signal: same as ``occurs_in_reference`` but with
+    # source genes in oncoref's full CTA candidate universe excluded from
+    # the reference set. Shared sequences in non-CTA genes remain present.
+    # Consumers opt into CTA-friendly policy by reading this flag instead
+    # of the raw one.
     occurs_in_non_CTA_reference: bool = False
 
     # Per-allele score for this epitope as computed by the configured

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -103,6 +103,8 @@ def predict_epitopes(
         epitope_config = EpitopeConfig()
 
     reference_proteome = ReferenceProteome(genome)
+    non_cta_reference_proteome = ReferenceProteome.from_genome(
+        genome, exclude_cta_genes=True)
 
     # Wrap bare mhctools predictors in a TopiaryPredictor
     if not isinstance(mhc_predictor, TopiaryPredictor):
@@ -214,6 +216,7 @@ def predict_epitopes(
             end_offset=peptide_end_offset)
 
         occurs_in_reference = reference_proteome.contains(peptide)
+        occurs_in_non_cta_reference = non_cta_reference_proteome.contains(peptide)
         if occurs_in_reference:
             logger.debug('Peptide %s occurs in reference', peptide)
             num_occurs_in_reference += 1
@@ -289,11 +292,11 @@ def predict_epitopes(
             'source_class': SOURCE_CLASS_MUTATION,
             'overlaps_mutation': overlaps_mutation,
             'occurs_in_reference': occurs_in_reference,
-            # ReferenceProteome doesn't yet know about CTAs, so the
-            # CTA-aware flag mirrors the raw one. When the CTA set
-            # is populated (via pirlygenes), this branch will diverge
-            # for CTA-matching peptides.
-            'occurs_in_non_CTA_reference': occurs_in_reference,
+            # Exact self after removing source genes in oncoref's full CTA
+            # candidate universe. This may diverge from the raw reference flag
+            # for CTA-family peptides; shared sequences in any non-CTA gene
+            # remain present because the filtered index retains those genes.
+            'occurs_in_non_CTA_reference': occurs_in_non_cta_reference,
             # Per-(peptide, allele) DSL score; threaded onto the
             # CandidateEpitope as ``per_allele_scores[allele]`` by
             # ``candidate_epitopes_from_rows``. Single source of

--- a/vaxrank/reference_proteome.py
+++ b/vaxrank/reference_proteome.py
@@ -18,10 +18,11 @@ Uses a set-based index for O(1) membership testing of peptide kmers.
 
 import gzip
 import io
-import os
 import logging
+import os
 import pickle
 import threading
+from functools import lru_cache
 
 from platformdirs import user_cache_dir
 from tqdm import tqdm
@@ -30,80 +31,47 @@ from .config.defaults import DEFAULT_MAX_KMER_LENGTH, DEFAULT_MIN_KMER_LENGTH
 
 logger = logging.getLogger(__name__)
 
-# Cancer-testis antigen (CTA) Ensembl gene IDs, derived from pirlygenes
-# CTA_gene_ids() (filtered & expressed). Inlined to avoid the heavy dependency.
-CTA_GENE_IDS = frozenset({
-    "ENSG00000006047", "ENSG00000007350", "ENSG00000010318", "ENSG00000042813",
-    "ENSG00000046774", "ENSG00000054796", "ENSG00000068985", "ENSG00000077800",
-    "ENSG00000077935", "ENSG00000092345", "ENSG00000095627", "ENSG00000099399",
-    "ENSG00000102021", "ENSG00000103023", "ENSG00000104755", "ENSG00000104804",
-    "ENSG00000104901", "ENSG00000106013", "ENSG00000106304", "ENSG00000114487",
-    "ENSG00000117148", "ENSG00000118434", "ENSG00000118491", "ENSG00000121101",
-    "ENSG00000122304", "ENSG00000123576", "ENSG00000123584", "ENSG00000124092",
-    "ENSG00000124227", "ENSG00000124260", "ENSG00000124467", "ENSG00000124490",
-    "ENSG00000125207", "ENSG00000126467", "ENSG00000126752", "ENSG00000126856",
-    "ENSG00000129862", "ENSG00000129864", "ENSG00000131126", "ENSG00000132446",
-    "ENSG00000135248", "ENSG00000137090", "ENSG00000137948", "ENSG00000139351",
-    "ENSG00000140478", "ENSG00000141096", "ENSG00000141255", "ENSG00000141316",
-    "ENSG00000141371", "ENSG00000141437", "ENSG00000142025", "ENSG00000142698",
-    "ENSG00000143006", "ENSG00000143452", "ENSG00000144962", "ENSG00000145309",
-    "ENSG00000146047", "ENSG00000147081", "ENSG00000147183", "ENSG00000147378",
-    "ENSG00000147381", "ENSG00000148156", "ENSG00000150628", "ENSG00000151962",
-    "ENSG00000152430", "ENSG00000152670", "ENSG00000153060", "ENSG00000153779",
-    "ENSG00000155087", "ENSG00000155495", "ENSG00000156009", "ENSG00000156269",
-    "ENSG00000158639", "ENSG00000159289", "ENSG00000159708", "ENSG00000161860",
-    "ENSG00000161973", "ENSG00000162039", "ENSG00000162641", "ENSG00000162771",
-    "ENSG00000162843", "ENSG00000163114", "ENSG00000163530", "ENSG00000164113",
-    "ENSG00000164304", "ENSG00000165583", "ENSG00000165584", "ENSG00000166049",
-    "ENSG00000166069", "ENSG00000166118", "ENSG00000166796", "ENSG00000168594",
-    "ENSG00000168757", "ENSG00000169059", "ENSG00000169551", "ENSG00000169800",
-    "ENSG00000170516", "ENSG00000170748", "ENSG00000170950", "ENSG00000170965",
-    "ENSG00000171402", "ENSG00000171794", "ENSG00000172073", "ENSG00000172717",
-    "ENSG00000174015", "ENSG00000174016", "ENSG00000174898", "ENSG00000175646",
-    "ENSG00000175809", "ENSG00000175820", "ENSG00000175877", "ENSG00000176256",
-    "ENSG00000176566", "ENSG00000176635", "ENSG00000176774", "ENSG00000176988",
-    "ENSG00000177294", "ENSG00000177673", "ENSG00000177689", "ENSG00000177947",
-    "ENSG00000177992", "ENSG00000178021", "ENSG00000178279", "ENSG00000178997",
-    "ENSG00000179046", "ENSG00000179088", "ENSG00000179407", "ENSG00000180138",
-    "ENSG00000180336", "ENSG00000181323", "ENSG00000181433", "ENSG00000182308",
-    "ENSG00000182459", "ENSG00000182583", "ENSG00000183206", "ENSG00000183434",
-    "ENSG00000183668", "ENSG00000184033", "ENSG00000184361", "ENSG00000184507",
-    "ENSG00000184650", "ENSG00000184735", "ENSG00000185264", "ENSG00000185686",
-    "ENSG00000185863", "ENSG00000186075", "ENSG00000186118", "ENSG00000186451",
-    "ENSG00000186788", "ENSG00000187003", "ENSG00000187191", "ENSG00000187475",
-    "ENSG00000187772", "ENSG00000188120", "ENSG00000188425", "ENSG00000188782",
-    "ENSG00000189023", "ENSG00000189064", "ENSG00000189186", "ENSG00000189252",
-    "ENSG00000189326", "ENSG00000189357", "ENSG00000196406", "ENSG00000196553",
-    "ENSG00000196862", "ENSG00000197172", "ENSG00000198021", "ENSG00000198033",
-    "ENSG00000198573", "ENSG00000198681", "ENSG00000198759", "ENSG00000198765",
-    "ENSG00000198870", "ENSG00000203907", "ENSG00000203909", "ENSG00000203926",
-    "ENSG00000204279", "ENSG00000204363", "ENSG00000204379", "ENSG00000204450",
-    "ENSG00000204849", "ENSG00000204941", "ENSG00000205359", "ENSG00000205642",
-    "ENSG00000205777", "ENSG00000212710", "ENSG00000213030", "ENSG00000213218",
-    "ENSG00000213401", "ENSG00000214107", "ENSG00000215113", "ENSG00000215115",
-    "ENSG00000215269", "ENSG00000215529", "ENSG00000215817", "ENSG00000216649",
-    "ENSG00000221826", "ENSG00000221867", "ENSG00000224659", "ENSG00000224902",
-    "ENSG00000226023", "ENSG00000226650", "ENSG00000226685", "ENSG00000226929",
-    "ENSG00000227234", "ENSG00000228517", "ENSG00000228927", "ENSG00000229549",
-    "ENSG00000230594", "ENSG00000230601", "ENSG00000231924", "ENSG00000233803",
-    "ENSG00000234068", "ENSG00000234414", "ENSG00000235631", "ENSG00000235699",
-    "ENSG00000236126", "ENSG00000236362", "ENSG00000236371", "ENSG00000236424",
-    "ENSG00000236446", "ENSG00000236761", "ENSG00000237671", "ENSG00000237957",
-    "ENSG00000238269", "ENSG00000240021", "ENSG00000241476", "ENSG00000242362",
-    "ENSG00000242389", "ENSG00000242875", "ENSG00000243130", "ENSG00000244395",
-    "ENSG00000244588", "ENSG00000250741", "ENSG00000258713", "ENSG00000258992",
-    "ENSG00000261649", "ENSG00000267978", "ENSG00000268009", "ENSG00000268447",
-    "ENSG00000268606", "ENSG00000268629", "ENSG00000268651", "ENSG00000268696",
-    "ENSG00000268988", "ENSG00000269058", "ENSG00000269586", "ENSG00000270806",
-    "ENSG00000271321", "ENSG00000271449", "ENSG00000273696", "ENSG00000274274",
-    "ENSG00000274391", "ENSG00000275793", "ENSG00000275969", "ENSG00000276040",
-    "ENSG00000277322",
-})
+
+@lru_cache(maxsize=1)
+def oncoref_cta_source_gene_ids() -> frozenset[str]:
+    """Full human CTA candidate universe owned by oncoref.
+
+    The broad, unfiltered universe is intentional for self-reference source
+    exclusions: a valid CTA peptide must not cancel itself merely because the
+    same sequence occurs in a held-out CTA paralog. Target admission uses the
+    narrower ``oncoref.cta.cta_gene_ids()`` set in the antigen layer.
+    """
+    from oncoref.cta import cta_unfiltered_gene_ids
+
+    return frozenset(str(gene_id).split(".")[0]
+                     for gene_id in cta_unfiltered_gene_ids())
+
+
+def _is_human_genome(genome) -> bool:
+    if genome is None:
+        return False
+    species = getattr(genome, "species", None)
+    latin_name = str(getattr(species, "latin_name", ""))
+    normalized = latin_name.strip().casefold().replace("_", " ")
+    return normalized in {"homo sapiens", "human"}
+
+
+def cta_source_gene_ids_for_genome(genome) -> frozenset[str]:
+    """Human CTA source exclusions, or an empty set for other species."""
+    if not _is_human_genome(genome):
+        return frozenset()
+    return oncoref_cta_source_gene_ids()
 
 # In-memory cache for loaded kmer sets to avoid repeated disk reads
 # Key: (species, release, min_len, max_len) -> set of kmers
 _kmer_set_cache: dict[tuple, set[str]] = {}
 _kmer_set_cache_lock = threading.Lock()
+
+# Filtered indexes are shared within a run. The genome object's identity is
+# part of the key so distinct test/custom genomes with the same release label
+# cannot contaminate one another.
+_filtered_kmer_set_cache: dict[tuple, set[str]] = {}
+_filtered_kmer_set_cache_lock = threading.Lock()
 
 
 def get_cache_dir() -> str:
@@ -292,6 +260,20 @@ def extract_kmers(sequences, min_len, max_len):
     return kmers
 
 
+def _resolve_kmer_lengths(min_kmer_length, max_kmer_length, epitope_lengths):
+    if epitope_lengths and (min_kmer_length is None or max_kmer_length is None):
+        lengths = sorted(epitope_lengths)
+        if min_kmer_length is None:
+            min_kmer_length = lengths[0]
+        if max_kmer_length is None:
+            max_kmer_length = lengths[-1]
+    if min_kmer_length is None:
+        min_kmer_length = DEFAULT_MIN_KMER_LENGTH
+    if max_kmer_length is None:
+        max_kmer_length = DEFAULT_MAX_KMER_LENGTH
+    return min_kmer_length, max_kmer_length
+
+
 def genome_protein_dict(genome, exclude_gene_ids=None):
     """
     Build a dict of transcript_id -> protein_sequence from a pyensembl genome,
@@ -307,23 +289,24 @@ def genome_protein_dict(genome, exclude_gene_ids=None):
     -------
     dict[str, str]
     """
-    if exclude_gene_ids:
-        exclude_tids = set()
-        for gene_id in exclude_gene_ids:
-            try:
-                exclude_tids.update(genome.transcript_ids_of_gene_id(gene_id))
-            except ValueError:
-                logger.warning("Gene ID %s not found in genome, skipping", gene_id)
-        logger.info(
-            "Excluding %d transcripts from %d genes",
-            len(exclude_tids), len(exclude_gene_ids))
-    else:
-        exclude_tids = set()
+    excluded_gene_ids = {
+        str(gene_id).split(".")[0] for gene_id in (exclude_gene_ids or [])
+    }
 
     proteins = {}
+    num_excluded_transcripts = 0
     for t in genome.transcripts():
-        if t.is_protein_coding and t.protein_sequence and t.transcript_id not in exclude_tids:
+        gene_id = str(t.gene_id).split(".")[0]
+        if gene_id in excluded_gene_ids:
+            num_excluded_transcripts += 1
+        elif t.is_protein_coding and t.protein_sequence:
             proteins[t.transcript_id] = t.protein_sequence
+    if excluded_gene_ids:
+        logger.info(
+            "Excluded %d transcripts from %d source genes",
+            num_excluded_transcripts,
+            len(excluded_gene_ids),
+        )
     return proteins
 
 
@@ -358,6 +341,7 @@ class ReferenceProteome:
         self.genome = genome
         self.min_kmer_length = min_kmer_length
         self.max_kmer_length = max_kmer_length
+        self.excluded_gene_ids = frozenset()
 
         if genome is not None:
             self._kmer_set = load_kmer_set_index(
@@ -387,16 +371,8 @@ class ReferenceProteome:
             CandidateEpitope lengths being predicted. Used to derive kmer range
             when min/max not explicitly set.
         """
-        if epitope_lengths and (min_kmer_length is None or max_kmer_length is None):
-            lengths = sorted(epitope_lengths)
-            if min_kmer_length is None:
-                min_kmer_length = lengths[0]
-            if max_kmer_length is None:
-                max_kmer_length = lengths[-1]
-        if min_kmer_length is None:
-            min_kmer_length = DEFAULT_MIN_KMER_LENGTH
-        if max_kmer_length is None:
-            max_kmer_length = DEFAULT_MAX_KMER_LENGTH
+        min_kmer_length, max_kmer_length = _resolve_kmer_lengths(
+            min_kmer_length, max_kmer_length, epitope_lengths)
 
         unique_seqs = set(proteins.values())
         logger.info(
@@ -410,6 +386,7 @@ class ReferenceProteome:
         obj.min_kmer_length = min_kmer_length
         obj.max_kmer_length = max_kmer_length
         obj._kmer_set = kmer_set
+        obj.excluded_gene_ids = frozenset()
         return obj
 
     @classmethod
@@ -435,32 +412,73 @@ class ReferenceProteome:
         min_kmer_length : int, optional
         max_kmer_length : int, optional
         """
-        all_exclude_ids = set(exclude_gene_ids or [])
+        min_kmer_length, max_kmer_length = _resolve_kmer_lengths(
+            min_kmer_length, max_kmer_length, epitope_lengths)
+
+        if genome is None:
+            return cls(
+                None,
+                min_kmer_length=min_kmer_length,
+                max_kmer_length=max_kmer_length,
+            )
+
+        all_exclude_ids = {
+            str(gene_id).split(".")[0] for gene_id in (exclude_gene_ids or [])
+        }
 
         if exclude_cta_genes:
-            logger.info("Excluding %d CTA gene IDs", len(CTA_GENE_IDS))
-            all_exclude_ids.update(CTA_GENE_IDS)
-
-        proteins = genome_protein_dict(genome, exclude_gene_ids=all_exclude_ids)
-
-        if exclude_fasta:
-            exclude_seqs = set(_read_fasta(exclude_fasta).values())
-            before = len(proteins)
-            proteins = {
-                tid: seq for tid, seq in proteins.items()
-                if seq not in exclude_seqs
-            }
+            cta_gene_ids = cta_source_gene_ids_for_genome(genome)
             logger.info(
-                "Excluded %d proteins matching FASTA %s",
-                before - len(proteins), exclude_fasta)
+                "Excluding %d oncoref CTA source gene IDs", len(cta_gene_ids))
+            all_exclude_ids.update(cta_gene_ids)
 
-        obj = cls.from_sequences(
-            proteins,
-            min_kmer_length=min_kmer_length,
-            max_kmer_length=max_kmer_length,
-            epitope_lengths=epitope_lengths,
+        # With no exclusions this is exactly the ordinary reference proteome;
+        # reuse its disk/in-memory cache rather than rebuilding from transcripts.
+        if exclude_cta_genes and not all_exclude_ids and not exclude_fasta:
+            return cls(
+                genome,
+                min_kmer_length=min_kmer_length,
+                max_kmer_length=max_kmer_length,
+            )
+
+        cache_key = (
+            id(genome),
+            frozenset(all_exclude_ids),
+            min_kmer_length,
+            max_kmer_length,
         )
+        kmer_set = None
+        if not exclude_fasta:
+            with _filtered_kmer_set_cache_lock:
+                kmer_set = _filtered_kmer_set_cache.get(cache_key)
+
+        if kmer_set is None:
+            proteins = genome_protein_dict(
+                genome, exclude_gene_ids=all_exclude_ids)
+
+            if exclude_fasta:
+                exclude_seqs = set(_read_fasta(exclude_fasta).values())
+                before = len(proteins)
+                proteins = {
+                    tid: seq for tid, seq in proteins.items()
+                    if seq not in exclude_seqs
+                }
+                logger.info(
+                    "Excluded %d proteins matching FASTA %s",
+                    before - len(proteins), exclude_fasta)
+
+            kmer_set = extract_kmers(
+                set(proteins.values()), min_kmer_length, max_kmer_length)
+            if not exclude_fasta:
+                with _filtered_kmer_set_cache_lock:
+                    _filtered_kmer_set_cache[cache_key] = kmer_set
+
+        obj = cls.__new__(cls)
         obj.genome = genome
+        obj.min_kmer_length = min_kmer_length
+        obj.max_kmer_length = max_kmer_length
+        obj._kmer_set = kmer_set
+        obj.excluded_gene_ids = frozenset(all_exclude_ids)
         return obj
 
     def contains(self, peptide: str) -> bool:

--- a/vaxrank/vaccine_peptide.py
+++ b/vaxrank/vaccine_peptide.py
@@ -175,9 +175,8 @@ class VaccinePeptide(DataclassSerializable):
         # behavior: peptides identical to WT land in self_epitopes
         # because they're in the reference. Viral peptides absent
         # from the reference land in target_epitopes. CTAs land in
-        # self_epitopes today; when consumers opt into the
-        # CTA-aware ``occurs_in_non_CTA_reference`` flag, CTAs will
-        # move to target_epitopes without changing this code.
+        # self_epitopes today. Antigen-aware consumers introduced by
+        # issue #303 use ``occurs_in_non_CTA_reference`` for CTA sources.
         self.target_epitopes = sorted(
             [e for e in self.epitopes if not e.occurs_in_reference],
             key=_epitope_sort_key,

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.9"
+__version__ = "3.1.10"
 
 
 def print_version():


### PR DESCRIPTION
Foundation for #303, #254, and #311.

This PR:
- pins oncoref 1.8.174 as the direct CTA authority;
- replaces the embedded CTA list with cta_unfiltered_gene_ids();
- builds an honest CTA-source-excluded reference alongside the complete reference;
- filters the broad CTA universe in one transcript pass and caches policy-specific indices;
- preserves self hits when a CTA peptide is also encoded by a non-CTA gene;
- bumps Vaxrank to 3.1.10.

Obvious-risk regressions cover PRAME, shared CTA/non-CTA sequences, human-only policy, versioned Ensembl IDs, cache reuse, and divergence of the raw and CTA-aware self flags.

Validation:
- ./lint.sh
- ./test.sh (865 passed)