### PR TITLE
Predict epitopes directly from CTA antigens

### DIFF
--- a/tests/test_vaccine_antigen.py
+++ b/tests/test_vaccine_antigen.py
@@ -5,10 +5,13 @@
 #       http://www.apache.org/licenses/LICENSE-2.0
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
 import pytest
+from mhctools import RandomBindingPredictor
 
-from vaxrank.candidate_epitope import CandidateEpitope
+from vaxrank.candidate_epitope import CandidateEpitope, SOURCE_CLASS_SELF
+from vaxrank.epitope_config import EpitopeConfig
 from vaxrank.epitope_logic import predict_epitopes
 from vaxrank.vaccine_antigen import (
     ANTIGEN_KIND_CTA,
@@ -225,16 +228,76 @@ def test_vaccine_peptide_fails_closed_for_held_out_or_mismatched_policy():
         )
 
 
-def test_prediction_refuses_non_mutation_antigen_until_admission_path_exists():
+def test_prediction_accepts_cta_antigen_without_fake_mutation_fragment():
     antigen = cta_antigen()
-    fragment = SimpleNamespace(amino_acids=antigen.amino_acids)
 
-    with pytest.raises(NotImplementedError, match="issue #303"):
-        predict_epitopes(
-            mhc_predictor=None,
-            protein_fragment=fragment,
+    epitopes = predict_epitopes(
+        mhc_predictor=RandomBindingPredictor(["HLA-A*02:01"]),
+        epitope_config=EpitopeConfig(min_epitope_score=0),
+        antigen=antigen,
+    )
+
+    assert epitopes
+    assert all(epitope.source_sequence == antigen.amino_acids
+               for epitope in epitopes)
+    assert all(epitope.source_class == SOURCE_CLASS_SELF
+               for epitope in epitopes)
+    assert all(epitope.overlaps_targetable for epitope in epitopes)
+    assert all(not epitope.overlaps_mutation for epitope in epitopes)
+    assert all("wt" not in epitope.comparators for epitope in epitopes)
+    assert all(
+        epitope.self_reference_match.antigen_kind == ANTIGEN_KIND_CTA
+        and epitope.self_reference_match.excluded_gene_ids == (
+            "ENSG00000185686",
+        )
+        for epitope in epitopes
+    )
+
+
+def test_cta_prediction_uses_antigen_specific_self_reference():
+    antigen = cta_antigen()
+    raw_reference = MagicMock()
+    raw_reference.contains.return_value = True
+    antigen_reference = MagicMock()
+    antigen_reference.contains.return_value = False
+    non_cta_reference = MagicMock()
+    non_cta_reference.contains.return_value = False
+
+    with patch(
+            "vaxrank.epitope_logic.ReferenceProteome") as reference_cls:
+        reference_cls.return_value = raw_reference
+        reference_cls.from_genome.side_effect = [
+            antigen_reference,
+            non_cta_reference,
+        ]
+        epitopes = predict_epitopes(
+            mhc_predictor=RandomBindingPredictor(["HLA-A*02:01"]),
+            epitope_config=EpitopeConfig(min_epitope_score=0),
             antigen=antigen,
         )
+
+    assert epitopes
+    assert all(epitope.occurs_in_reference for epitope in epitopes)
+    assert all(not epitope.occurs_in_self_reference for epitope in epitopes)
+    assert reference_cls.from_genome.call_args_list == [
+        call(
+            None,
+            exclude_gene_ids=("ENSG00000185686",),
+        ),
+        call(None, exclude_cta_genes=True),
+    ]
+
+
+def test_mutation_prediction_requires_fragment_for_wt_coordinates():
+    antigen = VaccineAntigen(
+        kind=ANTIGEN_KIND_MUTATION,
+        amino_acids="ACDEFGHIKL",
+        targetable_mask=TargetableMask((AminoAcidInterval(4, 5),)),
+        tumor_specificity=admitted_attestation(),
+    )
+
+    with pytest.raises(ValueError, match="requires a mutation fragment"):
+        predict_epitopes(mhc_predictor=None, antigen=antigen)
 
 
 def test_vaccine_antigen_json_roundtrip_preserves_policy():

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -26,11 +26,15 @@ from .epitope_config import EpitopeConfig
 from .epitope_dsl import build_filter_node, build_score_node, drop_empty_sample_name
 from .mutant_protein_fragment import MutantProteinFragment
 from .candidate_epitope import (
-    CandidateEpitope, SOURCE_CLASS_MUTATION,
+    CandidateEpitope, SOURCE_CLASS_MUTATION, SOURCE_CLASS_SELF,
     candidate_epitopes_from_rows,
 )
 from .reference_proteome import ReferenceProteome
-from .vaccine_antigen import ANTIGEN_KIND_MUTATION, VaccineAntigen
+from .vaccine_antigen import (
+    ANTIGEN_KIND_CTA,
+    ANTIGEN_KIND_MUTATION,
+    VaccineAntigen,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +70,7 @@ def slice_epitopes(epitopes, start_offset, end_offset):
 
 def predict_epitopes(
         mhc_predictor,
-        protein_fragment : MutantProteinFragment,
+        protein_fragment: Optional[MutantProteinFragment] = None,
         epitope_config : Optional[EpitopeConfig] = None,
         genome : Optional[Genome] = None,
         antigen: Optional[VaccineAntigen] = None) -> list[CandidateEpitope]:
@@ -82,7 +86,8 @@ def predict_epitopes(
         rolled into each CandidateEpitope's mutant context.
 
     protein_fragment
-        Protein sub-sequence to run MHC binding predictor over
+        Legacy mutation fragment. Required for mutation antigens so WT
+        comparator coordinates can be reconstructed; omitted for CTA antigens.
 
     epitope_config
         Configuration object with parameters for scoring epitopes, if
@@ -92,8 +97,8 @@ def predict_epitopes(
         Genome whose proteome to use for reference peptide filtering
 
     antigen
-        Source-agnostic antigen semantics. When omitted, the mutation fragment
-        is adapted to a ``VaccineAntigen`` with identical mutation behavior.
+        Source sequence, targetability, and exact-self semantics. When omitted,
+        ``protein_fragment`` is adapted to a mutation ``VaccineAntigen``.
 
     Returns
     -------
@@ -108,14 +113,37 @@ def predict_epitopes(
     if epitope_config is None:
         epitope_config = EpitopeConfig()
     if antigen is None:
+        if protein_fragment is None:
+            raise ValueError(
+                "predict_epitopes requires a VaccineAntigen or mutation fragment"
+            )
         antigen = VaccineAntigen.from_mutant_protein_fragment(protein_fragment)
-    elif antigen.amino_acids != protein_fragment.amino_acids:
+    elif (
+        protein_fragment is not None
+        and antigen.amino_acids != protein_fragment.amino_acids
+    ):
         raise ValueError("Antigen and protein fragment amino-acid sequences differ")
-    if antigen.kind != ANTIGEN_KIND_MUTATION:
-        raise NotImplementedError(
-            "Non-mutation antigen prediction requires the construct-admission "
-            "vertical slice from issue #303"
+    if antigen.kind == ANTIGEN_KIND_MUTATION and protein_fragment is None:
+        raise ValueError(
+            "Mutation antigen prediction requires a mutation fragment for "
+            "WT comparator coordinates"
         )
+    if antigen.kind not in {ANTIGEN_KIND_MUTATION, ANTIGEN_KIND_CTA}:
+        raise NotImplementedError(
+            f"Prediction for {antigen.kind!r} antigens is not implemented"
+        )
+
+    source_name = (
+        antigen.source_identifier
+        or antigen.gene_name
+        or antigen.gene_id
+        or antigen.kind
+    )
+    source_class = (
+        SOURCE_CLASS_MUTATION
+        if antigen.kind == ANTIGEN_KIND_MUTATION
+        else SOURCE_CLASS_SELF
+    )
 
     reference_proteome = ReferenceProteome(genome)
     if antigen.self_reference_excluded_gene_ids:
@@ -137,11 +165,11 @@ def predict_epitopes(
     # Run predictions via Topiary
     try:
         predictions_df = topiary_predictor.predict_from_named_sequences(
-            {protein_fragment.gene_name: protein_fragment.amino_acids})
+            {source_name: antigen.amino_acids})
     except Exception:
         logger.error(
-            'MHC prediction errored for protein fragment %s, with traceback: %s',
-            protein_fragment, traceback.format_exc())
+            'MHC prediction errored for antigen %s, with traceback: %s',
+            antigen, traceback.format_exc())
         return []
 
     if predictions_df.empty:
@@ -312,11 +340,11 @@ def predict_epitopes(
         )
         rows.append({
             'peptide': peptide,
-            'source': protein_fragment.amino_acids,
+            'source': antigen.amino_acids,
             'offset': peptide_start_offset,
             'mutant': mutant_pred,
             'wt': wt_pred,
-            'source_class': SOURCE_CLASS_MUTATION,
+            'source_class': source_class,
             'overlaps_mutation': overlaps_mutation,
             'overlaps_targetable': overlaps_targetable,
             'occurs_in_reference': occurs_in_reference,

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.16"
+__version__ = "3.1.17"
 
 
 def print_version():


### PR DESCRIPTION
Advances #303 by making `VaccineAntigen` the sequence and policy authority for epitope prediction and admitting the first non-mutation prediction path.

- allows admitted or report-only CTA antigens to be predicted without fabricating a `MutantProteinFragment`
- retains the legacy mutation adapter and requires a real fragment only for mutation WT-coordinate reconstruction
- derives predictor source names and candidate source sequence from the antigen
- emits CTA candidates as self-derived, target-mask-aware records without WT comparators
- constructs exact-self results from the antigen-specific excluded-gene policy
- preserves raw-reference and historical non-CTA-reference signals separately
- continues to fail explicitly for ERV, splice, and viral antigen kinds until their admission vertical slices land

Obvious-risk regressions cover PRAME-style CTA source exclusion, raw-self versus antigen-specific-self divergence, absence of fake mutation/WT provenance, and fail-closed mutation WT reconstruction.

Version: 3.1.17

Local verification:
- `./lint.sh`
- `./test.sh` (945 passed)