### PR TITLE
Support antigen-backed vaccine peptides

### DIFF
--- a/tests/test_core_logic_config.py
+++ b/tests/test_core_logic_config.py
@@ -469,6 +469,9 @@ def test_vaccine_peptide_zero_epitope_limit_keeps_all():
     """A value of 0 means no truncation of mutant epitope list."""
     fragment = MagicMock()
     fragment.amino_acids = "ACDEFGHIK"
+    fragment.mutant_amino_acid_start_offset = 4
+    fragment.mutant_amino_acid_end_offset = 5
+    fragment.supporting_reference_transcripts = []
 
     epitope1 = _make_epitope("ACDEFGHIK", ic50=100.0, wt_ic50=200.0,
                              percentile_rank=0.5)

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -96,6 +96,8 @@ class _FakeFragment:
 
     def __init__(self, amino_acids="A" * 25, n_alt_reads=9):
         self.amino_acids = amino_acids
+        self.mutant_amino_acid_start_offset = 12
+        self.mutant_amino_acid_end_offset = 13
         self.n_alt_reads = n_alt_reads
         self.n_alt_reads_supporting_protein_sequence = n_alt_reads
         self.n_mutant_amino_acids = 1

--- a/tests/test_vaccine_antigen.py
+++ b/tests/test_vaccine_antigen.py
@@ -156,13 +156,13 @@ def test_self_reference_match_rejects_excluded_or_inconsistent_sources():
 
 def test_vaccine_peptide_uses_targetable_mask_and_antigen_self_result():
     antigen = cta_antigen()
-    fragment = SimpleNamespace(amino_acids=antigen.amino_acids)
     target = CandidateEpitope(
         sequence="ACDEFGHI",
         source_sequence=antigen.amino_acids,
         overlaps_targetable=True,
         occurs_in_reference=True,
         self_reference_match=antigen.self_reference_match("ACDEFGHI", False),
+        per_allele_scores={"HLA-A*02:01": 2.0},
     )
     non_target = CandidateEpitope(
         sequence="CDEFGHIK",
@@ -182,14 +182,26 @@ def test_vaccine_peptide_uses_targetable_mask_and_antigen_self_result():
     )
 
     vaccine_peptide = VaccinePeptide(
-        mutant_protein_fragment=fragment,
         antigen=antigen,
         epitopes=[target, non_target, exact_self],
+        combined_score_expr="target_epitope_score",
+        ranking_rules=(
+            "target_epitope_score",
+            "manufacturability",
+            "self_epitope_score",
+        ),
     )
 
+    assert vaccine_peptide.mutant_protein_fragment is None
+    assert vaccine_peptide.amino_acids == antigen.amino_acids
     assert vaccine_peptide.target_epitopes == [target]
     assert vaccine_peptide.non_target_epitopes == [non_target]
     assert vaccine_peptide.self_epitopes == [exact_self]
+    assert vaccine_peptide.combined_score == 2.0
+    restored = VaccinePeptide.from_json(vaccine_peptide.to_json())
+    assert restored.antigen == antigen
+    assert restored.mutant_protein_fragment is None
+    assert restored.amino_acids == antigen.amino_acids
 
 
 def test_vaccine_peptide_fails_closed_for_held_out_or_mismatched_policy():
@@ -203,9 +215,8 @@ def test_vaccine_peptide_fails_closed_for_held_out_or_mismatched_policy():
             evidence_source="test fixture",
         ),
     )
-    fragment = SimpleNamespace(amino_acids=held_out.amino_acids)
     with pytest.raises(ValueError, match="held-out antigen"):
-        VaccinePeptide(mutant_protein_fragment=fragment, antigen=held_out)
+        VaccinePeptide(antigen=held_out)
 
     antigen = cta_antigen()
     wrong_policy = SelfReferenceMatch(
@@ -220,11 +231,34 @@ def test_vaccine_peptide_fails_closed_for_held_out_or_mismatched_policy():
     )
     with pytest.raises(ValueError, match="does not match antigen kind"):
         VaccinePeptide(
+            antigen=antigen,
+            epitopes=[epitope],
+        )
+
+
+def test_antigen_backed_vaccine_peptide_rejects_mutation_only_scoring():
+    antigen = cta_antigen()
+
+    with pytest.raises(ValueError, match="combined_score_expr uses"):
+        VaccinePeptide(antigen=antigen)
+    with pytest.raises(ValueError, match="combined_score_expr uses"):
+        VaccinePeptide(
+            antigen=antigen,
+            combined_score_expr="n_alt_reads + target_epitope_score",
+            ranking_rules=("target_epitope_score",),
+        )
+    with pytest.raises(ValueError, match="ranking_rules use"):
+        VaccinePeptide(
+            antigen=antigen,
+            combined_score_expr="target_epitope_score",
+            ranking_rules=("target_epitope_score", "n_alt_reads"),
+        )
+    with pytest.raises(ValueError, match="must not carry a mutation fragment"):
+        VaccinePeptide(
             mutant_protein_fragment=SimpleNamespace(
                 amino_acids=antigen.amino_acids
             ),
             antigen=antigen,
-            epitopes=[epitope],
         )
 
 

