### PR TITLE
Bypass stale PyPI release metadata

### DIFF
--- a/release_upload.py
+++ b/release_upload.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from secrets import token_hex
 import subprocess
 import sys
 import time
@@ -42,10 +43,11 @@ def pypi_release_filenames(
     request_timeout_seconds: float = 10.0,
 ) -> frozenset[str]:
     """Return filenames currently published for one PyPI release."""
-    url = "%s/%s/%s/json" % (
+    url = "%s/%s/%s/json?cache_bust=%s" % (
         json_base_url.rstrip("/"),
         quote(project, safe=""),
         quote(version, safe=""),
+        token_hex(8),
     )
     try:
         with urlopen(url, timeout=request_timeout_seconds) as response:

--- a/tests/test_release_upload.py
+++ b/tests/test_release_upload.py
@@ -39,6 +39,7 @@ def test_pypi_release_filenames_reads_exact_release_metadata(monkeypatch):
         }).encode("utf-8"))
 
     monkeypatch.setattr(release_upload, "urlopen", open_url)
+    monkeypatch.setattr(release_upload, "token_hex", lambda length: "fresh-token")
 
     assert pypi_release_filenames(
         "vaxrank",
@@ -47,9 +48,32 @@ def test_pypi_release_filenames_reads_exact_release_metadata(monkeypatch):
         request_timeout_seconds=7,
     ) == {"vaxrank-3.1.28.tar.gz"}
     assert observed == {
-        "url": "https://packages.example/pypi/vaxrank/3.1.28/json",
+        "url": (
+            "https://packages.example/pypi/vaxrank/3.1.28/json"
+            "?cache_bust=fresh-token"
+        ),
         "timeout": 7,
     }
+
+
+def test_pypi_release_filenames_uses_a_fresh_url_for_each_poll(monkeypatch):
+    urls = []
+    tokens = iter(["first-token", "second-token"])
+
+    def open_url(url, *, timeout):
+        urls.append(url)
+        return io.BytesIO(b'{"urls": []}')
+
+    monkeypatch.setattr(release_upload, "urlopen", open_url)
+    monkeypatch.setattr(release_upload, "token_hex", lambda length: next(tokens))
+
+    pypi_release_filenames("vaxrank", "3.1.28")
+    pypi_release_filenames("vaxrank", "3.1.28")
+
+    assert urls == [
+        "https://pypi.org/pypi/vaxrank/3.1.28/json?cache_bust=first-token",
+        "https://pypi.org/pypi/vaxrank/3.1.28/json?cache_bust=second-token",
+    ]
 
 
 def test_pypi_release_filenames_treats_missing_release_as_empty(monkeypatch):

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.28"
+__version__ = "3.1.29"
 
 
 def print_version():


### PR DESCRIPTION
Closes #334

## Summary
- add a fresh cache-busting token to every exact-release PyPI JSON request
- prevent polling from reusing a cached pre-release 404 after an artifact upload
- add direct regression coverage for distinct metadata URLs on successive polls
- bump vaxrank to 3.1.29

## Verification
- `./lint.sh`
- `./test.sh tests/test_release_upload.py tests/test_deploy_script.py` (12 passed)
- `./test.sh` (991 passed)