### PR TITLE
Add public reference proteome cache API

### DIFF
--- a/tests/test_reference_proteome.py
+++ b/tests/test_reference_proteome.py
@@ -31,10 +31,9 @@ from vaxrank.reference_proteome import (
     get_cache_dir,
     DEFAULT_MIN_KMER_LENGTH,
     DEFAULT_MAX_KMER_LENGTH,
-    _filtered_kmer_set_cache,
-    _kmer_set_cache,
-    _protein_source_snapshot_cache,
+    clear_reference_proteome_caches,
     cta_source_gene_ids_for_genome,
+    ensembl_dataset_cache_identity,
     oncoref_cta_source_gene_ids,
     self_reference_matches,
 )
@@ -275,8 +274,7 @@ def test_load_kmer_set_loads_from_cache_when_exists():
         genome = create_mock_genome([], species_name="test_species", release=100)
 
         # Clear in-memory cache to test disk cache loading
-        cache_key = ("test_species", 100, 8, 8)
-        _kmer_set_cache.pop(cache_key, None)
+        clear_reference_proteome_caches()
 
         with patch('vaxrank.reference_proteome.get_cache_dir', return_value=tmpdir):
             # Should load from disk cache, not build new index
@@ -765,7 +763,7 @@ def test_self_reference_matches_without_genome_are_explicitly_incomplete():
 
 
 def test_ensembl_source_snapshot_cache_tracks_resolved_source_files(tmp_path):
-    _protein_source_snapshot_cache.clear()
+    clear_reference_proteome_caches()
     gtf_path = tmp_path / "test.gtf"
     protein_path = tmp_path / "test.fa"
     gtf_path.write_text("annotation-v1")
@@ -794,10 +792,13 @@ def test_ensembl_source_snapshot_cache_tracks_resolved_source_files(tmp_path):
 
     first = self_reference_matches(["ACDEFGHI"], antigen, genome)
     repeated = self_reference_matches(["ACDEFGHI"], antigen, genome)
+    first_identity = ensembl_dataset_cache_identity(genome)
 
     assert first == repeated
     assert first["ACDEFGHI"].occurs
     assert genome.transcripts.call_count == 1
+    assert len(first_identity) == 64
+    assert ensembl_dataset_cache_identity(genome) == first_identity
 
     protein_path.write_text("protein-v2-with-different-size")
     genome.transcripts.return_value = [
@@ -808,10 +809,33 @@ def test_ensembl_source_snapshot_cache_tracks_resolved_source_files(tmp_path):
     assert changed["LMNPQRST"].occurs
     assert changed["LMNPQRST"].sources[0].gene_id == "G2"
     assert genome.transcripts.call_count == 2
+    assert ensembl_dataset_cache_identity(genome) != first_identity
+
+
+def test_ensembl_dataset_identity_depends_on_content_not_install_path(tmp_path):
+    identities = []
+    for directory_name in ("first", "second"):
+        directory = tmp_path / directory_name
+        directory.mkdir()
+        gtf_path = directory / "test.gtf"
+        protein_path = directory / "test.fa"
+        gtf_path.write_text("same-annotation")
+        protein_path.write_text("same-proteins")
+        genome = Genome(
+            reference_name="test-reference",
+            annotation_name="test-annotation",
+            annotation_version="1",
+            gtf_path_or_url=str(gtf_path),
+            protein_fasta_paths_or_urls=[str(protein_path)],
+        )
+        identities.append(ensembl_dataset_cache_identity(genome))
+
+    assert identities[0] == identities[1]
+    assert ensembl_dataset_cache_identity(object()) is None
 
 
 def test_filtered_reference_proteome_is_cached_per_genome_and_policy():
-    _filtered_kmer_set_cache.clear()
+    clear_reference_proteome_caches()
     t1 = create_mock_transcript("T1", "ABCDEFGHIJ", gene_id="G1")
     t2 = create_mock_transcript("T2", "KLMNOPQRST", gene_id="G2")
     genome = create_mock_genome([t1, t2], release=112)
@@ -825,12 +849,22 @@ def test_filtered_reference_proteome_is_cached_per_genome_and_policy():
             genome, exclude_gene_ids={"G1"},
             min_kmer_length=8, max_kmer_length=8)
 