--- a/vaxrank/combined_score_dsl.py
+++ b/vaxrank/combined_score_dsl.py
@@ -24,11 +24,16 @@ Mirrors the per-epitope DSL in :mod:`vaxrank.epitope_dsl` but at the
 Bindings (read-only scalars from the active VaccinePeptide):
 
   ``target_epitope_score``
-      Sum of per-epitope scores across the VP's mutant ligands
+      Sum of per-epitope scores across the VP's target ligands
       (after EpitopeConfig filtering / scoring).
 
   ``self_epitope_score``
-      Same metric for the WT-aligned ligands (when present).
+      Same metric for exact-self ligands (when present).
+
+The two bindings above are source-agnostic. The remaining bindings are
+mutation-specific and exist only when the VaccinePeptide carries a real
+``MutantProteinFragment``. Antigen-backed candidates fail at construction if
+their expression references one of these unavailable mutation fields.
 
   ``expression_score``
       ``sqrt(n_alt_reads)`` — the canonical "expression strength"
@@ -98,6 +103,10 @@ _HEADLINE_BINDINGS = (
     'self_epitope_score',
     'expression_score',
 )
+_REQUIRED_HEADLINE_BINDINGS = (
+    'target_epitope_score',
+    'self_epitope_score',
+)
 
 
 # Functions exposed to the expression namespace. All real-valued and
@@ -112,6 +121,11 @@ _FUNCTIONS = {
     'abs': abs,
     'pow': pow,
 }
+
+SOURCE_AGNOSTIC_BINDINGS = frozenset({
+    "target_epitope_score",
+    "self_epitope_score",
+})
 
 # AST node types the parser permits. Every other node type raises at
 # parse time so the user gets the rejection at config-load, not at
@@ -181,6 +195,19 @@ def parse_combined_score_expr(expr):
     return tree
 
 
+def combined_score_binding_names(expr_or_tree):
+    """Return data-binding identifiers referenced by a score expression."""
+    tree = (
+        parse_combined_score_expr(expr_or_tree)
+        if isinstance(expr_or_tree, str)
+        else expr_or_tree
+    )
+    return frozenset(
+        node.id for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and node.id not in _FUNCTIONS
+    )
+
+
 def _bindings_from_vaccine_peptide(vp):
     """Read-only namespace of the scalars exposed to the DSL.
 
@@ -189,11 +216,15 @@ def _bindings_from_vaccine_peptide(vp):
     (``n_alt_reads``) without needing to know which struct holds
     each value.
     """
-    frag = vp.mutant_protein_fragment
-    return {
+    bindings = {
         'target_epitope_score': float(vp.target_epitope_score),
         'self_epitope_score': float(getattr(
             vp, 'self_epitope_score', 0.0) or 0.0),
+    }
+    frag = vp.mutant_protein_fragment
+    if frag is None:
+        return bindings
+    bindings.update({
         'expression_score': float(vp.expression_score),
         'n_alt_reads': float(frag.n_alt_reads or 0),
         'n_ref_reads': float(frag.n_ref_reads or 0),
@@ -203,7 +234,8 @@ def _bindings_from_vaccine_peptide(vp):
         'n_mutant_amino_acids': float(
             frag.mutant_amino_acid_end_offset
             - frag.mutant_amino_acid_start_offset),
-    }
+    })
+    return bindings
 
 
 def evaluate_combined_score(expr_or_tree, vaccine_peptide):
@@ -243,7 +275,7 @@ def evaluate_combined_score(expr_or_tree, vaccine_peptide):
         ))
     except Exception as e:
         # Opinionated preview: surface the per-VP *score* axes
-        # (mutant / wildtype / expression) since those are what
+        # (target / self / mutation expression when available) since those are what
         # users actually look at when a score expression goes
         # sideways. Read counts and mutant-AA count live in the
         # DEBUG dump; per-VP exceptions can fan out across the
