### PR TITLE
Compose complete-window and near-self safety evidence

### DIFF
--- a/tests/test_antigen_safety.py
+++ b/tests/test_antigen_safety.py
@@ -1,0 +1,360 @@
+import json
+
+import pytest
+
+from vaxrank import (
+    AminoAcidInterval,
+    AntigenSafetyAssessment,
+    EmittedSafetyLigand,
+    PatientHLARiskLigandIndex,
+    ProteinResolutionCoverage,
+    RiskLigand,
+    RiskLigandCoverage,
+    RiskLigandIndexProvenance,
+    RiskLigandPrediction,
+    RiskLigandSelectionPolicy,
+    RiskLigandSource,
+    SafetyPrediction,
+    SafetyPredictionCoverage,
+    TargetableMask,
+    TissueRiskEvidence,
+    TumorSpecificityAttestation,
+    VaccineAntigen,
+    WindowSafetyAssessment,
+    assess_antigen_safety,
+    near_self_queries_for_window,
+)
+from vaxrank.near_self import NEAR_SELF_REASON_QUERY_OUTSIDE_INDEX
+from vaxrank.vaccine_antigen import (
+    ANTIGEN_KIND_MUTATION,
+    ATTESTATION_ADMITTED,
+    SelfReferenceMatch,
+)
+
+
+def test_public_antigen_safety_composes_complete_window_and_near_self_evidence():
+    antigen = VaccineAntigen(
+        kind=ANTIGEN_KIND_MUTATION,
+        amino_acids="CCCCCCCCCAAAAAAAAIGGGGGGGGG",
+        targetable_mask=TargetableMask((
+            AminoAcidInterval(17, 18),
+            AminoAcidInterval(26, 27),
+        )),
+        tumor_specificity=TumorSpecificityAttestation(
+            status=ATTESTATION_ADMITTED,
+            evidence_kind="somatic_variant",
+            evidence_source="test",
+            patient_specific=True,
+        ),
+        gene_name="TP53",
+        source_identifier="TP53:p.R175H",
+    )
+    affinity_a = SafetyPrediction(
+        kind="pMHC_affinity",
+        predictor_name="netMHCpan",
+        predictor_version="4.2",
+        allele="HLA-A*02:01",
+        percentile_rank=0.1,
+    )
+    affinity_b = SafetyPrediction(
+        kind="pMHC_affinity",
+        predictor_name="netMHCpan",
+        predictor_version="4.2",
+        allele="HLA-B*07:02",
+        percentile_rank=0.2,
+    )
+    presentation_a = SafetyPrediction(
+        kind="pMHC_presentation",
+        predictor_name="MHCflurry-presentation",
+        predictor_version="2.1.4",
+        allele="HLA-A*02:01",
+        percentile_rank=0.3,
+    )
+    window = WindowSafetyAssessment(
+        antigen=antigen,
+        window_start_offset=0,
+        window_end_offset=len(antigen.amino_acids),
+        ligands=(
+            EmittedSafetyLigand(
+                peptide="CCCCCCCCC",
+                window_start_offset=0,
+                window_end_offset=9,
+                antigen_start_offset=0,
+                antigen_end_offset=9,
+                overlaps_targetable=False,
+                self_reference_match=SelfReferenceMatch(
+                    peptide="CCCCCCCCC",
+                    occurs=False,
+                    antigen_kind=ANTIGEN_KIND_MUTATION,
+                ),
+                predictions=(affinity_a,),
+            ),
+            EmittedSafetyLigand(
+                peptide="AAAAAAAAI",
+                window_start_offset=9,
+                window_end_offset=18,
+                antigen_start_offset=9,
+                antigen_end_offset=18,
+                overlaps_targetable=True,
+                self_reference_match=SelfReferenceMatch(
+                    peptide="AAAAAAAAI",
+                    occurs=False,
+                    antigen_kind=ANTIGEN_KIND_MUTATION,
+                ),
+                predictions=(affinity_a, affinity_b, presentation_a),
+            ),
+            EmittedSafetyLigand(
+                peptide="GGGGGGGGG",
+                window_start_offset=18,
+                window_end_offset=27,
+                antigen_start_offset=18,
+                antigen_end_offset=27,
+                overlaps_targetable=True,
+                self_reference_match=SelfReferenceMatch(
+                    peptide="GGGGGGGGG",
+                    occurs=True,
+                    antigen_kind=ANTIGEN_KIND_MUTATION,
+                ),
+                predictions=(affinity_a,),
+            ),
+        ),
+        coverage=(
+            SafetyPredictionCoverage(
+                kind="pMHC_affinity",
+                predictor_name="netMHCpan",
+                predictor_version="4.2",
+                alleles=("HLA-A*02:01", "HLA-B*07:02"),
+                peptide_lengths=(9,),
+                prediction_count=4,
+            ),
+            SafetyPredictionCoverage(
+                kind="pMHC_presentation",
+                predictor_name="MHCflurry-presentation",
+                predictor_version="2.1.4",
+                alleles=("HLA-A*02:01",),
+                peptide_lengths=(9,),
+                prediction_count=1,
+            ),
+        ),
+        genome_release="110",
+    )
+
+    tissue_evidence = TissueRiskEvidence(
+        tissue_group="heart",
+        hpa_tissue="heart muscle",
+        cell_type="cardiomyocytes",
+        level="High",
+        reliability="Enhanced",
+    )
+    risk_source = RiskLigandSource(
+        source_sequence_name="risk_000001_ENSG000001",
+        protein_sequence_sha256="a" * 64,
+        gene_id="ENSG000001",
+        gene_name="RISK1",
+        transcript_ids=("ENST000001",),
+        protein_ids=("ENSP000001",),
+        protein_offsets=(4,),
+        tissue_evidence=(tissue_evidence,),
+    )
+    risk_ligand = RiskLigand(
+        peptide="AAAAAAAAL",
+        allele="HLA-A*02:01",
+        predictions=(RiskLigandPrediction(
+            kind="pMHC_affinity",
+            predictor_name="netMHCpan",
+            predictor_version="4.2",
+            allele="HLA-A*02:01",
+            score=0.99,
+            value=20.0,
+            percentile_rank=0.1,
+        ),),
+        inclusion_kinds=("pMHC_affinity",),
+        sources=(risk_source,),
+    )
+    risk_index = PatientHLARiskLigandIndex(
+        alleles=("HLA-A*02:01",),
+        peptide_lengths=(9,),
+        selection_policy=RiskLigandSelectionPolicy(),
+        ligands=(risk_ligand,),
+        protein_resolution_coverage=ProteinResolutionCoverage(
+            requested_gene_count=1,
+            resolved_gene_count=1,
+            unresolved_gene_ids=(),
+            protein_coding_transcript_count=1,
+            invalid_sequence_transcript_count=0,
+            distinct_sequence_count=1,
+        ),
+        coverage=RiskLigandCoverage(
+            prediction_row_count=1,
+            configured_prediction_row_count=1,
+            passing_prediction_row_count=1,
+            retained_ligand_count=1,
+        ),
+        provenance=RiskLigandIndexProvenance(
+            genome_release="110",
+            species="Homo sapiens",
+            protein_resolution_policy="all_protein_coding_isoforms",
+            tissue_risk_policy_sha256="b" * 64,
+            hpa_source_sha256="c" * 64,
+            cta_unfiltered_gene_ids_sha256="d" * 64,
+            predictor_identities=("pMHC_affinity|netMHCpan|4.2",),
+            cache_identity_sha256="e" * 64,
+        ),
+    )
+
+    queries = near_self_queries_for_window(window)
+    assert len(window.target_ligands) == 1
+    assert [query.allele for query in queries] == [
+        "HLA-A*02:01",
+        "HLA-B*07:02",
+    ]
+    assert {query.source_offset for query in queries} == {9}
+    assert len({query.target_id for query in queries}) == 1
+
+    result = assess_antigen_safety(window, risk_index)
+    by_allele = {
+        assessment.normalized_allele: assessment
+        for assessment in result.near_self_assessments
+    }
+    assert by_allele["HLA-A*02:01"].nearest_distance == 1
+    assert by_allele["HLA-A*02:01"].nearest_hits[0].substitutions[0].matrix_score == 2
+    assert (
+        NEAR_SELF_REASON_QUERY_OUTSIDE_INDEX
+        in by_allele["HLA-B*07:02"].reason_codes
+    )
+    assert not result.has_complete_near_self_coverage
+    assert result.risk_index_provenance == risk_index.provenance
+
+    rows = result.near_self_rows()
+    assert len(rows) == 2
+    risk_row = next(row for row in rows if row["risk_gene_id"])
+    assert risk_row["risk_gene_id"] == "ENSG000001"
+    assert risk_row["tissue_group"] == "heart"
+    assert risk_row["substitutions"] == "8:I>L:2"
+    missing_row = next(row for row in rows if not row["risk_gene_id"])
+    assert missing_row["risk_peptide"] == ""
+    assert NEAR_SELF_REASON_QUERY_OUTSIDE_INDEX in missing_row["reason_codes"]
+    assert all(
+        not isinstance(value, (dict, list, tuple))
+        for row in rows
+        for value in row.values()
+    )
+
+    payload = result.to_report_dict()
+    assert json.loads(json.dumps(payload)) == payload
+    assert AntigenSafetyAssessment.from_json(result.to_json()) == result
+    with pytest.raises(ValueError, match="every target ligand/allele"):
+        AntigenSafetyAssessment(
+            window_assessment=window,
+            risk_index_provenance=risk_index.provenance,
+            near_self_assessments=result.near_self_assessments[:1],
+        )
+
+
+def test_repeated_target_peptide_positions_remain_distinct_public_queries():
+    antigen = VaccineAntigen(
+        kind=ANTIGEN_KIND_MUTATION,
+        amino_acids="AAAAAAAAI" * 2,
+        targetable_mask=TargetableMask((
+            AminoAcidInterval(8, 9),
+            AminoAcidInterval(17, 18),
+        )),
+        tumor_specificity=TumorSpecificityAttestation(
+            status=ATTESTATION_ADMITTED,
+            evidence_kind="somatic_variant",
+            evidence_source="test",
+            patient_specific=True,
+        ),
+        source_identifier="repeated-target",
+    )
+    prediction = SafetyPrediction(
+        kind="pMHC_affinity",
+        predictor_name="netMHCpan",
+        predictor_version="4.2",
+        allele="HLA-A*02:01",
+        percentile_rank=0.1,
+    )
+    self_match = SelfReferenceMatch(
+        peptide="AAAAAAAAI",
+        occurs=False,
+        antigen_kind=ANTIGEN_KIND_MUTATION,
+    )
+    window = WindowSafetyAssessment(
+        antigen=antigen,
+        window_start_offset=0,
+        window_end_offset=18,
+        ligands=(
+            EmittedSafetyLigand(
+                peptide="AAAAAAAAI",
+                window_start_offset=0,
+                window_end_offset=9,
+                antigen_start_offset=0,
+                antigen_end_offset=9,
+                overlaps_targetable=True,
+                self_reference_match=self_match,
+                predictions=(prediction,),
+            ),
+            EmittedSafetyLigand(
+                peptide="AAAAAAAAI",
+                window_start_offset=9,
+                window_end_offset=18,
+                antigen_start_offset=9,
+                antigen_end_offset=18,
+                overlaps_targetable=True,
+                self_reference_match=self_match,
+                predictions=(prediction,),
+            ),
+        ),
+        coverage=(SafetyPredictionCoverage(
+            kind="pMHC_affinity",
+            predictor_name="netMHCpan",
+            predictor_version="4.2",
+            alleles=("HLA-A*02:01",),
+            peptide_lengths=(9,),
+            prediction_count=2,
+        ),),
+    )
+
+    queries = near_self_queries_for_window(window)
+
+    assert [query.source_offset for query in queries] == [0, 9]
+    assert len({query.target_id for query in queries}) == 2
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    ("kind", "predictor_name", "predictor_version", "allele"),
+)
+def test_safety_prediction_requires_complete_model_and_allele_provenance(
+    missing_field,
+):
+    values = {
+        "kind": "pMHC_affinity",
+        "predictor_name": "netMHCpan",
+        "predictor_version": "4.2",
+        "allele": "HLA-A*02:01",
+    }
+    values[missing_field] = ""
+
+    with pytest.raises(ValueError, match="predictor, version, and allele"):
+        SafetyPrediction(**values)
+
+
+def test_safety_prediction_normalizes_nonhuman_alleles_through_mhcgnomes():
+    prediction = SafetyPrediction(
+        kind="pMHC_affinity",
+        predictor_name="netMHCpan",
+        predictor_version="4.2",
+        allele="H-2-Kb",
+    )
+    coverage = SafetyPredictionCoverage(
+        kind="pMHC_affinity",
+        predictor_name="netMHCpan",
+        predictor_version="4.2",
+        alleles=("H-2-Kb",),
+        peptide_lengths=(8,),
+        prediction_count=1,
+    )
+
+    assert prediction.allele == "H2-K*b"
+    assert coverage.alleles == ("H2-K*b",)

