### PR TITLE
Add source-agnostic VaccineAntigen model

### DIFF
--- a/tests/test_epitope_prediction.py
+++ b/tests/test_epitope_prediction.py
@@ -63,11 +63,16 @@ def test_reference_peptide_logic(mouse_genome):
     e_not_in_ref, p_not_in_ref = by_key[('LDVIVNCDE', 'H-2-Kb')]
     ok_(e_in_ref.occurs_in_reference)
     ok_(not e_not_in_ref.occurs_in_reference)
+    assert e_in_ref.self_reference_match.occurs
+    assert not e_not_in_ref.self_reference_match.occurs
+    assert e_in_ref.overlaps_targetable == e_in_ref.overlaps_mutation
+    assert e_not_in_ref.overlaps_targetable == e_not_in_ref.overlaps_mutation
 
     # Build a VaccinePeptide from these two Epitopes; the mutant /
     # wildtype split comes out of __post_init__.
     vaccine_peptide = VaccinePeptide(
         protein_fragment, [e_in_ref, e_not_in_ref])
+    assert vaccine_peptide.antigen.kind == "mutation"
 
     eq_(_legacy_score_one(p_in_ref.value, p_in_ref.percentile_rank),
         vaccine_peptide.self_epitope_score)

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -23,6 +23,7 @@ from varcode import Variant
 
 from vaxrank.mutant_protein_fragment import MutantProteinFragment
 from vaxrank.candidate_epitope import COMPARATOR_WT, CandidateEpitope, Peptide
+from vaxrank.vaccine_antigen import VaccineAntigen
 from vaxrank.vaccine_peptide import VaccinePeptide
 
 
@@ -52,6 +53,8 @@ def _sample_epitope(
     ic50=2.0,
     overlaps_mutation=True,
     occurs_in_reference=False,
+    overlaps_targetable=None,
+    self_reference_match=None,
 ):
     mutant_pred = Prediction(
         kind='pMHC_affinity', predictor_name='ImaginationMHCpan',
@@ -73,7 +76,9 @@ def _sample_epitope(
             source_sequence='SSIINFEQL', offset=1,
             predictions=(wt_pred,))},
         overlaps_mutation=overlaps_mutation,
-        occurs_in_reference=occurs_in_reference)
+        overlaps_targetable=overlaps_targetable,
+        occurs_in_reference=occurs_in_reference,
+        self_reference_match=self_reference_match)
 
 
 class _FakeVariant:
@@ -184,6 +189,7 @@ def test_vaccine_peptide_to_dict_omits_derived_fields():
     for derived in (
         "target_epitopes",
         "self_epitopes",
+        "non_target_epitopes",
         "target_epitope_score",
         "self_epitope_score",
         "manufacturability_scores",
@@ -207,7 +213,14 @@ def test_vaccine_peptide_json_roundtrip_with_real_fragment():
     flat records. This is the path the CLI writes out — we want
     __post_init__ to re-derive the mutant/wildtype split after load and
     scores to re-compute consistently."""
-    mutant = _sample_epitope(peptide_sequence="SIINFEKL", ic50=500.0)
+    fragment = _sample_fragment()
+    antigen = VaccineAntigen.from_mutant_protein_fragment(fragment)
+    mutant = _sample_epitope(
+        peptide_sequence="SIINFEKL",
+        ic50=500.0,
+        overlaps_targetable=True,
+        self_reference_match=antigen.self_reference_match("SIINFEKL", False),
+    )
     wildtype = _sample_epitope(
         peptide_sequence="TESTWILD",
         ic50=50.0,
@@ -215,7 +228,7 @@ def test_vaccine_peptide_json_roundtrip_with_real_fragment():
         occurs_in_reference=True,
     )
     vp = VaccinePeptide(
-        mutant_protein_fragment=_sample_fragment(),
+        mutant_protein_fragment=fragment,
         epitopes=[mutant, wildtype],
         manufacturability_rules=("cysteine_count", "cterm_hydropathy"),
         combined_score_expr="target_epitope_score",
@@ -224,6 +237,10 @@ def test_vaccine_peptide_json_roundtrip_with_real_fragment():
 
     # Wire-level invariants
     assert restored.mutant_protein_fragment == vp.mutant_protein_fragment
+    assert restored.antigen == vp.antigen
+    assert restored.target_epitopes[0].self_reference_match == (
+        vp.target_epitopes[0].self_reference_match
+    )
     assert restored.manufacturability_rules == vp.manufacturability_rules
     assert restored.combined_score_expr == vp.combined_score_expr
 

--- a/tests/test_vaccine_antigen.py
+++ b/tests/test_vaccine_antigen.py
@@ -1,0 +1,233 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from vaxrank.candidate_epitope import CandidateEpitope
+from vaxrank.epitope_logic import predict_epitopes
+from vaxrank.vaccine_antigen import (
+    ANTIGEN_KIND_CTA,
+    ANTIGEN_KIND_MUTATION,
+    ATTESTATION_ADMITTED,
+    ATTESTATION_HELD_OUT,
+    ATTESTATION_OVERRIDDEN,
+    AminoAcidInterval,
+    SelfReferenceMatch,
+    SelfReferenceSource,
+    TargetableMask,
+    TumorSpecificityAttestation,
+    VaccineAntigen,
+)
+from vaxrank.vaccine_peptide import VaccinePeptide
+
+
+def admitted_attestation():
+    return TumorSpecificityAttestation(
+        status=ATTESTATION_ADMITTED,
+        evidence_kind="patient_tumor_expression",
+        evidence_source="test fixture",
+        patient_specific=True,
+        rationale_code="test_admission",
+    )
+
+
+def cta_antigen(sequence="ACDEFGHIKL"):
+    return VaccineAntigen(
+        kind=ANTIGEN_KIND_CTA,
+        amino_acids=sequence,
+        targetable_mask=TargetableMask((AminoAcidInterval(0, len(sequence)),)),
+        tumor_specificity=admitted_attestation(),
+        self_reference_excluded_gene_ids=("ENSG00000185686.4",),
+        gene_name="PRAME",
+        gene_id="ENSG00000185686.4",
+    )
+
+
+def test_targetable_interval_validation_and_deletion_parity():
+    with pytest.raises(ValueError, match="non-negative"):
+        AminoAcidInterval(-1, 1)
+    with pytest.raises(ValueError, match="must not precede"):
+        AminoAcidInterval(2, 1)
+
+    deletion = AminoAcidInterval(4, 4)
+    assert deletion.overlaps(0, 8)
+    assert not deletion.overlaps(4, 8)
+
+
+def test_targetable_mask_rejects_ambiguous_or_out_of_bounds_intervals():
+    with pytest.raises(ValueError, match="sorted"):
+        TargetableMask((AminoAcidInterval(5, 6), AminoAcidInterval(1, 2)))
+    with pytest.raises(ValueError, match="must not overlap"):
+        TargetableMask((AminoAcidInterval(1, 4), AminoAcidInterval(3, 5)))
+    with pytest.raises(ValueError, match="extends beyond"):
+        VaccineAntigen(
+            kind=ANTIGEN_KIND_CTA,
+            amino_acids="ABCDE",
+            targetable_mask=TargetableMask((AminoAcidInterval(0, 6),)),
+            tumor_specificity=admitted_attestation(),
+        )
+    with pytest.raises(ValueError, match="requires targetable content"):
+        VaccineAntigen(
+            kind=ANTIGEN_KIND_CTA,
+            amino_acids="ACDEF",
+            targetable_mask=TargetableMask(),
+            tumor_specificity=admitted_attestation(),
+        )
+
+
+def test_attestation_requires_known_status_evidence_and_override_reason():
+    with pytest.raises(ValueError, match="Unknown tumor-specificity status"):
+        TumorSpecificityAttestation("unknown", "expression", "fixture")
+    with pytest.raises(ValueError, match="kind and source are required"):
+        TumorSpecificityAttestation(ATTESTATION_ADMITTED, "", "fixture")
+    with pytest.raises(ValueError, match="requires an override reason"):
+        TumorSpecificityAttestation(
+            ATTESTATION_OVERRIDDEN, "clinical_review", "fixture"
+        )
+
+
+def test_mutation_adapter_preserves_target_span_and_source_ids():
+    transcript = SimpleNamespace(
+        gene_id="ENSG00000123456.9",
+        transcript_id="ENST000001",
+        protein_id="ENSP000001",
+    )
+    fragment = SimpleNamespace(
+        amino_acids="ABCDEFGHIJ",
+        mutant_amino_acid_start_offset=3,
+        mutant_amino_acid_end_offset=4,
+        supporting_reference_transcripts=[transcript],
+        gene_name="GENE1",
+        variant="1:100 A>G",
+    )
+
+    antigen = VaccineAntigen.from_mutant_protein_fragment(fragment)
+
+    assert antigen.kind == ANTIGEN_KIND_MUTATION
+    assert antigen.interval_is_targetable(0, 4)
+    assert not antigen.interval_is_targetable(4, 8)
+    assert antigen.gene_id == "ENSG00000123456"
+    assert antigen.transcript_ids == ("ENST000001",)
+    assert antigen.protein_ids == ("ENSP000001",)
+    assert antigen.self_reference_excluded_gene_ids == ()
+    assert antigen.tumor_specificity.admits_construct
+
+
+def test_self_reference_match_rejects_excluded_or_inconsistent_sources():
+    prame_source = SelfReferenceSource(gene_id="ENSG00000185686")
+    with pytest.raises(ValueError, match="cannot include excluded genes"):
+        SelfReferenceMatch(
+            peptide="SIINFEKL",
+            occurs=True,
+            antigen_kind=ANTIGEN_KIND_CTA,
+            excluded_gene_ids=("ENSG00000185686",),
+            sources=(prame_source,),
+            source_provenance_complete=True,
+        )
+    with pytest.raises(ValueError, match="must agree with its source list"):
+        SelfReferenceMatch(
+            peptide="SIINFEKL",
+            occurs=True,
+            antigen_kind=ANTIGEN_KIND_CTA,
+            source_provenance_complete=True,
+        )
+
+
+def test_vaccine_peptide_uses_targetable_mask_and_antigen_self_result():
+    antigen = cta_antigen()
+    fragment = SimpleNamespace(amino_acids=antigen.amino_acids)
+    target = CandidateEpitope(
+        sequence="ACDEFGHI",
+        source_sequence=antigen.amino_acids,
+        overlaps_targetable=True,
+        occurs_in_reference=True,
+        self_reference_match=antigen.self_reference_match("ACDEFGHI", False),
+    )
+    non_target = CandidateEpitope(
+        sequence="CDEFGHIK",
+        source_sequence=antigen.amino_acids,
+        offset=1,
+        overlaps_targetable=False,
+        occurs_in_reference=False,
+        self_reference_match=antigen.self_reference_match("CDEFGHIK", False),
+    )
+    exact_self = CandidateEpitope(
+        sequence="DEFGHIKL",
+        source_sequence=antigen.amino_acids,
+        offset=2,
+        overlaps_targetable=True,
+        occurs_in_reference=False,
+        self_reference_match=antigen.self_reference_match("DEFGHIKL", True),
+    )
+
+    vaccine_peptide = VaccinePeptide(
+        mutant_protein_fragment=fragment,
+        antigen=antigen,
+        epitopes=[target, non_target, exact_self],
+    )
+
+    assert vaccine_peptide.target_epitopes == [target]
+    assert vaccine_peptide.non_target_epitopes == [non_target]
+    assert vaccine_peptide.self_epitopes == [exact_self]
+
+
+def test_vaccine_peptide_fails_closed_for_held_out_or_mismatched_policy():
+    held_out = VaccineAntigen(
+        kind=ANTIGEN_KIND_CTA,
+        amino_acids="ACDEFGHIKL",
+        targetable_mask=TargetableMask((AminoAcidInterval(0, 10),)),
+        tumor_specificity=TumorSpecificityAttestation(
+            status=ATTESTATION_HELD_OUT,
+            evidence_kind="missing_patient_expression",
+            evidence_source="test fixture",
+        ),
+    )
+    fragment = SimpleNamespace(amino_acids=held_out.amino_acids)
+    with pytest.raises(ValueError, match="held-out antigen"):
+        VaccinePeptide(mutant_protein_fragment=fragment, antigen=held_out)
+
+    antigen = cta_antigen()
+    wrong_policy = SelfReferenceMatch(
+        peptide="ACDEFGHI",
+        occurs=False,
+        antigen_kind=ANTIGEN_KIND_MUTATION,
+    )
+    epitope = CandidateEpitope(
+        sequence="ACDEFGHI",
+        overlaps_targetable=True,
+        self_reference_match=wrong_policy,
+    )
+    with pytest.raises(ValueError, match="does not match antigen kind"):
+        VaccinePeptide(
+            mutant_protein_fragment=SimpleNamespace(
+                amino_acids=antigen.amino_acids
+            ),
+            antigen=antigen,
+            epitopes=[epitope],
+        )
+
+
+def test_prediction_refuses_non_mutation_antigen_until_admission_path_exists():
+    antigen = cta_antigen()
+    fragment = SimpleNamespace(amino_acids=antigen.amino_acids)
+
+    with pytest.raises(NotImplementedError, match="issue #303"):
+        predict_epitopes(
+            mhc_predictor=None,
+            protein_fragment=fragment,
+            antigen=antigen,
+        )
+
+
+def test_vaccine_antigen_json_roundtrip_preserves_policy():
+    antigen = cta_antigen()
+
+    restored = VaccineAntigen.from_json(antigen.to_json())
+
+    assert restored == antigen
+    assert restored.self_reference_excluded_gene_ids == ("ENSG00000185686",)

--- a/tests/test_vaccine_antigen.py
+++ b/tests/test_vaccine_antigen.py
@@ -67,8 +67,15 @@ def test_targetable_mask_rejects_ambiguous_or_out_of_bounds_intervals():
     with pytest.raises(ValueError, match="extends beyond"):
         VaccineAntigen(
             kind=ANTIGEN_KIND_CTA,
-            amino_acids="ABCDE",
+            amino_acids="ACDEF",
             targetable_mask=TargetableMask((AminoAcidInterval(0, 6),)),
+            tumor_specificity=admitted_attestation(),
+        )
+    with pytest.raises(ValueError, match="non-canonical amino acids: J"):
+        VaccineAntigen(
+            kind=ANTIGEN_KIND_CTA,
+            amino_acids="ACDEFGHIJL",
+            targetable_mask=TargetableMask((AminoAcidInterval(0, 10),)),
             tumor_specificity=admitted_attestation(),
         )
     with pytest.raises(ValueError, match="requires targetable content"):
@@ -98,7 +105,7 @@ def test_mutation_adapter_preserves_target_span_and_source_ids():
         protein_id="ENSP000001",
     )
     fragment = SimpleNamespace(
-        amino_acids="ABCDEFGHIJ",
+        amino_acids="ACDEFGHIKL",
         mutant_amino_acid_start_offset=3,
         mutant_amino_acid_end_offset=4,
         supporting_reference_transcripts=[transcript],
@@ -135,6 +142,12 @@ def test_self_reference_match_rejects_excluded_or_inconsistent_sources():
             occurs=True,
             antigen_kind=ANTIGEN_KIND_CTA,
             source_provenance_complete=True,
+        )
+    with pytest.raises(ValueError, match="non-canonical amino acids: X"):
+        SelfReferenceMatch(
+            peptide="SIINFEKX",
+            occurs=False,
+            antigen_kind=ANTIGEN_KIND_CTA,
         )
 
 

--- a/vaxrank/__init__.py
+++ b/vaxrank/__init__.py
@@ -16,14 +16,28 @@ from .epitope_config import EpitopeConfig
 from .epitope_logic import predict_epitopes
 from .candidate_epitope import CandidateEpitope, Peptide
 from .vaccine_config import VaccineConfig
+from .vaccine_antigen import (
+    AminoAcidInterval,
+    SelfReferenceMatch,
+    SelfReferenceSource,
+    TargetableMask,
+    TumorSpecificityAttestation,
+    VaccineAntigen,
+)
 from .vaccine_peptide import VaccinePeptide
 from .version import __version__
 
 __all__ = [
     "__version__",
+    "AminoAcidInterval",
     "CandidateEpitope",
     "EpitopeConfig",
     "Peptide",
+    "SelfReferenceMatch",
+    "SelfReferenceSource",
+    "TargetableMask",
+    "TumorSpecificityAttestation",
+    "VaccineAntigen",
     "VaccineConfig",
     "VaccinePeptide",
     "predict_epitopes",

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -94,6 +94,7 @@ from topiary.ranking import KIND_ALIASES as _KIND_ALIASES
 
 if TYPE_CHECKING:
     from mhctools.pred import Prediction
+    from .vaccine_antigen import SelfReferenceMatch
 
 
 def _resolve_kind(kind: str) -> str:
@@ -501,6 +502,11 @@ class CandidateEpitope(Peptide):
     # mutation-flavored reports / audits. Viral / self leave at False.
     overlaps_mutation: bool = False
 
+    # Source-agnostic targetability. ``None`` means the legacy producer did
+    # not supply a mask result and remains eligible for backwards-compatible
+    # target/self splitting. New producers always supply a boolean.
+    overlaps_targetable: Optional[bool] = None
+
     # Raw safety signal: this peptide's exact sequence appears
     # somewhere in the patient's reference proteome. True means a
     # cross-reactivity risk (the peptide matches a self-protein).
@@ -514,6 +520,11 @@ class CandidateEpitope(Peptide):
     # Consumers opt into CTA-friendly policy by reading this flag instead
     # of the raw one.
     occurs_in_non_CTA_reference: bool = False
+
+    # Antigen-aware exact-self result. New producers populate this and
+    # consumers read ``occurs_in_self_reference`` below. ``None`` retains the
+    # raw-reference behavior for legacy files and external-input loaders.
+    self_reference_match: Optional["SelfReferenceMatch"] = None
 
     # Per-allele score for this epitope as computed by the configured
     # :class:`~vaxrank.epitope_config.EpitopeConfig` ``score_expr``
@@ -538,6 +549,20 @@ class CandidateEpitope(Peptide):
         codebase.
         """
         return float(sum(self.per_allele_scores.values()))
+
+    @property
+    def occurs_in_self_reference(self) -> bool:
+        """Exact-self status under this epitope's antigen policy."""
+        if self.self_reference_match is not None:
+            return self.self_reference_match.occurs
+        return self.occurs_in_reference
+
+    @property
+    def is_targetable(self) -> bool:
+        """Whether this epitope overlaps explicitly targetable content."""
+        if self.overlaps_targetable is not None:
+            return self.overlaps_targetable
+        return True
 
     def __hash__(self) -> int:
         # Inherited from Peptide in spirit, but ``@dataclass(frozen=True)``
@@ -589,8 +614,10 @@ class CandidateEpitope(Peptide):
             comparators=self.comparators,
             source_class=self.source_class,
             overlaps_mutation=self.overlaps_mutation,
+            overlaps_targetable=self.overlaps_targetable,
             occurs_in_reference=self.occurs_in_reference,
             occurs_in_non_CTA_reference=self.occurs_in_non_CTA_reference,
+            self_reference_match=self.self_reference_match,
             per_allele_scores=dict(self.per_allele_scores))
 
     @classmethod