@@ -252,10 +284,10 @@ def evaluate_combined_score(expr_or_tree, vaccine_peptide):
         preview = {
             k: bindings[k] for k in _HEADLINE_BINDINGS if k in bindings
         }
-        missing = [k for k in _HEADLINE_BINDINGS if k not in bindings]
+        missing = [k for k in _REQUIRED_HEADLINE_BINDINGS if k not in bindings]
         if missing:
             # Soft contract: ``_bindings_from_vaccine_peptide`` is
-            # supposed to populate every headline binding. If a
+            # supposed to populate every source-agnostic headline binding. If a
             # future refactor renames or drops one, the preview will
             # silently shrink — surface that through a warning so
             # the maintainer notices instead of users wondering why

--- a/vaxrank/ranking.py
+++ b/vaxrank/ranking.py
@@ -92,6 +92,13 @@ DEFAULT_RANKING_RULES = (
     "mutation_distance_from_edge",
 )
 
+MUTATION_SPECIFIC_RANKING_RULES = frozenset({
+    "n_alt_reads",
+    "n_alt_reads_supporting",
+    "n_mutant_amino_acids",
+    "mutation_distance_from_edge",
+})
+
 
 def compute_ranking_tuple(peptide, rules=None):
     """Apply the ordered rule list against a ``VaccinePeptide`` and return

--- a/vaxrank/vaccine_peptide.py
+++ b/vaxrank/vaccine_peptide.py
@@ -17,6 +17,8 @@ import numpy as np
 from serializable import DataclassSerializable
 
 from .combined_score_dsl import (
+    SOURCE_AGNOSTIC_BINDINGS,
+    combined_score_binding_names,
     evaluate_combined_score,
     parse_combined_score_expr,
 )
@@ -24,9 +26,13 @@ from .manufacturability import (
     ManufacturabilityScores,
     compute_manufacturability_tuple,
 )
-from .ranking import compute_ranking_tuple
+from .ranking import (
+    DEFAULT_RANKING_RULES,
+    MUTATION_SPECIFIC_RANKING_RULES,
+    compute_ranking_tuple,
+)
 from .vaccine_config import DEFAULT_COMBINED_SCORE_EXPR
-from .vaccine_antigen import VaccineAntigen
+from .vaccine_antigen import ANTIGEN_KIND_MUTATION, VaccineAntigen
 
 
 @dataclass
@@ -40,7 +46,8 @@ class VaccinePeptide(DataclassSerializable):
 
     Parameters
     ----------
-    mutant_protein_fragment : MutantProteinFragment
+    mutant_protein_fragment : MutantProteinFragment, optional
+        Required for mutation antigens and omitted for other antigen kinds.
 
     epitopes : list of CandidateEpitope
 
@@ -90,7 +97,7 @@ class VaccinePeptide(DataclassSerializable):
         (byte-identical with prior releases).
     """
 
-    mutant_protein_fragment: Any
+    mutant_protein_fragment: Any = None
     epitopes: list = field(default_factory=list)
     num_target_epitopes_to_keep: Optional[int] = None
     sort_epitopes_by: str = "ic50"
@@ -127,24 +134,35 @@ class VaccinePeptide(DataclassSerializable):
         )
         if self.antigen is None and fragment_has_targetable_interval:
             self.antigen = VaccineAntigen.from_mutant_protein_fragment(fragment)
-        if self.antigen is not None:
-            if not self.antigen.tumor_specificity.admits_construct:
+        if self.antigen is None:
+            raise ValueError(
+                "VaccinePeptide requires a VaccineAntigen or mutation fragment"
+            )
+        if not self.antigen.tumor_specificity.admits_construct:
+            raise ValueError(
+                "A held-out antigen cannot be used to construct a VaccinePeptide"
+            )
+        if self.antigen.kind == ANTIGEN_KIND_MUTATION and fragment is None:
+            raise ValueError(
+                "A mutation VaccinePeptide requires its MutantProteinFragment"
+            )
+        if self.antigen.kind != ANTIGEN_KIND_MUTATION and fragment is not None:
+            raise ValueError(
+                "A non-mutation VaccinePeptide must not carry a mutation fragment"
+            )
+        if (
+            fragment is not None
+            and fragment.amino_acids != self.antigen.amino_acids
+        ):
+            raise ValueError(
+                "VaccineAntigen and fragment amino-acid sequences differ"
+            )
+        for epitope in self.epitopes:
+            match = epitope.self_reference_match
+            if match is not None and match.antigen_kind != self.antigen.kind:
                 raise ValueError(
-                    "A held-out antigen cannot be used to construct a VaccinePeptide"
+                    "Epitope self-reference policy does not match antigen kind"
                 )
