### PR TITLE
Make PyPI release uploads bounded and idempotent

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -128,6 +128,9 @@ if [[ "${DRY_RUN}" -eq 1 ]]; then
 fi
 
 "$PYTHON" -m twine check dist/*
-"$PYTHON" -m twine upload dist/*
+"$PYTHON" release_upload.py \
+  --project vaxrank \
+  --version "${VERSION}" \
+  dist/*
 git tag "${TAG}"
 git push --tags

--- a/lint.sh
+++ b/lint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -o errexit
 
-ruff check vaxrank tests
+ruff check vaxrank tests release_upload.py
 echo 'Passes ruff check'

--- a/release_upload.py
+++ b/release_upload.py
@@ -1,0 +1,221 @@
+"""Bounded, idempotent PyPI uploads for vaxrank releases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Callable, Iterable
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import urlopen
+
+
+PYPI_JSON_BASE_URL = "https://pypi.org/pypi"
+DEFAULT_UPLOAD_TIMEOUT_SECONDS = 60.0
+DEFAULT_VERIFY_TIMEOUT_SECONDS = 30.0
+DEFAULT_VERIFY_POLL_SECONDS = 1.0
+
+
+class ReleaseUploadError(RuntimeError):
+    """Raised when the complete release artifact set cannot be verified."""
+
+
+def expected_release_filenames(project: str, version: str) -> frozenset[str]:
+    """Return the wheel and source-distribution names built by vaxrank."""
+    wheel_project = project.replace("-", "_")
+    return frozenset({
+        f"{wheel_project}-{version}-py3-none-any.whl",
+        f"{project}-{version}.tar.gz",
+    })
+
+
+def pypi_release_filenames(
+    project: str,
+    version: str,
+    *,
+    json_base_url: str = PYPI_JSON_BASE_URL,
+    request_timeout_seconds: float = 10.0,
+) -> frozenset[str]:
+    """Return filenames currently published for one PyPI release."""
+    url = "%s/%s/%s/json" % (
+        json_base_url.rstrip("/"),
+        quote(project, safe=""),
+        quote(version, safe=""),
+    )
+    try:
+        with urlopen(url, timeout=request_timeout_seconds) as response:
+            payload = json.load(response)
+    except HTTPError as error:
+        if error.code == 404:
+            return frozenset()
+        raise
+    return frozenset(item["filename"] for item in payload.get("urls", ()))
+
+
+def upload_distribution(
+    distribution_path: str | Path,
+    *,
+    python_executable: str = sys.executable,
+    timeout_seconds: float = DEFAULT_UPLOAD_TIMEOUT_SECONDS,
+    repository_url: str | None = None,
+) -> None:
+    """Upload one distribution with a finite timeout and quiet progress."""
+    command = [
+        python_executable,
+        "-m",
+        "twine",
+        "upload",
+        "--disable-progress-bar",
+    ]
+    if repository_url:
+        command.extend(["--repository-url", repository_url])
+    command.append(str(distribution_path))
+    subprocess.run(command, check=True, timeout=timeout_seconds)
+
+
+def wait_for_release_file(
+    filename: str,
+    fetch_release_filenames: Callable[[], Iterable[str]],
+    *,
+    timeout_seconds: float = DEFAULT_VERIFY_TIMEOUT_SECONDS,
+    poll_seconds: float = DEFAULT_VERIFY_POLL_SECONDS,
+) -> bool:
+    """Poll release metadata until ``filename`` is visible or time expires."""
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        if filename in set(fetch_release_filenames()):
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(poll_seconds, remaining))
+
+
+def publish_release(
+    distribution_paths: Iterable[str | Path],
+    *,
+    expected_filenames: Iterable[str],
+    fetch_release_filenames: Callable[[], Iterable[str]],
+    upload_file: Callable[[Path], None],
+    verify_timeout_seconds: float = DEFAULT_VERIFY_TIMEOUT_SECONDS,
+    verify_poll_seconds: float = DEFAULT_VERIFY_POLL_SECONDS,
+) -> frozenset[str]:
+    """Upload missing artifacts and reconcile every response with PyPI state.
+
+    A timeout or nonzero Twine exit is ambiguous: the server may have accepted
+    the immutable file before the client lost its response. This operation
+    therefore verifies server state after every attempt and treats the file as
+    published only when its exact filename appears in release metadata.
+    """
+    paths_by_name = {
+        Path(distribution_path).name: Path(distribution_path)
+        for distribution_path in distribution_paths
+    }
+    expected = frozenset(expected_filenames)
+    if frozenset(paths_by_name) != expected:
+        raise ReleaseUploadError(
+            "Distribution files do not match the expected release set: "
+            f"expected={sorted(expected)}, observed={sorted(paths_by_name)}"
+        )
+
+    published = frozenset(fetch_release_filenames())
+    for filename in sorted(expected):
+        if filename in published:
+            print(f"Already published: {filename}")
+            continue
+
+        upload_error = None
+        try:
+            upload_file(paths_by_name[filename])
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+            upload_error = error
+
+        if not wait_for_release_file(
+            filename,
+            fetch_release_filenames,
+            timeout_seconds=verify_timeout_seconds,
+            poll_seconds=verify_poll_seconds,
+        ):
+            message = f"PyPI did not publish {filename} after the upload attempt"
+            if upload_error is not None:
+                raise ReleaseUploadError(message) from upload_error
+            raise ReleaseUploadError(message)
+        if upload_error is not None:
+            print(f"Reconciled ambiguous upload from PyPI state: {filename}")
+        else:
+            print(f"Published: {filename}")
+        published = frozenset(fetch_release_filenames())
+
+    published = frozenset(fetch_release_filenames())
+    missing = expected - published
+    if missing:
+        raise ReleaseUploadError(
+            f"PyPI release is missing expected files: {sorted(missing)}"
+        )
+    return published
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Upload and verify one complete vaxrank release."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--json-base-url", default=PYPI_JSON_BASE_URL)
+    parser.add_argument("--repository-url")
+    parser.add_argument(
+        "--upload-timeout-seconds",
+        type=float,
+        default=float(os.environ.get(
+            "VAXRANK_UPLOAD_TIMEOUT_SECONDS",
+            DEFAULT_UPLOAD_TIMEOUT_SECONDS,
+        )),
+    )
+    parser.add_argument(
+        "--verify-timeout-seconds",
+        type=float,
+        default=float(os.environ.get(
+            "VAXRANK_VERIFY_TIMEOUT_SECONDS",
+            DEFAULT_VERIFY_TIMEOUT_SECONDS,
+        )),
+    )
+    parser.add_argument("distributions", nargs="+")
+    args = parser.parse_args(argv)
+
+    expected = expected_release_filenames(args.project, args.version)
+
+    def fetch_release_filenames():
+        return pypi_release_filenames(
+            args.project,
+            args.version,
+            json_base_url=args.json_base_url,
+        )
+
+    def upload_file(path):
+        upload_distribution(
+            path,
+            python_executable=sys.executable,
+            timeout_seconds=args.upload_timeout_seconds,
+            repository_url=args.repository_url,
+        )
+
+    published = publish_release(
+        args.distributions,
+        expected_filenames=expected,
+        fetch_release_filenames=fetch_release_filenames,
+        upload_file=upload_file,
+        verify_timeout_seconds=args.verify_timeout_seconds,
+    )
+    print(
+        "Verified PyPI release files: %s"
+        % ", ".join(sorted(expected & published))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_upload.py
+++ b/tests/test_release_upload.py
@@ -1,0 +1,199 @@
+import io
+import json
+import subprocess
+from pathlib import Path
+from urllib.error import HTTPError
+
+import pytest
+import release_upload
+
+from release_upload import (
+    ReleaseUploadError,
+    expected_release_filenames,
+    main,
+    pypi_release_filenames,
+    publish_release,
+    upload_distribution,
+    wait_for_release_file,
+)
+
+
+EXPECTED = expected_release_filenames("vaxrank", "3.1.28")
+PATHS = tuple(Path("dist") / filename for filename in EXPECTED)
+
+
+def test_expected_release_filenames_are_exact_wheel_and_sdist():
+    assert EXPECTED == {
+        "vaxrank-3.1.28-py3-none-any.whl",
+        "vaxrank-3.1.28.tar.gz",
+    }
+
+
+def test_pypi_release_filenames_reads_exact_release_metadata(monkeypatch):
+    observed = {}
+
+    def open_url(url, *, timeout):
+        observed.update(url=url, timeout=timeout)
+        return io.BytesIO(json.dumps({
+            "urls": [{"filename": "vaxrank-3.1.28.tar.gz"}],
+        }).encode("utf-8"))
+
+    monkeypatch.setattr(release_upload, "urlopen", open_url)
+
+    assert pypi_release_filenames(
+        "vaxrank",
+        "3.1.28",
+        json_base_url="https://packages.example/pypi/",
+        request_timeout_seconds=7,
+    ) == {"vaxrank-3.1.28.tar.gz"}
+    assert observed == {
+        "url": "https://packages.example/pypi/vaxrank/3.1.28/json",
+        "timeout": 7,
+    }
+
+
+def test_pypi_release_filenames_treats_missing_release_as_empty(monkeypatch):
+    def open_url(url, *, timeout):
+        raise HTTPError(url, 404, "Not Found", {}, None)
+
+    monkeypatch.setattr(release_upload, "urlopen", open_url)
+    assert pypi_release_filenames("vaxrank", "3.1.28") == frozenset()
+
+
+def test_upload_distribution_is_bounded_and_disables_progress(monkeypatch):
+    observed = {}
+
+    def run(command, *, check, timeout):
+        observed.update(command=command, check=check, timeout=timeout)
+
+    monkeypatch.setattr(subprocess, "run", run)
+    upload_distribution(
+        "dist/vaxrank-3.1.28.tar.gz",
+        python_executable="release-python",
+        timeout_seconds=17,
+    )
+
+    assert observed == {
+        "command": [
+            "release-python",
+            "-m",
+            "twine",
+            "upload",
+            "--disable-progress-bar",
+            "dist/vaxrank-3.1.28.tar.gz",
+        ],
+        "check": True,
+        "timeout": 17,
+    }
+
+
+def test_wait_for_release_file_observes_eventual_metadata():
+    responses = iter([set(), {"vaxrank-3.1.28.tar.gz"}])
+
+    assert wait_for_release_file(
+        "vaxrank-3.1.28.tar.gz",
+        lambda: next(responses),
+        timeout_seconds=1,
+        poll_seconds=0,
+    )
+
+
+def test_timeout_after_server_acceptance_is_reconciled():
+    published = set()
+
+    def fetch_release_filenames():
+        return published
+
+    def upload_file(path):
+        published.add(path.name)
+        raise subprocess.TimeoutExpired(["twine", "upload"], timeout=60)
+
+    result = publish_release(
+        PATHS,
+        expected_filenames=EXPECTED,
+        fetch_release_filenames=fetch_release_filenames,
+        upload_file=upload_file,
+        verify_timeout_seconds=0,
+    )
+
+    assert EXPECTED <= result
+
+
+def test_partial_release_uploads_only_missing_file_and_retry_is_safe():
+    wheel = "vaxrank-3.1.28-py3-none-any.whl"
+    sdist = "vaxrank-3.1.28.tar.gz"
+    published = {wheel}
+    uploaded = []
+
+    def fetch_release_filenames():
+        return published
+
+    def upload_file(path):
+        uploaded.append(path.name)
+        published.add(path.name)
+
+    publish_release(
+        PATHS,
+        expected_filenames=EXPECTED,
+        fetch_release_filenames=fetch_release_filenames,
+        upload_file=upload_file,
+        verify_timeout_seconds=0,
+    )
+    publish_release(
+        PATHS,
+        expected_filenames=EXPECTED,
+        fetch_release_filenames=fetch_release_filenames,
+        upload_file=upload_file,
+        verify_timeout_seconds=0,
+    )
+
+    assert uploaded == [sdist]
+
+
+def test_failed_upload_without_server_artifact_fails_hard():
+    def upload_file(path):
+        raise subprocess.TimeoutExpired(["twine", "upload", path], timeout=60)
+
+    with pytest.raises(ReleaseUploadError, match="did not publish"):
+        publish_release(
+            PATHS,
+            expected_filenames=EXPECTED,
+            fetch_release_filenames=frozenset,
+            upload_file=upload_file,
+            verify_timeout_seconds=0,
+        )
+
+
+def test_unexpected_distribution_set_is_rejected_before_upload():
+    with pytest.raises(ReleaseUploadError, match="do not match"):
+        publish_release(
+            ["dist/vaxrank-3.1.28.tar.gz"],
+            expected_filenames=EXPECTED,
+            fetch_release_filenames=frozenset,
+            upload_file=lambda path: None,
+            verify_timeout_seconds=0,
+        )
+
+
+def test_main_passes_exact_artifact_contract_to_publisher(monkeypatch, capsys):
+    observed = {}
+
+    def publish_release_call(distribution_paths, **kwargs):
+        observed.update(
+            distribution_paths=tuple(distribution_paths),
+            expected_filenames=kwargs["expected_filenames"],
+        )
+        return EXPECTED
+
+    monkeypatch.setattr(release_upload, "publish_release", publish_release_call)
+
+    assert main([
+        "--project", "vaxrank",
+        "--version", "3.1.28",
+        *[str(path) for path in PATHS],
+    ]) == 0
+    assert observed == {
+        "distribution_paths": tuple(str(path) for path in PATHS),
+        "expected_filenames": EXPECTED,
+    }
+    assert "Verified PyPI release files" in capsys.readouterr().out

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.27"
+__version__ = "3.1.28"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

- replace one unbounded multi-file Twine call with a public release operation that uploads wheel and sdist independently
- disable Twine progress rendering and impose a 60-second timeout per artifact
- reconcile successful, failed, and timed-out attempts against exact PyPI JSON filenames
- skip already-published immutable files safely and refuse to tag an incomplete artifact pair
- include the release uploader in lint and bump vaxrank to 3.1.28

## Regression coverage

Ten direct tests cover exact filenames, PyPI metadata and 404s, progress suppression, subprocess timeout, eventual visibility, timeout-after-acceptance, partial release recovery, idempotent retry, hard failure, and CLI wiring.

## Verification

- ./lint.sh
- ./test.sh: 990 passed in 82.09 seconds

Closes #334