### PR TITLE
Add oncoref-backed CTA admission evidence

### DIFF
--- a/tests/test_cta_admission.py
+++ b/tests/test_cta_admission.py
@@ -1,0 +1,240 @@
+import json
+
+import pandas as pd
+import pytest
+
+from vaxrank.cta_admission import (
+    CTA_REASON_CANONICAL_EXPRESSION_PASS,
+    CTA_REASON_EXPLICIT_OVERRIDE,
+    CTA_REASON_EXPRESSION_BELOW_THRESHOLD,
+    CTA_REASON_NONCANONICAL_HELD_OUT,
+    CTAAdmissionAssessment,
+    CTAAdmissionError,
+    CTAAdmissionPolicy,
+    CTAOverrideEvidence,
+    PatientTumorExpressionEvidence,
+    assess_cta_antigen,
+)
+from vaxrank.vaccine_antigen import (
+    ATTESTATION_ADMITTED,
+    ATTESTATION_HELD_OUT,
+    ATTESTATION_OVERRIDDEN,
+    TumorSpecificityEvidence,
+)
+
+
+PRAME = "ENSG00000185686"
+HELD_OUT = "ENSG00000279804"
+OTHER_CTA = "ENSG00000199999"
+
+
+def _frame():
+    rows = []
+    for gene_id, symbol, canonical in (
+        (PRAME, "PRAME", True),
+        (HELD_OUT, "PRAMEF18", False),
+        (OTHER_CTA, "OTHERCTA", False),
+    ):
+        rows.append({
+            "Ensembl_Gene_ID": gene_id,
+            "Symbol": symbol,
+            "passes_filters": True,
+            "never_expressed": not canonical,
+            "specificity_status": (
+                "canonical_default" if canonical else "canonical_low_expression"
+            ),
+            "specificity_action": (
+                "include_default" if canonical else "exclude_default"
+            ),
+            "specificity_source_anchor": "derived:oncoref.cta.passes_filters",
+            "specificity_rationale": "fixture",
+            "restriction": "TESTIS",
+            "restriction_confidence": "HIGH",
+            "safety_flags": "",
+            "source_databases": "CTpedia",
+            "Canonical_Transcript_ID": f"ENST_{symbol}",
+        })
+    return pd.DataFrame(rows)
+
+
+def _patch_oncoref(monkeypatch, *, frame=None, canonical=None, unfiltered=None):
+    monkeypatch.setattr(
+        "oncoref.cta.cta_evidence", lambda: _frame() if frame is None else frame
+    )
+    monkeypatch.setattr(
+        "oncoref.cta.cta_gene_ids", lambda: {PRAME} if canonical is None else canonical
+    )
+    monkeypatch.setattr(
+        "oncoref.cta.cta_unfiltered_gene_ids",
+        lambda: {PRAME, HELD_OUT, OTHER_CTA}
+        if unfiltered is None else unfiltered,
+    )
+
+
+def _expression(gene_id=PRAME, value=5.0, unit="TPM"):
+    return PatientTumorExpressionEvidence(
+        gene_id=gene_id,
+        sample_id="patient-tumor-1",
+        value=value,
+        unit=unit,
+        evidence_source="RNA-seq workflow",
+        evidence_version="1.2.3",
+        assay="bulk RNA-seq",
+    )
+
+
+def _policy(minimum=5.0, unit="TPM"):
+    return CTAAdmissionPolicy(
+        min_tumor_expression=minimum,
+        expression_unit=unit,
+    )
+
+
+def _assess(gene_id=PRAME, expression=None, policy=None, override=None):
+    return assess_cta_antigen(
+        amino_acids="ACDEFGHIKLMN",
+        gene_id=gene_id,
+        tumor_expression=expression or _expression(gene_id),
+        policy=policy or _policy(),
+        override_evidence=override,
+    )
+
+
+def test_canonical_cta_at_expression_threshold_is_admitted(monkeypatch):
+    _patch_oncoref(monkeypatch)
+    result = _assess()
+
+    assert result.antigen.tumor_specificity.status == ATTESTATION_ADMITTED
+    assert result.antigen.tumor_specificity.rationale_code == (
+        CTA_REASON_CANONICAL_EXPRESSION_PASS
+    )
+    assert result.antigen.tumor_specificity.admits_construct
+    assert result.antigen.targetable_mask.overlaps(0, 1)
+    assert result.antigen.gene_name == "PRAME"
+    assert result.antigen.transcript_ids == ("ENST_PRAME",)
+    assert result.antigen.self_reference_excluded_gene_ids == tuple(sorted({
+        PRAME, HELD_OUT, OTHER_CTA
+    }))
+    assert result.reference_evidence.canonical_default
+    assert result.reference_evidence.oncoref_version == "1.8.174"
+    records = result.antigen.tumor_specificity.evidence_records
+    assert [record.evidence_kind for record in records] == [
+        "oncoref_cta_membership", "patient_tumor_expression"
+    ]
+    assert records[1].numeric_value == records[1].threshold == 5.0
+
+    payload = result.to_report_dict()
+    assert json.loads(json.dumps(payload))["antigen"]["gene_name"] == "PRAME"
+    assert CTAAdmissionAssessment.from_json(result.to_json()) == result
+
+
+def test_expression_below_threshold_is_held_out_even_with_override(monkeypatch):
+    _patch_oncoref(monkeypatch)
+    result = _assess(
+        expression=_expression(value=4.99),
+        override=CTAOverrideEvidence("review", "2026-08", "clinical rationale"),
+    )
+    attestation = result.antigen.tumor_specificity
+    assert attestation.status == ATTESTATION_HELD_OUT
+    assert attestation.rationale_code == CTA_REASON_EXPRESSION_BELOW_THRESHOLD
+    assert not attestation.admits_construct
+    assert all(
+        record.evidence_kind != "cta_admission_override"
+        for record in attestation.evidence_records
+    )
+
+
+def test_noncanonical_cta_requires_explicit_versioned_override(monkeypatch):
+    _patch_oncoref(monkeypatch)
+    held = _assess(gene_id=HELD_OUT)
+    assert held.antigen.tumor_specificity.status == ATTESTATION_HELD_OUT
+    assert held.antigen.tumor_specificity.rationale_code == (
+        CTA_REASON_NONCANONICAL_HELD_OUT
+    )
+
+    override = CTAOverrideEvidence(
+        evidence_source="tumor board",
+        evidence_version="protocol-7",
+        rationale="orthogonal tumor-specificity evidence",
+        evidence_id="review-123",
+    )
+    admitted = _assess(gene_id=HELD_OUT, override=override)
+    attestation = admitted.antigen.tumor_specificity
+    assert attestation.status == ATTESTATION_OVERRIDDEN
+    assert attestation.rationale_code == CTA_REASON_EXPLICIT_OVERRIDE
+    assert attestation.override_reason == override.rationale
+    assert attestation.requires_review
+    assert attestation.evidence_records[-1].evidence_kind == (
+        "cta_admission_override"
+    )
+
+
+def test_gene_outside_unfiltered_oncoref_universe_is_not_a_cta(monkeypatch):
+    _patch_oncoref(monkeypatch)
+    with pytest.raises(CTAAdmissionError, match="not in oncoref"):
+        _assess(gene_id="ENSG_NOT_CTA")
+
+
+@pytest.mark.parametrize(
+    "expression, policy, message",
+    [
+        (_expression(gene_id=HELD_OUT), _policy(), "gene IDs differ"),
+        (_expression(unit="nTPM"), _policy(unit="TPM"), "units do not match"),
+    ],
+)
+def test_expression_must_match_cta_gene_and_policy_units(
+    monkeypatch, expression, policy, message
+):
+    _patch_oncoref(monkeypatch)
+    with pytest.raises(ValueError, match=message):
+        _assess(expression=expression, policy=policy)
+
+
+@pytest.mark.parametrize("value", [-1, float("nan"), float("inf")])
+def test_invalid_quantitative_expression_fails(value):
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        _expression(value=value)
+
+
+def test_expression_policy_rejects_zero_threshold():
+    with pytest.raises(ValueError, match="greater than zero"):
+        _policy(minimum=0)
+
+
+def test_oncoref_missing_ambiguous_or_untyped_evidence_fails_closed(monkeypatch):
+    _patch_oncoref(monkeypatch, canonical=set(), unfiltered=set())
+    with pytest.raises(CTAAdmissionError, match="empty CTA reference"):
+        _assess()
+
+    duplicate = pd.concat([_frame(), _frame().iloc[[0]]], ignore_index=True)
+    _patch_oncoref(monkeypatch, frame=duplicate)
+    with pytest.raises(CTAAdmissionError, match="Expected one"):
+        _assess()
+
+    malformed = _frame().astype({"passes_filters": object})
+    malformed.loc[0, "passes_filters"] = "unknown"
+    _patch_oncoref(monkeypatch, frame=malformed)
+    with pytest.raises(CTAAdmissionError, match="not boolean"):
+        _assess()
+
+
+def test_generic_attestation_evidence_rejects_unversioned_quantitation():
+    with pytest.raises(ValueError, match="requires units"):
+        TumorSpecificityEvidence(
+            evidence_kind="expression",
+            evidence_source="fixture",
+            numeric_value=1.0,
+        )
+
+
+def test_live_oncoref_prame_regression_uses_two_distinct_cta_sets():
+    from oncoref.cta import cta_gene_ids, cta_unfiltered_gene_ids
+
+    result = _assess()
+    assert PRAME in cta_gene_ids()
+    assert PRAME in cta_unfiltered_gene_ids()
+    assert len(cta_unfiltered_gene_ids()) > len(cta_gene_ids())
+    assert result.antigen.tumor_specificity.status == ATTESTATION_ADMITTED
+    assert set(result.antigen.self_reference_excluded_gene_ids) == {
+        gene_id.split(".")[0] for gene_id in cta_unfiltered_gene_ids()
+    }