--- a/vaxrank/__init__.py
+++ b/vaxrank/__init__.py
@@ -28,13 +28,16 @@ from .vaccine_antigen import (
 from .vaccine_peptide import VaccinePeptide
 from .vaccine_library import antigen_construct_name, select_antigen_window
 from .safety_assessment import (
+    AntigenSafetyAssessment,
     ConstructBoundary,
     EmittedSafetyLigand,
     SafetyAssessmentError,
     SafetyPrediction,
     SafetyPredictionCoverage,
     WindowSafetyAssessment,
+    assess_antigen_safety,
     assess_vaccine_antigen_window,
+    near_self_queries_for_window,
     safety_assessment_from_prediction_frame,
 )
 from .tissue_risk import (
@@ -101,6 +104,7 @@ __all__ = [
     "__version__",
     "AminoAcidInterval",
     "AminoAcidSubstitutionMatrix",
+    "AntigenSafetyAssessment",
     "BLOSUM62",
     "CandidateEpitope",
     "CTAAdmissionAssessment",
@@ -156,6 +160,7 @@ __all__ = [
     "VaccineConfig",
     "VaccinePeptide",
     "WindowSafetyAssessment",
+    "assess_antigen_safety",
     "assess_vaccine_antigen_window",
     "assess_near_self",
     "assess_near_self_queries",
@@ -165,6 +170,7 @@ __all__ = [
     "build_patient_hla_risk_ligand_index",
     "build_cta_vaccine_antigen",
     "derive_tissue_risk_proteins",
+    "near_self_queries_for_window",
     "predict_epitopes",
     "run_vaxrank",
     "resolve_tissue_risk_policy",

--- a/vaxrank/near_self.py
+++ b/vaxrank/near_self.py
@@ -323,7 +323,7 @@ class NearSelfAssessment(DataclassSerializable):
         return incomplete_reasons.isdisjoint(self.reason_codes)
 
     def to_report_dict(self) -> dict:
-        return asdict(self)
+        return json.loads(json.dumps(asdict(self)))
 
 
 def assess_near_self_queries(

--- a/vaxrank/safety_assessment.py
+++ b/vaxrank/safety_assessment.py
@@ -16,10 +16,18 @@ from dataclasses import asdict, dataclass, field
 from numbers import Integral
 from typing import Any, Optional
 
+from mhcgnomes import parse as parse_mhc
 from serializable import DataclassSerializable
 from topiary import TopiaryPredictor
 
+from .near_self import (
+    DEFAULT_NEAR_SELF_COMPARATOR,
+    NearSelfAssessment,
+    NearSelfQuery,
+    assess_near_self_queries,
+)
 from .reference_proteome import ReferenceProteome
+from .risk_ligand import PatientHLARiskLigandIndex, RiskLigandIndexProvenance
 from .vaccine_antigen import SelfReferenceMatch, VaccineAntigen
 
 
@@ -89,8 +97,26 @@ class SafetyPrediction(DataclassSerializable):
     percentile_rank: Optional[float] = None
 
     def __post_init__(self):
-        if not self.kind:
-            raise ValueError("Safety prediction kind is required")
+        if not all((
+            self.kind,
+            self.predictor_name,
+            self.predictor_version,
+            self.allele,
+        )):
+            raise ValueError(
+                "Safety prediction kind, predictor, version, and allele are required"
+            )
+        try:
+            allele = parse_mhc(str(self.allele), raise_on_error=True)
+        except Exception as error:
+            raise ValueError(
+                f"Invalid safety prediction MHC allele {self.allele!r}"
+            ) from error
+        if allele is None:
+            raise ValueError(
+                f"Invalid safety prediction MHC allele {self.allele!r}"
+            )
+        object.__setattr__(self, "allele", allele.to_string())
         for label in ("score", "value", "percentile_rank"):
             value = getattr(self, label)
             if value is not None and not math.isfinite(value):
@@ -118,9 +144,20 @@ class SafetyPredictionCoverage(DataclassSerializable):
     prediction_count: int
 
     def __post_init__(self):
-        if not self.kind:
-            raise ValueError("Prediction coverage kind is required")
-        object.__setattr__(self, "alleles", tuple(sorted(set(self.alleles))))
+        if not all((self.kind, self.predictor_name, self.predictor_version)):
+            raise ValueError(
+                "Prediction coverage kind, predictor, and version are required"
+            )
+        try:
+            alleles = tuple(sorted({
+                parse_mhc(str(allele), raise_on_error=True).to_string()
+                for allele in self.alleles
+            }))
+        except Exception as error:
+            raise ValueError("Prediction coverage contains an invalid MHC allele") from error
+        if not alleles:
+            raise ValueError("Prediction coverage requires at least one MHC allele")
+        object.__setattr__(self, "alleles", alleles)
         object.__setattr__(
             self, "peptide_lengths", tuple(sorted(set(self.peptide_lengths)))
         )
@@ -357,6 +394,233 @@ class WindowSafetyAssessment(DataclassSerializable):
                     "percentile_rank": prediction.percentile_rank,
                 })
         return rows
+
+    @property
+    def target_ligands(self) -> tuple[EmittedSafetyLigand, ...]:
+        """Targetable ligands that are absent from the applicable self reference."""
+        return tuple(
+            ligand
+            for ligand in self.ligands
+            if ligand.overlaps_targetable and not ligand.occurs_in_self_reference
+        )
+
+
+def near_self_queries_for_window(
+    window_assessment: WindowSafetyAssessment,
+) -> tuple[NearSelfQuery, ...]:
+    """Create one traceable near-self query per target ligand and patient allele."""
+    source_name = window_assessment.antigen.display_identifier
+    queries = []
+    for ligand in window_assessment.target_ligands:
+        target_id = "%s:%d-%d:%s" % (
+            source_name,
+            ligand.antigen_start_offset,
+            ligand.antigen_end_offset,
+            ligand.peptide,
+        )
+        for allele in sorted({
+            prediction.allele for prediction in ligand.predictions
+        }):
+            queries.append(NearSelfQuery(
+                peptide=ligand.peptide,
+                allele=allele,
+                target_id=target_id,
+                source_name=source_name,
+                source_offset=ligand.antigen_start_offset,
+            ))
+    return tuple(queries)
+
+
+@dataclass(frozen=True)
+class AntigenSafetyAssessment(DataclassSerializable):
+    """Complete-window and tissue-risk near-self facts for one antigen window."""
+
+    window_assessment: WindowSafetyAssessment
+    risk_index_provenance: RiskLigandIndexProvenance
+    near_self_assessments: tuple[NearSelfAssessment, ...]
+
+    def __post_init__(self):
+        assessments = tuple(sorted(
+            self.near_self_assessments,
+            key=lambda assessment: (
+                assessment.query.source_offset,
+                assessment.query.peptide,
+                assessment.normalized_allele,
+                assessment.query.target_id,
+            ),
+        ))
+        expected_queries = near_self_queries_for_window(self.window_assessment)
+        expected_identities = {
+            (
+                query.target_id,
+                query.peptide,
+                query.allele,
+                query.source_name,
+                query.source_offset,
+            )
+            for query in expected_queries
+        }
+        observed_identities = [
+            (
+                assessment.query.target_id,
+                assessment.query.peptide,
+                assessment.query.allele,
+                assessment.query.source_name,
+                assessment.query.source_offset,
+            )
+            for assessment in assessments
+        ]
+        if len(observed_identities) != len(set(observed_identities)):
+            raise ValueError("Antigen safety assessment has duplicate near-self queries")
+        if set(observed_identities) != expected_identities:
+            raise ValueError(
+                "Antigen safety assessment does not cover every target ligand/allele"
+            )
+        if any(
+            assessment.risk_index_cache_identity_sha256
+            != self.risk_index_provenance.cache_identity_sha256
+            for assessment in assessments
+        ):
+            raise ValueError(
+                "Antigen safety assessment and near-self risk-index provenance differ"
+            )
+        object.__setattr__(self, "near_self_assessments", assessments)
+
+    @property
+    def has_complete_near_self_coverage(self) -> bool:
+        """Whether every target query has complete risk-index coverage."""
+        return all(
+            assessment.has_complete_coverage
+            for assessment in self.near_self_assessments
+        )
+
+    def to_report_dict(self) -> dict:
+        """JSON-compatible evidence tree for safety audit reports."""
+        return {
+            "window_assessment": self.window_assessment.to_report_dict(),
+            "risk_index_provenance": _json_native(
+                asdict(self.risk_index_provenance)
+            ),
+            "near_self_assessments": [
+                assessment.to_report_dict()
+                for assessment in self.near_self_assessments
+            ],
+        }
+
+    def near_self_rows(self) -> list[dict]:
+        """Flat primitive-valued near-self rows for CSV/DataFrame reports."""
+        rows = []
+        for assessment in self.near_self_assessments:
+            base = {
+                "antigen_kind": self.window_assessment.antigen.kind,
+                "antigen_source_identifier": (
+                    self.window_assessment.antigen.source_identifier
+                ),
+                "window_start_offset": self.window_assessment.window_start_offset,
+                "window_end_offset": self.window_assessment.window_end_offset,
+                "target_id": assessment.query.target_id,
+                "target_peptide": assessment.query.peptide,
+                "target_antigen_offset": assessment.query.source_offset,
+                "allele": assessment.normalized_allele,
+                "nearest_distance": assessment.nearest_distance,
+                "reason_codes": ";".join(assessment.reason_codes),
+                "has_complete_coverage": assessment.has_complete_coverage,
+                "comparator_metric": assessment.comparator.metric,
+                "substitution_matrix": assessment.comparator.matrix_name,
+                "substitution_matrix_version": assessment.comparator.matrix_version,
+                "substitution_matrix_sha256": assessment.comparator.matrix_sha256,
+                "risk_index_cache_identity_sha256": (
+                    assessment.risk_index_cache_identity_sha256
+                ),
+                "risk_index_genome_release": (
+                    self.risk_index_provenance.genome_release
+                ),
+                "risk_index_protein_resolution_policy": (
+                    self.risk_index_provenance.protein_resolution_policy
+                ),
+                "risk_index_predictor_identities": ";".join(
+                    self.risk_index_provenance.predictor_identities
+                ),
+                "risk_index_hpa_source_sha256": (
+                    self.risk_index_provenance.hpa_source_sha256
+                ),
+                "risk_index_cta_gene_set_sha256": (
+                    self.risk_index_provenance.cta_unfiltered_gene_ids_sha256
+                ),
+            }
+            if not assessment.nearest_hits:
+                rows.append(base | {
+                    "risk_peptide": "",
+                    "risk_inclusion_kinds": "",
+                    "substitutions": "",
+                    "risk_gene_id": "",
+                    "risk_gene_name": "",
+                    "risk_transcript_ids": "",
+                    "risk_protein_ids": "",
+                    "risk_protein_offsets": "",
+                    "tissue_group": "",
+                    "hpa_tissue": "",
+                    "cell_type": "",
+                    "hpa_level": "",
+                    "hpa_reliability": "",
+                })
+                continue
+            for hit in assessment.nearest_hits:
+                substitutions = ";".join(
+                    "%d:%s>%s:%d" % (
+                        substitution.position,
+                        substitution.target_residue,
+                        substitution.risk_residue,
+                        substitution.matrix_score,
+                    )
+                    for substitution in hit.substitutions
+                )
+                for source in hit.risk_ligand.sources:
+                    tissue_evidence = source.tissue_evidence or (None,)
+                    for evidence in tissue_evidence:
+                        rows.append(base | {
+                            "risk_peptide": hit.risk_ligand.peptide,
+                            "risk_inclusion_kinds": ";".join(
+                                hit.risk_ligand.inclusion_kinds
+                            ),
+                            "substitutions": substitutions,
+                            "risk_gene_id": source.gene_id,
+                            "risk_gene_name": source.gene_name,
+                            "risk_transcript_ids": ";".join(source.transcript_ids),
+                            "risk_protein_ids": ";".join(source.protein_ids),
+                            "risk_protein_offsets": ";".join(
+                                str(offset) for offset in source.protein_offsets
+                            ),
+                            "tissue_group": (
+                                evidence.tissue_group if evidence else ""
+                            ),
+                            "hpa_tissue": evidence.hpa_tissue if evidence else "",
+                            "cell_type": evidence.cell_type if evidence else "",
+                            "hpa_level": evidence.level if evidence else "",
+                            "hpa_reliability": (
+                                evidence.reliability if evidence else ""
+                            ),
+                        })
+        return rows
+
+
+def assess_antigen_safety(
+    window_assessment: WindowSafetyAssessment,
+    risk_index: PatientHLARiskLigandIndex,
+    *,
+    comparator=DEFAULT_NEAR_SELF_COMPARATOR,
+) -> AntigenSafetyAssessment:
+    """Combine complete-window safety facts with policy-neutral near-self facts."""
+    queries = near_self_queries_for_window(window_assessment)
+    return AntigenSafetyAssessment(
+        window_assessment=window_assessment,
+        risk_index_provenance=risk_index.provenance,
+        near_self_assessments=assess_near_self_queries(
+            queries,
+            risk_index,
+            comparator=comparator,
+        ),
+    )
 
 
 def _json_native(value):

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.20"
+__version__ = "3.1.21"
 
 
 def print_version():


### PR DESCRIPTION
Closes #254.

Final construct enforcement and product decisions remain tracked by #311.

## Summary
- add public `near_self_queries_for_window` and `assess_antigen_safety` APIs
- add immutable `AntigenSafetyAssessment` with complete mapping/provenance invariants
- expose targetable, non-exact-self ligands through `WindowSafetyAssessment.target_ligands`
- deduplicate multi-model predictions into one near-self query per ligand/allele while preserving repeated peptide positions
- emit primitive-valued near-self rows with substitution, risk-protein, tissue, HPA, CTA-set, genome, model, and cache provenance
- require complete predictor/version/allele provenance and normalize alleles through mhcgnomes
- make near-self report trees genuinely JSON-native
- bump vaxrank to 3.1.21

## Verification
- `./lint.sh`
- focused safety/risk suite: 50 passed
- `./test.sh`: 959 passed
- added-code scan: no private helper functions or classes