### PR TITLE
Add public biological normalization APIs

### DIFF
--- a/tests/test_biological_normalization.py
+++ b/tests/test_biological_normalization.py
@@ -1,0 +1,33 @@
+import pytest
+
+from vaxrank import (
+    has_only_standard_amino_acids,
+    normalize_ensembl_gene_id,
+    normalize_mhc_allele,
+    validate_amino_acid_sequence,
+)
+
+
+def test_normalize_ensembl_gene_id_removes_version_and_whitespace():
+    assert normalize_ensembl_gene_id(" ENSG00000185686.4 ") == "ENSG00000185686"
+    assert normalize_ensembl_gene_id("ENSG00000185686") == "ENSG00000185686"
+    assert normalize_ensembl_gene_id("") == ""
+    assert normalize_ensembl_gene_id(None) == ""
+
+
+def test_normalize_mhc_allele_uses_mhcgnomes_for_human_and_mouse_alleles():
+    assert normalize_mhc_allele("A*02:01") == "HLA-A*02:01"
+    assert normalize_mhc_allele("H2-Kb") == "H2-K*b"
+    with pytest.raises(ValueError, match="Invalid MHC allele"):
+        normalize_mhc_allele("not-an-allele")
+
+
+def test_canonical_amino_acid_validation_has_boolean_and_raising_apis():
+    assert has_only_standard_amino_acids("ACDEFGHIKLMNPQRSTVWY")
+    assert has_only_standard_amino_acids("")
+    assert not has_only_standard_amino_acids("ACDEX")
+    validate_amino_acid_sequence("SIINFEKL", "Target peptide")
+    with pytest.raises(ValueError, match="sequence is required"):
+        validate_amino_acid_sequence("", "Target peptide")
+    with pytest.raises(ValueError, match="non-canonical amino acids: J, X"):
+        validate_amino_acid_sequence("AXJ", "Target peptide")

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -349,7 +349,7 @@ def test_truncate_at_stop_codon_helper():
 def test_has_only_standard_amino_acids_helper():
     """The 20 canonical AAs pass; non-standard residues (selenocysteine
     U, pyrrolysine O, ambiguous X / B / Z / J, stop *) fail."""
-    from vaxrank.vaccine_library import has_only_standard_amino_acids
+    from vaxrank import has_only_standard_amino_acids
     assert has_only_standard_amino_acids("KLQGHSAPVL")
     assert has_only_standard_amino_acids("")
     for non_standard in ("U", "O", "X", "B", "Z", "J", "*"):

--- a/vaxrank/__init__.py
+++ b/vaxrank/__init__.py
@@ -12,6 +12,12 @@
 
 
 from .core_logic import run_vaxrank
+from .amino_acids import (
+    STANDARD_AMINO_ACIDS,
+    has_only_standard_amino_acids,
+    validate_amino_acid_sequence,
+)
+from .identifiers import normalize_ensembl_gene_id, normalize_mhc_allele
 from .epitope_config import EpitopeConfig
 from .epitope_logic import predict_epitopes
 from .candidate_epitope import CandidateEpitope, Peptide