--- a/tests/test_reference_proteome.py
+++ b/tests/test_reference_proteome.py
@@ -657,7 +657,7 @@ def test_cta_source_exclusion_is_human_only():
 def test_cta_shared_sequence_remains_self_through_non_cta_gene():
     """Removing a CTA source gene must not remove a shared non-CTA peptide."""
     prame_gene_id = "ENSG00000185686"
-    shared = "ABCDEFGHIJ"
+    shared = "ACDEFGHIKL"
     cta = create_mock_transcript("CTA_TX", shared, gene_id=prame_gene_id)
     non_cta = create_mock_transcript("SELF_TX", shared, gene_id="ENSG_NON_CTA")
     genome = create_mock_genome(
@@ -669,7 +669,7 @@ def test_cta_shared_sequence_remains_self_through_non_cta_gene():
             genome, exclude_cta_genes=True,
             min_kmer_length=8, max_kmer_length=8)
 
-    assert ref.contains("ABCDEFGH")
+    assert ref.contains("ACDEFGHI")
 
 
 def test_filtered_reference_proteome_is_cached_per_genome_and_policy():
@@ -677,13 +677,52 @@ def test_filtered_reference_proteome_is_cached_per_genome_and_policy():
     t1 = create_mock_transcript("T1", "ABCDEFGHIJ", gene_id="G1")
     t2 = create_mock_transcript("T2", "KLMNOPQRST", gene_id="G2")
     genome = create_mock_genome([t1, t2], release=112)
