### PR TITLE
Preserve complete self-reference source provenance

### DIFF
--- a/tests/test_epitope_prediction.py
+++ b/tests/test_epitope_prediction.py
@@ -65,6 +65,13 @@ def test_reference_peptide_logic(mouse_genome):
     ok_(not e_not_in_ref.occurs_in_reference)
     assert e_in_ref.self_reference_match.occurs
     assert not e_not_in_ref.self_reference_match.occurs
+    assert e_in_ref.self_reference_match.source_provenance_complete
+    assert e_not_in_ref.self_reference_match.source_provenance_complete
+    assert any(
+        source.protein_id == "ENSMUSP00000033506"
+        for source in e_in_ref.self_reference_match.sources
+    )
+    assert e_not_in_ref.self_reference_match.sources == ()
     assert e_in_ref.overlaps_targetable == e_in_ref.overlaps_mutation
     assert e_not_in_ref.overlaps_targetable == e_not_in_ref.overlaps_mutation
 

--- a/tests/test_reference_proteome.py
+++ b/tests/test_reference_proteome.py
@@ -735,6 +735,7 @@ def test_self_reference_matches_preserve_retained_source_provenance():
         "PROTEIN_SELF_TX_2",
     ]
     assert all(source.gene_id != prame_gene_id for source in shared.sources)
+    assert {source.species for source in shared.sources} == {"Homo sapiens"}
     assert type(shared).from_json(shared.to_json()) == shared
 
     prame_only = matches["CDEFGHIK"]

--- a/tests/test_reference_proteome.py
+++ b/tests/test_reference_proteome.py
@@ -19,6 +19,7 @@ import pickle
 import tempfile
 from unittest.mock import MagicMock, patch
 
