### PR TITLE
Verify uploads from PyPI project metadata

### DIFF
--- a/release_upload.py
+++ b/release_upload.py
@@ -42,11 +42,10 @@ def pypi_release_filenames(
     json_base_url: str = PYPI_JSON_BASE_URL,
     request_timeout_seconds: float = 10.0,
 ) -> frozenset[str]:
-    """Return filenames currently published for one PyPI release."""
-    url = "%s/%s/%s/json?cache_bust=%s" % (
+    """Return one release's filenames from PyPI's project metadata."""
+    url = "%s/%s/json?cache_bust=%s" % (
         json_base_url.rstrip("/"),
         quote(project, safe=""),
-        quote(version, safe=""),
         token_hex(8),
     )
     try:
@@ -56,7 +55,8 @@ def pypi_release_filenames(
         if error.code == 404:
             return frozenset()
         raise
-    return frozenset(item["filename"] for item in payload.get("urls", ()))
+    releases = payload.get("releases", {})
+    return frozenset(item["filename"] for item in releases.get(version, ()))
 
 
 def upload_distribution(

--- a/tests/test_release_upload.py
+++ b/tests/test_release_upload.py
@@ -29,13 +29,15 @@ def test_expected_release_filenames_are_exact_wheel_and_sdist():
     }
 
 
-def test_pypi_release_filenames_reads_exact_release_metadata(monkeypatch):
+def test_pypi_release_filenames_reads_project_release_map(monkeypatch):
     observed = {}
 
     def open_url(url, *, timeout):
         observed.update(url=url, timeout=timeout)
         return io.BytesIO(json.dumps({
-            "urls": [{"filename": "vaxrank-3.1.28.tar.gz"}],
+            "releases": {
+                "3.1.28": [{"filename": "vaxrank-3.1.28.tar.gz"}],
+            },
         }).encode("utf-8"))
 
     monkeypatch.setattr(release_upload, "urlopen", open_url)
@@ -49,7 +51,7 @@ def test_pypi_release_filenames_reads_exact_release_metadata(monkeypatch):
     ) == {"vaxrank-3.1.28.tar.gz"}
     assert observed == {
         "url": (
-            "https://packages.example/pypi/vaxrank/3.1.28/json"
+            "https://packages.example/pypi/vaxrank/json"
             "?cache_bust=fresh-token"
         ),
         "timeout": 7,
@@ -62,7 +64,7 @@ def test_pypi_release_filenames_uses_a_fresh_url_for_each_poll(monkeypatch):
 
     def open_url(url, *, timeout):
         urls.append(url)
-        return io.BytesIO(b'{"urls": []}')
+        return io.BytesIO(b'{"releases": {}}')
 
     monkeypatch.setattr(release_upload, "urlopen", open_url)
     monkeypatch.setattr(release_upload, "token_hex", lambda length: next(tokens))
@@ -71,8 +73,8 @@ def test_pypi_release_filenames_uses_a_fresh_url_for_each_poll(monkeypatch):
     pypi_release_filenames("vaxrank", "3.1.28")
 
     assert urls == [
-        "https://pypi.org/pypi/vaxrank/3.1.28/json?cache_bust=first-token",
-        "https://pypi.org/pypi/vaxrank/3.1.28/json?cache_bust=second-token",
+        "https://pypi.org/pypi/vaxrank/json?cache_bust=first-token",
+        "https://pypi.org/pypi/vaxrank/json?cache_bust=second-token",
     ]
 
 

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.29"
+__version__ = "3.1.30"
 
 
 def print_version():


### PR DESCRIPTION
Closes #334

## Summary
- verify release artifacts through the project-wide PyPI JSON release map
- avoid the version-specific JSON endpoint, which remained 404 for minutes after successful uploads
- retain fresh cache-busting tokens on every poll
- test the exact project-release lookup and distinct successive URLs
- bump vaxrank to 3.1.30

## Verification
- `./lint.sh`
- `./test.sh tests/test_release_upload.py tests/test_deploy_script.py` (12 passed)
- `./test.sh` (991 passed)