-            if (
-                hasattr(fragment, "amino_acids")
-                and fragment.amino_acids != self.antigen.amino_acids
-            ):
-                raise ValueError(
-                    "VaccineAntigen and fragment amino-acid sequences differ"
-                )
-            for epitope in self.epitopes:
-                match = epitope.self_reference_match
-                if match is not None and match.antigen_kind != self.antigen.kind:
-                    raise ValueError(
-                        "Epitope self-reference policy does not match antigen kind"
-                    )
 
         # Normalize the optional collection/tuple fields.
         self.manufacturability_thresholds = self.manufacturability_thresholds or {}
@@ -162,6 +180,31 @@ class VaccinePeptide(DataclassSerializable):
             self.combined_score_expr = DEFAULT_COMBINED_SCORE_EXPR
         self._combined_score_expr_ast = parse_combined_score_expr(
             self.combined_score_expr)
+        if fragment is None:
+            unavailable_bindings = (
+                combined_score_binding_names(self._combined_score_expr_ast)
+                - SOURCE_AGNOSTIC_BINDINGS
+            )
+            if unavailable_bindings:
+                raise ValueError(
+                    "Antigen-backed VaccinePeptide combined_score_expr uses "
+                    "mutation-only or unknown binding(s): %s"
+                    % ", ".join(sorted(unavailable_bindings))
+                )
+            resolved_ranking_rules = (
+                DEFAULT_RANKING_RULES
+                if self.ranking_rules is None
+                else self.ranking_rules
+            )
+            mutation_rules = (
+                set(resolved_ranking_rules) & MUTATION_SPECIFIC_RANKING_RULES
+            )
+            if mutation_rules:
+                raise ValueError(
+                    "Antigen-backed VaccinePeptide ranking_rules use "
+                    "mutation-only rule(s): %s"
+                    % ", ".join(sorted(mutation_rules))
+                )
 
         # Sort key over CandidateEpitope: pick the strongest pMHC_affinity
         # record across all predictors / alleles inside the CandidateEpitope.
@@ -241,8 +284,13 @@ class VaccinePeptide(DataclassSerializable):
             e.epitope_score for e in self.target_epitopes)
 
         self.manufacturability_scores = ManufacturabilityScores.from_amino_acids(
-            self.mutant_protein_fragment.amino_acids
+            self.amino_acids
         )
+
+    @property
+    def amino_acids(self):
+        """Amino-acid sequence of this vaccine candidate."""
+        return self.antigen.amino_acids
 
     def peptide_synthesis_difficulty_score_tuple(
             self,
@@ -304,6 +352,10 @@ class VaccinePeptide(DataclassSerializable):
         # the default combined-score expression uses; if the user
         # writes a different ``combined_score_expr`` that doesn't
         # reference it, this property is still queryable for reports.
+        if self.mutant_protein_fragment is None:
+            raise ValueError(
+                "Mutation RNA expression_score is unavailable for this antigen"
+            )
         return np.sqrt(self.mutant_protein_fragment.n_alt_reads)
 
     @property
@@ -327,11 +379,12 @@ class VaccinePeptide(DataclassSerializable):
         ]
         epitopes = self.target_epitopes + self.self_epitopes + non_target_only
         d = {
-            "mutant_protein_fragment": self.mutant_protein_fragment,
             "epitopes": epitopes,
             "num_target_epitopes_to_keep": self.num_target_epitopes_to_keep,
             "sort_epitopes_by": self.sort_epitopes_by,
         }
+        if self.mutant_protein_fragment is not None:
+            d["mutant_protein_fragment"] = self.mutant_protein_fragment
         if self.antigen is not None:
             d["antigen"] = self.antigen
         if self.manufacturability_thresholds:

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.18"
+__version__ = "3.1.19"
 
 
 def print_version():


### PR DESCRIPTION
Advances #303.

This makes VaccinePeptide source-agnostic without manufacturing fake MutantProteinFragment objects:

- derives the candidate sequence and manufacturability from VaccineAntigen
- keeps mutation fragments mandatory only for mutation antigens
- exposes target/self score bindings to all antigen kinds
- rejects mutation-only score bindings and ranking rules for non-mutation antigens
- rejects held-out antigens, policy mismatches, and fake mutation wrappers
- preserves legacy mutation construction and serialization

Version: 3.1.19

Validation:
- ./lint.sh
- ./test.sh: 949 passed