@@ -636,11 +663,14 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
       ``wt``         Prediction|None — parallel WT prediction, optional
       ``source_class``               str|None, default None
       ``overlaps_mutation``          bool,     default False
+      ``overlaps_targetable``        bool|None, default None for legacy rows
       ``occurs_in_reference``        bool,     default False
       ``occurs_in_non_CTA_reference`` bool,    default False — when
                                      producers don't yet integrate a
                                      CTA database, pass the same
                                      value as ``occurs_in_reference``.
+      ``self_reference_match``       SelfReferenceMatch|None — explicit
+                                     antigen-aware exact-self result.
 
     Semantics:
 
@@ -673,8 +703,10 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
                 'wt_peptide': None,
                 'source_class': row.get('source_class'),
                 'overlaps_mutation': False,
+                'overlaps_targetable': None,
                 'occurs_in_reference': False,
                 'occurs_in_non_CTA_reference': False,
+                'self_reference_match': None,
                 # Accumulator for per-allele DSL scores. Same allele
                 # may appear in multiple rows (different predictors);
                 # all rows for one allele share the same score by
@@ -684,9 +716,28 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
             groups[key] = slot
         slot['mutant_preds'].append(row['mutant'])
         slot['overlaps_mutation'] |= bool(row.get('overlaps_mutation', False))