-    assert first._kmer_set is second._kmer_set
+    assert not first.contains("ABCDEFGH")
+    assert second.contains("KLMNOPQR")
     assert extract.call_count == 1
+
+    clear_reference_proteome_caches()
+    with patch(
+            "vaxrank.reference_proteome.extract_kmers",
+            wraps=extract_kmers) as extract_after_clear:
+        ReferenceProteome.from_genome(
+            genome, exclude_gene_ids={"G1"},
+            min_kmer_length=8, max_kmer_length=8)
+    assert extract_after_clear.call_count == 1
 
 
 def test_filtered_cache_is_keyed_by_protein_content_and_policy():
-    _filtered_kmer_set_cache.clear()
+    clear_reference_proteome_caches()
     first = create_mock_genome([
         create_mock_transcript("T1", "ACDEFGHIKL", gene_id="G1")
     ], release=113)
@@ -858,9 +892,8 @@ def test_filtered_cache_is_keyed_by_protein_content_and_policy():
     assert not first_ref.contains("LMNPQRST")
     assert second_ref.contains("LMNPQRST")
     assert not second_ref.contains("ACDEFGHI")
-    assert equivalent_ref._kmer_set is first_ref._kmer_set
+    assert equivalent_ref.contains("ACDEFGHI")
     assert extract.call_count == 2
-    assert len(_filtered_kmer_set_cache) == 2
 
 
 def test_from_genome_with_exclude_fasta(tmp_path):

--- a/vaxrank/__init__.py
+++ b/vaxrank/__init__.py
@@ -116,7 +116,11 @@ from .cta_admission import (
     assess_cta_antigen,
     build_cta_vaccine_antigen,
 )