+from pyensembl import Genome
 
 from vaxrank.reference_proteome import (
     ReferenceProteome,
@@ -32,8 +33,18 @@ from vaxrank.reference_proteome import (
     DEFAULT_MAX_KMER_LENGTH,
     _filtered_kmer_set_cache,
     _kmer_set_cache,
+    _protein_source_snapshot_cache,
     cta_source_gene_ids_for_genome,
     oncoref_cta_source_gene_ids,
+    self_reference_matches,
+)
+from vaxrank.vaccine_antigen import (
+    ANTIGEN_KIND_CTA,
+    ATTESTATION_ADMITTED,
+    AminoAcidInterval,
+    TargetableMask,
+    TumorSpecificityAttestation,
+    VaccineAntigen,
 )
 
 from .common import eq_, ok_
@@ -52,6 +63,8 @@ def create_mock_transcript(transcript_id, protein_sequence, is_protein_coding=Tr
     transcript.protein_sequence = protein_sequence
     transcript.is_protein_coding = is_protein_coding
     transcript.gene_id = gene_id or f"GENE_{transcript_id}"
+    transcript.gene_name = transcript.gene_id
+    transcript.protein_id = f"PROTEIN_{transcript_id}"
     return transcript
 
 
@@ -670,6 +683,130 @@ def test_cta_shared_sequence_remains_self_through_non_cta_gene():
             min_kmer_length=8, max_kmer_length=8)
 
     assert ref.contains("ACDEFGHI")
+
+
+def test_self_reference_matches_preserve_retained_source_provenance():
+    prame_gene_id = "ENSG00000185686"
+    prame = create_mock_transcript(
+        "PRAME_TX", "ACDEFGHIKL", gene_id=prame_gene_id
+    )
+    retained_1 = create_mock_transcript(
+        "SELF_TX_1", "MACDEFGHIV", gene_id="ENSG_SELF_1"
+    )
+    retained_2 = create_mock_transcript(
+        "SELF_TX_2", "ACDEFGHIMN", gene_id="ENSG_SELF_2"
+    )
+    genome = create_mock_genome(
+        [prame, retained_2, retained_1],
+        species_name="Homo sapiens",
+        release=114,
+    )
+    antigen = VaccineAntigen(
+        kind=ANTIGEN_KIND_CTA,
+        amino_acids=prame.protein_sequence,
+        targetable_mask=TargetableMask((AminoAcidInterval(0, 10),)),
+        tumor_specificity=TumorSpecificityAttestation(
+            status=ATTESTATION_ADMITTED,
+            evidence_kind="test",
+            evidence_source="test fixture",
+        ),
+        self_reference_excluded_gene_ids=(prame_gene_id,),
+        gene_id=prame_gene_id,
+    )
+
+    matches = self_reference_matches(
+        ["ACDEFGHI", "CDEFGHIK"], antigen, genome
+    )
+
+    shared = matches["ACDEFGHI"]
+    assert shared.occurs
+    assert shared.source_provenance_complete
+    assert shared.genome_release == "114"
+    assert [source.gene_id for source in shared.sources] == [
+        "ENSG_SELF_1",
+        "ENSG_SELF_2",
+    ]
+    assert [source.transcript_id for source in shared.sources] == [
+        "SELF_TX_1",
+        "SELF_TX_2",
+    ]
+    assert [source.protein_id for source in shared.sources] == [
+        "PROTEIN_SELF_TX_1",
+        "PROTEIN_SELF_TX_2",
+    ]
+    assert all(source.gene_id != prame_gene_id for source in shared.sources)
+    assert type(shared).from_json(shared.to_json()) == shared
+
+    prame_only = matches["CDEFGHIK"]
+    assert not prame_only.occurs
+    assert prame_only.source_provenance_complete
+    assert prame_only.sources == ()
+    assert prame_only.excluded_gene_ids == (prame_gene_id,)
+
+
+def test_self_reference_matches_without_genome_are_explicitly_incomplete():
+    antigen = VaccineAntigen(
+        kind=ANTIGEN_KIND_CTA,
+        amino_acids="ACDEFGHIKL",
+        targetable_mask=TargetableMask((AminoAcidInterval(0, 10),)),
+        tumor_specificity=TumorSpecificityAttestation(
+            status=ATTESTATION_ADMITTED,
+            evidence_kind="test",
+            evidence_source="test fixture",
+        ),
+    )
+
+    match = self_reference_matches(["ACDEFGHI"], antigen, None)["ACDEFGHI"]
+
+    assert not match.occurs
+    assert not match.source_provenance_complete
+    assert match.sources == ()
+
+
+def test_ensembl_source_snapshot_cache_tracks_resolved_source_files(tmp_path):
+    _protein_source_snapshot_cache.clear()
+    gtf_path = tmp_path / "test.gtf"
+    protein_path = tmp_path / "test.fa"
+    gtf_path.write_text("annotation-v1")
+    protein_path.write_text("protein-v1")
+    genome = Genome(
+        reference_name="test-reference",
+        annotation_name="test-annotation",
+        annotation_version="1",
+        gtf_path_or_url=str(gtf_path),
+        protein_fasta_paths_or_urls=[str(protein_path)],
+    )
+    first_transcript = create_mock_transcript(
+        "T1", "ACDEFGHIKL", gene_id="G1"
+    )
+    genome.transcripts = MagicMock(return_value=[first_transcript])
+    antigen = VaccineAntigen(
+        kind=ANTIGEN_KIND_CTA,
+        amino_acids="ACDEFGHIKL",
+        targetable_mask=TargetableMask((AminoAcidInterval(0, 10),)),
+        tumor_specificity=TumorSpecificityAttestation(
+            status=ATTESTATION_ADMITTED,
+            evidence_kind="test",
+            evidence_source="test fixture",
+        ),
+    )
+
+    first = self_reference_matches(["ACDEFGHI"], antigen, genome)
+    repeated = self_reference_matches(["ACDEFGHI"], antigen, genome)
+
+    assert first == repeated
+    assert first["ACDEFGHI"].occurs
+    assert genome.transcripts.call_count == 1
+
+    protein_path.write_text("protein-v2-with-different-size")
+    genome.transcripts.return_value = [
+        create_mock_transcript("T2", "LMNPQRSTVW", gene_id="G2")
+    ]
+    changed = self_reference_matches(["LMNPQRST"], antigen, genome)
+
+    assert changed["LMNPQRST"].occurs
+    assert changed["LMNPQRST"].sources[0].gene_id == "G2"
+    assert genome.transcripts.call_count == 2
 
 
 def test_filtered_reference_proteome_is_cached_per_genome_and_policy():

--- a/tests/test_vaccine_antigen.py
+++ b/tests/test_vaccine_antigen.py
@@ -280,10 +280,6 @@ def test_cta_prediction_uses_antigen_specific_self_reference():
     assert all(epitope.occurs_in_reference for epitope in epitopes)
     assert all(not epitope.occurs_in_self_reference for epitope in epitopes)
     assert reference_cls.from_genome.call_args_list == [
-        call(
-            None,
-            exclude_gene_ids=("ENSG00000185686",),
-        ),
         call(None, exclude_cta_genes=True),
     ]
 

--- a/vaxrank/__init__.py
+++ b/vaxrank/__init__.py
@@ -93,6 +93,7 @@ from .cta_admission import (
     assess_cta_antigen,
     build_cta_vaccine_antigen,
 )
+from .reference_proteome import self_reference_matches
 from .version import __version__
 
 __all__ = [
@@ -168,4 +169,5 @@ __all__ = [
     "resolve_tissue_risk_protein_sequences",
     "risk_ligand_index_from_prediction_frame",
     "safety_assessment_from_prediction_frame",
+    "self_reference_matches",
 ]

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -29,7 +29,7 @@ from .candidate_epitope import (
     CandidateEpitope, SOURCE_CLASS_MUTATION, SOURCE_CLASS_SELF,
     candidate_epitopes_from_rows,
 )
-from .reference_proteome import ReferenceProteome
+from .reference_proteome import ReferenceProteome, self_reference_matches
 from .vaccine_antigen import (
     ANTIGEN_KIND_CTA,
     ANTIGEN_KIND_MUTATION,
@@ -146,13 +146,6 @@ def predict_epitopes(
     )
 
     reference_proteome = ReferenceProteome(genome)
-    if antigen.self_reference_excluded_gene_ids:
-        antigen_reference_proteome = ReferenceProteome.from_genome(
-            genome,
-            exclude_gene_ids=antigen.self_reference_excluded_gene_ids,
-        )
-    else:
-        antigen_reference_proteome = reference_proteome
     non_cta_reference_proteome = ReferenceProteome.from_genome(
         genome, exclude_cta_genes=True)
 
@@ -191,6 +184,10 @@ def predict_epitopes(
             predictions_df, filter_node, default_methods=default_methods)
         if predictions_df.empty:
             return []
+
+    antigen_self_matches = self_reference_matches(
+        predictions_df["peptide"], antigen, genome
+    )
 
     # Evaluate the score expression once; indexed by
     # (source_sequence_name, peptide, peptide_offset, allele) group tuple.
@@ -270,7 +267,6 @@ def predict_epitopes(
         )
 
         occurs_in_reference = reference_proteome.contains(peptide)
-        occurs_in_antigen_reference = antigen_reference_proteome.contains(peptide)
         occurs_in_non_cta_reference = non_cta_reference_proteome.contains(peptide)
         if occurs_in_reference:
             logger.debug('Peptide %s occurs in reference', peptide)
@@ -353,11 +349,7 @@ def predict_epitopes(
             # for CTA-family peptides; shared sequences in any non-CTA gene
             # remain present because the filtered index retains those genes.
             'occurs_in_non_CTA_reference': occurs_in_non_cta_reference,
-            'self_reference_match': antigen.self_reference_match(
-                peptide,
-                occurs_in_antigen_reference,
-                genome_release=str(getattr(genome, "release", "") or ""),
-            ),
+            'self_reference_match': antigen_self_matches[peptide],
             # Per-(peptide, allele) DSL score; threaded onto the
             # CandidateEpitope as ``per_allele_scores[allele]`` by
             # ``candidate_epitopes_from_rows``. Single source of

--- a/vaxrank/reference_proteome.py
+++ b/vaxrank/reference_proteome.py
@@ -157,6 +157,9 @@ def _protein_source_snapshot(genome):
         if cached is not None:
             return cached
 
+    species = str(
+        getattr(getattr(genome, "species", None), "latin_name", "") or ""
+    )
     sources_by_sequence: dict[str, set[SelfReferenceSource]] = {}
     for transcript in genome.transcripts():
         if not transcript.is_protein_coding or not transcript.protein_sequence:
@@ -173,6 +176,7 @@ def _protein_source_snapshot(genome):
             ),
             protein_id=str(getattr(transcript, "protein_id", "") or ""),
             gene_name=str(getattr(transcript, "gene_name", "") or ""),
+            species=species,
         )
         sources_by_sequence.setdefault(
             transcript.protein_sequence, set()
@@ -188,6 +192,7 @@ def _protein_source_snapshot(genome):
                     source.transcript_id,
                     source.protein_id,
                     source.gene_name,
+                    source.species,
                 ),
             )),
         )