-    first = ReferenceProteome.from_genome(
-        genome, exclude_gene_ids={"G1"}, min_kmer_length=8, max_kmer_length=8)
-    second = ReferenceProteome.from_genome(
-        genome, exclude_gene_ids={"G1"}, min_kmer_length=8, max_kmer_length=8)
+    with patch(
+            "vaxrank.reference_proteome.extract_kmers",
+            wraps=extract_kmers) as extract:
+        first = ReferenceProteome.from_genome(
+            genome, exclude_gene_ids={"G1"},
+            min_kmer_length=8, max_kmer_length=8)
+        second = ReferenceProteome.from_genome(
+            genome, exclude_gene_ids={"G1"},
+            min_kmer_length=8, max_kmer_length=8)
 
     assert first._kmer_set is second._kmer_set
-    assert genome.transcripts.call_count == 1
+    assert extract.call_count == 1
+
+
+def test_filtered_cache_is_keyed_by_protein_content_and_policy():
+    _filtered_kmer_set_cache.clear()
+    first = create_mock_genome([
+        create_mock_transcript("T1", "ACDEFGHIKL", gene_id="G1")
+    ], release=113)
+    second = create_mock_genome([
+        create_mock_transcript("T2", "LMNPQRSTVW", gene_id="G2")
+    ], release=113)
+    equivalent = create_mock_genome([
+        create_mock_transcript("T1", "ACDEFGHIKL", gene_id="G1")
+    ], release=999)
+
+    with patch(
+            "vaxrank.reference_proteome.extract_kmers",
+            wraps=extract_kmers) as extract:
+        first_ref = ReferenceProteome.from_genome(
+            first, exclude_gene_ids={"IGNORED"},
+            min_kmer_length=8, max_kmer_length=8)
+        second_ref = ReferenceProteome.from_genome(
+            second, exclude_gene_ids={"IGNORED"},
+            min_kmer_length=8, max_kmer_length=8)
+        equivalent_ref = ReferenceProteome.from_genome(
+            equivalent, exclude_gene_ids={"IGNORED"},
+            min_kmer_length=8, max_kmer_length=8)
+
+    assert first_ref.contains("ACDEFGHI")
+    assert not first_ref.contains("LMNPQRST")
+    assert second_ref.contains("LMNPQRST")
+    assert not second_ref.contains("ACDEFGHI")
+    assert equivalent_ref._kmer_set is first_ref._kmer_set
+    assert extract.call_count == 2
+    assert len(_filtered_kmer_set_cache) == 2
 
 
 def test_from_genome_with_exclude_fasta(tmp_path):

--- a/vaxrank/__init__.py
+++ b/vaxrank/__init__.py
@@ -22,6 +22,7 @@ from .vaccine_antigen import (
     SelfReferenceSource,
     TargetableMask,
     TumorSpecificityAttestation,
+    TumorSpecificityEvidence,
     VaccineAntigen,
 )
 from .vaccine_peptide import VaccinePeptide