+        overlaps_targetable = row.get('overlaps_targetable')
+        if overlaps_targetable is not None:
+            existing_targetable = slot['overlaps_targetable']
+            if (
+                existing_targetable is not None
+                and existing_targetable != bool(overlaps_targetable)
+            ):
+                raise ValueError(
+                    "Conflicting targetable-mask results for one candidate epitope"
+                )
+            slot['overlaps_targetable'] = bool(overlaps_targetable)
         slot['occurs_in_reference'] |= bool(row.get('occurs_in_reference', False))
         slot['occurs_in_non_CTA_reference'] |= bool(
             row.get('occurs_in_non_CTA_reference', False))
+        self_reference_match = row.get('self_reference_match')
+        if self_reference_match is not None:
+            existing_match = slot['self_reference_match']
+            if existing_match is not None and existing_match != self_reference_match:
+                raise ValueError(
+                    "Conflicting self-reference matches for one candidate epitope"
+                )
+            slot['self_reference_match'] = self_reference_match
         if 'allele_score' in row:
             slot['per_allele_scores'][row['mutant'].allele] = float(
                 row['allele_score'])
@@ -717,8 +768,10 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
             comparators=comparators,
             source_class=slot['source_class'],
             overlaps_mutation=slot['overlaps_mutation'],
+            overlaps_targetable=slot['overlaps_targetable'],
             occurs_in_reference=slot['occurs_in_reference'],
             occurs_in_non_CTA_reference=slot['occurs_in_non_CTA_reference'],
+            self_reference_match=slot['self_reference_match'],
             per_allele_scores=dict(slot['per_allele_scores']),
         ))
     return out

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -30,6 +30,7 @@ from .candidate_epitope import (
     candidate_epitopes_from_rows,
 )
 from .reference_proteome import ReferenceProteome
+from .vaccine_antigen import ANTIGEN_KIND_MUTATION, VaccineAntigen
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +68,8 @@ def predict_epitopes(
         mhc_predictor,
         protein_fragment : MutantProteinFragment,
         epitope_config : Optional[EpitopeConfig] = None,
-        genome : Optional[Genome] = None) -> list[CandidateEpitope]:
+        genome : Optional[Genome] = None,
+        antigen: Optional[VaccineAntigen] = None) -> list[CandidateEpitope]:
     """
     Parameters
     ----------
@@ -89,6 +91,10 @@ def predict_epitopes(
     genome
         Genome whose proteome to use for reference peptide filtering
 
+    antigen
+        Source-agnostic antigen semantics. When omitted, the mutation fragment
+        is adapted to a ``VaccineAntigen`` with identical mutation behavior.
+
     Returns
     -------
     list[CandidateEpitope]
@@ -101,8 +107,24 @@ def predict_epitopes(
     """
     if epitope_config is None:
         epitope_config = EpitopeConfig()
