### PR TITLE
Bound reference indexes to predicted peptide lengths

### DIFF
--- a/tests/test_epitope_prediction.py
+++ b/tests/test_epitope_prediction.py
@@ -118,8 +118,17 @@ def test_predict_epitopes_records_distinct_non_cta_reference_flag(mouse_genome):
     assert epitopes
     assert all(epitope.occurs_in_reference for epitope in epitopes)
     assert all(not epitope.occurs_in_non_CTA_reference for epitope in epitopes)
+    reference_cls.assert_called_once_with(
+        mouse_genome,
+        min_kmer_length=9,
+        max_kmer_length=9,
+    )
     reference_cls.from_genome.assert_called_once_with(
-        mouse_genome, exclude_cta_genes=True)
+        mouse_genome,
+        exclude_cta_genes=True,
+        min_kmer_length=9,
+        max_kmer_length=9,
+    )
 
 def test_predict_epitopes_returns_one_row_per_predictor_for_multimodel(mouse_genome):
     """Multi-model TopiaryPredictor (post-2.24, #261) keeps each

--- a/tests/test_safety_assessment.py
+++ b/tests/test_safety_assessment.py
@@ -274,6 +274,36 @@ def test_high_level_api_checks_reference_exclusions_and_serializes():
     assert WindowSafetyAssessment.from_json(result.to_json()) == result
 
 
+def test_high_level_api_indexes_only_predicted_peptide_lengths():
+    from unittest.mock import patch
+
+    class StubPredictor(TopiaryPredictor):
+        def __init__(self):
+            pass
+
+        def predict_from_named_sequences(self, sequences):
+            sequence = next(iter(sequences.values()))
+            return pd.DataFrame([_row(sequence[:9], 0)])
+
+    genome = object()
+    with patch(
+        "vaxrank.safety_assessment.ReferenceProteome"
+    ) as reference_proteome_cls:
+        reference_proteome_cls.return_value.contains.return_value = False
+        result = assess_vaccine_antigen_window(
+            StubPredictor(),
+            _antigen(),
+            genome=genome,
+        )
+
+    assert result.ligands
+    reference_proteome_cls.assert_called_once_with(
+        genome,
+        min_kmer_length=9,
+        max_kmer_length=9,
+    )
+
+
 def test_construct_boundary_must_be_internal_to_window():
     antigen = _antigen()
     with pytest.raises(ValueError, match="outside"):

--- a/tests/test_vaccine_antigen.py
+++ b/tests/test_vaccine_antigen.py
@@ -292,18 +292,13 @@ def test_cta_prediction_uses_antigen_specific_self_reference():
     antigen = cta_antigen()
     raw_reference = MagicMock()
     raw_reference.contains.return_value = True
-    antigen_reference = MagicMock()
-    antigen_reference.contains.return_value = False
     non_cta_reference = MagicMock()
     non_cta_reference.contains.return_value = False
 
     with patch(
             "vaxrank.epitope_logic.ReferenceProteome") as reference_cls:
         reference_cls.return_value = raw_reference
-        reference_cls.from_genome.side_effect = [
-            antigen_reference,
-            non_cta_reference,
-        ]
+        reference_cls.from_genome.return_value = non_cta_reference
         epitopes = predict_epitopes(
             mhc_predictor=RandomBindingPredictor(["HLA-A*02:01"]),
             epitope_config=EpitopeConfig(min_epitope_score=0),
@@ -314,7 +309,12 @@ def test_cta_prediction_uses_antigen_specific_self_reference():
     assert all(epitope.occurs_in_reference for epitope in epitopes)
     assert all(not epitope.occurs_in_self_reference for epitope in epitopes)
     assert reference_cls.from_genome.call_args_list == [
-        call(None, exclude_cta_genes=True),
+        call(
+            None,
+            exclude_cta_genes=True,
+            min_kmer_length=9,
+            max_kmer_length=9,
+        ),
     ]
 
 

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -20,7 +20,6 @@ from pyensembl import Genome
 from topiary import TopiaryPredictor
 from topiary.ranking import EvalContext, apply_filter
 
-from .config.defaults import DEFAULT_MIN_KMER_LENGTH
 from .epitope_config import EpitopeConfig
 from .epitope_dsl import build_filter_node, build_score_node, drop_empty_sample_name
 from .mutant_protein_fragment import MutantProteinFragment
@@ -127,10 +126,6 @@ def predict_epitopes(
         else SOURCE_CLASS_SELF
     )
 
-    reference_proteome = ReferenceProteome(genome)
-    non_cta_reference_proteome = ReferenceProteome.from_genome(
-        genome, exclude_cta_genes=True)
-
     # Wrap bare mhctools predictors in a TopiaryPredictor
     if not isinstance(mhc_predictor, TopiaryPredictor):
         topiary_predictor = TopiaryPredictor(models=[mhc_predictor])
@@ -166,6 +161,27 @@ def predict_epitopes(
             predictions_df, filter_node, default_methods=default_methods)
         if predictions_df.empty:
             return []
+
+    # Index only peptide lengths that survived prediction and filtering.
+    # The legacy constructor default spans 8-15 aa; loading that full range
+    # for an ordinary 9-mer MHC-I run can consume more than 10 GB even though
+    # no other lengths are queried.
+    peptide_lengths = tuple(sorted({
+        len(str(peptide)) for peptide in predictions_df["peptide"]
+    }))
+    min_peptide_length = peptide_lengths[0]
+    max_peptide_length = peptide_lengths[-1]
+    reference_proteome = ReferenceProteome(
+        genome,
+        min_kmer_length=min_peptide_length,
+        max_kmer_length=max_peptide_length,
+    )
+    non_cta_reference_proteome = ReferenceProteome.from_genome(
+        genome,
+        exclude_cta_genes=True,
+        min_kmer_length=min_peptide_length,
+        max_kmer_length=max_peptide_length,
+    )
 
     antigen_self_matches = self_reference_matches(
         predictions_df["peptide"], antigen, genome
@@ -208,7 +224,6 @@ def predict_epitopes(
     # frame keys cleanly by mutant peptide. ``predict_from_named_peptides``
     # scores the exact peptide given (no k-mer sliding).
     wt_predictions_grouped = {}
-    min_peptide_length = min(predictions_df["peptide_length"]) if len(predictions_df) > 0 else DEFAULT_MIN_KMER_LENGTH
     valid_wt_peptides = {
         mutant_pep: wt_pep
         for mutant_pep, wt_pep in wt_peptides.items()

--- a/vaxrank/safety_assessment.py
+++ b/vaxrank/safety_assessment.py
@@ -780,19 +780,11 @@ def assess_vaccine_antigen_window(
     """
     if genome is not None and reference_proteome is not None:
         raise ValueError("Pass genome or reference_proteome, not both")
