### PR TITLE
Assemble constructs from source-agnostic vaccine antigens

### DIFF
--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -31,6 +31,7 @@ from vaxrank.coverage import (
     summarize_construction_decisions,
 )
 from vaxrank.candidate_epitope import CandidateEpitope, Peptide
+from vaxrank.vaccine_peptide import VaccinePeptide
 
 
 def _ep(peptide, allele, *, presentation_pct=None, affinity_pct=None,
@@ -56,14 +57,25 @@ def _ep(peptide, allele, *, presentation_pct=None, affinity_pct=None,
         overlaps_mutation=True, occurs_in_reference=False)
 
 
-def _vp(epitopes, *, combined_score=1.0, gene_name='GENE'):
-    """Minimal VaccinePeptide-like record (CandidateEpitope shape)."""
-    return SimpleNamespace(
-        target_epitopes=epitopes,
-        mutant_protein_fragment=SimpleNamespace(
-            gene_name=gene_name, amino_acids='AAAAAAA'),
-        combined_score=combined_score,
-        manufacturability_scores=None)
+def vaccine_peptide_with_score(
+        epitopes, *, combined_score=1.0, gene_name='GENE'):
+    """Build a real mutation peptide with deterministic scoring."""
+    fragment = SimpleNamespace(
+        gene_name=gene_name,
+        amino_acids='AAAAAAAAA',
+        mutant_amino_acid_start_offset=0,
+        mutant_amino_acid_end_offset=9,
+        n_alt_reads=1,
+        n_ref_reads=0,
+        n_overlapping_reads=1,
+        n_alt_reads_supporting_protein_sequence=1,
+        supporting_reference_transcripts=(),
+    )
+    return VaccinePeptide(
+        mutant_protein_fragment=fragment,
+        epitopes=epitopes,
+        combined_score_expr=str(combined_score),
+    )
 
 
 # -- compute_coverage --------------------------------------------------
@@ -150,7 +162,7 @@ def test_antigen_tier_per_allele_takes_best_peptide():
     """One antigen has many sliding-window peptides; the antigen's
     tier for an allele is the *best* tier any of its peptides
     achieves."""
-    vp = _vp([
+    vp = vaccine_peptide_with_score([
         _ep('AAAAAAAA', 'HLA-A*02:01', presentation_pct=1.8),  # low
         _ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3),  # strong
         _ep('DDDDDDDD', 'HLA-A*02:01', presentation_pct=0.9),  # medium
@@ -166,10 +178,10 @@ def test_selector_prefers_coverage_over_score():
     """When the top-scoring antigen covers no targets and a
     lower-scoring one covers a strong-tier target, the selector
     picks the lower-scoring one first."""
-    high_score_uncovered = _vp(
+    high_score_uncovered = vaccine_peptide_with_score(
         [_ep('AAAAAAAA', 'HLA-A*02:01', presentation_pct=3.0)],
         combined_score=10.0, gene_name='HIGH')
-    low_score_strong = _vp(
+    low_score_strong = vaccine_peptide_with_score(
         [_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3)],
         combined_score=1.0, gene_name='LOW')
     candidates = [
@@ -187,13 +199,13 @@ def test_selector_falls_back_to_score_when_coverage_satisfied():
     """Once every target allele is covered at strong tier, the
     selector reverts to pure score order — so an already-covered
     pool gives the same selection as today's behavior."""
-    a = _vp(
+    a = vaccine_peptide_with_score(
         [_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3)],
         combined_score=10.0, gene_name='A')
-    b = _vp(
+    b = vaccine_peptide_with_score(
         [_ep('AAAAAAAA', 'HLA-A*02:01', presentation_pct=0.4)],
         combined_score=8.0, gene_name='B')
-    c = _vp(
+    c = vaccine_peptide_with_score(
         [_ep('DDDDDDDD', 'HLA-A*02:01', presentation_pct=0.5)],
         combined_score=12.0, gene_name='C')
     candidates = [('vA', [a]), ('vB', [b]), ('vC', [c])]
@@ -211,9 +223,11 @@ def test_selector_falls_back_to_score_when_coverage_satisfied():
 
 def test_selector_no_op_with_empty_targets():
     """Empty target_alleles → return ranked[:n] unchanged."""
-    a = _vp([_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3)],
+    a = vaccine_peptide_with_score([
+        _ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3)],
             combined_score=10.0)
-    b = _vp([_ep('AAAAAAAA', 'HLA-B*07:02', presentation_pct=0.4)],
+    b = vaccine_peptide_with_score([
+        _ep('AAAAAAAA', 'HLA-B*07:02', presentation_pct=0.4)],
             combined_score=8.0)
     candidates = [('vA', [a]), ('vB', [b])]
     selected = select_antigens_for_coverage(
@@ -225,13 +239,13 @@ def test_selector_spreads_across_multiple_alleles():
     """With three target alleles and three antigens each covering a
     different one, the selector picks all three (one per allele)
     rather than three of the same allele."""
-    a02 = _vp(
+    a02 = vaccine_peptide_with_score(
         [_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.2)],
         combined_score=5.0, gene_name='A02')
-    b07 = _vp(
+    b07 = vaccine_peptide_with_score(
         [_ep('AAAAAAAA', 'HLA-B*07:02', presentation_pct=0.2)],
         combined_score=5.0, gene_name='B07')
-    c03 = _vp(
+    c03 = vaccine_peptide_with_score(
         [_ep('CCCCCCCC', 'HLA-C*03:04', presentation_pct=0.2)],
         combined_score=5.0, gene_name='C03')
     candidates = [('vA', [a02]), ('vB', [b07]), ('vC', [c03])]
@@ -248,10 +262,10 @@ def test_selector_spreads_across_multiple_alleles():
 def test_summarize_includes_coverage_for_selected_pool():
     """The summary's ``coverage`` field is computed over the
     *selected* antigens, not the full ranked input."""
-    selected_a = _vp(
+    selected_a = vaccine_peptide_with_score(
         [_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3)],
         combined_score=10.0, gene_name='SELECTED')
-    dropped_b = _vp(
+    dropped_b = vaccine_peptide_with_score(
         [_ep('DDDDDDDD', 'HLA-B*07:02', presentation_pct=0.3)],
         combined_score=1.0, gene_name='DROPPED')
     ranked = [
@@ -338,7 +352,7 @@ def test_summarize_per_row_has_allele_tiers_and_manufacturability():
     tier map (drives the ``covers A*02:01 (strong)`` annotation)
     plus the manufacturability dict (peptide construction view
     renders it)."""
-    vp = _vp(
+    vp = vaccine_peptide_with_score(
         [_ep('SIINFEKL', 'HLA-A*02:01', presentation_pct=0.3)],
         combined_score=5.0, gene_name='GENEX')
     # Stub the manufacturability_scores like ManufacturabilityScores

--- a/tests/test_design_matrix.py
+++ b/tests/test_design_matrix.py
@@ -46,9 +46,10 @@ from varcode import Variant
 from vaxrank.mrna import RNAConstructConfig, assemble_mrna_constructs
 from vaxrank.peptide import PeptideConstructConfig, assemble_peptide_constructs
 from vaxrank.candidate_epitope import CandidateEpitope, Peptide
+from vaxrank.vaccine_peptide import VaccinePeptide
 
 
-def _make_vaccine_peptide(
+def make_mutation_vaccine_peptide(
         amino_acids, gene_name, mut_start, mut_end, n_alt_reads,
         epitope_seqs_with_ic50):
     """Build a stub VaccinePeptide-shaped object that the assemblers
@@ -63,6 +64,7 @@ def _make_vaccine_peptide(
         mutant_amino_acid_start_offset=mut_start,
         mutant_amino_acid_end_offset=mut_end,
         n_alt_reads=n_alt_reads,
+        supporting_reference_transcripts=(),
     )
     epitopes = [
         CandidateEpitope.from_peptide(
@@ -78,17 +80,16 @@ def _make_vaccine_peptide(
             overlaps_mutation=True, occurs_in_reference=False)
         for seq, ic50 in epitope_seqs_with_ic50
     ]
-    return SimpleNamespace(
+    return VaccinePeptide(
         mutant_protein_fragment=fragment,
-        target_epitopes=epitopes,
-        self_epitopes=[],
+        epitopes=epitopes,
     )
 
 
 def _ranked_three_variants():
     """Three variants × multiple ligand candidates each, suitable for
     every cell of the design matrix."""
-    a1 = _make_vaccine_peptide(
+    a1 = make_mutation_vaccine_peptide(
         "AAKLQGHSAPVLDVIVNCD", gene_name="GENEA",
         mut_start=2, mut_end=12, n_alt_reads=10,
         epitope_seqs_with_ic50=[
@@ -96,14 +97,14 @@ def _ranked_three_variants():
             ("LQGHSAPVL", 80.0),    # second
             ("QGHSAPVLD", 220.0),   # third
         ])
-    a2 = _make_vaccine_peptide(
+    a2 = make_mutation_vaccine_peptide(
         "MNNVDEILGRWESPVKLPK", gene_name="GENEB",
         mut_start=2, mut_end=12, n_alt_reads=8,
         epitope_seqs_with_ic50=[
             ("NVDEILGRW", 45.0),
             ("VDEILGRWE", 110.0),
         ])
-    a3 = _make_vaccine_peptide(
+    a3 = make_mutation_vaccine_peptide(
         "AAVVVGADGVGKSALTIIQ", gene_name="GENEC",
         mut_start=4, mut_end=14, n_alt_reads=6,
         epitope_seqs_with_ic50=[

--- a/tests/test_junction_swap.py
+++ b/tests/test_junction_swap.py
@@ -19,6 +19,7 @@ from vaxrank.junction_swap import (
     junction_kmers,
     optimize_linkers,
 )
+from vaxrank.vaccine_peptide import VaccinePeptide
 
 
 class StubPredictor:
@@ -203,10 +204,8 @@ def test_assemble_with_optimizer_uses_chosen_linkers():
     fragment_b = SimpleNamespace(
         amino_acids=a2, gene_name='GENEB',
         mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=len(a2))
-    pep_a = SimpleNamespace(
-        mutant_protein_fragment=fragment_a, target_epitopes=[])
-    pep_b = SimpleNamespace(
-        mutant_protein_fragment=fragment_b, target_epitopes=[])
+    pep_a = VaccinePeptide(mutant_protein_fragment=fragment_a)
+    pep_b = VaccinePeptide(mutant_protein_fragment=fragment_b)
     pairs = [
         (Variant('1', 100, 'A', 'T'), [pep_a]),
         (Variant('2', 200, 'A', 'T'), [pep_b]),
@@ -252,10 +251,8 @@ def test_assemble_with_optimizer_falls_back_when_predictor_missing(caplog):
     fragment_b = SimpleNamespace(
         amino_acids="MNNVD", gene_name='G',
         mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=5)
-    pep_a = SimpleNamespace(
-        mutant_protein_fragment=fragment_a, target_epitopes=[])
-    pep_b = SimpleNamespace(
-        mutant_protein_fragment=fragment_b, target_epitopes=[])
+    pep_a = VaccinePeptide(mutant_protein_fragment=fragment_a)
+    pep_b = VaccinePeptide(mutant_protein_fragment=fragment_b)
     pairs = [
         (Variant('1', 100, 'A', 'T'), [pep_a]),
         (Variant('2', 200, 'A', 'T'), [pep_b]),
@@ -293,10 +290,8 @@ def test_assemble_default_kept_when_candidates_dont_help():
     fragment_b = SimpleNamespace(
         amino_acids="MNNVD", gene_name='G',
         mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=5)
-    pep_a = SimpleNamespace(
-        mutant_protein_fragment=fragment_a, target_epitopes=[])
-    pep_b = SimpleNamespace(
-        mutant_protein_fragment=fragment_b, target_epitopes=[])
+    pep_a = VaccinePeptide(mutant_protein_fragment=fragment_a)
+    pep_b = VaccinePeptide(mutant_protein_fragment=fragment_b)
     pairs = [
         (Variant('1', 100, 'A', 'T'), [pep_a]),
         (Variant('2', 200, 'A', 'T'), [pep_b]),
@@ -427,10 +422,8 @@ def test_assemble_manifest_chosen_uses_canonical_linker_names():
     fragment_b = SimpleNamespace(
         amino_acids="MNNVD", gene_name='G',
         mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=5)
-    pep_a = SimpleNamespace(
-        mutant_protein_fragment=fragment_a, target_epitopes=[])
-    pep_b = SimpleNamespace(
-        mutant_protein_fragment=fragment_b, target_epitopes=[])
+    pep_a = VaccinePeptide(mutant_protein_fragment=fragment_a)
+    pep_b = VaccinePeptide(mutant_protein_fragment=fragment_b)
     pairs = [
         (Variant('1', 100, 'A', 'T'), [pep_a]),
         (Variant('2', 200, 'A', 'T'), [pep_b]),
@@ -466,21 +459,23 @@ def test_assemble_manifest_chosen_uses_canonical_linker_names():
     a2 = "DVIVNCDESLLAS"
     g4s2_kmers = junction_kmers(a1, "GGGGSGGGGS", a2, k_lengths=(9,))
     rank_table = {(g4s2_kmers[0], "HLA-A*02:01"): 0.05}
+    fragment_a = SimpleNamespace(
+        amino_acids=a1,
+        gene_name='G',
+        mutant_amino_acid_start_offset=0,
+        mutant_amino_acid_end_offset=len(a1),
+    )
+    fragment_b = SimpleNamespace(
+        amino_acids=a2,
+        gene_name='G',
+        mutant_amino_acid_start_offset=0,
+        mutant_amino_acid_end_offset=len(a2),
+    )
     pairs2 = [
         (Variant('1', 100, 'A', 'T'),
-         [SimpleNamespace(
-             mutant_protein_fragment=SimpleNamespace(
-                 amino_acids=a1, gene_name='G',
-                 mutant_amino_acid_start_offset=0,
-                 mutant_amino_acid_end_offset=len(a1)),
-             target_epitopes=[])]),
+         [VaccinePeptide(mutant_protein_fragment=fragment_a)]),
         (Variant('2', 200, 'A', 'T'),
-         [SimpleNamespace(
-             mutant_protein_fragment=SimpleNamespace(
-                 amino_acids=a2, gene_name='G',
-                 mutant_amino_acid_start_offset=0,
-                 mutant_amino_acid_end_offset=len(a2)),
-             target_epitopes=[])]),
+         [VaccinePeptide(mutant_protein_fragment=fragment_b)]),
     ]
     options2 = RNAConstructConfig(
         signal_peptide=None, include_mitd=False,
@@ -553,8 +548,7 @@ def test_packing_uses_longest_candidate_for_size_cap():
             amino_acids="KLQGHSAPVL", gene_name='G%d' % k,
             mutant_amino_acid_start_offset=0,
             mutant_amino_acid_end_offset=10)
-        pep = SimpleNamespace(
-            mutant_protein_fragment=frag, target_epitopes=[])
+        pep = VaccinePeptide(mutant_protein_fragment=frag)
         pairs.append((Variant(str(k + 1), 100 + k, 'A', 'T'), [pep]))
 
     # Budget: HBB UTRs (~50 + 132 nt) + start codon 3 nt + 3 antigens

--- a/tests/test_mrna.py
+++ b/tests/test_mrna.py
@@ -34,6 +34,7 @@ from vaxrank.mrna_library import (
     UTR_5P_HBB,
 )
 from vaxrank.vaccine_library import get_linker
+from vaxrank.vaccine_peptide import VaccinePeptide
 
 # (G4S)3 was a static entry in 2.12.x; in 2.13+ it is parsed from the
 # compositional grammar. Resolve via get_linker so the test references
@@ -77,25 +78,50 @@ def _translate(dna):
     return ''.join(table.get(dna[i:i + 3], 'X') for i in range(0, len(dna) - 2, 3))
 
 
-def _peptide_stub(amino_acids, gene_name='GENE'):
-    fragment = SimpleNamespace(amino_acids=amino_acids, gene_name=gene_name)
-    return SimpleNamespace(mutant_protein_fragment=fragment)
+def mutation_vaccine_peptide(amino_acids, gene_name='GENE'):
+    fragment = SimpleNamespace(
+        amino_acids=amino_acids,
+        gene_name=gene_name,
+        mutant_amino_acid_start_offset=0,
+        mutant_amino_acid_end_offset=len(amino_acids),
+        n_alt_reads=1,
+        n_ref_reads=0,
+        n_overlapping_reads=1,
+        n_alt_reads_supporting_protein_sequence=1,
+        supporting_reference_transcripts=(),
+    )
+    return VaccinePeptide(
+        mutant_protein_fragment=fragment,
+    )
 
 
 def _variant_pair(amino_acids, contig='1', start=1000, gene_name='GENE'):
     variant = Variant(contig, start, 'A', 'T')
-    return (variant, [_peptide_stub(amino_acids, gene_name=gene_name)])
+    return (variant, [mutation_vaccine_peptide(
+        amino_acids, gene_name=gene_name)])
 
 
 # ---- mRNA ranking-decisions summary (#270) ------------------------------
 
 
-def _vp_with_score(amino_acids, gene_name, combined_score):
-    """Like ``_peptide_stub`` but with a settable ``combined_score``
-    so we can verify the ordered list comes through."""
-    fragment = SimpleNamespace(amino_acids=amino_acids, gene_name=gene_name)
-    return SimpleNamespace(
-        mutant_protein_fragment=fragment, combined_score=combined_score)
+def mutation_vaccine_peptide_with_score(
+        amino_acids, gene_name, combined_score):
+    """Build a real mutation peptide with a deterministic test score."""
+    fragment = SimpleNamespace(
+        amino_acids=amino_acids,
+        gene_name=gene_name,
+        mutant_amino_acid_start_offset=0,
+        mutant_amino_acid_end_offset=len(amino_acids),
+        n_alt_reads=1,
+        n_ref_reads=0,
+        n_overlapping_reads=1,
+        n_alt_reads_supporting_protein_sequence=1,
+        supporting_reference_transcripts=(),
+    )
+    return VaccinePeptide(
+        mutant_protein_fragment=fragment,
+        combined_score_expr=str(combined_score),
+    )
 
 
 def test_summarize_mrna_ranking_decisions_splits_at_cap():
@@ -104,7 +130,8 @@ def test_summarize_mrna_ranking_decisions_splits_at_cap():
     ``total_ranked`` are surfaced for the report header."""
     pairs = [
         (Variant('1', 100 + i, 'A', 'T'),
-         [_vp_with_score("KLQGHSAPVLDVIVN", "GENE%d" % i, 100.0 - i)])
+         [mutation_vaccine_peptide_with_score(
+             "KLQGHSAPVLDVIVN", "GENE%d" % i, 100.0 - i)])
         for i in range(7)
     ]
     options = RNAConstructConfig(
@@ -129,9 +156,11 @@ def test_summarize_mrna_ranking_decisions_no_drops_when_under_cap():
     is selected and ``dropped`` is empty."""
     pairs = [
         (Variant('1', 100, 'A', 'T'),
-         [_vp_with_score("KLQGHSAPVLDVIVN", "GENE_A", 50.0)]),
+         [mutation_vaccine_peptide_with_score(
+             "KLQGHSAPVLDVIVN", "GENE_A", 50.0)]),
         (Variant('1', 200, 'A', 'T'),
-         [_vp_with_score("MNNVDEILGRWESPV", "GENE_B", 30.0)]),
+         [mutation_vaccine_peptide_with_score(
+             "MNNVDEILGRWESPV", "GENE_B", 30.0)]),
     ]
     options = RNAConstructConfig(
         antigens_per_construct=5, max_constructs=2)  # cap = 10
@@ -913,16 +942,8 @@ def test_junction_swap_meta_appears_in_elements_when_optimizer_runs():
                         (p, "HLA-A*02:01"), 99.0)))
             return out
 
-    fragment_a = SimpleNamespace(
-        amino_acids=a1, gene_name='GENEA',
-        mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=len(a1))
-    fragment_b = SimpleNamespace(
-        amino_acids=a2, gene_name='GENEB',
-        mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=len(a2))
-    pep_a = SimpleNamespace(
-        mutant_protein_fragment=fragment_a, target_epitopes=[])
-    pep_b = SimpleNamespace(
-        mutant_protein_fragment=fragment_b, target_epitopes=[])
+    pep_a = mutation_vaccine_peptide(a1, gene_name='GENEA')
+    pep_b = mutation_vaccine_peptide(a2, gene_name='GENEB')
     pairs = [
         (Variant('1', 100, 'A', 'T'), [pep_a]),
         (Variant('2', 200, 'A', 'T'), [pep_b]),

--- a/tests/test_peptide.py
+++ b/tests/test_peptide.py
@@ -21,39 +21,38 @@ from types import SimpleNamespace
 import pytest
 from varcode import Variant
 
+from vaxrank.candidate_epitope import CandidateEpitope
 from vaxrank.peptide import (
     PeptideConstructConfig,
     assemble_peptide_constructs,
     write_peptide_outputs,
 )
+from vaxrank.vaccine_peptide import VaccinePeptide
 
 
-def _peptide_stub(amino_acids, gene_name='GENE',
-                  target_epitopes=None,
-                  manufacturability_scores=None,
-                  mut_start=None, mut_end=None):
+def mutation_vaccine_peptide(
+        amino_acids, gene_name='GENE', target_epitopes=None,
+        mut_start=None, mut_end=None):
     fragment = SimpleNamespace(
         amino_acids=amino_acids,
         gene_name=gene_name,
         mutant_amino_acid_start_offset=(0 if mut_start is None else mut_start),
         mutant_amino_acid_end_offset=(
             len(amino_acids) if mut_end is None else mut_end),
+        supporting_reference_transcripts=(),
     )
-    return SimpleNamespace(
+    return VaccinePeptide(
         mutant_protein_fragment=fragment,
-        target_epitopes=target_epitopes or [],
-        manufacturability_scores=manufacturability_scores,
+        epitopes=target_epitopes or [],
     )
 
 
 def _variant_pair(amino_acids, contig='1', start=1000, gene_name='GENE',
-                  epitopes=None, manufacturability=None,
-                  mut_start=None, mut_end=None):
+                  epitopes=None, mut_start=None, mut_end=None):
     variant = Variant(contig, start, 'A', 'T')
-    peptide = _peptide_stub(
+    peptide = mutation_vaccine_peptide(
         amino_acids, gene_name=gene_name,
         target_epitopes=epitopes,
-        manufacturability_scores=manufacturability,
         mut_start=mut_start, mut_end=mut_end)
     return (variant, [peptide])
 
@@ -104,7 +103,12 @@ def test_slp_emits_full_fragment_when_mutation_exceeds_cap():
 
 
 def test_minimal_epitope_uses_top_prediction():
-    epitope = SimpleNamespace(sequence="KLAGHSPVL")
+    epitope = CandidateEpitope(
+        sequence="KLAGHSPVL",
+        source_sequence="KLQGHSAPVLDVIVNCDESLLAS",
+        overlaps_mutation=True,
+        occurs_in_reference=False,
+    )
     pairs = [_variant_pair(
         "KLQGHSAPVLDVIVNCDESLLAS", gene_name='GENEA',
         epitopes=[epitope])]
@@ -119,7 +123,12 @@ def test_minimal_epitope_skips_peptides_without_predictions():
         _variant_pair("KLQGHSAPVLDVIVN", gene_name='GENEA', epitopes=[]),
         _variant_pair(
             "MNNVDEILGRWESPV", start=200, gene_name='GENEB',
-            epitopes=[SimpleNamespace(sequence="MNNVDEILG")]),
+            epitopes=[CandidateEpitope(
+                sequence="MNNVDEILG",
+                source_sequence="MNNVDEILGRWESPV",
+                overlaps_mutation=True,
+                occurs_in_reference=False,
+            )]),
     ]
     constructs = assemble_peptide_constructs(
         pairs, options=PeptideConstructConfig(mode='minimal_epitope'))
@@ -187,7 +196,12 @@ def test_minimal_epitope_manufacturability_matches_emitted_sequence():
     # The emitted sequence is the predicted epitope, not the full
     # source vaccine peptide; manufacturability must follow the emitted
     # sequence.
-    epitope = SimpleNamespace(sequence="KAAAAAA")  # no cysteines
+    epitope = CandidateEpitope(
+        sequence="KAAAAAA",
+        source_sequence="KAAAAAACCC",
+        overlaps_mutation=True,
+        occurs_in_reference=False,
+    )
     pairs = [_variant_pair(
         "KAAAAAACCC",  # source has cysteines; emitted does not
         epitopes=[epitope])]
@@ -222,15 +236,7 @@ def test_no_antigens_returns_empty():
 
 
 def test_write_peptide_outputs_fasta_manifest_orderform():
-    pairs = [_variant_pair(
-        "KLQGHSAPVLDVIVN",
-        manufacturability=SimpleNamespace(
-            cterm_7mer_gravy_score=0.1, max_7mer_gravy_score=0.2,
-            difficult_n_terminal_residue=False, c_terminal_cysteine=False,
-            c_terminal_proline=False, cysteine_count=0,
-            n_terminal_asparagine=False, n_terminal_methionine=False,
-            aspartate_proline_bond_count=0,
-        ))]
+    pairs = [_variant_pair("KLQGHSAPVLDVIVN")]
     options = PeptideConstructConfig(n_terminal_acetylation=True,
                              c_terminal_amidation=True)
     constructs = assemble_peptide_constructs(pairs, options=options)
@@ -298,12 +304,12 @@ def test_candidates_per_slot_emits_alternates():
     fragment_b = SimpleNamespace(
         amino_acids="LQGHSAPVLDV", gene_name='GENEA',  # alternate window
         mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=11)
-    peptide_a = SimpleNamespace(
-        mutant_protein_fragment=fragment_a, target_epitopes=[],
-        manufacturability_scores=None)
-    peptide_b = SimpleNamespace(
-        mutant_protein_fragment=fragment_b, target_epitopes=[],
-        manufacturability_scores=None)
+    peptide_a = mutation_vaccine_peptide(
+        fragment_a.amino_acids, gene_name='GENEA', target_epitopes=[],
+        mut_start=0, mut_end=11)
+    peptide_b = mutation_vaccine_peptide(
+        fragment_b.amino_acids, gene_name='GENEA', target_epitopes=[],
+        mut_start=0, mut_end=11)
     from varcode import Variant
     pairs = [(Variant('1', 100, 'A', 'T'), [peptide_a, peptide_b])]
     constructs = assemble_peptide_constructs(
@@ -322,12 +328,12 @@ def test_candidates_per_slot_default_is_one():
     fragment_b = SimpleNamespace(
         amino_acids="LQGHSAPVLDV", gene_name='GENE',
         mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=11)
-    pa = SimpleNamespace(
-        mutant_protein_fragment=fragment_a, target_epitopes=[],
-        manufacturability_scores=None)
-    pb = SimpleNamespace(
-        mutant_protein_fragment=fragment_b, target_epitopes=[],
-        manufacturability_scores=None)
+    pa = mutation_vaccine_peptide(
+        fragment_a.amino_acids, gene_name='GENE', target_epitopes=[],
+        mut_start=0, mut_end=11)
+    pb = mutation_vaccine_peptide(
+        fragment_b.amino_acids, gene_name='GENE', target_epitopes=[],
+        mut_start=0, mut_end=11)
     from varcode import Variant
     pairs = [(Variant('1', 100, 'A', 'T'), [pa, pb])]
     [c] = assemble_peptide_constructs(pairs, options=PeptideConstructConfig())
@@ -343,9 +349,9 @@ def test_max_constructs_caps_peptide_pool():
             amino_acids="KLQGHSAPVLD", gene_name='G%d' % i,
             mutant_amino_acid_start_offset=0,
             mutant_amino_acid_end_offset=11)
-        peptide = SimpleNamespace(
-            mutant_protein_fragment=fragment, target_epitopes=[],
-            manufacturability_scores=None)
+        peptide = mutation_vaccine_peptide(
+            fragment.amino_acids, gene_name='G%d' % i, target_epitopes=[],
+            mut_start=0, mut_end=11)
         pairs.append((Variant('1', 100 + i, 'A', 'T'), [peptide]))
     constructs = assemble_peptide_constructs(pairs, options=PeptideConstructConfig())
     assert len(constructs) == 20  # default

--- a/tests/test_vaccine_library.py
+++ b/tests/test_vaccine_library.py
@@ -15,6 +15,46 @@
 import pytest
 
 from vaxrank import mrna_library, vaccine_library
+from vaxrank.vaccine_antigen import (
+    ANTIGEN_KIND_CTA,
+    ATTESTATION_ADMITTED,
+    AminoAcidInterval,
+    TargetableMask,
+    TumorSpecificityAttestation,
+    VaccineAntigen,
+)
+from vaxrank.vaccine_peptide import VaccinePeptide
+
+
+def cta_vaccine_peptide(sequence, source_identifier="ENSG00000185686"):
+    antigen = VaccineAntigen(
+        kind=ANTIGEN_KIND_CTA,
+        amino_acids=sequence,
+        targetable_mask=TargetableMask((
+            AminoAcidInterval(0, len(sequence)),
+        )),
+        tumor_specificity=TumorSpecificityAttestation(
+            status=ATTESTATION_ADMITTED,
+            evidence_kind="oncoref_cta_and_patient_tumor_expression",
+            evidence_source="test fixture",
+        ),
+        self_reference_excluded_gene_ids=("ENSG00000185686",),
+        gene_name="PRAME",
+        gene_id="ENSG00000185686",
+        protein_ids=("ENSP_PRAME",),
+        species="Homo sapiens",
+        source_identifier=source_identifier,
+    )
+    peptide = VaccinePeptide(
+        antigen=antigen,
+        combined_score_expr="target_epitope_score",
+        ranking_rules=(
+            "target_epitope_score",
+            "manufacturability",
+            "self_epitope_score",
+        ),
+    )
+    return antigen, peptide
 
 
 def test_mrna_library_exports_old_string_constants():
@@ -132,9 +172,7 @@ def test_construct_name_format_consistent_across_modalities():
     fragment = SimpleNamespace(
         amino_acids="KLQGHSAPVLDVIVN", gene_name='G',
         mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=15)
-    peptide = SimpleNamespace(
-        mutant_protein_fragment=fragment, target_epitopes=[],
-        manufacturability_scores=None)
+    peptide = VaccinePeptide(mutant_protein_fragment=fragment)
     pairs = [(Variant('1', 1000, 'A', 'T'), [peptide])]
 
     [m] = assemble_mrna_constructs(pairs, options=RNAConstructConfig())
@@ -270,13 +308,14 @@ def test_select_antigen_window_centers_on_mutation():
     # and could drop the mutation when it sat past the head of the
     # fragment. The shared helper must center on mutant_amino_acid_*_offset.
     from types import SimpleNamespace
-    from vaxrank.vaccine_library import select_antigen_window
+    from vaxrank import select_antigen_window
     fragment = SimpleNamespace(
         amino_acids="A" * 40 + "WHY" + "A" * 7,  # mutation at 40-43
         mutant_amino_acid_start_offset=40,
         mutant_amino_acid_end_offset=43,
     )
-    window = select_antigen_window(fragment, "test", 30)
+    antigen = VaccineAntigen.from_mutant_protein_fragment(fragment)
+    window = select_antigen_window(antigen, "test", 30)
     assert len(window) == 30
     assert "WHY" in window
 
@@ -289,7 +328,8 @@ def test_select_antigen_window_short_fragment_passthrough():
         mutant_amino_acid_start_offset=0,
         mutant_amino_acid_end_offset=10,
     )
-    assert select_antigen_window(fragment, "test", 30) == "KLQGHSAPVL"
+    antigen = VaccineAntigen.from_mutant_protein_fragment(fragment)
+    assert select_antigen_window(antigen, "test", 30) == "KLQGHSAPVL"
 
 
 def test_select_antigen_window_warns_when_mutation_exceeds_cap(caplog):
@@ -302,10 +342,36 @@ def test_select_antigen_window_warns_when_mutation_exceeds_cap(caplog):
         mutant_amino_acid_end_offset=30,
     )
     with caplog.at_level(logging.WARNING):
-        result = select_antigen_window(fragment, "test", 20)
+        antigen = VaccineAntigen.from_mutant_protein_fragment(fragment)
+        result = select_antigen_window(antigen, "test", 20)
     # Untruncated since mutation > cap
     assert result == fragment.amino_acids
     assert any("longer than" in r.message for r in caplog.records)
+
+
+def test_select_antigen_window_preserves_discontiguous_targetable_span():
+    from vaxrank.vaccine_library import select_antigen_window
+
+    sequence = "A" * 10 + "C" + "A" * 8 + "W" + "A" * 20
+    antigen = VaccineAntigen(
+        kind=ANTIGEN_KIND_CTA,
+        amino_acids=sequence,
+        targetable_mask=TargetableMask((
+            AminoAcidInterval(10, 11),
+            AminoAcidInterval(19, 20),
+        )),
+        tumor_specificity=TumorSpecificityAttestation(
+            status=ATTESTATION_ADMITTED,
+            evidence_kind="test",
+            evidence_source="test fixture",
+        ),
+    )
+
+    window = select_antigen_window(antigen, "test", 20)
+
+    assert len(window) == 20
+    assert "C" in window
+    assert "W" in window
 
 
 # ---- end-to-end: both modalities from the same ranked list ----------------
@@ -328,9 +394,7 @@ def test_both_modalities_emit_compatible_manifests(tmp_path):
     fragment = SimpleNamespace(
         amino_acids="KLQGHSAPVLDVIVN", gene_name='GENE',
         mutant_amino_acid_start_offset=5, mutant_amino_acid_end_offset=10)
-    peptide = SimpleNamespace(
-        mutant_protein_fragment=fragment, target_epitopes=[],
-        manufacturability_scores=None)
+    peptide = VaccinePeptide(mutant_protein_fragment=fragment)
     pairs = [(Variant('1', 1000, 'A', 'T'), [peptide])]
 
     p_constructs = assemble_peptide_constructs(
@@ -369,19 +433,21 @@ def test_both_modalities_emit_compatible_manifests(tmp_path):
 def test_iter_named_antigens_naming_format():
     from types import SimpleNamespace
     from varcode import Variant
+    from vaxrank import antigen_construct_name
     from vaxrank.vaccine_library import iter_named_antigens
 
     fragment = SimpleNamespace(
         amino_acids="KLQGH", gene_name='GENE',
         mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=5)
-    peptide = SimpleNamespace(
-        mutant_protein_fragment=fragment, target_epitopes=[])
+    peptide = VaccinePeptide(mutant_protein_fragment=fragment)
     pairs = [(Variant('1', 1000, 'A', 'T'), [peptide])]
-    [(name, frag, pep)] = list(iter_named_antigens(pairs))
+    [(name, antigen, pep)] = list(iter_named_antigens(pairs))
     # Gene up front, category parenthesized; no mutation spelled out
     # because GENE contributes only one variant to this set.
     assert name == "GENE (SNV)"
-    assert frag is fragment
+    assert antigen.display_gene_name == "GENE"
+    assert antigen_construct_name(pairs[0][0], antigen) == name
+    assert antigen is peptide.antigen
     assert pep is peptide
 
 
@@ -394,9 +460,10 @@ def test_iter_named_antigens_alt_suffix():
         f = SimpleNamespace(
             amino_acids=aa, gene_name='G',
             mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=len(aa))
-        return SimpleNamespace(mutant_protein_fragment=f)
+        return VaccinePeptide(mutant_protein_fragment=f)
 
-    pairs = [(Variant('1', 100, 'A', 'T'), [_peptide("ABC"), _peptide("DEF"), _peptide("GHI")])]
+    pairs = [(Variant('1', 100, 'A', 'T'), [
+        _peptide("ACD"), _peptide("EFG"), _peptide("HIK")])]
     names = [n for n, _, _ in iter_named_antigens(pairs, candidates_per_slot=3)]
     assert names == ["G (SNV)", "G (SNV alt1)", "G (SNV alt2)"]
 
@@ -411,9 +478,9 @@ def test_iter_named_antigens_disambiguates_multi_variant_gene():
 
     def _peptide(gene):
         f = SimpleNamespace(
-            amino_acids="ABC", gene_name=gene,
+            amino_acids="ACD", gene_name=gene,
             mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=3)
-        return SimpleNamespace(mutant_protein_fragment=f)
+        return VaccinePeptide(mutant_protein_fragment=f)
 
     pairs = [
         (Variant('1', 100, 'A', 'T'), [_peptide('TP53')]),     # SNV
@@ -449,7 +516,7 @@ def test_iter_named_antigens_handles_missing_gene_name():
     fragment = SimpleNamespace(
         amino_acids="KLQ", gene_name=None,
         mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=3)
-    peptide = SimpleNamespace(mutant_protein_fragment=fragment)
+    peptide = VaccinePeptide(mutant_protein_fragment=fragment)
     pairs = [(Variant('1', 100, 'A', 'T'), [peptide])]
     [(name, _, _)] = list(iter_named_antigens(pairs))
     assert name == "unknown (SNV)"
@@ -464,10 +531,10 @@ def test_iter_named_antigens_caps_at_candidates_per_slot():
         f = SimpleNamespace(
             amino_acids=aa, gene_name='G',
             mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=len(aa))
-        return SimpleNamespace(mutant_protein_fragment=f)
+        return VaccinePeptide(mutant_protein_fragment=f)
 
     pairs = [(Variant('1', 100, 'A', 'T'),
-              [_peptide("ABC"), _peptide("DEF"), _peptide("GHI")])]
+              [_peptide("ACD"), _peptide("EFG"), _peptide("HIK")])]
     # candidates_per_slot=2 → only top 2 walked
     out = list(iter_named_antigens(pairs, candidates_per_slot=2))
     assert len(out) == 2
@@ -489,14 +556,81 @@ def test_peptide_and_mrna_names_match_for_same_input():
     fragment = SimpleNamespace(
         amino_acids="KLQGHSAPVLDVIVN", gene_name='GENE',
         mutant_amino_acid_start_offset=5, mutant_amino_acid_end_offset=10)
-    peptide = SimpleNamespace(
-        mutant_protein_fragment=fragment, target_epitopes=[],
-        manufacturability_scores=None)
+    peptide = VaccinePeptide(mutant_protein_fragment=fragment)
     pairs = [(Variant('1', 1000, 'A', 'T'), [peptide])]
 
     [p] = assemble_peptide_constructs(pairs, options=PeptideConstructConfig())
     [m] = assemble_mrna_constructs(pairs, options=RNAConstructConfig())
     assert p.antigen_names == m.antigen_names
+
+
+def test_cta_antigen_enters_peptide_and_mrna_constructs_without_fragment():
+    from vaxrank.coverage import summarize_construction_decisions
+    from vaxrank.mrna import RNAConstructConfig, assemble_mrna_constructs
+    from vaxrank.mrna import summarize_mrna_ranking_decisions
+    from vaxrank.peptide import PeptideConstructConfig, assemble_peptide_constructs
+
+    antigen, peptide = cta_vaccine_peptide("MALWMRLLPLLALLALWGPDPAAA")
+    ranked = [(antigen, [peptide])]
+
+    [peptide_construct] = assemble_peptide_constructs(
+        ranked,
+        options=PeptideConstructConfig(max_antigen_length_aa=25),
+    )
+    [mrna_construct] = assemble_mrna_constructs(
+        ranked,
+        options=RNAConstructConfig(
+            signal_peptide=None,
+            include_mitd=False,
+            max_antigen_length_aa=25,
+        ),
+    )
+
+    assert peptide.mutant_protein_fragment is None
+    assert peptide_construct.antigen_names == ["PRAME (CTA)"]
+    assert peptide_construct.sequence == antigen.amino_acids
+    assert mrna_construct.antigen_names == ["PRAME (CTA)"]
+    assert mrna_construct.antigens[0]["aa"] == antigen.amino_acids
+
+    mrna_summary = summarize_mrna_ranking_decisions(
+        ranked, RNAConstructConfig())
+    construction_summary = summarize_construction_decisions(
+        ranked, cap=1, target_alleles=[])
+    for summary in (mrna_summary, construction_summary):
+        assert summary["selected"][0]["gene_name"] == "PRAME"
+        assert summary["selected"][0]["description"] == (
+            "PRAME_ENSG00000185686"
+        )
+
+
+def test_nonmutation_names_disambiguate_distinct_sources():
+    from vaxrank.vaccine_library import (
+        antigen_construct_name,
+        iter_named_antigens,
+    )
+
+    antigen_a, peptide_a = cta_vaccine_peptide(
+        "MALWMRLLP", "PRAME-isoform-a")
+    antigen_b, peptide_b = cta_vaccine_peptide(
+        "MALWMRLLA", "PRAME-isoform-b")
+
+    names = [
+        name for name, _, _ in iter_named_antigens([
+            (antigen_a, [peptide_a]),
+            (antigen_b, [peptide_b]),
+        ])
+    ]
+
+    assert names == [
+        "PRAME (CTA @ PRAME-isoform-a)",
+        "PRAME (CTA @ PRAME-isoform-b)",
+    ]
+    assert antigen_a.display_identifier == "PRAME-isoform-a"
+    assert antigen_construct_name(
+        antigen_a,
+        antigen_a,
+        include_source=True,
+    ) == names[0]
 
 
 # ---- compositional grammar (#247 prep) ------------------------------------

--- a/vaxrank/__init__.py
+++ b/vaxrank/__init__.py
@@ -26,6 +26,7 @@ from .vaccine_antigen import (
     VaccineAntigen,
 )
 from .vaccine_peptide import VaccinePeptide
+from .vaccine_library import antigen_construct_name, select_antigen_window
 from .safety_assessment import (
     ConstructBoundary,
     EmittedSafetyLigand,
@@ -159,6 +160,7 @@ __all__ = [
     "assess_near_self",
     "assess_near_self_queries",
     "assess_cta_antigen",
+    "antigen_construct_name",
     "build_hpa_reference_provenance",
     "build_patient_hla_risk_ligand_index",
     "build_cta_vaccine_antigen",
@@ -170,4 +172,5 @@ __all__ = [
     "risk_ligand_index_from_prediction_frame",
     "safety_assessment_from_prediction_frame",
     "self_reference_matches",
+    "select_antigen_window",
 ]

--- a/vaxrank/coverage.py
+++ b/vaxrank/coverage.py
@@ -62,6 +62,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+from .vaccine_library import antigen_description
+
 
 # Default tier thresholds (% rank). Stable, hardcoded for now —
 # expose as CLI knobs later if a user actually needs to tune them.
@@ -242,7 +244,7 @@ def summarize_construction_decisions(
     Parameters
     ----------
     ranked_variants_with_vaccine_peptides : list[tuple]
-        ``[(Variant, [VaccinePeptide])]`` — the score-ranked input.
+        ``[(source, [VaccinePeptide])]`` — the score-ranked input.
     cap : int
         Number of antigens this modality can hold
         (``antigens_per_construct × max_constructs`` for both
@@ -277,11 +279,10 @@ def summarize_construction_decisions(
     }
 
     def _row(item):
-        variant, peptides = item
+        source, peptides = item
         vp = peptides[0] if peptides else None
-        gene_name = (
-            getattr(vp.mutant_protein_fragment, 'gene_name', '')
-            if vp is not None else '')
+        antigen = vp.antigen if vp is not None else None
+        gene_name = antigen.display_gene_name if antigen is not None else ""
         rank = rank_by_id.get(id(item), 0)
         # Per-allele tier for this antigen — drives the
         # ``covers A*02:01 (strong)`` annotation in the report.
@@ -299,9 +300,10 @@ def summarize_construction_decisions(
         return {
             'rank': rank,
             'gene_name': gene_name or '',
-            'description': '%s_%s' % (
-                gene_name or '?',
-                getattr(variant, 'short_description', str(variant))),
+            'description': (
+                antigen_description(source, antigen)
+                if antigen is not None else str(source)
+            ),
             'combined_score': (
                 float(vp.combined_score) if vp is not None else 0.0),
             'allele_tiers': {
@@ -322,7 +324,7 @@ def summarize_construction_decisions(
     coverage_records: list = []
     if target_alleles:
         all_epitopes = []
-        for variant, peptides in selected:
+        for _source, peptides in selected:
             for vp in (peptides or [])[:1]:
                 all_epitopes.extend(
                     getattr(vp, 'target_epitopes', None) or [])

--- a/vaxrank/mrna.py
+++ b/vaxrank/mrna.py
@@ -343,7 +343,7 @@ def summarize_mrna_ranking_decisions(
     Parameters
     ----------
     ranked_variants_with_vaccine_peptides : list[tuple]
-        ``[(Variant, [VaccinePeptide])]`` — vaxrank's canonical
+        ``[(source, [VaccinePeptide])]`` — vaxrank's canonical
         ranked-output shape.
     options : RNAConstructConfig
         Construct-assembly knobs; the cap comes from
@@ -369,38 +369,32 @@ def summarize_mrna_ranking_decisions(
         index in the ranked list).
     """
     cap = options.antigens_per_construct * options.max_constructs
+    from .coverage import summarize_construction_decisions
+    construction_summary = summarize_construction_decisions(
+        ranked_variants_with_vaccine_peptides,
+        cap=cap,
+        target_alleles=[],
+    )
 
-    def _row(rank, variant, peptides):
-        vp = peptides[0] if peptides else None
-        gene_name = (
-            getattr(vp.mutant_protein_fragment, 'gene_name', '')
-            if vp is not None else '')
-        return {
-            'rank': rank,
-            'gene_name': gene_name or '',
-            'description': '%s_%s' % (
-                gene_name or '?',
-                getattr(variant, 'short_description', str(variant))),
-            'combined_score': (
-                float(vp.combined_score) if vp is not None else 0.0),
-        }
-
-    selected = []
-    dropped = []
-    for i, (variant, peptides) in enumerate(
-            ranked_variants_with_vaccine_peptides):
-        rank = i + 1
-        if i < cap:
-            selected.append(_row(rank, variant, peptides))
-        else:
-            dropped.append(_row(rank, variant, peptides))
     return {
         'antigens_per_construct': options.antigens_per_construct,
         'max_constructs': options.max_constructs,
         'cap': cap,
         'total_ranked': len(ranked_variants_with_vaccine_peptides),
-        'selected': selected,
-        'dropped': dropped,
+        'selected': [
+            {
+                key: row[key]
+                for key in ("rank", "gene_name", "description", "combined_score")
+            }
+            for row in construction_summary['selected']
+        ],
+        'dropped': [
+            {
+                key: row[key]
+                for key in ("rank", "gene_name", "description", "combined_score")
+            }
+            for row in construction_summary['dropped']
+        ],
     }
 
 
@@ -413,9 +407,10 @@ def _antigen_aa_sequences(ranked_vaccine_peptides, max_antigen_length_aa,
     Dispatches on ``antigen_content`` (shared semantics with
     ``peptide._antigen_records``):
 
-    - ``'mutation_spanning'``: emit a mutation-centered window of up
-      to ``max_antigen_length_aa`` per VaccinePeptide (canonical mRNA
-      antigen — BioNTech FixVac-style 25mer).
+    - ``'mutation_spanning'``: legacy configuration name for a window that
+      preserves the antigen's targetable span, up to
+      ``max_antigen_length_aa`` per VaccinePeptide (canonical mRNA antigen —
+      BioNTech FixVac-style 25mer for mutation antigens).
     - ``'minimal_epitope'``: emit the top ``epitopes_per_antigen``
       MHC ligands per VaccinePeptide as separate (short) antigens.
       Concatenated minimal-epitope mRNA constructs (the
@@ -434,7 +429,7 @@ def _antigen_aa_sequences(ranked_vaccine_peptides, max_antigen_length_aa,
         raise ValueError(
             "antigen_content must be 'mutation_spanning' or "
             "'minimal_epitope'; got %r" % antigen_content)
-    for name, fragment, peptide in iter_named_antigens(
+    for name, antigen, peptide in iter_named_antigens(
             ranked_vaccine_peptides, candidates_per_slot=candidates_per_slot):
         if antigen_content == "minimal_epitope":
             tops = top_target_epitopes(peptide, n=epitopes_per_antigen)
@@ -448,7 +443,7 @@ def _antigen_aa_sequences(ranked_vaccine_peptides, max_antigen_length_aa,
                 yield name + suffix, ep.sequence
         else:
             window = select_antigen_window(
-                fragment, name, max_antigen_length_aa)
+                antigen, name, max_antigen_length_aa)
             if len(window) < min_antigen_length_aa:
                 logger.warning(
                     "Antigen %s emitted at %d aa, below "
@@ -688,7 +683,7 @@ def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
 
     Parameters
     ----------
-    ranked_vaccine_peptides : list[(varcode.Variant, list[VaccinePeptide])]
+    ranked_vaccine_peptides : list[(source, list[VaccinePeptide])]
     options : RNAConstructConfig or None
     mhc_predictor : optional, mhctools.BasePredictor
         Required when ``options.optimize_linkers`` is True.

--- a/vaxrank/peptide.py
+++ b/vaxrank/peptide.py
@@ -160,8 +160,9 @@ def _antigen_records(ranked_vaccine_peptides, antigen_content,
     """Yield ``(name, amino_acids)`` per antigen.
 
     Dispatch on ``antigen_content``:
-      - ``'mutation_spanning'``: emit one mutation-centered window per
-        VaccinePeptide (or per ``candidates_per_slot`` alternates).
+      - ``'mutation_spanning'``: legacy configuration name for one window
+        preserving all targetable antigen content per VaccinePeptide (or per
+        ``candidates_per_slot`` alternates).
       - ``'minimal_epitope'``: emit the top
         ``epitopes_per_antigen`` MHC ligands per VaccinePeptide as
         independent antigens. ``epitopes_per_antigen=1`` (default) is
@@ -171,7 +172,7 @@ def _antigen_records(ranked_vaccine_peptides, antigen_content,
     Naming + alt-suffix logic comes from ``iter_named_antigens``,
     shared with mRNA assembly so antigen names match across types.
     """
-    for base_name, fragment, peptide in iter_named_antigens(
+    for base_name, antigen, peptide in iter_named_antigens(
             ranked_vaccine_peptides, candidates_per_slot=candidates_per_slot):
         if antigen_content == "minimal_epitope":
             tops = top_target_epitopes(peptide, n=epitopes_per_antigen)
@@ -192,9 +193,10 @@ def _antigen_records(ranked_vaccine_peptides, antigen_content,
                     name = "%s (%s)" % (base_name, tag)
                 yield name, ep.sequence
         else:
-            # mutation_spanning: pick a mutation-centered window
+            # Legacy-named mutation_spanning mode is target-mask based for all
+            # antigen kinds.
             yield base_name, select_antigen_window(
-                fragment, base_name, max_antigen_length_aa)
+                antigen, base_name, max_antigen_length_aa)
 
 
 def _manufacturability_for(sequence):
@@ -266,7 +268,7 @@ def assemble_peptide_constructs(
 
     Parameters
     ----------
-    ranked_vaccine_peptides : list[(varcode.Variant, list[VaccinePeptide])]
+    ranked_vaccine_peptides : list[(source, list[VaccinePeptide])]
     options : PeptideConstructConfig or None
     target_alleles : optional, list[str]
         Patient MHC alleles. When non-empty, the selector reorders

--- a/vaxrank/vaccine_antigen.py
+++ b/vaxrank/vaccine_antigen.py
@@ -282,6 +282,29 @@ class VaccineAntigen(DataclassSerializable):
     def interval_is_targetable(self, start: int, end: int) -> bool:
         return self.targetable_mask.overlaps(start, end)
 
+    def targetable_span(self) -> AminoAcidInterval:
+        """Smallest contiguous interval containing all targetable residues."""
+        intervals = self.targetable_mask.intervals
+        if not intervals:
+            raise ValueError("Vaccine antigen has no targetable content")
+        return AminoAcidInterval(intervals[0].start, intervals[-1].end)
+
+    @property
+    def display_identifier(self) -> str:
+        """Best stable source identifier for reports and construct labels."""
+        identifiers = (
+            (self.source_identifier,)
+            + self.protein_ids
+            + self.transcript_ids
+            + ((self.gene_id,) if self.gene_id else ())
+        )
+        return next((value for value in identifiers if value), self.kind)
+
+    @property
+    def display_gene_name(self) -> str:
+        """Best available gene label for reports and construct labels."""
+        return self.gene_name or self.gene_id or "unknown"
+
     @classmethod
     def from_mutant_protein_fragment(cls, fragment: Any) -> "VaccineAntigen":
         """Represent a legacy mutation fragment without changing its policy."""

--- a/vaxrank/vaccine_library.py
+++ b/vaxrank/vaccine_library.py
@@ -12,7 +12,7 @@
 
 """Shared assembly utilities used by both mRNA and peptide construct modes.
 
-Contains the linker library and the mutation-centered window selector
+Contains the linker library and the target-preserving antigen window selector
 that both ``vaxrank.mrna`` and ``vaxrank.peptide`` need.
 
 A linker is anything that goes between concatenated antigens. Some
@@ -71,6 +71,8 @@ import logging
 import re
 from dataclasses import dataclass
 from typing import Optional
+
+from .vaccine_antigen import ANTIGEN_KIND_MUTATION, VaccineAntigen
 
 logger = logging.getLogger(__name__)
 
@@ -537,18 +539,43 @@ def get_linker(name):
             name, ', '.join(all_linker_names())))
 
 
-def _variant_category(variant):
-    """Coarse antigen category for naming — ``SNV`` / ``INDEL`` (the
-    LENS ``antigen_source`` vocabulary), derived from the variant
-    itself so it's identical on the pipeline and LENS / pVACseq paths.
-    """
-    if getattr(variant, 'is_snv', False):
-        return 'SNV'
-    if (getattr(variant, 'is_insertion', False)
-            or getattr(variant, 'is_deletion', False)
-            or getattr(variant, 'is_indel', False)):
-        return 'INDEL'
-    return 'variant'
+def antigen_description(source, antigen):
+    """Stable source-aware description for construct selection reports."""
+    if antigen.kind == ANTIGEN_KIND_MUTATION:
+        source_description = getattr(source, "short_description", None) or str(source)
+    else:
+        source_description = antigen.display_identifier
+    return "%s_%s" % (antigen.display_gene_name, source_description)
+
+
+def antigen_construct_name(
+        source, antigen, *, include_source=False, alternate_index=0):
+    """Build the stable name shared by peptide and mRNA constructs."""
+    if antigen.kind == ANTIGEN_KIND_MUTATION:
+        if getattr(source, 'is_snv', False):
+            category = 'SNV'
+        elif (getattr(source, 'is_insertion', False)
+              or getattr(source, 'is_deletion', False)
+              or getattr(source, 'is_indel', False)):
+            category = 'INDEL'
+        else:
+            category = 'variant'
+    else:
+        category = antigen.kind
+    if include_source:
+        if antigen.kind == ANTIGEN_KIND_MUTATION:
+            source_detail = "%s:%s %s>%s" % (
+                source.contig,
+                source.start,
+                source.ref or '-',
+                source.alt or '-',
+            )
+        else:
+            source_detail = antigen.display_identifier
+        category = "%s @ %s" % (category, source_detail)
+    if alternate_index > 0:
+        category = "%s alt%d" % (category, alternate_index)
+    return "%s (%s)" % (antigen.display_gene_name, category)
 
 
 def gene_names_from_antigen_names(antigen_names):
@@ -566,10 +593,14 @@ def gene_names_from_antigen_names(antigen_names):
 
 
 def iter_named_antigens(ranked_vaccine_peptides, candidates_per_slot=1):
-    """Yield ``(name, fragment, vaccine_peptide)`` per ranked candidate.
+    """Yield ``(name, antigen, vaccine_peptide)`` per ranked candidate.
 
     Both peptide and mRNA assembly walk the same ranked list and need
-    the same per-candidate name. The name reads ``GENE (CATEGORY)`` —
+    the same per-candidate name. Identity and sequence come from the
+    source-agnostic ``VaccineAntigen`` attached to each peptide; the first
+    item in each ranked pair is consulted only for mutation coordinates.
+
+    The name reads ``GENE (CATEGORY)`` —
     e.g. ``FYN (INDEL)`` — keeping the gene up front and the antigen
     category (SNV / INDEL) parenthesized. The specific mutation is
     appended *only* when a gene contributes more than one variant to
@@ -581,68 +612,77 @@ def iter_named_antigens(ranked_vaccine_peptides, candidates_per_slot=1):
 
     Parameters
     ----------
-    ranked_vaccine_peptides : list[(varcode.Variant, list[VaccinePeptide])]
+    ranked_vaccine_peptides : list[(source, list[VaccinePeptide])]
     candidates_per_slot : int
         How many ranked alternates to walk per variant.
     """
-    def _gene_of(variant, peptides):
-        return (getattr(peptides[0].mutant_protein_fragment, 'gene_name', None)
-                or 'unknown')
-
-    # Pre-pass: which genes contribute 2+ distinct variants? Those
-    # need the mutation spelled out to tell their antigens apart.
-    variants_per_gene = {}
-    for variant, peptides in ranked_vaccine_peptides:
+    # Pre-pass: which genes contribute multiple distinct antigens? Those need
+    # their source spelled out. Identical alternate windows do not make the
+    # base name ambiguous.
+    identities_per_gene = {}
+    for source, peptides in ranked_vaccine_peptides:
         if not peptides:
             continue
-        gene = _gene_of(variant, peptides)
-        variants_per_gene.setdefault(gene, set()).add(
-            (variant.contig, variant.start, variant.ref, variant.alt))
+        antigen = peptides[0].antigen
+        gene = antigen.display_gene_name
+        identity = (
+            (
+                antigen.kind,
+                source.contig,
+                source.start,
+                source.ref,
+                source.alt,
+            )
+            if antigen.kind == ANTIGEN_KIND_MUTATION
+            else antigen
+        )
+        identities_per_gene.setdefault(gene, set()).add(
+            identity)
     ambiguous_genes = {
-        g for g, keys in variants_per_gene.items() if len(keys) > 1}
+        gene for gene, identities in identities_per_gene.items()
+        if len(identities) > 1
+    }
 
-    for variant, peptides in ranked_vaccine_peptides:
+    for source, peptides in ranked_vaccine_peptides:
         if not peptides:
             continue
-        gene = _gene_of(variant, peptides)
         for idx, peptide in enumerate(peptides[:max(1, candidates_per_slot)]):
-            fragment = peptide.mutant_protein_fragment
-            detail = _variant_category(variant)
-            if gene in ambiguous_genes:
-                detail = "%s @ %s:%s %s>%s" % (
-                    detail, variant.contig, variant.start,
-                    variant.ref or '-', variant.alt or '-')
-            if idx > 0:
-                detail = "%s alt%d" % (detail, idx)
-            yield "%s (%s)" % (gene, detail), fragment, peptide
+            antigen = peptide.antigen
+            gene = antigen.display_gene_name
+            yield antigen_construct_name(
+                source,
+                antigen,
+                include_source=gene in ambiguous_genes,
+                alternate_index=idx,
+            ), antigen, peptide
 
 
-def select_antigen_window(fragment, base_name, max_length_aa):
-    """Return a sub-window of the vaccine peptide that preserves the mutation.
+def select_antigen_window(antigen, base_name, max_length_aa):
+    """Return a sub-window that preserves all targetable antigen content.
 
     A naive ``amino_acids[:max_length_aa]`` truncation can drop the
-    mutated residues entirely when the mutation sits past the head of
-    the fragment. This helper centers a window of ``max_length_aa`` on
-    the mutation (using ``mutant_amino_acid_*_offset`` from the fragment).
-    If the mutation itself exceeds the cap (rare; long inframe
-    insertions), the full fragment is emitted unchanged with a warning.
+    targetable residues entirely when they sit past the head of the antigen.
+    This helper centers a window of ``max_length_aa`` on the smallest span
+    containing the antigen's explicit targetable mask. If that span exceeds
+    the cap, the full antigen is emitted unchanged with a warning.
 
     Used by both ``vaxrank.peptide`` (SLP mode) and ``vaxrank.mrna``
     (per-antigen window in concatenated constructs).
     """
-    aa = fragment.amino_acids
+    if not isinstance(antigen, VaccineAntigen):
+        raise TypeError("select_antigen_window requires a VaccineAntigen")
+    aa = antigen.amino_acids
     if len(aa) <= max_length_aa:
         return aa
-    mut_start = getattr(fragment, 'mutant_amino_acid_start_offset', 0)
-    mut_end = getattr(fragment, 'mutant_amino_acid_end_offset', len(aa))
-    mut_len = mut_end - mut_start
-    if mut_len > max_length_aa:
+    targetable_span = antigen.targetable_span()
+    targetable_length = targetable_span.end - targetable_span.start
+    if targetable_length > max_length_aa:
         logger.warning(
-            "Mutation in %s spans %d aa, longer than the antigen-length "
-            "cap (%d); emitting full fragment without truncation.",
-            base_name, mut_len, max_length_aa)
+            "Targetable content in %s spans %d aa, longer than the antigen-length "
+            "cap (%d); emitting the full antigen without truncation.",
+            base_name, targetable_length, max_length_aa)
         return aa
-    midpoint = (mut_start + mut_end) // 2
+    midpoint = (targetable_span.start + targetable_span.end) // 2
     half = max_length_aa // 2
     start = max(0, midpoint - half)
     end = min(len(aa), start + max_length_aa)

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.19"
+__version__ = "3.1.20"
 
 
 def print_version():


### PR DESCRIPTION
Advances #303.

## Summary
- make `VaccineAntigen` the sequence, target-span, identity, and display source used by peptide and mRNA assembly
- expose and directly test public `antigen_construct_name` and `select_antigen_window` APIs
- assemble and report admitted CTA antigens such as PRAME without a fake mutation fragment
- retain mutation naming, alternate selection, coverage summaries, and construct output compatibility
- replace fragment-shaped test doubles with real public `VaccinePeptide` objects
- bump vaxrank to 3.1.20

## Verification
- `./lint.sh`
- `./test.sh` (952 passed)
- focused construct/model suite (193 passed)
- added-code scan confirms no private helper functions or classes