+    if antigen is None:
+        antigen = VaccineAntigen.from_mutant_protein_fragment(protein_fragment)
+    elif antigen.amino_acids != protein_fragment.amino_acids:
+        raise ValueError("Antigen and protein fragment amino-acid sequences differ")
+    if antigen.kind != ANTIGEN_KIND_MUTATION:
+        raise NotImplementedError(
+            "Non-mutation antigen prediction requires the construct-admission "
+            "vertical slice from issue #303"
+        )
 
     reference_proteome = ReferenceProteome(genome)
+    if antigen.self_reference_excluded_gene_ids:
+        antigen_reference_proteome = ReferenceProteome.from_genome(
+            genome,
+            exclude_gene_ids=antigen.self_reference_excluded_gene_ids,
+        )
+    else:
+        antigen_reference_proteome = reference_proteome
     non_cta_reference_proteome = ReferenceProteome.from_genome(
         genome, exclude_cta_genes=True)
 
@@ -158,9 +180,11 @@ def predict_epitopes(
         peptide_length = row["peptide_length"]
         peptide_end_offset = peptide_start_offset + peptide_length
 
-        overlaps_mutation = protein_fragment.interval_overlaps_mutation(
-            start_offset=peptide_start_offset,
-            end_offset=peptide_end_offset)
+        overlaps_targetable = antigen.interval_is_targetable(
+            peptide_start_offset, peptide_end_offset)
+        overlaps_mutation = (
+            antigen.kind == ANTIGEN_KIND_MUTATION and overlaps_targetable
+        )
 
         if overlaps_mutation and peptide not in wt_peptides:
             full_reference_protein_sequence = (
@@ -211,11 +235,14 @@ def predict_epitopes(
         peptide_start_offset = row["peptide_offset"]
         peptide_end_offset = peptide_start_offset + peptide_length
 
-        overlaps_mutation = protein_fragment.interval_overlaps_mutation(
-            start_offset=peptide_start_offset,
-            end_offset=peptide_end_offset)
+        overlaps_targetable = antigen.interval_is_targetable(
+            peptide_start_offset, peptide_end_offset)
+        overlaps_mutation = (
+            antigen.kind == ANTIGEN_KIND_MUTATION and overlaps_targetable
+        )
 
         occurs_in_reference = reference_proteome.contains(peptide)
+        occurs_in_antigen_reference = antigen_reference_proteome.contains(peptide)
         occurs_in_non_cta_reference = non_cta_reference_proteome.contains(peptide)
         if occurs_in_reference:
             logger.debug('Peptide %s occurs in reference', peptide)
@@ -291,12 +318,18 @@ def predict_epitopes(
             'wt': wt_pred,
             'source_class': SOURCE_CLASS_MUTATION,
             'overlaps_mutation': overlaps_mutation,
+            'overlaps_targetable': overlaps_targetable,
             'occurs_in_reference': occurs_in_reference,
             # Exact self after removing source genes in oncoref's full CTA
             # candidate universe. This may diverge from the raw reference flag
             # for CTA-family peptides; shared sequences in any non-CTA gene
             # remain present because the filtered index retains those genes.
             'occurs_in_non_CTA_reference': occurs_in_non_cta_reference,
+            'self_reference_match': antigen.self_reference_match(
+                peptide,
+                occurs_in_antigen_reference,
+                genome_release=str(getattr(genome, "release", "") or ""),
+            ),
             # Per-(peptide, allele) DSL score; threaded onto the
             # CandidateEpitope as ``per_allele_scores[allele]`` by
             # ``candidate_epitopes_from_rows``. Single source of

--- a/vaxrank/vaccine_antigen.py
+++ b/vaxrank/vaccine_antigen.py
@@ -39,10 +39,21 @@ ATTESTATION_STATUSES = frozenset({
     ATTESTATION_HELD_OUT,
     ATTESTATION_OVERRIDDEN,
 })
+STANDARD_AMINO_ACIDS = frozenset("ACDEFGHIKLMNPQRSTVWY")
 
 
 def _normalized_gene_id(gene_id: str) -> str:
     return str(gene_id).split(".")[0]
+
+
+def _validate_amino_acids(sequence: str, label: str) -> None:
+    if not sequence:
+        raise ValueError(f"{label} amino-acid sequence is required")
+    invalid = sorted(set(sequence) - STANDARD_AMINO_ACIDS)
+    if invalid:
+        raise ValueError(
+            f"{label} contains non-canonical amino acids: {', '.join(invalid)}"
+        )
 
 
 @dataclass(frozen=True)
@@ -164,6 +175,7 @@ class SelfReferenceMatch(DataclassSerializable):
     def __post_init__(self):
         if self.antigen_kind not in ANTIGEN_KINDS:
             raise ValueError(f"Unknown antigen kind {self.antigen_kind!r}")
+        _validate_amino_acids(self.peptide, "Self-reference peptide")
         excluded_gene_ids = tuple(sorted({
             _normalized_gene_id(gene_id) for gene_id in self.excluded_gene_ids
         }))
@@ -203,8 +215,7 @@ class VaccineAntigen(DataclassSerializable):
                 f"Unknown antigen kind {self.kind!r}; expected one of "
                 f"{sorted(ANTIGEN_KINDS)}"
             )
-        if not self.amino_acids:
-            raise ValueError("Vaccine antigen amino-acid sequence is required")
+        _validate_amino_acids(self.amino_acids, "Vaccine antigen")
         if (
             self.tumor_specificity.admits_construct
             and not self.targetable_mask.intervals

--- a/vaxrank/vaccine_antigen.py
+++ b/vaxrank/vaccine_antigen.py
@@ -1,0 +1,290 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Source-agnostic antigen targetability and exact-self result types."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from serializable import DataclassSerializable
+
+
+ANTIGEN_KIND_MUTATION = "mutation"
+ANTIGEN_KIND_CTA = "CTA"
+ANTIGEN_KIND_ERV = "ERV"
+ANTIGEN_KIND_SPLICE = "splice"
+ANTIGEN_KIND_VIRAL = "viral"
+ANTIGEN_KINDS = frozenset({
+    ANTIGEN_KIND_MUTATION,
+    ANTIGEN_KIND_CTA,
+    ANTIGEN_KIND_ERV,
+    ANTIGEN_KIND_SPLICE,
+    ANTIGEN_KIND_VIRAL,
+})
+
+ATTESTATION_ADMITTED = "admitted"
+ATTESTATION_HELD_OUT = "held_out"
+ATTESTATION_OVERRIDDEN = "overridden"
+ATTESTATION_STATUSES = frozenset({
+    ATTESTATION_ADMITTED,
+    ATTESTATION_HELD_OUT,
+    ATTESTATION_OVERRIDDEN,
+})
+
+
+def _normalized_gene_id(gene_id: str) -> str:
+    return str(gene_id).split(".")[0]
+
+
+@dataclass(frozen=True)
+class AminoAcidInterval(DataclassSerializable):
+    """Zero-based, half-open targetable interval.
+
+    ``start == end`` is allowed for deletion junctions and retains the
+    historical ``MutantProteinFragment.interval_overlaps_mutation`` behavior.
+    """
+
+    start: int
+    end: int
+
+    def __post_init__(self):
+        if self.start < 0:
+            raise ValueError("Amino-acid interval start must be non-negative")
+        if self.end < self.start:
+            raise ValueError("Amino-acid interval end must not precede start")
+
+    def overlaps(self, start: int, end: int) -> bool:
+        if start < 0 or end < start:
+            raise ValueError("Query interval must be a valid half-open interval")
+        return start < self.end and end > self.start
+
+
+@dataclass(frozen=True)
+class TargetableMask(DataclassSerializable):
+    """Explicit amino-acid regions carrying tumor-targetable content."""
+
+    intervals: tuple[AminoAcidInterval, ...] = field(default_factory=tuple)
+
+    def __post_init__(self):
+        intervals = tuple(self.intervals)
+        if intervals != self.intervals:
+            object.__setattr__(self, "intervals", intervals)
+        sorted_intervals = tuple(sorted(
+            intervals,
+            key=lambda interval: (interval.start, interval.end),
+        ))
+        if sorted_intervals != intervals:
+            raise ValueError("Targetable intervals must be sorted")
+        for previous, current in zip(intervals, intervals[1:]):
+            if current.start < previous.end:
+                raise ValueError("Targetable intervals must not overlap")
+
+    def overlaps(self, start: int, end: int) -> bool:
+        return any(interval.overlaps(start, end) for interval in self.intervals)
+
+    def validate_for_sequence(self, amino_acids: str) -> None:
+        sequence_length = len(amino_acids)
+        for interval in self.intervals:
+            if interval.end > sequence_length:
+                raise ValueError(
+                    "Targetable interval extends beyond antigen amino-acid sequence"
+                )
+
+
+@dataclass(frozen=True)
+class TumorSpecificityAttestation(DataclassSerializable):
+    """Evidence-bearing decision about construct admission."""
+
+    status: str
+    evidence_kind: str
+    evidence_source: str
+    evidence_version: str = ""
+    patient_specific: bool = False
+    rationale_code: str = ""
+    requires_review: bool = False
+    override_reason: str = ""
+
+    def __post_init__(self):
+        if self.status not in ATTESTATION_STATUSES:
+            raise ValueError(
+                f"Unknown tumor-specificity status {self.status!r}; "
+                f"expected one of {sorted(ATTESTATION_STATUSES)}"
+            )
+        if not self.evidence_kind or not self.evidence_source:
+            raise ValueError("Tumor-specificity evidence kind and source are required")
+        if self.status == ATTESTATION_OVERRIDDEN and not self.override_reason:
+            raise ValueError("An overridden attestation requires an override reason")
+
+    @property
+    def admits_construct(self) -> bool:
+        return self.status in {ATTESTATION_ADMITTED, ATTESTATION_OVERRIDDEN}
+
+
+@dataclass(frozen=True)
+class SelfReferenceSource(DataclassSerializable):
+    """One non-excluded protein source for an exact peptide match."""
+
+    gene_id: str
+    transcript_id: str = ""
+    protein_id: str = ""
+    gene_name: str = ""
+
+    def __post_init__(self):
+        if not self.gene_id:
+            raise ValueError("Self-reference source requires a gene ID")
+        object.__setattr__(self, "gene_id", _normalized_gene_id(self.gene_id))
+
+
+@dataclass(frozen=True)
+class SelfReferenceMatch(DataclassSerializable):
+    """Antigen-aware exact-self classification for one peptide.
+
+    ``source_provenance_complete`` explicitly distinguishes the transitional
+    set-membership index from the later provenance-complete index. Missing
+    provenance is never represented as evidence that no source exists.
+    """
+
+    peptide: str
+    occurs: bool
+    antigen_kind: str
+    excluded_gene_ids: tuple[str, ...] = field(default_factory=tuple)
+    sources: tuple[SelfReferenceSource, ...] = field(default_factory=tuple)
+    source_provenance_complete: bool = False
+    genome_release: str = ""
+
+    def __post_init__(self):
+        if self.antigen_kind not in ANTIGEN_KINDS:
+            raise ValueError(f"Unknown antigen kind {self.antigen_kind!r}")
+        excluded_gene_ids = tuple(sorted({
+            _normalized_gene_id(gene_id) for gene_id in self.excluded_gene_ids
+        }))
+        sources = tuple(self.sources)
+        object.__setattr__(self, "excluded_gene_ids", excluded_gene_ids)
+        object.__setattr__(self, "sources", sources)
+        if sources and not self.occurs:
+            raise ValueError("A non-occurring self match cannot have match sources")
+        if self.source_provenance_complete and self.occurs != bool(sources):
+            raise ValueError(
+                "A provenance-complete match must agree with its source list"
+            )
+        excluded = set(excluded_gene_ids)
+        if any(source.gene_id in excluded for source in sources):
+            raise ValueError("Self-match sources cannot include excluded genes")
+
+
+@dataclass(frozen=True)
+class VaccineAntigen(DataclassSerializable):
+    """Source-agnostic antigen content, targetability, and admission evidence."""
+
+    kind: str
+    amino_acids: str
+    targetable_mask: TargetableMask
+    tumor_specificity: TumorSpecificityAttestation
+    self_reference_excluded_gene_ids: tuple[str, ...] = field(default_factory=tuple)
+    gene_name: str = ""
+    gene_id: str = ""
+    transcript_ids: tuple[str, ...] = field(default_factory=tuple)
+    protein_ids: tuple[str, ...] = field(default_factory=tuple)
+    species: str = ""
+    source_identifier: str = ""
+
+    def __post_init__(self):
+        if self.kind not in ANTIGEN_KINDS:
+            raise ValueError(
+                f"Unknown antigen kind {self.kind!r}; expected one of "
+                f"{sorted(ANTIGEN_KINDS)}"
+            )
+        if not self.amino_acids:
+            raise ValueError("Vaccine antigen amino-acid sequence is required")
+        if (
+            self.tumor_specificity.admits_construct
+            and not self.targetable_mask.intervals
+        ):
+            raise ValueError("An admitted antigen requires targetable content")
+        self.targetable_mask.validate_for_sequence(self.amino_acids)
+        excluded_gene_ids = tuple(sorted({
+            _normalized_gene_id(gene_id)
+            for gene_id in self.self_reference_excluded_gene_ids
+        }))
+        object.__setattr__(
+            self, "self_reference_excluded_gene_ids", excluded_gene_ids
+        )
+        if self.gene_id:
+            object.__setattr__(self, "gene_id", _normalized_gene_id(self.gene_id))
+        object.__setattr__(self, "transcript_ids", tuple(self.transcript_ids))
+        object.__setattr__(self, "protein_ids", tuple(self.protein_ids))
+
+    def interval_is_targetable(self, start: int, end: int) -> bool:
+        return self.targetable_mask.overlaps(start, end)
+
+    @classmethod
+    def from_mutant_protein_fragment(cls, fragment: Any) -> "VaccineAntigen":
+        """Represent a legacy mutation fragment without changing its policy."""
+        transcripts = tuple(
+            getattr(fragment, "supporting_reference_transcripts", ()) or ()
+        )
+        gene_ids = tuple(sorted({
+            _normalized_gene_id(getattr(transcript, "gene_id", ""))
+            for transcript in transcripts
+            if getattr(transcript, "gene_id", "")
+        }))
+        transcript_ids = tuple(sorted({
+            str(getattr(transcript, "transcript_id", ""))
+            for transcript in transcripts
+            if getattr(transcript, "transcript_id", "")
+        }))
+        protein_ids = tuple(sorted({
+            str(getattr(transcript, "protein_id", ""))
+            for transcript in transcripts
+            if getattr(transcript, "protein_id", "")
+        }))
+        variant = getattr(fragment, "variant", None)
+        source_identifier = str(
+            getattr(variant, "short_description", "") or variant or ""
+        )
+        return cls(
+            kind=ANTIGEN_KIND_MUTATION,
+            amino_acids=fragment.amino_acids,
+            targetable_mask=TargetableMask((AminoAcidInterval(
+                fragment.mutant_amino_acid_start_offset,
+                fragment.mutant_amino_acid_end_offset,
+            ),)),
+            tumor_specificity=TumorSpecificityAttestation(
+                status=ATTESTATION_ADMITTED,
+                evidence_kind="somatic_variant",
+                evidence_source="vaxrank mutation input",
+                patient_specific=True,
+                rationale_code="legacy_mutation_admission",
+            ),
+            gene_name=str(getattr(fragment, "gene_name", "") or ""),
+            gene_id=gene_ids[0] if len(gene_ids) == 1 else "",
+            transcript_ids=transcript_ids,
+            protein_ids=protein_ids,
+            source_identifier=source_identifier,
+        )
+
+    def self_reference_match(
+        self,
+        peptide: str,
+        occurs: bool,
+        *,
+        genome_release: str = "",
+    ) -> SelfReferenceMatch:
+        """Build an explicit membership-only result for current indexes."""
+        return SelfReferenceMatch(
+            peptide=peptide,
+            occurs=occurs,
+            antigen_kind=self.kind,
+            excluded_gene_ids=self.self_reference_excluded_gene_ids,
+            source_provenance_complete=False,
+            genome_release=genome_release,
+        )

--- a/vaxrank/vaccine_peptide.py
+++ b/vaxrank/vaccine_peptide.py
@@ -26,6 +26,7 @@ from .manufacturability import (
 )
 from .ranking import compute_ranking_tuple
 from .vaccine_config import DEFAULT_COMBINED_SCORE_EXPR
+from .vaccine_antigen import VaccineAntigen
 
 
 @dataclass
@@ -100,6 +101,7 @@ class VaccinePeptide(DataclassSerializable):
     # is no fallback mode enum — this string is the single mechanism.
     combined_score_expr: Optional[str] = None
     ranking_rules: Optional[tuple] = None
+    antigen: Optional[VaccineAntigen] = None
 
     # Derived attributes computed in __post_init__ — not part of the
     # serialized form. `init=False` keeps them out of the generated
@@ -107,11 +109,43 @@ class VaccinePeptide(DataclassSerializable):
     # value for any pathway that inspects fields before __post_init__.
     target_epitopes: list = field(default_factory=list, init=False, repr=False)
     self_epitopes: list = field(default_factory=list, init=False, repr=False)
+    non_target_epitopes: list = field(default_factory=list, init=False, repr=False)
     self_epitope_score: float = field(default=0.0, init=False, repr=False)
     target_epitope_score: float = field(default=0.0, init=False, repr=False)
     manufacturability_scores: Any = field(default=None, init=False, repr=False)
 
     def __post_init__(self):
+        fragment = self.mutant_protein_fragment
+        mutation_start = getattr(
+            fragment, "mutant_amino_acid_start_offset", None
+        )
+        mutation_end = getattr(fragment, "mutant_amino_acid_end_offset", None)
+        fragment_has_targetable_interval = (
+            isinstance(getattr(fragment, "amino_acids", None), str)
+            and isinstance(mutation_start, int)
+            and isinstance(mutation_end, int)
+        )
+        if self.antigen is None and fragment_has_targetable_interval:
+            self.antigen = VaccineAntigen.from_mutant_protein_fragment(fragment)
+        if self.antigen is not None:
+            if not self.antigen.tumor_specificity.admits_construct:
+                raise ValueError(
+                    "A held-out antigen cannot be used to construct a VaccinePeptide"
+                )
+            if (
+                hasattr(fragment, "amino_acids")
+                and fragment.amino_acids != self.antigen.amino_acids
+            ):
+                raise ValueError(
+                    "VaccineAntigen and fragment amino-acid sequences differ"
+                )
+            for epitope in self.epitopes:
+                match = epitope.self_reference_match
+                if match is not None and match.antigen_kind != self.antigen.kind:
+                    raise ValueError(
+                        "Epitope self-reference policy does not match antigen kind"
+                    )
+
         # Normalize the optional collection/tuple fields.
         self.manufacturability_thresholds = self.manufacturability_thresholds or {}
         if self.manufacturability_rules is not None:
@@ -167,18 +201,16 @@ class VaccinePeptide(DataclassSerializable):
             ic50s = _usable_prediction_values(affinity_leaves, "value")
             return min(ic50s) if ic50s else float("inf")
 
-        # Universal target/self split — source-agnostic. An epitope
-        # whose exact sequence appears in the patient's reference
-        # proteome (``occurs_in_reference``) is unsafe by default
-        # (would cross-react with self on normal tissue). For
-        # mutation-derived candidates this matches the historical
-        # behavior: peptides identical to WT land in self_epitopes
-        # because they're in the reference. Viral peptides absent
-        # from the reference land in target_epitopes. CTAs land in
-        # self_epitopes today. Antigen-aware consumers introduced by
-        # issue #303 use ``occurs_in_non_CTA_reference`` for CTA sources.
+        # Source-agnostic target/self split. New producers require explicit
+        # targetable-mask overlap and use the antigen-aware exact-self result.
+        # Legacy rows have ``overlaps_targetable=None`` and retain their old
+        # eligibility; ``occurs_in_self_reference`` falls back to the raw
+        # reference boolean when no explicit result was serialized.
         self.target_epitopes = sorted(
-            [e for e in self.epitopes if not e.occurs_in_reference],
+            [
+                e for e in self.epitopes
+                if e.is_targetable and not e.occurs_in_self_reference
+            ],
             key=_epitope_sort_key,
         )
         if self.num_target_epitopes_to_keep:
@@ -187,7 +219,11 @@ class VaccinePeptide(DataclassSerializable):
             )
 
         self.self_epitopes = sorted(
-            [e for e in self.epitopes if e.occurs_in_reference],
+            [e for e in self.epitopes if e.occurs_in_self_reference],
+            key=_epitope_sort_key,
+        )
+        self.non_target_epitopes = sorted(
+            [e for e in self.epitopes if not e.is_targetable],
             key=_epitope_sort_key,
         )
 
@@ -282,16 +318,22 @@ class VaccinePeptide(DataclassSerializable):
 
     def to_dict(self):
         # The persisted form combines the filtered target + self lists
-        # back into a single `epitopes` list. Also trims fields that match
-        # their defaults so the JSON stays small and older readers don't
-        # see keys they don't understand.
-        epitopes = self.target_epitopes + self.self_epitopes
+        # with non-target/non-self safety facts back into one ``epitopes``
+        # list. Exact-self non-targets already appear in ``self_epitopes`` and
+        # are not duplicated. Also trim fields that match their defaults.
+        non_target_only = [
+            epitope for epitope in self.non_target_epitopes
+            if not epitope.occurs_in_self_reference
+        ]
+        epitopes = self.target_epitopes + self.self_epitopes + non_target_only
         d = {
             "mutant_protein_fragment": self.mutant_protein_fragment,
             "epitopes": epitopes,
             "num_target_epitopes_to_keep": self.num_target_epitopes_to_keep,
             "sort_epitopes_by": self.sort_epitopes_by,
         }
+        if self.antigen is not None:
+            d["antigen"] = self.antigen
         if self.manufacturability_thresholds:
             d["manufacturability_thresholds"] = self.manufacturability_thresholds
         if self.manufacturability_rules is not None:

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.10"
+__version__ = "3.1.11"
 
 
 def print_version():


### PR DESCRIPTION
Implements the mutation-parity/model foundation of #303 and prepares #254 and #311.

This PR:
- adds public immutable VaccineAntigen, TargetableMask, TumorSpecificityAttestation, and SelfReferenceMatch types;
- adapts every real mutation fragment to an admitted mutation antigen without removing the legacy fragment API;
- makes predict_epitopes emit explicit targetable-mask and antigen-aware exact-self facts;
- makes VaccinePeptide consume those facts, retain non-target ligands, and reject held-out or policy-mismatched antigens;
- explicitly refuses non-mutation prediction until the reviewed CTA admission vertical slice lands;
- preserves the policy objects through JSON serialization;
- bumps Vaxrank to 3.1.11.

Obvious-risk regressions cover invalid/overlapping/out-of-range masks, deletion-junction parity, versioned source IDs, missing override reasons, excluded self sources, incomplete provenance, non-target ligands, raw-vs-antigen self divergence, held-out antigens, policy mismatches, unsupported non-mutation prediction, and JSON round trips.

Validation:
- ./lint.sh
- ./test.sh (874 passed)