@@ -82,6 +83,16 @@ from .near_self import (
     assess_near_self,
     assess_near_self_queries,
 )
+from .cta_admission import (
+    CTAAdmissionAssessment,
+    CTAAdmissionError,
+    CTAAdmissionPolicy,
+    CTAOverrideEvidence,
+    CTAReferenceEvidence,
+    PatientTumorExpressionEvidence,
+    assess_cta_antigen,
+    build_cta_vaccine_antigen,
+)
 from .version import __version__
 
 __all__ = [
@@ -90,6 +101,11 @@ __all__ = [
     "AminoAcidSubstitutionMatrix",
     "BLOSUM62",
     "CandidateEpitope",
+    "CTAAdmissionAssessment",
+    "CTAAdmissionError",
+    "CTAAdmissionPolicy",
+    "CTAOverrideEvidence",
+    "CTAReferenceEvidence",
     "ConstructBoundary",
     "DEFAULT_NEAR_SELF_COMPARATOR",
     "EmittedSafetyLigand",
@@ -105,6 +121,7 @@ __all__ = [
     "PROTEIN_RESOLUTION_ALL_ISOFORMS",
     "PROTEIN_RESOLUTION_LONGEST_ISOFORM",
     "PatientHLARiskLigandIndex",
+    "PatientTumorExpressionEvidence",
     "ProteinResolutionCoverage",
     "ResolvedRiskProtein",
     "RiskCoverageGap",
@@ -132,6 +149,7 @@ __all__ = [
     "TissueRiskPolicy",
     "TissueRiskProtein",
     "TumorSpecificityAttestation",
+    "TumorSpecificityEvidence",
     "VaccineAntigen",
     "VaccineConfig",
     "VaccinePeptide",
@@ -139,8 +157,10 @@ __all__ = [
     "assess_vaccine_antigen_window",
     "assess_near_self",
     "assess_near_self_queries",
+    "assess_cta_antigen",
     "build_hpa_reference_provenance",
     "build_patient_hla_risk_ligand_index",
+    "build_cta_vaccine_antigen",
     "derive_tissue_risk_proteins",
     "predict_epitopes",
     "run_vaxrank",

--- a/vaxrank/cta_admission.py
+++ b/vaxrank/cta_admission.py
@@ -1,0 +1,413 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Direct-oncoref CTA admission and antigen construction."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+import pandas as pd
+from serializable import DataclassSerializable
+
+from .vaccine_antigen import (
+    ANTIGEN_KIND_CTA,
+    ATTESTATION_ADMITTED,
+    ATTESTATION_HELD_OUT,
+    ATTESTATION_OVERRIDDEN,
+    AminoAcidInterval,
+    TargetableMask,
+    TumorSpecificityAttestation,
+    TumorSpecificityEvidence,
+    VaccineAntigen,
+)
+
+
+CTA_REASON_CANONICAL_EXPRESSION_PASS = "cta_canonical_expression_pass"
+CTA_REASON_EXPRESSION_BELOW_THRESHOLD = "cta_expression_below_threshold"
+CTA_REASON_NONCANONICAL_HELD_OUT = "cta_noncanonical_held_out"
+CTA_REASON_EXPLICIT_OVERRIDE = "cta_explicit_evidence_override"
+
+
+class CTAAdmissionError(RuntimeError):
+    """Raised when CTA admission evidence cannot be resolved unambiguously."""
+
+
+def _gene_id(value) -> str:
+    return str(value).strip().split(".")[0]
+
+
+def _finite_nonnegative(value, label: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{label} must be numeric") from error
+    if not math.isfinite(result) or result < 0:
+        raise ValueError(f"{label} must be finite and non-negative")
+    return result
+
+
+def _clean(value) -> str:
+    if value is None or pd.isna(value):
+        return ""
+    return str(value)
+
+
+def _required_bool(value, label: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value in (0, 1):
+        return bool(value)
+    text = _clean(value).strip().casefold()
+    if text == "true":
+        return True
+    if text == "false":
+        return False
+    raise CTAAdmissionError(f"oncoref CTA {label} is not boolean")
+
+
+def _fingerprint(value) -> str:
+    return hashlib.sha256(json.dumps(
+        value, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class CTAAdmissionPolicy(DataclassSerializable):
+    """Run-specific quantitative tumor-expression admission rule."""
+
+    min_tumor_expression: float
+    expression_unit: str
+
+    def __post_init__(self):
+        object.__setattr__(
+            self,
+            "min_tumor_expression",
+            _finite_nonnegative(
+                self.min_tumor_expression, "Minimum tumor expression"
+            ),
+        )
+        if self.min_tumor_expression <= 0:
+            raise ValueError("Minimum tumor expression must be greater than zero")
+        if not self.expression_unit:
+            raise ValueError("CTA expression policy requires an explicit unit")
+
+
+@dataclass(frozen=True)
+class PatientTumorExpressionEvidence(DataclassSerializable):
+    gene_id: str
+    sample_id: str
+    value: float
+    unit: str
+    evidence_source: str
+    evidence_version: str
+    assay: str = ""
+
+    def __post_init__(self):
+        gene_id = _gene_id(self.gene_id)
+        if not gene_id or not self.sample_id:
+            raise ValueError("Tumor expression requires gene and patient sample IDs")
+        if (
+            not self.unit
+            or not self.evidence_source
+            or not self.evidence_version
+            or not self.assay
+        ):
+            raise ValueError(
+                "Tumor expression requires assay, units, and versioned provenance"
+            )
+        object.__setattr__(self, "gene_id", gene_id)
+        object.__setattr__(
+            self, "value", _finite_nonnegative(self.value, "Tumor expression")
+        )
+
+
+@dataclass(frozen=True)
+class CTAOverrideEvidence(DataclassSerializable):
+    evidence_source: str
+    evidence_version: str
+    rationale: str
+    evidence_id: str = ""
+
+    def __post_init__(self):
+        if not self.evidence_source or not self.evidence_version or not self.rationale:
+            raise ValueError("CTA override requires versioned evidence and rationale")
+
+
+@dataclass(frozen=True)
+class CTAReferenceEvidence(DataclassSerializable):
+    gene_id: str
+    gene_name: str
+    canonical_default: bool
+    unfiltered_candidate: bool
+    passes_filters: bool
+    never_expressed: bool
+    specificity_status: str
+    specificity_action: str
+    specificity_source_anchor: str
+    specificity_rationale: str
+    restriction: str
+    restriction_confidence: str
+    safety_flags: str
+    source_databases: str
+    canonical_transcript_id: str
+    oncoref_version: str
+    oncoref_data_version: str
+    oncoref_source_matrix_version: str
+    canonical_gene_ids_sha256: str
+    unfiltered_gene_ids_sha256: str
+    source_row_sha256: str
+
+    def __post_init__(self):
+        object.__setattr__(self, "gene_id", _gene_id(self.gene_id))
+        for digest in (
+            self.canonical_gene_ids_sha256,
+            self.unfiltered_gene_ids_sha256,
+            self.source_row_sha256,
+        ):
+            if len(digest) != 64:
+                raise ValueError("CTA reference evidence requires SHA-256 provenance")
+
+
+@dataclass(frozen=True)
+class CTAAdmissionAssessment(DataclassSerializable):
+    antigen: VaccineAntigen
+    policy: CTAAdmissionPolicy
+    tumor_expression: PatientTumorExpressionEvidence
+    reference_evidence: CTAReferenceEvidence
+    override_evidence: Optional[CTAOverrideEvidence] = None
+
+    def __post_init__(self):
+        if self.antigen.kind != ANTIGEN_KIND_CTA:
+            raise ValueError("CTA assessment requires a CTA vaccine antigen")
+        if self.antigen.gene_id != self.reference_evidence.gene_id:
+            raise ValueError("CTA antigen and reference evidence genes differ")
+
+    def to_report_dict(self) -> dict:
+        return asdict(self)
+
+
+def _resolve_reference_evidence(gene_id: str):
+    import oncoref
+    from oncoref.cta import cta_evidence, cta_gene_ids, cta_unfiltered_gene_ids
+    from oncoref.version import DATA_VERSION, SOURCE_MATRIX_VERSION
+
+    canonical_ids = frozenset(_gene_id(value) for value in cta_gene_ids())
+    unfiltered_ids = frozenset(
+        _gene_id(value) for value in cta_unfiltered_gene_ids()
+    )
+    if not canonical_ids or not unfiltered_ids:
+        raise CTAAdmissionError("oncoref returned an empty CTA reference set")
+    if gene_id not in unfiltered_ids:
+        raise CTAAdmissionError(
+            f"Gene {gene_id} is not in oncoref's CTA candidate universe"
+        )
+    frame = cta_evidence()
+    required = {
+        "Ensembl_Gene_ID",
+        "Symbol",
+        "passes_filters",
+        "never_expressed",
+        "specificity_status",
+        "specificity_action",
+        "specificity_source_anchor",
+        "specificity_rationale",
+        "restriction",
+        "restriction_confidence",
+        "safety_flags",
+        "source_databases",
+        "Canonical_Transcript_ID",
+    }
+    missing = required - set(frame.columns)
+    if missing:
+        raise CTAAdmissionError(
+            f"oncoref CTA evidence is missing columns: {sorted(missing)}"
+        )
+    normalized_ids = frame["Ensembl_Gene_ID"].map(_gene_id)
+    rows = frame.loc[normalized_ids == gene_id]
+    if len(rows) != 1:
+        raise CTAAdmissionError(
+            f"Expected one oncoref CTA evidence row for {gene_id}; found {len(rows)}"
+        )
+    row = rows.iloc[0]
+    row_payload = {
+        column: _clean(row[column]) for column in sorted(required)
+    }
+    evidence = CTAReferenceEvidence(
+        gene_id=gene_id,
+        gene_name=_clean(row["Symbol"]),
+        canonical_default=gene_id in canonical_ids,
+        unfiltered_candidate=True,
+        passes_filters=_required_bool(row["passes_filters"], "passes_filters"),
+        never_expressed=_required_bool(
+            row["never_expressed"], "never_expressed"
+        ),
+        specificity_status=_clean(row["specificity_status"]),
+        specificity_action=_clean(row["specificity_action"]),
+        specificity_source_anchor=_clean(row["specificity_source_anchor"]),
+        specificity_rationale=_clean(row["specificity_rationale"]),
+        restriction=_clean(row["restriction"]),
+        restriction_confidence=_clean(row["restriction_confidence"]),
+        safety_flags=_clean(row["safety_flags"]),
+        source_databases=_clean(row["source_databases"]),
+        canonical_transcript_id=_clean(row["Canonical_Transcript_ID"]),
+        oncoref_version=oncoref.__version__,
+        oncoref_data_version=DATA_VERSION,
+        oncoref_source_matrix_version=SOURCE_MATRIX_VERSION,
+        canonical_gene_ids_sha256=_fingerprint(sorted(canonical_ids)),
+        unfiltered_gene_ids_sha256=_fingerprint(sorted(unfiltered_ids)),
+        source_row_sha256=_fingerprint(row_payload),
+    )
+    return evidence, tuple(sorted(unfiltered_ids))
+
+
+def assess_cta_antigen(
+    *,
+    amino_acids: str,
+    gene_id: str,
+    tumor_expression: PatientTumorExpressionEvidence,
+    policy: CTAAdmissionPolicy,
+    override_evidence: Optional[CTAOverrideEvidence] = None,
+    transcript_ids: tuple[str, ...] = (),
+    protein_ids: tuple[str, ...] = (),
+    species: str = "Homo sapiens",
+    source_identifier: str = "",
+) -> CTAAdmissionAssessment:
+    """Resolve oncoref CTA status and patient-expression construct admission."""
+    gene_id = _gene_id(gene_id)
+    if tumor_expression.gene_id != gene_id:
+        raise ValueError("CTA and tumor-expression gene IDs differ")
+    if tumor_expression.unit != policy.expression_unit:
+        raise ValueError(
+            "CTA tumor-expression units do not match the admission policy"
+        )
+    reference, self_excluded_gene_ids = _resolve_reference_evidence(gene_id)
+    expression_passes = tumor_expression.value >= policy.min_tumor_expression
+
+    if reference.canonical_default and expression_passes:
+        status = ATTESTATION_ADMITTED
+        rationale_code = CTA_REASON_CANONICAL_EXPRESSION_PASS
+        requires_review = False
+        override_reason = ""
+    elif not expression_passes:
+        status = ATTESTATION_HELD_OUT
+        rationale_code = CTA_REASON_EXPRESSION_BELOW_THRESHOLD
+        requires_review = True
+        override_reason = ""
+    elif override_evidence is None:
+        status = ATTESTATION_HELD_OUT
+        rationale_code = CTA_REASON_NONCANONICAL_HELD_OUT
+        requires_review = True
+        override_reason = ""
+    else:
+        status = ATTESTATION_OVERRIDDEN
+        rationale_code = CTA_REASON_EXPLICIT_OVERRIDE
+        requires_review = True
+        override_reason = override_evidence.rationale
+
+    reference_record = TumorSpecificityEvidence(
+        evidence_kind="oncoref_cta_membership",
+        evidence_source="oncoref.cta",
+        evidence_version=reference.oncoref_version,
+        subject_id=gene_id,
+        passed=reference.canonical_default,
+        details=(
+            ("specificity_status", reference.specificity_status),
+            ("specificity_action", reference.specificity_action),
+            ("restriction", reference.restriction),
+            ("restriction_confidence", reference.restriction_confidence),
+            ("source_row_sha256", reference.source_row_sha256),
+        ),
+    )
+    expression_record = TumorSpecificityEvidence(
+        evidence_kind="patient_tumor_expression",
+        evidence_source=tumor_expression.evidence_source,
+        evidence_version=tumor_expression.evidence_version,
+        subject_id=gene_id,
+        sample_id=tumor_expression.sample_id,
+        patient_specific=True,
+        passed=expression_passes,
+        numeric_value=tumor_expression.value,
+        unit=tumor_expression.unit,
+        threshold=policy.min_tumor_expression,
+        details=(("assay", tumor_expression.assay),),
+    )
+    records = [reference_record, expression_record]
+    if status == ATTESTATION_OVERRIDDEN:
+        records.append(TumorSpecificityEvidence(
+            evidence_kind="cta_admission_override",
+            evidence_source=override_evidence.evidence_source,
+            evidence_version=override_evidence.evidence_version,
+            subject_id=gene_id,
+            passed=True,
+            details=(
+                ("evidence_id", override_evidence.evidence_id),
+                ("rationale", override_evidence.rationale),
+            ),
+        ))
+
+    antigen = VaccineAntigen(
+        kind=ANTIGEN_KIND_CTA,
+        amino_acids=amino_acids,
+        targetable_mask=TargetableMask((
+            AminoAcidInterval(0, len(amino_acids)),
+        )),
+        tumor_specificity=TumorSpecificityAttestation(
+            status=status,
+            evidence_kind="oncoref_cta_and_patient_tumor_expression",
+            evidence_source="oncoref.cta plus patient tumor expression",
+            evidence_version=reference.oncoref_version,
+            patient_specific=True,
+            rationale_code=rationale_code,
+            requires_review=requires_review,
+            override_reason=override_reason,
+            evidence_records=tuple(records),
+        ),
+        self_reference_excluded_gene_ids=self_excluded_gene_ids,
+        gene_name=reference.gene_name,
+        gene_id=gene_id,
+        transcript_ids=transcript_ids or (
+            (reference.canonical_transcript_id,)
+            if reference.canonical_transcript_id else ()
+        ),
+        protein_ids=protein_ids,
+        species=species,
+        source_identifier=source_identifier or gene_id,
+    )
+    return CTAAdmissionAssessment(
+        antigen=antigen,
+        policy=policy,
+        tumor_expression=tumor_expression,
+        reference_evidence=reference,
+        override_evidence=override_evidence,
+    )
+
+
+def build_cta_vaccine_antigen(
+    *,
+    amino_acids: str,
+    gene_id: str,
+    tumor_expression: PatientTumorExpressionEvidence,
+    policy: CTAAdmissionPolicy,
+    override_evidence: Optional[CTAOverrideEvidence] = None,
+    transcript_ids: tuple[str, ...] = (),
+    protein_ids: tuple[str, ...] = (),
+    species: str = "Homo sapiens",
+    source_identifier: str = "",
+) -> VaccineAntigen:
+    """Build a CTA antigen while retaining evidence in its attestation."""
+    return assess_cta_antigen(
+        amino_acids=amino_acids,
+        gene_id=gene_id,
+        tumor_expression=tumor_expression,
+        policy=policy,
+        override_evidence=override_evidence,
+        transcript_ids=transcript_ids,
+        protein_ids=protein_ids,
+        species=species,
+        source_identifier=source_identifier,
+    ).antigen

--- a/vaxrank/reference_proteome.py
+++ b/vaxrank/reference_proteome.py
@@ -17,6 +17,7 @@ Uses a set-based index for O(1) membership testing of peptide kmers.
 """
 
 import gzip
+import hashlib
 import io
 import logging
 import os
@@ -67,11 +68,22 @@ def cta_source_gene_ids_for_genome(genome) -> frozenset[str]:
 _kmer_set_cache: dict[tuple, set[str]] = {}
 _kmer_set_cache_lock = threading.Lock()
 
-# Filtered indexes are shared within a run. The genome object's identity is
-# part of the key so distinct test/custom genomes with the same release label
-# cannot contaminate one another.
+# Filtered indexes are shared within a run. Their keys describe the retained
+# protein content and filtering policy, so equivalent inputs can share work
+# while distinct genome objects or releases cannot contaminate one another.
 _filtered_kmer_set_cache: dict[tuple, set[str]] = {}
 _filtered_kmer_set_cache_lock = threading.Lock()
+
+
+def _protein_content_digest(proteins: dict[str, str]) -> str:
+    """Return a deterministic digest of transcript IDs and protein sequences."""
+    digest = hashlib.sha256()
+    for transcript_id, sequence in sorted(proteins.items()):
+        for value in (transcript_id, sequence):
+            encoded = value.encode("utf-8")
+            digest.update(len(encoded).to_bytes(8, "big"))
+            digest.update(encoded)
+    return digest.hexdigest()
 
 
 def get_cache_dir() -> str:
@@ -441,21 +453,22 @@ class ReferenceProteome:
                 max_kmer_length=max_kmer_length,
             )
 
-        cache_key = (
-            id(genome),
-            frozenset(all_exclude_ids),
-            min_kmer_length,
-            max_kmer_length,
-        )
+        proteins = genome_protein_dict(
+            genome, exclude_gene_ids=all_exclude_ids)
+        cache_key = None
         kmer_set = None
+
         if not exclude_fasta:
+            cache_key = (
+                _protein_content_digest(proteins),
+                frozenset(all_exclude_ids),
+                min_kmer_length,
+                max_kmer_length,
+            )
             with _filtered_kmer_set_cache_lock:
                 kmer_set = _filtered_kmer_set_cache.get(cache_key)
 
         if kmer_set is None:
-            proteins = genome_protein_dict(
-                genome, exclude_gene_ids=all_exclude_ids)
-
             if exclude_fasta:
                 exclude_seqs = set(_read_fasta(exclude_fasta).values())
                 before = len(proteins)

--- a/vaxrank/vaccine_antigen.py
+++ b/vaxrank/vaccine_antigen.py
@@ -12,8 +12,9 @@
 
 """Source-agnostic antigen targetability and exact-self result types."""
 
+import math
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Optional
 
 from serializable import DataclassSerializable
 
@@ -112,6 +113,38 @@ class TargetableMask(DataclassSerializable):
 
 
 @dataclass(frozen=True)
+class TumorSpecificityEvidence(DataclassSerializable):
+    """One machine-readable input to a tumor-specificity attestation."""
+
+    evidence_kind: str
+    evidence_source: str
+    evidence_version: str = ""
+    subject_id: str = ""
+    sample_id: str = ""
+    patient_specific: bool = False
+    passed: Optional[bool] = None
+    numeric_value: Optional[float] = None
+    unit: str = ""
+    threshold: Optional[float] = None
+    details: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+
+    def __post_init__(self):
+        if not self.evidence_kind or not self.evidence_source:
+            raise ValueError("Tumor-specificity evidence kind and source are required")
+        for label in ("numeric_value", "threshold"):
+            value = getattr(self, label)
+            if value is not None and not math.isfinite(value):
+                raise ValueError(f"Tumor-specificity {label} must be finite")
+        if (self.numeric_value is not None or self.threshold is not None) and not self.unit:
+            raise ValueError("Quantitative tumor-specificity evidence requires units")
+        details = tuple(sorted({
+            (str(name), str(value)) for name, value in self.details
+            if str(name)
+        }))
+        object.__setattr__(self, "details", details)
+
+
+@dataclass(frozen=True)
 class TumorSpecificityAttestation(DataclassSerializable):
     """Evidence-bearing decision about construct admission."""
 
@@ -123,6 +156,9 @@ class TumorSpecificityAttestation(DataclassSerializable):
     rationale_code: str = ""
     requires_review: bool = False
     override_reason: str = ""
+    evidence_records: tuple[TumorSpecificityEvidence, ...] = field(
+        default_factory=tuple
+    )
 
     def __post_init__(self):
         if self.status not in ATTESTATION_STATUSES:
@@ -134,6 +170,14 @@ class TumorSpecificityAttestation(DataclassSerializable):
             raise ValueError("Tumor-specificity evidence kind and source are required")
         if self.status == ATTESTATION_OVERRIDDEN and not self.override_reason:
             raise ValueError("An overridden attestation requires an override reason")
+        records = tuple(self.evidence_records)
+        if records and self.patient_specific != any(
+            record.patient_specific for record in records
+        ):
+            raise ValueError(
+                "Attestation patient-specific flag disagrees with evidence records"
+            )
+        object.__setattr__(self, "evidence_records", records)
 
     @property
     def admits_construct(self) -> bool:

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.15"
+__version__ = "3.1.16"
 
 
 def print_version():


### PR DESCRIPTION
Implements the CTA admission-policy slice of #303.

- uses direct pinned oncoref CTA APIs, never an intermediary or copied gene list
- uses cta_gene_ids for canonical default target admission
- uses cta_unfiltered_gene_ids for antigen-specific exact-self source exclusions
- requires versioned quantitative patient-tumor expression evidence, a nonzero run-specific threshold, matching units, assay, and sample identity
- keeps low-expression/specificity-held-out candidates reportable but not construct-admitted
- permits noncanonical candidates only through explicit versioned evidence-bearing overrides, without allowing overrides to bypass missing patient expression
- serializes selected oncoref restriction/specificity evidence, full-set fingerprints, source-row fingerprint, expression threshold/result, and override provenance
- adds generic typed tumor-specificity evidence records to VaccineAntigen attestations
- fixes the filtered reference-proteome cache collision found by the first CI run, using retained protein content and policy instead of Python object identity

Obvious-risk regressions cover PRAME, the two-set admission/exclusion distinction, exact threshold behavior, low expression, unit/gene mismatch, unknown genes, empty/missing/duplicate/malformed oncoref evidence, invalid quantitation, unversioned evidence, override behavior, and cache isolation/reuse across custom genome objects.

This PR intentionally does not yet remove the non-mutation prediction guard; that source-agnostic prediction refactor is the next #303 slice.

Closes #320.

Version: 3.1.16

Local verification:
- ./lint.sh
- ./test.sh (943 passed)