@@ -154,6 +160,7 @@ __all__ = [
     "RiskLigandSource",
     "RiskPercentileThreshold",
     "RiskProteinSequenceSet",
+    "STANDARD_AMINO_ACIDS",
     "SAFETY_MODE_AUDIT",
     "SAFETY_MODE_ENFORCE",
     "SAFETY_MODE_OFF",
@@ -192,7 +199,10 @@ __all__ = [
     "build_cta_vaccine_antigen",
     "derive_tissue_risk_proteins",
     "evaluate_antigen_safety_policy",
+    "has_only_standard_amino_acids",
     "near_self_queries_for_window",
+    "normalize_ensembl_gene_id",
+    "normalize_mhc_allele",
     "predict_epitopes",
     "run_vaxrank",
     "resolve_tissue_risk_policy",
@@ -201,4 +211,5 @@ __all__ = [
     "safety_assessment_from_prediction_frame",
     "self_reference_matches",
     "select_antigen_window",
+    "validate_amino_acid_sequence",
 ]

--- a/vaxrank/amino_acids.py
+++ b/vaxrank/amino_acids.py
@@ -1,0 +1,22 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Validation of amino-acid sequences used in vaccine safety models."""
+
+STANDARD_AMINO_ACIDS = frozenset("ACDEFGHIKLMNPQRSTVWY")
+
+
+def has_only_standard_amino_acids(sequence: str) -> bool:
+    """Return whether every residue belongs to the standard amino-acid set."""
+    return all(residue in STANDARD_AMINO_ACIDS for residue in sequence)
+
+
+def validate_amino_acid_sequence(sequence: str, label: str) -> None:
+    """Reject empty sequences and residues outside the standard alphabet."""
+    if not sequence:
+        raise ValueError(f"{label} amino-acid sequence is required")
+    invalid = sorted(set(sequence) - STANDARD_AMINO_ACIDS)
+    if invalid:
+        raise ValueError(
+            f"{label} contains non-canonical amino acids: {', '.join(invalid)}"
+        )

--- a/vaxrank/cta_admission.py
+++ b/vaxrank/cta_admission.py
@@ -14,6 +14,7 @@ from typing import Optional
 import pandas as pd
 from serializable import DataclassSerializable
 
+from .identifiers import normalize_ensembl_gene_id
 from .vaccine_antigen import (
     ANTIGEN_KIND_CTA,
     ATTESTATION_ADMITTED,
@@ -35,10 +36,6 @@ CTA_REASON_EXPLICIT_OVERRIDE = "cta_explicit_evidence_override"
 
 class CTAAdmissionError(RuntimeError):
     """Raised when CTA admission evidence cannot be resolved unambiguously."""
-
-
-def _gene_id(value) -> str:
-    return str(value).strip().split(".")[0]
 
 
 def _finite_nonnegative(value, label: str) -> float:
@@ -108,7 +105,7 @@ class PatientTumorExpressionEvidence(DataclassSerializable):
     assay: str = ""
 
     def __post_init__(self):
-        gene_id = _gene_id(self.gene_id)
+        gene_id = normalize_ensembl_gene_id(self.gene_id)
         if not gene_id or not self.sample_id:
             raise ValueError("Tumor expression requires gene and patient sample IDs")
         if (
@@ -163,7 +160,9 @@ class CTAReferenceEvidence(DataclassSerializable):
     source_row_sha256: str
 
     def __post_init__(self):
-        object.__setattr__(self, "gene_id", _gene_id(self.gene_id))
+        object.__setattr__(
+            self, "gene_id", normalize_ensembl_gene_id(self.gene_id)
+        )
         for digest in (
             self.canonical_gene_ids_sha256,
             self.unfiltered_gene_ids_sha256,
@@ -196,9 +195,12 @@ def _resolve_reference_evidence(gene_id: str):
     from oncoref.cta import cta_evidence, cta_gene_ids, cta_unfiltered_gene_ids
     from oncoref.version import DATA_VERSION, SOURCE_MATRIX_VERSION
 
-    canonical_ids = frozenset(_gene_id(value) for value in cta_gene_ids())
+    canonical_ids = frozenset(
+        normalize_ensembl_gene_id(value) for value in cta_gene_ids()
+    )
     unfiltered_ids = frozenset(
-        _gene_id(value) for value in cta_unfiltered_gene_ids()
+        normalize_ensembl_gene_id(value)
+        for value in cta_unfiltered_gene_ids()
     )
     if not canonical_ids or not unfiltered_ids:
         raise CTAAdmissionError("oncoref returned an empty CTA reference set")
@@ -227,7 +229,7 @@ def _resolve_reference_evidence(gene_id: str):
         raise CTAAdmissionError(
             f"oncoref CTA evidence is missing columns: {sorted(missing)}"
         )
-    normalized_ids = frame["Ensembl_Gene_ID"].map(_gene_id)
+    normalized_ids = frame["Ensembl_Gene_ID"].map(normalize_ensembl_gene_id)
     rows = frame.loc[normalized_ids == gene_id]
     if len(rows) != 1:
         raise CTAAdmissionError(
@@ -278,7 +280,7 @@ def assess_cta_antigen(
     source_identifier: str = "",
 ) -> CTAAdmissionAssessment:
     """Resolve oncoref CTA status and patient-expression construct admission."""
-    gene_id = _gene_id(gene_id)
+    gene_id = normalize_ensembl_gene_id(gene_id)
     if tumor_expression.gene_id != gene_id:
         raise ValueError("CTA and tumor-expression gene IDs differ")
     if tumor_expression.unit != policy.expression_unit:

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -43,12 +43,10 @@ import os
 
 import pandas as pd
 
+from .amino_acids import has_only_standard_amino_acids
 from .epitope_io import detect_lens_predictors
 from .mutant_protein_fragment import MutantProteinFragment
-from .vaccine_library import (
-    has_only_standard_amino_acids,
-    truncate_at_stop_codon,
-)
+from .vaccine_library import truncate_at_stop_codon
 from .vaccine_peptide import VaccinePeptide
 
 # pVACseq scoring column priority. Sniffed against the row dict; the first

--- a/vaxrank/identifiers.py
+++ b/vaxrank/identifiers.py
@@ -1,0 +1,26 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Canonical forms for biological identifiers used across vaxrank."""
+
+from typing import Optional
+
+from mhcgnomes import parse as parse_mhc
+
+
+def normalize_ensembl_gene_id(value: Optional[str]) -> str:
+    """Strip whitespace and an optional Ensembl stable-ID version suffix."""
+    if value is None:
+        return ""
+    return str(value).strip().split(".")[0]
+
+
+def normalize_mhc_allele(value: str) -> str:
+    """Return the mhcgnomes canonical representation of an MHC allele."""
+    try:
+        allele = parse_mhc(str(value), raise_on_error=True)
+    except Exception as error:
+        raise ValueError(f"Invalid MHC allele {value!r}") from error
+    if allele is None:
+        raise ValueError(f"Invalid MHC allele {value!r}")
+    return allele.to_string()

--- a/vaxrank/near_self.py
+++ b/vaxrank/near_self.py
@@ -23,15 +23,15 @@ from numbers import Integral
 from typing import Optional
 
 import numpy as np
-from mhcgnomes import parse as parse_mhc
 from serializable import DataclassSerializable
 
+from .amino_acids import STANDARD_AMINO_ACIDS, validate_amino_acid_sequence
+from .identifiers import normalize_mhc_allele
 from .risk_ligand import (
     PatientHLARiskLigandIndex,
     RiskCoverageGap,
     RiskLigand,
 )
-from .vaccine_antigen import STANDARD_AMINO_ACIDS
 
 
 NEAR_SELF_REASON_NO_RISK_LIGANDS = "no_same_allele_length_risk_ligands"
@@ -66,24 +66,6 @@ BLOSUM62_ROWS = (
 
 class NearSelfError(RuntimeError):
     """Raised when similarity evidence cannot be computed unambiguously."""
-
-
-def _normalize_allele(value: str) -> str:
-    try:
-        parsed = parse_mhc(str(value), raise_on_error=True)
-    except Exception as error:
-        raise NearSelfError(f"Invalid MHC allele {value!r}") from error
-    if parsed is None:
-        raise NearSelfError(f"Invalid MHC allele {value!r}")
-    return parsed.to_string()
-
-
-def _validate_peptide(peptide: str, label: str):
-    invalid = sorted(set(peptide) - STANDARD_AMINO_ACIDS)
-    if not peptide or invalid:
-        raise NearSelfError(
-            f"{label} must contain only canonical amino acids; invalid={invalid}"
-        )
 
 
 @dataclass(frozen=True)
@@ -246,8 +228,9 @@ class NearSelfQuery(DataclassSerializable):
     source_offset: int = 0
 
     def __post_init__(self):
-        invalid = sorted(set(self.peptide) - STANDARD_AMINO_ACIDS)
-        if not self.peptide or invalid:
+        try:
+            validate_amino_acid_sequence(self.peptide, "Near-self query")
+        except ValueError:
             raise ValueError("Near-self query requires a canonical peptide")
         if (
             isinstance(self.source_offset, bool)
@@ -358,8 +341,11 @@ def assess_near_self_queries(
     )
     results = []
     for query in queries:
-        _validate_peptide(query.peptide, "Target peptide")
-        allele = _normalize_allele(query.allele)
+        try:
+            validate_amino_acid_sequence(query.peptide, "Target peptide")
+            allele = normalize_mhc_allele(query.allele)
+        except ValueError as error:
+            raise NearSelfError(str(error)) from error
         group_key = (allele, len(query.peptide))
         gaps = tuple(
             gap for gap in risk_index.coverage.missing_combinations

--- a/vaxrank/reference_proteome.py
+++ b/vaxrank/reference_proteome.py
@@ -32,6 +32,7 @@ from pyensembl import Genome
 from tqdm import tqdm
 
 from .config.defaults import DEFAULT_MAX_KMER_LENGTH, DEFAULT_MIN_KMER_LENGTH
+from .identifiers import normalize_ensembl_gene_id
 from .vaccine_antigen import (
     SelfReferenceMatch,
     SelfReferenceSource,
@@ -52,8 +53,10 @@ def oncoref_cta_source_gene_ids() -> frozenset[str]:
     """
     from oncoref.cta import cta_unfiltered_gene_ids
 
-    return frozenset(str(gene_id).split(".")[0]
-                     for gene_id in cta_unfiltered_gene_ids())
+    return frozenset(
+        normalize_ensembl_gene_id(gene_id)
+        for gene_id in cta_unfiltered_gene_ids()
+    )
 
 
 def _is_human_genome(genome) -> bool:
@@ -164,7 +167,9 @@ def _protein_source_snapshot(genome):
     for transcript in genome.transcripts():
         if not transcript.is_protein_coding or not transcript.protein_sequence:
             continue
-        gene_id = str(getattr(transcript, "gene_id", "") or "").split(".")[0]
+        gene_id = normalize_ensembl_gene_id(
+            getattr(transcript, "gene_id", "") or ""
+        )
         if not gene_id:
             raise ValueError(
                 "Protein-coding self-reference transcript is missing a gene ID"
@@ -420,13 +425,14 @@ def genome_protein_dict(genome, exclude_gene_ids=None):
     dict[str, str]
     """
     excluded_gene_ids = {
-        str(gene_id).split(".")[0] for gene_id in (exclude_gene_ids or [])
+        normalize_ensembl_gene_id(gene_id)
+        for gene_id in (exclude_gene_ids or [])
     }
 
     proteins = {}
     num_excluded_transcripts = 0
     for t in genome.transcripts():
-        gene_id = str(t.gene_id).split(".")[0]
+        gene_id = normalize_ensembl_gene_id(t.gene_id)
         if gene_id in excluded_gene_ids:
             num_excluded_transcripts += 1
         elif t.is_protein_coding and t.protein_sequence:
@@ -618,7 +624,8 @@ class ReferenceProteome:
             )
 
         all_exclude_ids = {
-            str(gene_id).split(".")[0] for gene_id in (exclude_gene_ids or [])
+            normalize_ensembl_gene_id(gene_id)
+            for gene_id in (exclude_gene_ids or [])
         }
 
         if exclude_cta_genes:

--- a/vaxrank/risk_ligand.py
+++ b/vaxrank/risk_ligand.py
@@ -11,15 +11,18 @@ import math
 from dataclasses import asdict, dataclass, field
 from typing import Any, Optional
 
-from mhcgnomes import parse as parse_mhc
 from serializable import DataclassSerializable
 from topiary import TopiaryPredictor
 
+from .amino_acids import (
+    has_only_standard_amino_acids,
+    validate_amino_acid_sequence,
+)
+from .identifiers import normalize_ensembl_gene_id, normalize_mhc_allele
 from .tissue_risk import (
     TissueRiskAssessment,
     TissueRiskEvidence,
 )
-from .vaccine_antigen import STANDARD_AMINO_ACIDS
 
 
 PROTEIN_RESOLUTION_ALL_ISOFORMS = "all_protein_coding_isoforms"
@@ -38,10 +41,6 @@ RISK_COMBINATION_POLICIES = frozenset({
 
 class RiskLigandError(RuntimeError):
     """Raised when a risk-ligand index cannot be built unambiguously."""
-
-
-def _gene_id(value) -> str:
-    return str(value).strip().split(".")[0]
 
 
 def _finite_or_none(value):
@@ -65,16 +64,6 @@ def _required_int(value, label: str) -> int:
     if not equivalent:
         raise RiskLigandError(f"{label} must be an integer")
     return result
-
-
-def _normalize_allele(value: str) -> str:
-    try:
-        parsed = parse_mhc(str(value), raise_on_error=True)
-    except Exception as error:
-        raise RiskLigandError(f"Invalid MHC allele {value!r}") from error
-    if parsed is None:
-        raise RiskLigandError(f"Invalid MHC allele {value!r}")
-    return parsed.to_string()
 
 
 def _json_native(value):
@@ -104,12 +93,19 @@ class ResolvedRiskProtein(DataclassSerializable):
     tissue_evidence: tuple[TissueRiskEvidence, ...]
 
     def __post_init__(self):
-        gene_id = _gene_id(self.gene_id)
-        invalid = sorted(set(self.amino_acids) - STANDARD_AMINO_ACIDS)
-        if not gene_id or not self.amino_acids or invalid:
+        gene_id = normalize_ensembl_gene_id(self.gene_id)
+        if not gene_id:
             raise ValueError(
                 "Resolved risk protein requires a canonical amino-acid sequence"
             )
+        try:
+            validate_amino_acid_sequence(
+                self.amino_acids, "Resolved risk protein"
+            )
+        except ValueError as error:
+            raise ValueError(
+                "Resolved risk protein requires a canonical amino-acid sequence"
+            ) from error
         if not self.transcript_ids or not self.tissue_evidence:
             raise ValueError(
                 "Resolved risk protein requires transcript and tissue provenance"
@@ -269,7 +265,7 @@ class RiskLigandPrediction(DataclassSerializable):
             and not 0.0 <= self.percentile_rank <= 100.0
         ):
             raise ValueError("Risk prediction percentile rank must be 0..100")
-        object.__setattr__(self, "allele", _normalize_allele(self.allele))
+        object.__setattr__(self, "allele", normalize_mhc_allele(self.allele))
 
     @property
     def identity(self) -> tuple[str, str, str, str]:
@@ -295,7 +291,9 @@ class RiskLigandSource(DataclassSerializable):
     def __post_init__(self):
         if not self.source_sequence_name or len(self.protein_sequence_sha256) != 64:
             raise ValueError("Risk ligand source requires protein sequence identity")
-        object.__setattr__(self, "gene_id", _gene_id(self.gene_id))
+        object.__setattr__(
+            self, "gene_id", normalize_ensembl_gene_id(self.gene_id)
+        )
         object.__setattr__(
             self, "transcript_ids", tuple(sorted(set(self.transcript_ids)))
         )
@@ -327,7 +325,7 @@ class RiskLigand(DataclassSerializable):
     def __post_init__(self):
         if not self.peptide or not self.allele or not self.sources:
             raise ValueError("Risk ligand requires peptide, allele, and sources")
-        allele = _normalize_allele(self.allele)
+        allele = normalize_mhc_allele(self.allele)
         predictions = tuple(sorted(self.predictions, key=lambda item: item.identity))
         identities = [prediction.identity for prediction in predictions]
         if len(identities) != len(set(identities)):
@@ -371,7 +369,7 @@ class RiskCoverageGap(DataclassSerializable):
             or self.expected_window_count <= self.observed_window_count
         ):
             raise ValueError("Risk coverage gaps require missing prediction windows")
-        object.__setattr__(self, "allele", _normalize_allele(self.allele))
+        object.__setattr__(self, "allele", normalize_mhc_allele(self.allele))
 
     @property
     def missing_window_count(self) -> int:
@@ -445,7 +443,9 @@ class PatientHLARiskLigandIndex(DataclassSerializable):
     provenance: RiskLigandIndexProvenance
 
     def __post_init__(self):
-        alleles = tuple(sorted({_normalize_allele(allele) for allele in self.alleles}))
+        alleles = tuple(sorted({
+            normalize_mhc_allele(allele) for allele in self.alleles
+        }))
         lengths = tuple(sorted(set(self.peptide_lengths)))
         if not alleles or not lengths or any(length <= 0 for length in lengths):
             raise ValueError("Risk index requires alleles and peptide lengths")
@@ -467,7 +467,7 @@ class PatientHLARiskLigandIndex(DataclassSerializable):
         object.__setattr__(self, "ligands", ligands)
 
     def for_allele_and_length(self, allele: str, peptide_length: int):
-        normalized = _normalize_allele(allele)
+        normalized = normalize_mhc_allele(allele)
         return tuple(
             ligand for ligand in self.ligands
             if ligand.allele == normalized and len(ligand.peptide) == peptide_length
@@ -511,7 +511,7 @@ def resolve_tissue_risk_protein_sequences(
                 sequence = (transcript.protein_sequence or "").rstrip("*")
             except Exception:
                 sequence = ""
-            if not sequence or set(sequence) - STANDARD_AMINO_ACIDS:
+            if not sequence or not has_only_standard_amino_acids(sequence):
                 invalid_count += 1
                 continue
             slot = by_sequence.setdefault(
@@ -604,7 +604,12 @@ def risk_ligand_index_from_prediction_frame(
 ) -> PatientHLARiskLigandIndex:
     """Build a patient-specific index from unfiltered topiary output."""
     selection_policy = selection_policy or RiskLigandSelectionPolicy()
-    normalized_alleles = tuple(sorted({_normalize_allele(a) for a in alleles}))
+    try:
+        normalized_alleles = tuple(sorted({
+            normalize_mhc_allele(allele) for allele in alleles
+        }))
+    except ValueError as error:
+        raise RiskLigandError(str(error)) from error
     lengths = tuple(sorted({
         _required_int(length, "Configured peptide length")
         for length in peptide_lengths
@@ -643,7 +648,10 @@ def risk_ligand_index_from_prediction_frame(
                 raise RiskLigandError(
                     "Risk prediction peptide does not match its source protein"
                 )
-            allele = _normalize_allele(row.get("allele"))
+            try:
+                allele = normalize_mhc_allele(row.get("allele"))
+            except ValueError as error:
+                raise RiskLigandError(str(error)) from error
             if allele not in normalized_alleles:
                 raise RiskLigandError("Risk predictor emitted an unconfigured allele")
             prediction = _prediction_from_row(row, allele)

--- a/vaxrank/safety_assessment.py
+++ b/vaxrank/safety_assessment.py
@@ -16,10 +16,10 @@ from dataclasses import asdict, dataclass, field
 from numbers import Integral
 from typing import Any, Optional
 
-from mhcgnomes import parse as parse_mhc
 from serializable import DataclassSerializable
 from topiary import TopiaryPredictor
 
+from .identifiers import normalize_mhc_allele
 from .near_self import (
     DEFAULT_NEAR_SELF_COMPARATOR,
     NearSelfAssessment,
@@ -107,16 +107,12 @@ class SafetyPrediction(DataclassSerializable):
                 "Safety prediction kind, predictor, version, and allele are required"
             )
         try:
-            allele = parse_mhc(str(self.allele), raise_on_error=True)
-        except Exception as error:
+            allele = normalize_mhc_allele(self.allele)
+        except ValueError as error:
             raise ValueError(
                 f"Invalid safety prediction MHC allele {self.allele!r}"
             ) from error
-        if allele is None:
-            raise ValueError(
-                f"Invalid safety prediction MHC allele {self.allele!r}"
-            )
-        object.__setattr__(self, "allele", allele.to_string())
+        object.__setattr__(self, "allele", allele)
         for label in ("score", "value", "percentile_rank"):
             value = getattr(self, label)
             if value is not None and not math.isfinite(value):
@@ -155,10 +151,9 @@ class SafetyPredictionCoverage(DataclassSerializable):
             )
         try:
             alleles = tuple(sorted({
-                parse_mhc(str(allele), raise_on_error=True).to_string()
-                for allele in self.alleles
+                normalize_mhc_allele(allele) for allele in self.alleles
             }))
-        except Exception as error:
+        except ValueError as error:
             raise ValueError("Prediction coverage contains an invalid MHC allele") from error
         if not alleles:
             raise ValueError("Prediction coverage requires at least one MHC allele")

--- a/vaxrank/safety_policy.py
+++ b/vaxrank/safety_policy.py
@@ -23,7 +23,7 @@ from .safety_assessment import (
     EmittedSafetyLigand,
     SafetyPrediction,
 )
-from .vaccine_antigen import STANDARD_AMINO_ACIDS
+from .amino_acids import STANDARD_AMINO_ACIDS
 
 
 SAFETY_MODE_OFF = "off"

--- a/vaxrank/tissue_risk.py
+++ b/vaxrank/tissue_risk.py
@@ -25,6 +25,7 @@ from typing import Optional
 import pandas as pd
 from serializable import DataclassSerializable
 
+from .identifiers import normalize_ensembl_gene_id
 
 DEFAULT_HPA_LEVELS = ("High", "Medium")
 DEFAULT_HPA_RELIABILITIES = ("Approved", "Enhanced", "Supported")
@@ -34,12 +35,6 @@ PRAME_GENE_ID = "ENSG00000185686"
 
 class TissueRiskDerivationError(RuntimeError):
     """Raised when HPA safety evidence is missing or inconsistent."""
-
-
-def _gene_id(value) -> str:
-    if pd.isna(value):
-        return ""
-    return str(value).strip().split(".")[0]
 
 
 def _text(value) -> str:
@@ -149,7 +144,7 @@ class TissueRiskProtein(DataclassSerializable):
     evidence: tuple[TissueRiskEvidence, ...]
 
     def __post_init__(self):
-        normalized = _gene_id(self.gene_id)
+        normalized = normalize_ensembl_gene_id(self.gene_id)
         if not normalized or not self.evidence:
             raise ValueError("Tissue-risk protein requires a gene ID and evidence")
         object.__setattr__(self, "gene_id", normalized)
@@ -322,8 +317,10 @@ def derive_tissue_risk_proteins(
             f"HPA normal-tissue data is missing columns: {sorted(missing_columns)}"
         )
 
-    cta_gene_ids = frozenset(_gene_id(gene_id)
-                             for gene_id in cta_unfiltered_gene_ids())
+    cta_gene_ids = frozenset(
+        normalize_ensembl_gene_id(gene_id)
+        for gene_id in cta_unfiltered_gene_ids()
+    )
     tissue_to_groups: dict[str, list[str]] = {}
     for group in policy.tissue_groups:
         for tissue in group.tissues:
@@ -350,7 +347,10 @@ def derive_tissue_risk_proteins(
         if not groups:
             continue
         counts["selected_tissue_rows"] += 1
-        gene_id = _gene_id(row["Gene"])
+        gene_id = (
+            "" if pd.isna(row["Gene"])
+            else normalize_ensembl_gene_id(row["Gene"])
+        )
         level = _text(row["Level"])
         reliability = _text(row["Reliability"])
         if not gene_id:

--- a/vaxrank/vaccine_antigen.py
+++ b/vaxrank/vaccine_antigen.py
@@ -18,6 +18,9 @@ from typing import Any, Optional
 
 from serializable import DataclassSerializable
 
+from .amino_acids import validate_amino_acid_sequence
+from .identifiers import normalize_ensembl_gene_id
+
 
 ANTIGEN_KIND_MUTATION = "mutation"
 ANTIGEN_KIND_CTA = "CTA"
@@ -40,23 +43,6 @@ ATTESTATION_STATUSES = frozenset({
     ATTESTATION_HELD_OUT,
     ATTESTATION_OVERRIDDEN,
 })
-STANDARD_AMINO_ACIDS = frozenset("ACDEFGHIKLMNPQRSTVWY")
-
-
-def _normalized_gene_id(gene_id: str) -> str:
-    return str(gene_id).split(".")[0]
-
-
-def _validate_amino_acids(sequence: str, label: str) -> None:
-    if not sequence:
-        raise ValueError(f"{label} amino-acid sequence is required")
-    invalid = sorted(set(sequence) - STANDARD_AMINO_ACIDS)
-    if invalid:
-        raise ValueError(
-            f"{label} contains non-canonical amino acids: {', '.join(invalid)}"
-        )
-
-
 @dataclass(frozen=True)
 class AminoAcidInterval(DataclassSerializable):
     """Zero-based, half-open targetable interval.
@@ -197,7 +183,9 @@ class SelfReferenceSource(DataclassSerializable):
     def __post_init__(self):
         if not self.gene_id:
             raise ValueError("Self-reference source requires a gene ID")
-        object.__setattr__(self, "gene_id", _normalized_gene_id(self.gene_id))
+        object.__setattr__(
+            self, "gene_id", normalize_ensembl_gene_id(self.gene_id)
+        )
 
 
 @dataclass(frozen=True)
@@ -220,9 +208,10 @@ class SelfReferenceMatch(DataclassSerializable):
     def __post_init__(self):
         if self.antigen_kind not in ANTIGEN_KINDS:
             raise ValueError(f"Unknown antigen kind {self.antigen_kind!r}")
-        _validate_amino_acids(self.peptide, "Self-reference peptide")
+        validate_amino_acid_sequence(self.peptide, "Self-reference peptide")
         excluded_gene_ids = tuple(sorted({
-            _normalized_gene_id(gene_id) for gene_id in self.excluded_gene_ids
+            normalize_ensembl_gene_id(gene_id)
+            for gene_id in self.excluded_gene_ids
         }))
         sources = tuple(self.sources)
         object.__setattr__(self, "excluded_gene_ids", excluded_gene_ids)
@@ -260,7 +249,7 @@ class VaccineAntigen(DataclassSerializable):
                 f"Unknown antigen kind {self.kind!r}; expected one of "
                 f"{sorted(ANTIGEN_KINDS)}"
             )
-        _validate_amino_acids(self.amino_acids, "Vaccine antigen")
+        validate_amino_acid_sequence(self.amino_acids, "Vaccine antigen")
         if (
             self.tumor_specificity.admits_construct
             and not self.targetable_mask.intervals
@@ -268,14 +257,16 @@ class VaccineAntigen(DataclassSerializable):
             raise ValueError("An admitted antigen requires targetable content")
         self.targetable_mask.validate_for_sequence(self.amino_acids)
         excluded_gene_ids = tuple(sorted({
-            _normalized_gene_id(gene_id)
+            normalize_ensembl_gene_id(gene_id)
             for gene_id in self.self_reference_excluded_gene_ids
         }))
         object.__setattr__(
             self, "self_reference_excluded_gene_ids", excluded_gene_ids
         )
         if self.gene_id:
-            object.__setattr__(self, "gene_id", _normalized_gene_id(self.gene_id))
+            object.__setattr__(
+                self, "gene_id", normalize_ensembl_gene_id(self.gene_id)
+            )
         object.__setattr__(self, "transcript_ids", tuple(self.transcript_ids))
         object.__setattr__(self, "protein_ids", tuple(self.protein_ids))
 
@@ -312,7 +303,7 @@ class VaccineAntigen(DataclassSerializable):
             getattr(fragment, "supporting_reference_transcripts", ()) or ()
         )
         gene_ids = tuple(sorted({
-            _normalized_gene_id(getattr(transcript, "gene_id", ""))
+            normalize_ensembl_gene_id(getattr(transcript, "gene_id", ""))
             for transcript in transcripts
             if getattr(transcript, "gene_id", "")
         }))

--- a/vaxrank/vaccine_library.py
+++ b/vaxrank/vaccine_library.py
@@ -709,9 +709,6 @@ def target_epitopes_sorted(vaccine_peptide):
         getattr(vaccine_peptide, 'target_epitopes', None) or [])
 
 
-_STANDARD_AMINO_ACIDS = set("ACDEFGHIKLMNPQRSTVWY")
-
-
 def truncate_at_stop_codon(amino_acids):
     """Truncate an amino-acid string at the first ``*`` (stop codon).
 
@@ -732,17 +729,6 @@ def truncate_at_stop_codon(amino_acids):
     if idx < 0:
         return amino_acids
     return amino_acids[:idx]
-
-
-def has_only_standard_amino_acids(amino_acids):
-    """True iff every character of ``amino_acids`` is one of the 20
-    standard amino acid letters. Used as a sanity gate before passing
-    sequences to manufacturability / hydropathy / codon-optimization
-    code that key off a 20-letter alphabet.
-    """
-    if not amino_acids:
-        return True
-    return all(aa in _STANDARD_AMINO_ACIDS for aa in amino_acids)
 
 
 def top_target_epitopes(vaccine_peptide, n=1):

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.22"
+__version__ = "3.1.23"
 
 
 def print_version():


### PR DESCRIPTION
Refs #328.

## Summary
- add public `normalize_ensembl_gene_id` and mhcgnomes-backed `normalize_mhc_allele` APIs
- add one public standard amino-acid alphabet, membership predicate, and raising validator
- replace duplicated private normalization helpers across antigen, CTA, tissue-risk, reference-proteome, risk-ligand, near-self, and safety-assessment paths
- remove the duplicate private amino-acid alphabet from construct assembly
- preserve domain-specific fail-closed errors at risk-index and near-self boundaries
- reduce private helpers added by the recent safety series from 31 to 23 without adding new private definitions
- bump vaxrank to 3.1.23

## Verification
- focused public API/error tests: 8 passed
- affected safety/antigen/reference suites: 143 passed
- `./lint.sh`
- `./test.sh`: 970 passed
- `git diff --check`
- staged added-code scan: no private helper functions or classes