-    if reference_proteome is None:
-        if genome is None:
-            raise ValueError(
-                "Safety assessment requires a genome or reference proteome"
-            )
-        if antigen.self_reference_excluded_gene_ids:
-            reference_proteome = ReferenceProteome.from_genome(
-                genome,
-                exclude_gene_ids=antigen.self_reference_excluded_gene_ids,
-            )
-        else:
-            reference_proteome = ReferenceProteome(genome)
-    else:
+    if reference_proteome is None and genome is None:
+        raise ValueError(
+            "Safety assessment requires a genome or reference proteome"
+        )
+    if reference_proteome is not None:
         expected_exclusions = frozenset(antigen.self_reference_excluded_gene_ids)
         actual_exclusions = frozenset(
             getattr(reference_proteome, "excluded_gene_ids", ())
@@ -823,6 +815,30 @@ def assess_vaccine_antigen_window(
         raise SafetyAssessmentError(
             f"MHC safety prediction failed for {source_name!r}"
         ) from error
+
+    if reference_proteome is None:
+        if predictions_df.empty:
+            # No ligand can match self, so do not build an unused genome index.
+            reference_proteome = ReferenceProteome(None)
+        else:
+            peptide_lengths = tuple(sorted({
+                len(str(peptide)) for peptide in predictions_df["peptide"]
+            }))
+            min_peptide_length = peptide_lengths[0]
+            max_peptide_length = peptide_lengths[-1]
+            if antigen.self_reference_excluded_gene_ids:
+                reference_proteome = ReferenceProteome.from_genome(
+                    genome,
+                    exclude_gene_ids=antigen.self_reference_excluded_gene_ids,
+                    min_kmer_length=min_peptide_length,
+                    max_kmer_length=max_peptide_length,
+                )
+            else:
+                reference_proteome = ReferenceProteome(
+                    genome,
+                    min_kmer_length=min_peptide_length,
+                    max_kmer_length=max_peptide_length,
+                )
 
     genome_release = str(getattr(genome, "release", "") or "")
     return safety_assessment_from_prediction_frame(

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.26"
+__version__ = "3.1.27"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

- defer reference-proteome construction until prediction/filtering identifies the peptide lengths that will actually be queried
- bound both ordinary epitope prediction and complete safety-window assessment to that observed range
- avoid building any genome index for an empty safety prediction frame
- simplify a stale CTA reference mock and pin exact 9-mer constructor arguments
- bump vaxrank to 3.1.27

## Evidence

- ./lint.sh
- ./test.sh: 980 passed in 80.95 seconds
- before: clean v3.1.26 release test took 7:23:12 and peaked at 13.2 GB
- after: former checkpoint passed in under one minute at about 4.9 GB RSS

The required B16 smoke exposed a separate stale CLI flag and is tracked in #335.

Closes #333