@@ -485,6 +490,7 @@ def self_reference_matches(
                 source.transcript_id,
                 source.protein_id,
                 source.gene_name,
+                source.species,
             ),
         ))
         result[peptide] = SelfReferenceMatch(

--- a/vaxrank/reference_proteome.py
+++ b/vaxrank/reference_proteome.py
@@ -19,16 +19,24 @@ Uses a set-based index for O(1) membership testing of peptide kmers.
 import gzip
 import hashlib
 import io
+import json
 import logging
 import os
 import pickle
 import threading
 from functools import lru_cache
+from typing import Iterable, Optional
 
 from platformdirs import user_cache_dir
+from pyensembl import Genome
 from tqdm import tqdm
 
 from .config.defaults import DEFAULT_MAX_KMER_LENGTH, DEFAULT_MIN_KMER_LENGTH
+from .vaccine_antigen import (
+    SelfReferenceMatch,
+    SelfReferenceSource,
+    VaccineAntigen,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +82,12 @@ _kmer_set_cache_lock = threading.Lock()
 _filtered_kmer_set_cache: dict[tuple, set[str]] = {}
 _filtered_kmer_set_cache_lock = threading.Lock()
 
+# Protein/source snapshots avoid reconstructing every pyensembl Transcript for
+# each antigen. Only concrete pyensembl genomes are cached, using their public
+# serialized definition and resolved local source-file identities.
+_protein_source_snapshot_cache: dict[str, tuple] = {}
+_protein_source_snapshot_cache_lock = threading.Lock()
+
 
 def _protein_content_digest(proteins: dict[str, str]) -> str:
     """Return a deterministic digest of transcript IDs and protein sequences."""
@@ -84,6 +98,105 @@ def _protein_content_digest(proteins: dict[str, str]) -> str:
             digest.update(len(encoded).to_bytes(8, "big"))
             digest.update(encoded)
     return digest.hexdigest()
+
+
+def _ensembl_dataset_cache_key(genome) -> Optional[str]:
+    """Identify one installed pyensembl annotation/protein dataset."""
+    if not isinstance(genome, Genome):
+        return None
+    files = []
+    try:
+        definition = genome.to_dict()
+        source_paths = [definition.get("gtf_path_or_url")]
+        source_paths.extend(
+            definition.get("transcript_fasta_paths_or_urls") or []
+        )
+        source_paths.extend(
+            definition.get("protein_fasta_paths_or_urls") or []
+        )
+        source_paths = [path for path in source_paths if path]
+        cached_paths = genome.required_local_files()
+        if len(source_paths) != len(cached_paths):
+            return None
+        for source_path, cached_path in zip(source_paths, cached_paths):
+            use_source_directly = (
+                "://" not in source_path
+                and not definition.get("copy_local_files_to_cache")
+                and not definition.get("decompress_on_download")
+            )
+            path = source_path if use_source_directly else cached_path
+            resolved_path = os.path.realpath(path)
+            stat = os.stat(resolved_path)
+            files.append((
+                resolved_path,
+                stat.st_dev,
+                stat.st_ino,
+                stat.st_size,
+                stat.st_mtime_ns,
+            ))
+    except OSError:
+        return None
+    payload = json.dumps(
+        {
+            "genome": definition,
+            "files": files,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _protein_source_snapshot(genome):
+    """Return distinct protein sequences with every Ensembl source."""
+    cache_key = _ensembl_dataset_cache_key(genome)
+    if cache_key is not None:
+        with _protein_source_snapshot_cache_lock:
+            cached = _protein_source_snapshot_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+    sources_by_sequence: dict[str, set[SelfReferenceSource]] = {}
+    for transcript in genome.transcripts():
+        if not transcript.is_protein_coding or not transcript.protein_sequence:
+            continue
+        gene_id = str(getattr(transcript, "gene_id", "") or "").split(".")[0]
+        if not gene_id:
+            raise ValueError(
+                "Protein-coding self-reference transcript is missing a gene ID"
+            )
+        source = SelfReferenceSource(
+            gene_id=gene_id,
+            transcript_id=str(
+                getattr(transcript, "transcript_id", "") or ""
+            ),
+            protein_id=str(getattr(transcript, "protein_id", "") or ""),
+            gene_name=str(getattr(transcript, "gene_name", "") or ""),
+        )
+        sources_by_sequence.setdefault(
+            transcript.protein_sequence, set()
+        ).add(source)
+
+    snapshot = tuple(
+        (
+            sequence,
+            tuple(sorted(
+                sources,
+                key=lambda source: (
+                    source.gene_id,
+                    source.transcript_id,
+                    source.protein_id,
+                    source.gene_name,
+                ),
+            )),
+        )
+        for sequence, sources in sorted(sources_by_sequence.items())
+    )
+    if cache_key is not None:
+        with _protein_source_snapshot_cache_lock:
+            _protein_source_snapshot_cache[cache_key] = snapshot
+    return snapshot
 
 
 def get_cache_dir() -> str:
@@ -320,6 +433,70 @@ def genome_protein_dict(genome, exclude_gene_ids=None):
             len(excluded_gene_ids),
         )
     return proteins
+
+
+def self_reference_matches(
+        peptides: Iterable[str],
+        antigen: VaccineAntigen,
+        genome) -> dict[str, SelfReferenceMatch]:
+    """Find every retained Ensembl source of each exact peptide.
+
+    The genome is traversed once for the batch. Source-gene exclusions come
+    exclusively from ``antigen.self_reference_excluded_gene_ids``; excluding a
+    CTA source therefore cannot erase a match encoded by a retained non-CTA
+    gene. With no genome, results remain explicitly provenance-incomplete.
+    """
+    unique_peptides = tuple(dict.fromkeys(peptides))
+    if not unique_peptides:
+        return {}
+    genome_release = str(getattr(genome, "release", "") or "")
+    if genome is None:
+        return {
+            peptide: antigen.self_reference_match(
+                peptide, False, genome_release=genome_release)
+            for peptide in unique_peptides
+        }
+
+    excluded_gene_ids = set(antigen.self_reference_excluded_gene_ids)
+    sources_by_peptide: dict[str, set[SelfReferenceSource]] = {
+        peptide: set() for peptide in unique_peptides
+    }
+    for sequence, sequence_sources in _protein_source_snapshot(genome):
+        retained_sources = tuple(
+            source for source in sequence_sources
+            if source.gene_id not in excluded_gene_ids
+        )
+        if not retained_sources:
+            continue
+        matching_peptides = [
+            peptide for peptide in unique_peptides if peptide in sequence
+        ]
+        if not matching_peptides:
+            continue
+        for peptide in matching_peptides:
+            sources_by_peptide[peptide].update(retained_sources)
+
+    result = {}
+    for peptide, sources in sources_by_peptide.items():
+        ordered_sources = tuple(sorted(
+            sources,
+            key=lambda source: (
+                source.gene_id,
+                source.transcript_id,
+                source.protein_id,
+                source.gene_name,
+            ),
+        ))
+        result[peptide] = SelfReferenceMatch(
+            peptide=peptide,
+            occurs=bool(ordered_sources),
+            antigen_kind=antigen.kind,
+            excluded_gene_ids=antigen.self_reference_excluded_gene_ids,
+            sources=ordered_sources,
+            source_provenance_complete=True,
+            genome_release=genome_release,
+        )
+    return result
 
 
 class ReferenceProteome:

--- a/vaxrank/vaccine_antigen.py
+++ b/vaxrank/vaccine_antigen.py
@@ -192,6 +192,7 @@ class SelfReferenceSource(DataclassSerializable):
     transcript_id: str = ""
     protein_id: str = ""
     gene_name: str = ""
+    species: str = ""
 
     def __post_init__(self):
         if not self.gene_id:

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.17"
+__version__ = "3.1.18"
 
 
 def print_version():


### PR DESCRIPTION
Advances #303 by replacing membership-only antigen self flags with provenance-complete exact-self results.

- adds a public batch `self_reference_matches` API over `VaccineAntigen` policy and a concrete Ensembl genome
- preserves every retained matching gene, transcript, protein, gene name, and species in deterministic order
- applies source-gene exclusions after grouping identical protein sequences, so CTA exclusion cannot erase a shared non-CTA source
- marks no-genome results explicitly provenance-incomplete instead of claiming complete negative evidence
- integrates complete `SelfReferenceMatch` records into `predict_epitopes`
- serializes source-complete matches through the existing immutable result types
- caches one protein/source snapshot per installed pyensembl dataset using its public serialized genome definition plus resolved local source-file identity; custom genomes remain uncached rather than relying on object identity

Obvious-risk regressions cover PRAME-only exclusion, peptide sharing across two retained non-CTA genes, complete negative evidence, exact Ensembl protein provenance in mutation prediction, species retention, JSON round-trip, snapshot reuse, and cache invalidation when the resolved source file changes.

Version: 3.1.18

Local verification:
- `./lint.sh`
- `./test.sh` (948 passed)
- focused provenance/cache/serialization/species tests (passed)