### PR TITLE
Add public prediction ingestion APIs

### DIFF
--- a/tests/test_nan_robustness.py
+++ b/tests/test_nan_robustness.py
@@ -8,7 +8,7 @@
 
 Two layered guarantees:
 
-1. ``epitope_logic._finite_or_none`` coerces NaN / Inf to ``None`` so
+1. ``finite_prediction_value`` coerces NaN / Inf to ``None`` so
    ``Prediction.value`` never carries NaN coming out of the topiary
    frame. The topiary frame legitimately emits NaN in the ``value``
    column for non-affinity kinds (``pMHC_presentation`` carries its
@@ -28,37 +28,54 @@ import pandas as pd
 import pytest
 
 
-# ---- _finite_or_none ----------------------------------------------------
+# ---- finite_prediction_value -------------------------------------------
 
 
-def test_finite_or_none_passes_through_finite():
-    from vaxrank.epitope_logic import _finite_or_none
+def test_finite_prediction_value_passes_through_finite():
+    from vaxrank import finite_prediction_value
 
-    assert _finite_or_none(0.0) == 0.0
-    assert _finite_or_none(123.456) == 123.456
-    assert _finite_or_none(-1e9) == -1e9
-
-
-def test_finite_or_none_coerces_nan_and_inf():
-    from vaxrank.epitope_logic import _finite_or_none
-
-    assert _finite_or_none(float('nan')) is None
-    assert _finite_or_none(float('inf')) is None
-    assert _finite_or_none(float('-inf')) is None
+    assert finite_prediction_value(0.0) == 0.0
+    assert finite_prediction_value(123.456) == 123.456
+    assert finite_prediction_value(-1e9) == -1e9
 
 
-def test_finite_or_none_passes_none():
-    from vaxrank.epitope_logic import _finite_or_none
+def test_finite_prediction_value_coerces_nan_and_inf():
+    from vaxrank import finite_prediction_value
 
-    assert _finite_or_none(None) is None
+    assert finite_prediction_value(float('nan')) is None
+    assert finite_prediction_value(float('inf')) is None
+    assert finite_prediction_value(float('-inf')) is None
 
 
-def test_finite_or_none_passes_ints():
-    """Ints are well-defined; should pass through."""
-    from vaxrank.epitope_logic import _finite_or_none
+def test_finite_prediction_value_passes_none():
+    from vaxrank import finite_prediction_value
 
-    assert _finite_or_none(0) == 0
-    assert _finite_or_none(42) == 42
+    assert finite_prediction_value(None) is None
+
+
+def test_finite_prediction_value_accepts_ints_and_numeric_strings():
+    from vaxrank import finite_prediction_value
+
+    assert finite_prediction_value(0) == 0.0
+    assert finite_prediction_value(42) == 42.0
+    assert finite_prediction_value("42.5") == 42.5
+
+
+def test_finite_prediction_value_rejects_non_numeric_input():
+    from vaxrank import finite_prediction_value
+
+    with pytest.raises(ValueError, match="not numeric"):
+        finite_prediction_value("strong")
+
+
+def test_prediction_integer_accepts_pandas_style_integral_float_only():
+    from vaxrank import prediction_integer
+
+    assert prediction_integer(9.0, "Peptide length") == 9
+    with pytest.raises(ValueError, match="Peptide length must be an integer"):
+        prediction_integer(9.5, "Peptide length")
+    with pytest.raises(ValueError, match="Peptide length must be an integer"):
+        prediction_integer(True, "Peptide length")
 
 
 # ---- predict_epitopes: presentation rows don't leak NaN ----------------

--- a/tests/test_risk_ligand.py
+++ b/tests/test_risk_ligand.py
@@ -11,6 +11,7 @@ from vaxrank.risk_ligand import (
     RISK_COMBINATION_INTERSECTION,
     PatientHLARiskLigandIndex,
     RiskLigandError,
+    RiskLigandPrediction,
     RiskLigandSelectionPolicy,
     build_patient_hla_risk_ligand_index,
     resolve_tissue_risk_protein_sequences,
@@ -126,6 +127,33 @@ def _row(source, peptide, offset, *, kind="pMHC_affinity",
         "prediction_method_name": predictor,
         "predictor_version": "2.1.4",
     }
+
+
+def test_risk_ligand_prediction_from_prediction_row_is_public():
+    row = _row(
+        "risk_000000_ENSG1",
+        "ACDEFGHIK",
+        0,
+        kind="pMHC_presentation",
+        allele="H-2-Kb",
+        percentile=0.5,
+    )
+
+    prediction = RiskLigandPrediction.from_prediction_row(row)
+
+    assert prediction.kind == "pMHC_presentation"
+    assert prediction.allele == "H2-K*b"
+    assert prediction.score == pytest.approx(0.995)
+    assert prediction.value is None
+    assert prediction.percentile_rank == 0.5
+
+
+def test_risk_ligand_prediction_from_prediction_row_rejects_bad_values():
+    row = _row("risk_000000_ENSG1", "ACDEFGHIK", 0)
+    row["percentile_rank"] = "top"
+
+    with pytest.raises(ValueError, match="not numeric"):
+        RiskLigandPrediction.from_prediction_row(row)
 
 
 def test_resolve_all_isoforms_deduplicates_sequences_and_exposes_gaps():

--- a/tests/test_safety_assessment.py
+++ b/tests/test_safety_assessment.py
@@ -61,6 +61,34 @@ def _row(peptide, offset, *, predictor="mhcflurry", kind="pMHC_affinity",
     }
 
 
+def test_safety_prediction_from_prediction_row_is_public_and_normalizes_values():
+    row = _row(
+        "ACDEFGHIK",
+        0,
+        predictor="mhcflurry-presentation",
+        kind="pMHC_presentation",
+        allele="H-2-Kb",
+        score="0.42",
+        value=float("nan"),
+        percentile_rank="1.7",
+    )
+
+    prediction = SafetyPrediction.from_prediction_row(row)
+
+    assert prediction.kind == "pMHC_presentation"
+    assert prediction.allele == "H2-K*b"
+    assert prediction.score == 0.42
+    assert prediction.value is None
+    assert prediction.percentile_rank == 1.7
+
+
+def test_safety_prediction_from_prediction_row_rejects_non_numeric_values():
+    row = _row("ACDEFGHIK", 0, score="strong")
+
+    with pytest.raises(ValueError, match="not numeric"):
+        SafetyPrediction.from_prediction_row(row)
+
+
 class _Reference:
     def __init__(self, peptides=(), excluded_gene_ids=()):
         self.peptides = set(peptides)

--- a/vaxrank/__init__.py
+++ b/vaxrank/__init__.py
@@ -18,6 +18,7 @@ from .amino_acids import (
     validate_amino_acid_sequence,
 )
 from .identifiers import normalize_ensembl_gene_id, normalize_mhc_allele
+from .prediction_input import finite_prediction_value, prediction_integer
 from .epitope_config import EpitopeConfig
 from .epitope_logic import predict_epitopes
 from .candidate_epitope import CandidateEpitope, Peptide
@@ -199,11 +200,13 @@ __all__ = [
     "build_cta_vaccine_antigen",
     "derive_tissue_risk_proteins",
     "evaluate_antigen_safety_policy",
+    "finite_prediction_value",
     "has_only_standard_amino_acids",
     "near_self_queries_for_window",
     "normalize_ensembl_gene_id",
     "normalize_mhc_allele",
     "predict_epitopes",
+    "prediction_integer",
     "run_vaxrank",
     "resolve_tissue_risk_policy",
     "resolve_tissue_risk_protein_sequences",

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -1604,7 +1604,7 @@ def ranked_vaccine_peptides_with_metadata_from_parsed_args(args):
         with open(args.output_json_file, 'w') as f:
             # ``ignore_nan=True`` is defense in depth — producers should
             # be coercing NaN/Inf to None before reaching the writer
-            # (see vaxrank.epitope_logic._finite_or_none), but if any
+            # (see vaxrank.finite_prediction_value), but if any
             # slips through (e.g. a future predictor adapter, or a
             # custom score expression), render it as JSON null instead
             # of crashing the whole report. Note: strict JSON doesn't

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 
-import math
 import traceback
 import logging
 from typing import Optional
@@ -25,6 +24,7 @@ from .config.defaults import DEFAULT_MIN_KMER_LENGTH
 from .epitope_config import EpitopeConfig
 from .epitope_dsl import build_filter_node, build_score_node, drop_empty_sample_name
 from .mutant_protein_fragment import MutantProteinFragment
+from .prediction_input import finite_prediction_value
 from .candidate_epitope import (
     CandidateEpitope, SOURCE_CLASS_MUTATION, SOURCE_CLASS_SELF,
     candidate_epitopes_from_rows,
@@ -37,24 +37,6 @@ from .vaccine_antigen import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _finite_or_none(x):
-    """Coerce ``None`` / NaN / Inf floats to ``None``.
-
-    Topiary frames legitimately carry NaN in the ``value`` column for
-    non-affinity kinds (``pMHC_presentation`` carries its probability
-    in ``score``, not ``value``). Pass-through writes NaN into
-    ``Prediction.value`` which then poisons every downstream consumer
-    — sorting, scoring, and especially JSON serialization (simplejson
-    rejects NaN / Inf for strict compliance). Producers should emit
-    ``None`` to mean "no IC50 for this kind", not ``NaN``.
-    """
-    if x is None:
-        return None
-    if isinstance(x, float) and (math.isnan(x) or math.isinf(x)):
-        return None
-    return x
 
 
 def slice_epitopes(epitopes, start_offset, end_offset):
@@ -289,11 +271,11 @@ def predict_epitopes(
         # (e.g. pMHC_presentation), both columns are legitimately NaN
         # in the topiary frame — coerce to None so the Prediction
         # carries an honest "no IC50" instead of a NaN poison pill.
-        ic50 = _finite_or_none(row.get("affinity"))
+        ic50 = finite_prediction_value(row.get("affinity"))
         if ic50 is None:
-            ic50 = _finite_or_none(row.get("value"))
+            ic50 = finite_prediction_value(row.get("value"))
 
-        percentile_rank = _finite_or_none(row.get("percentile_rank"))
+        percentile_rank = finite_prediction_value(row.get("percentile_rank"))
 
         # Resolve WT comparator only when the peptide overlaps the
         # mutation — non-overlapping peptides aren't neoepitopes and
@@ -308,9 +290,9 @@ def predict_epitopes(
                         'No prediction for too-short WT epitope %s: possible stop-loss variant',
                         wt_peptide)
             else:
-                wt_ic50 = _finite_or_none(wt_row.get("affinity"))
+                wt_ic50 = finite_prediction_value(wt_row.get("affinity"))
                 if wt_ic50 is None:
-                    wt_ic50 = _finite_or_none(wt_row.get("value"))
+                    wt_ic50 = finite_prediction_value(wt_row.get("value"))
                 tool = row.get("prediction_method_name", "")
                 wt_pred = Prediction(
                     kind=row.get("kind") or "pMHC_affinity",

--- a/vaxrank/prediction_input.py
+++ b/vaxrank/prediction_input.py
@@ -1,0 +1,41 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Validation and normalization for tabular prediction input values."""
+
+import math
+
+
+def finite_prediction_value(value, label: str = "Prediction value"):
+    """Return a finite float or ``None`` for a missing/non-finite value.
+
+    Prediction frames use NaN for fields that do not apply to a prediction
+    kind.  Converting those values to ``None`` keeps serialized prediction
+    evidence standards-compliant while rejecting non-numeric input.
+    """
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{label} {value!r} is not numeric") from error
+    return result if math.isfinite(result) else None
+
+
+def prediction_integer(value, label: str) -> int:
+    """Return an exactly integral prediction-frame value.
+
+    Floating point representations such as ``9.0`` are accepted because
+    pandas commonly widens integer columns, while booleans and fractional
+    values are rejected.
+    """
+    if isinstance(value, bool):
+        raise ValueError(f"{label} must be an integer")
+    try:
+        result = int(value)
+        equivalent = float(value) == result
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{label} must be an integer") from error
+    if not equivalent:
+        raise ValueError(f"{label} must be an integer")
+    return result

--- a/vaxrank/risk_ligand.py
+++ b/vaxrank/risk_ligand.py
@@ -19,6 +19,7 @@ from .amino_acids import (
     validate_amino_acid_sequence,
 )
 from .identifiers import normalize_ensembl_gene_id, normalize_mhc_allele
+from .prediction_input import finite_prediction_value, prediction_integer
 from .tissue_risk import (
     TissueRiskAssessment,
     TissueRiskEvidence,
@@ -41,29 +42,6 @@ RISK_COMBINATION_POLICIES = frozenset({
 
 class RiskLigandError(RuntimeError):
     """Raised when a risk-ligand index cannot be built unambiguously."""
-
-
-def _finite_or_none(value):
-    if value is None:
-        return None
-    try:
-        value = float(value)
-    except (TypeError, ValueError) as error:
-        raise RiskLigandError(f"Prediction value {value!r} is not numeric") from error
-    return value if math.isfinite(value) else None
-
-
-def _required_int(value, label: str) -> int:
-    if isinstance(value, bool):
-        raise RiskLigandError(f"{label} must be an integer")
-    try:
-        result = int(value)
-        equivalent = float(value) == result
-    except (TypeError, ValueError) as error:
-        raise RiskLigandError(f"{label} must be an integer") from error
-    if not equivalent:
-        raise RiskLigandError(f"{label} must be an integer")
-    return result
 
 
 def _json_native(value):
@@ -266,6 +244,22 @@ class RiskLigandPrediction(DataclassSerializable):
         ):
             raise ValueError("Risk prediction percentile rank must be 0..100")
         object.__setattr__(self, "allele", normalize_mhc_allele(self.allele))
+
+    @classmethod
+    def from_prediction_row(cls, row: Any) -> "RiskLigandPrediction":
+        """Build risk-ligand evidence from one topiary prediction row."""
+        value = finite_prediction_value(row.get("affinity"))
+        if value is None:
+            value = finite_prediction_value(row.get("value"))
+        return cls(
+            kind=str(row.get("kind") or ""),
+            predictor_name=str(row.get("prediction_method_name") or ""),
+            predictor_version=str(row.get("predictor_version") or ""),
+            allele=str(row.get("allele") or ""),
+            score=finite_prediction_value(row.get("score")),
+            value=value,
+            percentile_rank=finite_prediction_value(row.get("percentile_rank")),
+        )
 
     @property
     def identity(self) -> tuple[str, str, str, str]:
@@ -576,24 +570,6 @@ def resolve_tissue_risk_protein_sequences(
     )
 
 
-def _prediction_from_row(row, allele: str) -> RiskLigandPrediction:
-    value = _finite_or_none(row.get("affinity"))
-    if value is None:
-        value = _finite_or_none(row.get("value"))
-    try:
-        return RiskLigandPrediction(
-            kind=str(row.get("kind") or ""),
-            predictor_name=str(row.get("prediction_method_name") or ""),
-            predictor_version=str(row.get("predictor_version") or ""),
-            allele=allele,
-            score=_finite_or_none(row.get("score")),
-            value=value,
-            percentile_rank=_finite_or_none(row.get("percentile_rank")),
-        )
-    except ValueError as error:
-        raise RiskLigandError(str(error)) from error
-
-
 def risk_ligand_index_from_prediction_frame(
     predictions_df,
     *,
@@ -610,10 +586,13 @@ def risk_ligand_index_from_prediction_frame(
         }))
     except ValueError as error:
         raise RiskLigandError(str(error)) from error
-    lengths = tuple(sorted({
-        _required_int(length, "Configured peptide length")
-        for length in peptide_lengths
-    }))
+    try:
+        lengths = tuple(sorted({
+            prediction_integer(length, "Configured peptide length")
+            for length in peptide_lengths
+        }))
+    except ValueError as error:
+        raise RiskLigandError(str(error)) from error
     if not normalized_alleles or not lengths or any(length <= 0 for length in lengths):
         raise ValueError("Risk index requires alleles and positive peptide lengths")
     sources_by_name = protein_sequences.sources_by_name()
@@ -634,8 +613,15 @@ def risk_ligand_index_from_prediction_frame(
                     "Risk prediction source does not match resolved proteins"
                 )
             peptide = str(row.get("peptide") or "")
-            length = _required_int(row.get("peptide_length"), "Peptide length")
-            offset = _required_int(row.get("peptide_offset"), "Peptide offset")
+            try:
+                length = prediction_integer(
+                    row.get("peptide_length"), "Peptide length"
+                )
+                offset = prediction_integer(
+                    row.get("peptide_offset"), "Peptide offset"
+                )
+            except ValueError as error:
+                raise RiskLigandError(str(error)) from error
             if length != len(peptide) or length not in lengths:
                 raise RiskLigandError(
                     "Risk prediction peptide length is inconsistent or unconfigured"
@@ -654,7 +640,10 @@ def risk_ligand_index_from_prediction_frame(
                 raise RiskLigandError(str(error)) from error
             if allele not in normalized_alleles:
                 raise RiskLigandError("Risk predictor emitted an unconfigured allele")
-            prediction = _prediction_from_row(row, allele)
+            try:
+                prediction = RiskLigandPrediction.from_prediction_row(row)
+            except ValueError as error:
+                raise RiskLigandError(str(error)) from error
             if prediction.kind not in thresholds:
                 continue
             configured_rows += 1

--- a/vaxrank/safety_assessment.py
+++ b/vaxrank/safety_assessment.py
@@ -27,6 +27,7 @@ from .near_self import (
     assess_near_self_queries,
 )
 from .reference_proteome import ReferenceProteome
+from .prediction_input import finite_prediction_value, prediction_integer
 from .risk_ligand import PatientHLARiskLigandIndex, RiskLigandIndexProvenance
 from .vaccine_antigen import SelfReferenceMatch, VaccineAntigen
 
@@ -36,34 +37,6 @@ SAFETY_REASON_NO_PREDICTIONS = "no_predictions_emitted"
 
 class SafetyAssessmentError(RuntimeError):
     """Raised when a safety inventory cannot be produced unambiguously."""
-
-
-def _finite_or_none(value):
-    if value is None:
-        return None
-    try:
-        value = float(value)
-    except (TypeError, ValueError) as error:
-        raise SafetyAssessmentError(
-            f"Prediction value {value!r} is not numeric"
-        ) from error
-    return value if math.isfinite(value) else None
-
-
-def _required_int(value, label: str) -> int:
-    if isinstance(value, bool):
-        raise SafetyAssessmentError(f"{label} must be an integer")
-    try:
-        result = int(value)
-    except (TypeError, ValueError) as error:
-        raise SafetyAssessmentError(f"{label} must be an integer") from error
-    try:
-        equivalent = float(value) == result
-    except (TypeError, ValueError):
-        equivalent = False
-    if not equivalent:
-        raise SafetyAssessmentError(f"{label} must be an integer")
-    return result
 
 
 @dataclass(frozen=True)
@@ -122,6 +95,22 @@ class SafetyPrediction(DataclassSerializable):
             and not 0.0 <= self.percentile_rank <= 100.0
         ):
             raise ValueError("Safety prediction percentile rank must be 0..100")
+
+    @classmethod
+    def from_prediction_row(cls, row: Any) -> "SafetyPrediction":
+        """Build complete safety evidence from one topiary prediction row."""
+        value = finite_prediction_value(row.get("affinity"))
+        if value is None:
+            value = finite_prediction_value(row.get("value"))
+        return cls(
+            kind=str(row.get("kind") or "pMHC_affinity"),
+            predictor_name=str(row.get("prediction_method_name") or ""),
+            predictor_version=str(row.get("predictor_version") or ""),
+            allele=str(row.get("allele") or ""),
+            score=finite_prediction_value(row.get("score")),
+            value=value,
+            percentile_rank=finite_prediction_value(row.get("percentile_rank")),
+        )
 
     @property
     def identity(self) -> tuple[str, str, str, str]:
@@ -631,21 +620,6 @@ def _json_native(value):
     return value
 
 
-def _safety_prediction_from_row(row: Any) -> SafetyPrediction:
-    value = _finite_or_none(row.get("affinity"))
-    if value is None:
-        value = _finite_or_none(row.get("value"))
-    return SafetyPrediction(
-        kind=str(row.get("kind") or "pMHC_affinity"),
-        predictor_name=str(row.get("prediction_method_name") or ""),
-        predictor_version=str(row.get("predictor_version") or ""),
-        allele=str(row.get("allele") or ""),
-        score=_finite_or_none(row.get("score")),
-        value=value,
-        percentile_rank=_finite_or_none(row.get("percentile_rank")),
-    )
-
-
 def safety_assessment_from_prediction_frame(
     predictions_df,
     *,
@@ -691,10 +665,13 @@ def safety_assessment_from_prediction_frame(
                     "Prediction source does not match the scanned window"
                 )
         peptide = str(row.get("peptide") or "")
-        offset = _required_int(row.get("peptide_offset"), "Peptide offset")
-        peptide_length = _required_int(
-            row.get("peptide_length"), "Peptide length"
-        )
+        try:
+            offset = prediction_integer(row.get("peptide_offset"), "Peptide offset")
+            peptide_length = prediction_integer(
+                row.get("peptide_length"), "Peptide length"
+            )
+        except ValueError as error:
+            raise SafetyAssessmentError(str(error)) from error
         if peptide_length != len(peptide):
             raise SafetyAssessmentError(
                 "Prediction peptide length does not match its sequence"
@@ -709,7 +686,10 @@ def safety_assessment_from_prediction_frame(
                 "Prediction peptide does not match the scanned window"
             )
 
-        prediction = _safety_prediction_from_row(row)
+        try:
+            prediction = SafetyPrediction.from_prediction_row(row)
+        except ValueError as error:
+            raise SafetyAssessmentError(str(error)) from error
         key = (peptide, offset)
         group = groups.setdefault(key, {"predictions": [], "identities": set()})
         if prediction.identity in group["identities"]:

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.23"
+__version__ = "3.1.24"
 
 
 def print_version():


### PR DESCRIPTION
Refs #328.

## Summary
- add public SafetyPrediction.from_prediction_row and RiskLigandPrediction.from_prediction_row constructors
- consolidate tabular numeric handling in public finite_prediction_value and prediction_integer operations
- remove seven duplicated/private adapters and migrate the legacy NaN tests off a de facto private API
- preserve domain-specific fail-closed errors at safety and risk-index boundaries
- bump vaxrank to 3.1.24

## Verification
- ./lint.sh
- 17 focused public-contract tests
- ./test.sh: 976 passed
- git diff --check

No private compatibility aliases were retained.