-from .reference_proteome import self_reference_matches
+from .reference_proteome import (
+    clear_reference_proteome_caches,
+    ensembl_dataset_cache_identity,
+    self_reference_matches,
+)
 from .version import __version__
 
 __all__ = [
@@ -198,8 +202,10 @@ __all__ = [
     "build_hpa_reference_provenance",
     "build_patient_hla_risk_ligand_index",
     "build_cta_vaccine_antigen",
+    "clear_reference_proteome_caches",
     "derive_tissue_risk_proteins",
     "evaluate_antigen_safety_policy",
+    "ensembl_dataset_cache_identity",
     "finite_prediction_value",
     "has_only_standard_amino_acids",
     "near_self_queries_for_window",

--- a/vaxrank/reference_proteome.py
+++ b/vaxrank/reference_proteome.py
@@ -91,6 +91,12 @@ _filtered_kmer_set_cache_lock = threading.Lock()
 _protein_source_snapshot_cache: dict[str, tuple] = {}
 _protein_source_snapshot_cache_lock = threading.Lock()
 
+# Source-file digests make dataset identities independent of installation
+# paths. File metadata avoids re-reading multi-gigabyte Ensembl inputs when
+# they have not changed.
+_ensembl_source_digest_cache: dict[tuple, str] = {}
+_ensembl_source_digest_cache_lock = threading.Lock()
+
 
 def _protein_content_digest(proteins: dict[str, str]) -> str:
     """Return a deterministic digest of transcript IDs and protein sequences."""
@@ -103,8 +109,18 @@ def _protein_content_digest(proteins: dict[str, str]) -> str:
     return digest.hexdigest()
 
 
-def _ensembl_dataset_cache_key(genome) -> Optional[str]:
-    """Identify one installed pyensembl annotation/protein dataset."""
+def ensembl_dataset_cache_identity(genome) -> Optional[str]:
+    """Return a content-based identity for an installed Ensembl dataset.
+
+    The identity combines the non-location parts of the public pyensembl
+    genome definition with SHA-256 digests of every resolved annotation,
+    transcript, and protein source file. Equivalent datasets installed at
+    different paths therefore share an identity, while a changed source file
+    invalidates cached protein provenance.
+
+    ``None`` means the object is not a concrete pyensembl ``Genome`` or its
+    required local files cannot be resolved.
+    """
     if not isinstance(genome, Genome):
         return None
     files = []
@@ -130,18 +146,41 @@ def _ensembl_dataset_cache_key(genome) -> Optional[str]:
             path = source_path if use_source_directly else cached_path
             resolved_path = os.path.realpath(path)
             stat = os.stat(resolved_path)
-            files.append((
+            digest_key = (
                 resolved_path,
                 stat.st_dev,
                 stat.st_ino,
                 stat.st_size,
                 stat.st_mtime_ns,
-            ))
+            )
+            with _ensembl_source_digest_cache_lock:
+                source_digest = _ensembl_source_digest_cache.get(digest_key)
+            if source_digest is None:
+                digest = hashlib.sha256()
+                with open(resolved_path, "rb") as source_file:
+                    while chunk := source_file.read(1024 * 1024):
+                        digest.update(chunk)
+                source_digest = digest.hexdigest()
+                with _ensembl_source_digest_cache_lock:
+                    _ensembl_source_digest_cache[digest_key] = source_digest
+            files.append((stat.st_size, source_digest))
     except OSError:
         return None
+    location_keys = {
+        "cache_directory_path",
+        "copy_local_files_to_cache",
+        "decompress_on_download",
+        "gtf_path_or_url",
+        "protein_fasta_paths_or_urls",
+        "transcript_fasta_paths_or_urls",
+    }
+    content_definition = {
+        key: value for key, value in definition.items()
+        if key not in location_keys
+    }
     payload = json.dumps(
         {
-            "genome": definition,
+            "genome": content_definition,
             "files": files,
         },
         sort_keys=True,
@@ -151,9 +190,22 @@ def _ensembl_dataset_cache_key(genome) -> Optional[str]:
     return hashlib.sha256(payload).hexdigest()
 
 
+def clear_reference_proteome_caches() -> None:
+    """Clear every in-memory reference-proteome and source-data cache."""
+    for lock, cache in (
+        (_kmer_set_cache_lock, _kmer_set_cache),
+        (_filtered_kmer_set_cache_lock, _filtered_kmer_set_cache),
+        (_protein_source_snapshot_cache_lock, _protein_source_snapshot_cache),
+        (_ensembl_source_digest_cache_lock, _ensembl_source_digest_cache),
+    ):
+        with lock:
+            cache.clear()
+    oncoref_cta_source_gene_ids.cache_clear()
+
+
 def _protein_source_snapshot(genome):
     """Return distinct protein sequences with every Ensembl source."""
-    cache_key = _ensembl_dataset_cache_key(genome)
+    cache_key = ensembl_dataset_cache_identity(genome)
     if cache_key is not None:
         with _protein_source_snapshot_cache_lock:
             cached = _protein_source_snapshot_cache.get(cache_key)

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.24"
+__version__ = "3.1.25"
 
 
 def print_version():


### PR DESCRIPTION
Refs #328.

## Summary
- add public ensembl_dataset_cache_identity using semantic genome metadata plus SHA-256 source-file content
- make equivalent datasets installed at different paths share identities and source changes invalidate snapshots
- add public clear_reference_proteome_caches for all in-memory reference and source-data caches
- stop reference-proteome tests from importing or mutating private cache dictionaries
- retain cache stores and locks as true private implementation details
- bump vaxrank to 3.1.25

## Verification
- ./lint.sh
- focused reference-proteome suite: 55 passed
- ./test.sh: 977 passed
- git diff --check

No object-identity cache key or private compatibility alias is introduced.