### PR TITLE
Repair the B16 end-to-end smoke

### DIFF
--- a/run-vaxrank-b16-test-data.sh
+++ b/run-vaxrank-b16-test-data.sh
@@ -1,16 +1,18 @@
-set -e
+#!/usr/bin/env bash
+
+set -euo pipefail
 set -x
 vaxrank \
     --download-reference-genome-data \
-    --vcf test/data/b16.f10/b16.vcf \
-    --bam test/data/b16.f10/b16.combined.bam \
+    --vcf tests/data/b16.f10/b16.vcf \
+    --bam tests/data/b16.f10/b16.combined.bam \
     --vaccine-peptide-length 15 \
-    --mhc-predictor netmhc \
+    --mhc-predictor random \
     --mhc-alleles H2-Kb,H2-Db \
     --mhc-epitope-lengths 8 \
     --padding-around-mutation 0 \
     --min-epitope-score 10e-100 \
-    --num-epitopes-per-peptide 5 \
+    --num-epitopes-per-vaccine-peptide 5 \
     --output-ascii-report vaccine-peptides-report.txt \
     --output-html-report vaccine-peptides-report.html \
     --output-pdf-report vaccine-peptides-report.pdf \

--- a/tests/test_b16_smoke_script.py
+++ b/tests/test_b16_smoke_script.py
@@ -1,0 +1,29 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+import shlex
+
+from vaxrank.cli.arg_parser import parse_vaxrank_args
+
+
+def test_b16_smoke_script_uses_current_self_contained_cli_contract():
+    repo_root = Path(__file__).resolve().parents[1]
+    script = (repo_root / "run-vaxrank-b16-test-data.sh").read_text()
+    assert script.startswith("#!/usr/bin/env bash\n")
+    command = script[script.index("vaxrank "):].replace("\\\n", " ")
+    parsed = parse_vaxrank_args(shlex.split(command)[1:])
+
+    assert all((repo_root / path).is_file() for path in parsed.vcf)
+    assert (repo_root / parsed.bam).is_file()
+    assert parsed.mhc_predictor == [["random"]]
+    assert parsed.num_epitopes_per_vaccine_peptide == 5

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.30"
+__version__ = "3.1.31"
 
 
 def print_version():


### PR DESCRIPTION
Closes #335

## Summary
- update the B16 command to current fixture paths and epitope-count CLI option
- use the self-contained random predictor so the required smoke has no proprietary executable dependency
- add a Bash shebang and strict error handling
- parse the checked-in command with the production parser in a direct contract test
- bump vaxrank to 3.1.31

## Verification
- `./lint.sh`
- `./test.sh` (992 passed)
- `bash ./run-vaxrank-b16-test-data.sh` (passed; generated all requested report formats)