### PR TITLE
Expose external bioinformatics parsing APIs

### DIFF
--- a/tests/test_dna_fallback.py
+++ b/tests/test_dna_fallback.py
@@ -15,7 +15,10 @@
 import pytest
 import varcode
 
-from vaxrank.mutant_protein_fragment import MutantProteinFragment, _find_mutation_region
+from vaxrank.mutant_protein_fragment import (
+    MutantProteinFragment,
+    find_mutation_region,
+)
 
 
 @pytest.fixture
@@ -25,13 +28,13 @@ def genome(human_genome_grch37):
 
 
 # ---------------------------------------------------------------------------
-# _find_mutation_region unit tests
+# find_mutation_region unit tests
 # ---------------------------------------------------------------------------
 
 def test_find_mutation_region_substitution():
     ref = "ABCDEFGH"
     mut = "ABCXEFGH"
-    start, end = _find_mutation_region(ref, mut)
+    start, end = find_mutation_region(ref, mut)
     assert start == 3
     assert end == 4
 
@@ -39,7 +42,7 @@ def test_find_mutation_region_substitution():
 def test_find_mutation_region_insertion():
     ref = "ABCDEFGH"
     mut = "ABCXXDEFGH"
-    start, end = _find_mutation_region(ref, mut)
+    start, end = find_mutation_region(ref, mut)
     assert start == 3
     assert end == 5  # two inserted AAs
 
@@ -47,7 +50,7 @@ def test_find_mutation_region_insertion():
 def test_find_mutation_region_deletion():
     ref = "ABCDEFGH"
     mut = "ABCFGH"
-    start, end = _find_mutation_region(ref, mut)
+    start, end = find_mutation_region(ref, mut)
     assert start == 3
     assert end == 3  # zero-length in mutant
 
@@ -55,14 +58,14 @@ def test_find_mutation_region_deletion():
 def test_find_mutation_region_frameshift():
     ref = "ABCDEFGH"
     mut = "ABCXYZ"
-    start, end = _find_mutation_region(ref, mut)
+    start, end = find_mutation_region(ref, mut)
     assert start == 3
     assert end == 6  # everything from pos 3 onward differs
 
 
 def test_find_mutation_region_identical():
     ref = "ABCDEFGH"
-    start, end = _find_mutation_region(ref, ref)
+    start, end = find_mutation_region(ref, ref)
     # start == len(ref), end == len(ref) — no mutation found
     assert start == len(ref)
 
@@ -70,7 +73,7 @@ def test_find_mutation_region_identical():
 def test_find_mutation_region_extension():
     ref = "ABCDEFGH"
     mut = "ABCDEFGHIJK"
-    start, end = _find_mutation_region(ref, mut)
+    start, end = find_mutation_region(ref, mut)
     assert start == 8
     assert end == 11
 

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -28,8 +28,9 @@ import pytest
 
 from vaxrank.epitope_io import load_lens
 from vaxrank.external_input import (
-    _mut_offsets_in_context,
-    _parse_variant_coords,
+    ExternalVariantEntry,
+    peptide_offsets_in_context,
+    parse_lens_variant_coordinates,
     ranked_from_lens_predictions,
 )
 
@@ -37,40 +38,54 @@ DATA_DIR = os.path.join(
     os.path.dirname(__file__), "data", "epitope_fixtures")
 
 
-def test_parse_variant_coords_extracts_chr_pos():
-    """``_parse_variant_coords`` extracts only (contig, pos), stripping
+def test_external_variant_entry_defaults_describe_an_empty_result():
+    entry = ExternalVariantEntry()
+
+    assert entry.variant is None
+    assert entry.vaccine_peptide is None
+    assert entry.had_transcript_ids is False
+    assert entry.resolved_transcript is False
+    assert entry.annotation is None
+    assert entry.dna_vaf is None
+    assert entry.unparseable is False
+
+
+def test_parse_lens_variant_coordinates_extracts_chr_pos():
+    """The parser extracts only (contig, pos), stripping
     the ``chr`` prefix LENS emits — pyensembl uses bare contigs, and
     keeping the prefix breaks ``variant.effect_on_transcript`` and
     renders the variant short_description as ``chrchr3 …``. Ref/alt
     come from the dedicated per-antigen-source columns
     (snv_ref_allele / snv_alt_allele etc.), looked up by
-    ``_variant_from_lens_row``."""
-    assert _parse_variant_coords("chr17:7675088:C:T") == ("17", 7675088)
-    assert _parse_variant_coords("chr1:26780312") == ("1", 26780312)
-    assert _parse_variant_coords("chr1:26780312:C") == ("1", 26780312)
+    ``variant_from_lens_row``."""
+    assert parse_lens_variant_coordinates(
+        "chr17:7675088:C:T") == ("17", 7675088)
+    assert parse_lens_variant_coordinates("chr1:26780312") == ("1", 26780312)
+    assert parse_lens_variant_coordinates(
+        "chr1:26780312:C") == ("1", 26780312)
     # Already-bare contig pass-through:
-    assert _parse_variant_coords("17:7675088") == ("17", 7675088)
+    assert parse_lens_variant_coordinates("17:7675088") == ("17", 7675088)
 
 
-def test_parse_variant_coords_returns_none_on_missing_or_malformed():
+def test_parse_lens_variant_coordinates_returns_none_on_malformed_input():
     for bad in ("garbage", "chr1:notapos:A:T", None, "", "   ",
                 "nan", "NaN"):
-        assert _parse_variant_coords(bad) is None
+        assert parse_lens_variant_coordinates(bad) is None
 
 
-def test_strip_lens_allele_handles_bracket_form():
+def test_normalize_lens_allele_handles_bracket_form():
     """LENS records alt alleles as bracketed strings: '[T]', '[CA]'.
     The helper strips brackets and returns the inner sequence."""
-    from vaxrank.external_input import _strip_lens_allele
-    assert _strip_lens_allele("[T]") == "T"
-    assert _strip_lens_allele("[CA]") == "CA"
-    assert _strip_lens_allele("T") == "T"   # already unbracketed
-    assert _strip_lens_allele("") is None
-    assert _strip_lens_allele(None) is None
-    assert _strip_lens_allele("nan") is None
+    from vaxrank.external_input import normalize_lens_allele
+    assert normalize_lens_allele("[T]") == "T"
+    assert normalize_lens_allele("[CA]") == "CA"
+    assert normalize_lens_allele("T") == "T"   # already unbracketed
+    assert normalize_lens_allele("") is None
+    assert normalize_lens_allele(None) is None
+    assert normalize_lens_allele("nan") is None
 
 
-# ---- _resolve_transcripts ------------------------------------------------
+# ---- resolve_external_transcripts ---------------------------------------
 
 class _StubGenome:
     """Minimal stand-in for pyensembl.EnsemblRelease used by tests.
@@ -91,25 +106,25 @@ class _StubGenome:
         raise ValueError("Transcript not found: %s" % tid)
 
 
-def test_resolve_transcripts_strips_version_suffix():
+def test_resolve_external_transcripts_strips_version_suffix():
     """LENS IDs carry version suffixes (``ENST00000312960.4``); pyensembl
     2.x doesn't strip them. The helper must, or every LENS lookup fails."""
-    from vaxrank.external_input import _resolve_transcripts
+    from vaxrank.external_input import resolve_external_transcripts
     sentinel = object()
     g = _StubGenome({'ENST00000312960': sentinel})
-    out = _resolve_transcripts(['ENST00000312960.4'], g)
+    out = resolve_external_transcripts(['ENST00000312960.4'], g)
     assert out == [sentinel]
     assert g.lookups == ['ENST00000312960']  # bare form was sent
 
 
-def test_resolve_transcripts_drops_unresolvable_ids():
+def test_resolve_external_transcripts_drops_unresolvable_ids():
     """A release-mismatch yields some IDs the configured release
     doesn't know. Drop quietly (DEBUG-logged) rather than crash; the
     caller's aggregate WARN summarizes the count."""
-    from vaxrank.external_input import _resolve_transcripts
+    from vaxrank.external_input import resolve_external_transcripts
     known = object()
     g = _StubGenome({'ENST00000000001': known})
-    out = _resolve_transcripts(
+    out = resolve_external_transcripts(
         ['ENST00000000001.1', 'ENST99999999999.7', ''],
         g)
     assert out == [known]
@@ -183,29 +198,29 @@ def test_infer_genome_build_from_lens_unknown_returns_none(tmp_path):
     assert infer_genome_build_from_lens(str(p)) is None
 
 
-def test_resolve_transcripts_returns_empty_when_no_genome():
+def test_resolve_external_transcripts_returns_empty_without_genome():
     """No --ensembl-release set → genome=None; resolution is a no-op
     and downstream code falls back to the empty-transcript path."""
-    from vaxrank.external_input import _resolve_transcripts
-    assert _resolve_transcripts(['ENST00000000001'], None) == []
-    assert _resolve_transcripts([], None) == []
+    from vaxrank.external_input import resolve_external_transcripts
+    assert resolve_external_transcripts(['ENST00000000001'], None) == []
+    assert resolve_external_transcripts([], None) == []
 
 
 def test_variant_from_lens_row_uses_real_snv_alleles():
     """SNV rows: ref/alt come from snv_ref_allele / snv_alt_allele.
     No placeholder genotype. The synthesized Variant carries the real
     biology so it can be fed to varcode-effect annotation safely."""
-    from vaxrank.external_input import _variant_from_lens_row
+    from vaxrank.external_input import variant_from_lens_row
     row = {
         'variant_coords': 'chr1:1624824',
         'antigen_source': 'SNV',
         'snv_ref_allele': 'C',
         'snv_alt_allele': '[T]',  # LENS's bracketed format
     }
-    v = _variant_from_lens_row(row)
+    v = variant_from_lens_row(row)
     assert v is not None
     # ``chr`` prefix stripped during parse so pyensembl-style lookups
-    # work; see ``_parse_variant_coords``.
+    # work; see ``parse_lens_variant_coordinates``.
     assert v.contig == "1"
     assert v.start == 1624824
     assert v.ref == "C"
@@ -217,14 +232,14 @@ def test_variant_from_lens_row_uses_real_indel_alleles():
     varcode normalizes indels (strips shared prefix), so ``CA → C``
     becomes ref='A' alt='' at start+1 — that's the canonical
     representation a downstream caller would expect."""
-    from vaxrank.external_input import _variant_from_lens_row
+    from vaxrank.external_input import variant_from_lens_row
     row = {
         'variant_coords': 'chr3:150742445',
         'antigen_source': 'INDEL',
         'indel_ref_allele': 'CA',
         'indel_alt_allele': '[C]',
     }
-    v = _variant_from_lens_row(row)
+    v = variant_from_lens_row(row)
     assert v is not None
     # varcode's canonical indel representation: shared prefix
     # stripped, position advanced to the differing base. Contig
@@ -239,26 +254,26 @@ def test_variant_from_lens_row_skips_non_snv_indel():
     """SPLICE / FUSION / CTA-SELF / ERV rows don't have variant_coords
     populated (NaN); the row-level helper returns None for these,
     and the caller skips them earlier on the empty-coords path."""
-    from vaxrank.external_input import _variant_from_lens_row
+    from vaxrank.external_input import variant_from_lens_row
     for src in ('SPLICE', 'FUSION', 'CTA/SELF', 'ERV'):
         row = {
             'variant_coords': None,
             'antigen_source': src,
         }
-        assert _variant_from_lens_row(row) is None
+        assert variant_from_lens_row(row) is None
 
 
 def test_variant_from_lens_row_skips_when_alleles_missing():
     """If the SNV row's allele columns are missing/NaN, return None
     rather than fabricate a placeholder."""
-    from vaxrank.external_input import _variant_from_lens_row
+    from vaxrank.external_input import variant_from_lens_row
     row = {
         'variant_coords': 'chr1:1000',
         'antigen_source': 'SNV',
         'snv_ref_allele': None,
         'snv_alt_allele': None,
     }
-    assert _variant_from_lens_row(row) is None
+    assert variant_from_lens_row(row) is None
 
 
 def test_real_lens_v19_subset_produces_ranked_entries():
@@ -358,23 +373,24 @@ def test_has_only_standard_amino_acids_helper():
             f"Should reject {non_standard!r}"
 
 
-def test_mut_offsets_in_context_finds_peptide():
+def test_peptide_offsets_in_context_finds_peptide():
     # AASVVGSSSSSGTR contains SVVGSSSSS at offset 2, length 9
-    start, end = _mut_offsets_in_context("SVVGSSSSS", "AASVVGSSSSSGTR")
+    start, end = peptide_offsets_in_context(
+        "SVVGSSSSS", "AASVVGSSSSSGTR")
     assert start == 2
     assert end == 11
 
 
-def test_mut_offsets_in_context_returns_none_when_not_found():
+def test_peptide_offsets_in_context_returns_none_when_not_found():
     """When the peptide isn't a substring of pep_context, return
     ``(None, None)`` so the caller drops the row instead of falsely
     claiming the entire context is the mutation span."""
-    start, end = _mut_offsets_in_context("XYZXYZ", "AASVVGSSSSSGTR")
+    start, end = peptide_offsets_in_context("XYZXYZ", "AASVVGSSSSSGTR")
     assert start is None
     assert end is None
     # Empty inputs also return None
-    assert _mut_offsets_in_context("", "AAVK") == (None, None)
-    assert _mut_offsets_in_context("AAVK", "") == (None, None)
+    assert peptide_offsets_in_context("", "AAVK") == (None, None)
+    assert peptide_offsets_in_context("AAVK", "") == (None, None)
 
 
 def test_lens_picks_strongest_binder_when_multiple_rows_per_variant():
@@ -401,19 +417,19 @@ def test_lens_picks_strongest_binder_when_multiple_rows_per_variant():
         "(STRNGLVLLL, IC50=18); got %r" % fragment.amino_acids)
 
 
-# ---- _patient_info_from_external ----------------------------------------
+# ---- patient_info_from_external -----------------------------------------
 
 def test_patient_info_from_external_proxy_counts():
     """The synthesized PatientInfo's variant counts come from the
     ranked output, not from VCF/BAM. Pin each count's definition so a
     later loader change can't silently shift the rendered template
     report headers."""
-    from vaxrank.external_input import _patient_info_from_external
+    from vaxrank.external_input import patient_info_from_external
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
     report_df, predictions = load_lens(path)
     ranked, _dna_vaf = ranked_from_lens_predictions(predictions, path)
-    info = _patient_info_from_external(
+    info = patient_info_from_external(
         ranked, path, patient_id='Pt-X', input_label='LENS report')
     assert info.patient_id == 'Pt-X'
     # PatientInfo on the external path no longer overloads
@@ -436,8 +452,8 @@ def test_patient_info_from_external_proxy_counts():
 
 def test_patient_info_from_external_empty_ranked():
     """No ranked variants → all counts zero, no crash."""
-    from vaxrank.external_input import _patient_info_from_external
-    info = _patient_info_from_external([], '/tmp/empty.tsv', patient_id='')
+    from vaxrank.external_input import patient_info_from_external
+    info = patient_info_from_external([], '/tmp/empty.tsv', patient_id='')
     assert info.num_somatic_variants == 0
     assert info.num_coding_effect_variants == 0
     assert info.num_variants_with_rna_support == 0
@@ -609,29 +625,24 @@ def test_pvacseq_id_parser_handles_dashed_and_dotted():
     """The parser accepts both modern (chr1-100000-100001-A-T) and
     legacy (1.123.A.T) ID forms, plus the 4-part dashed variant
     (chr1-100000-A-T) without an explicit end position. Returns
-    ``(Variant, alleles_real)`` matching the LENS-path shape;
-    pVACseq IDs always carry real ref/alt so alleles_real is True.
+    The returned Variant carries the real ref/alt nucleotides from the ID.
 
     The parser strips ``chr`` prefixes so pyensembl-style downstream
     lookups (``variant.effect_on_transcript``) work — same rationale
-    as ``_parse_variant_coords`` on the LENS path."""
-    from vaxrank.external_input import _parse_pvacseq_id
+    as ``parse_lens_variant_coordinates`` on the LENS path."""
+    from vaxrank.external_input import parse_pvacseq_variant
 
     for vid, expected in [
         ("chr1-100000-100001-A-T", ("1", 100000, "A", "T")),
         ("chr1-100000-A-T", ("1", 100000, "A", "T")),
         ("1.123.A.T", ("1", 123, "A", "T")),
     ]:
-        v, alleles_real = _parse_pvacseq_id(vid)
+        v = parse_pvacseq_variant(vid)
         assert v is not None
         assert (v.contig, v.start, v.ref, v.alt) == expected
-        assert alleles_real is True, (
-            "pVACseq IDs carry real ref/alt; alleles_real must be True")
-    # Garbage / wrong shape returns (None, False) instead of raising
+    # Garbage / wrong shape returns None instead of raising
     for bad in ("garbage", "chr1-notapos-A-T", None, ""):
-        v, alleles_real = _parse_pvacseq_id(bad)
-        assert v is None
-        assert alleles_real is False
+        assert parse_pvacseq_variant(bad) is None
 
 
 def test_pvacseq_drives_mrna_construct_assembly_end_to_end():

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -225,11 +225,13 @@ def ranked_sorted_by_target_score(ranked):
 
 
 @dataclasses.dataclass
-class _ExternalVariantEntry:
-    """One variant's contribution to an external loader's output,
-    plus the per-variant stats the loader aggregates. Lets the
-    per-variant build live in a helper while the loader stays a thin
-    accumulate-and-summarize loop."""
+class ExternalVariantEntry:
+    """Represent one external variant and its translation status.
+
+    LENS ingestion records the parsed variant and optional vaccine peptide
+    alongside the transcript, annotation, VAF, and parsing outcomes that are
+    aggregated into the final external-input report.
+    """
     variant: object = None
     vaccine_peptide: object = None
     had_transcript_ids: bool = False
@@ -261,7 +263,7 @@ def _first_str(row, *names):
     return str(value) if value is not None else ""
 
 
-def _parse_variant_coords(coords):
+def parse_lens_variant_coordinates(coords):
     """Parse a LENS ``variant_coords`` string into ``(contig, pos)``
     or ``None`` if the cell is empty / malformed.
 
@@ -274,7 +276,7 @@ def _parse_variant_coords(coords):
     looked up from the dedicated per-antigen-source columns
     (``snv_ref_allele`` / ``snv_alt_allele`` for SNVs,
     ``indel_ref_allele`` / ``indel_alt_allele`` for indels) by
-    :func:`_variant_from_lens_row`, which builds the actual
+    :func:`variant_from_lens_row`, which builds the actual
     ``Variant``.
 
     NaN / empty / 'nan' returns ``None`` — non-SNV antigen rows
@@ -305,7 +307,7 @@ def _parse_variant_coords(coords):
         return None
 
 
-def _strip_lens_allele(value):
+def normalize_lens_allele(value):
     """LENS records alt alleles as bracketed strings: ``'[T]'``,
     ``'[CA]'``. Strip the brackets and return the inner sequence;
     return None for missing / NaN / empty."""
@@ -325,7 +327,7 @@ def _strip_lens_allele(value):
     return s or None
 
 
-def _resolve_transcripts(transcript_ids, genome):
+def resolve_external_transcripts(transcript_ids, genome):
     """Resolve a list of Ensembl transcript-ID strings to pyensembl
     ``Transcript`` objects.
 
@@ -445,7 +447,7 @@ def installed_ensembl_releases_for_build(build):
     return sorted(set(releases))
 
 
-def _variant_from_lens_row(row, genome=None):
+def variant_from_lens_row(row, genome=None):
     """Build a ``varcode.Variant`` from a LENS row using real ref/alt.
 
     LENS dedicates per-antigen-source columns for ref/alt:
@@ -463,17 +465,17 @@ def _variant_from_lens_row(row, genome=None):
     NaN ``variant_coords`` and are skipped upstream.
     """
     from varcode import Variant
-    coords_parsed = _parse_variant_coords(row.get('variant_coords'))
+    coords_parsed = parse_lens_variant_coordinates(row.get('variant_coords'))
     if coords_parsed is None:
         return None
     contig, pos = coords_parsed
     antigen_source = (row.get('antigen_source') or '').upper()
     if antigen_source == 'SNV':
-        ref = _strip_lens_allele(row.get('snv_ref_allele'))
-        alt = _strip_lens_allele(row.get('snv_alt_allele'))
+        ref = normalize_lens_allele(row.get('snv_ref_allele'))
+        alt = normalize_lens_allele(row.get('snv_alt_allele'))
     elif antigen_source == 'INDEL':
-        ref = _strip_lens_allele(row.get('indel_ref_allele'))
-        alt = _strip_lens_allele(row.get('indel_alt_allele'))
+        ref = normalize_lens_allele(row.get('indel_ref_allele'))
+        alt = normalize_lens_allele(row.get('indel_alt_allele'))
     else:
         # SPLICE / FUSION / CTA-SELF / ERV rows have neither variant
         # coords (NaN handled above) nor SNV/INDEL alleles. Caller
@@ -496,19 +498,19 @@ def _variant_from_lens_row(row, genome=None):
         return None
 
 
-def _mut_offsets_in_context(peptide, pep_context):
+def peptide_offsets_in_context(peptide, peptide_context):
     """Locate the neoepitope inside its surrounding context.
 
     Returns ``(start, end)`` AA offsets of the peptide within
-    ``pep_context``. Returns ``(None, None)`` when the peptide can't
+    ``peptide_context``. Returns ``(None, None)`` when the peptide can't
     be located — the caller should drop the row rather than fabricate
     a mutation span. Previously this defaulted to "the whole context
     is the mutation," which falsely told downstream code that every
     residue was mutated.
     """
-    if not pep_context or not peptide:
+    if not peptide_context or not peptide:
         return None, None
-    idx = pep_context.find(peptide)
+    idx = peptide_context.find(peptide)
     if idx < 0:
         return None, None
     return idx, idx + len(peptide)
@@ -602,7 +604,7 @@ def _read_counts_from_lens_row(row):
 def _lens_ranked_entry(coords, group_rows, by_peptide, genome,
                        vaccine_peptide_length, affinity_cols, rank_cols,
                        num_target_epitopes_to_keep):
-    """Build one variant's :class:`_ExternalVariantEntry` from a LENS
+    """Build one variant's :class:`ExternalVariantEntry` from a LENS
     row group. Returns the entry (with ``unparseable`` / ``vaccine_peptide``
     None for rows that can't be turned into an antigen); the caller
     aggregates the stats and the ranked list."""
@@ -610,13 +612,13 @@ def _lens_ranked_entry(coords, group_rows, by_peptide, genome,
     # Build the Variant from REAL ref/alt columns (snv_*_allele /
     # indel_*_allele depending on antigen_source). variant_coords gives
     # only chr:pos in LENS v1.9; the alleles live in dedicated columns.
-    variant = _variant_from_lens_row(rep, genome=genome)
+    variant = variant_from_lens_row(rep, genome=genome)
     if variant is None:
         logger.debug(
             "Could not build Variant from LENS row at coords=%r "
             "(antigen_source=%r); skipping.", coords,
             rep.get('antigen_source'))
-        return _ExternalVariantEntry(unparseable=True)
+        return ExternalVariantEntry(unparseable=True)
 
     peptide = rep.get('peptide') or ""
     pep_context = rep.get('pep_context') or ""
@@ -633,7 +635,7 @@ def _lens_ranked_entry(coords, group_rows, by_peptide, genome,
         logger.debug(
             "Dropped LENS row for variant %r: peptide / pep_context "
             "empty after stop-codon truncation.", coords)
-        return _ExternalVariantEntry()
+        return ExternalVariantEntry()
     # Some LENS files emit non-standard residues (U / O / X / B / Z / J);
     # vaxrank's manufacturability / hydropathy code is keyed off the 20
     # canonical AAs, so drop the row rather than crash.
@@ -642,7 +644,7 @@ def _lens_ranked_entry(coords, group_rows, by_peptide, genome,
             "Dropped LENS row for variant %r: pep_context %r contains "
             "non-standard residues (allowed: 20 canonical AAs).",
             coords, pep_context)
-        return _ExternalVariantEntry()
+        return ExternalVariantEntry()
     # Preserve LENS's own gene name; fall back to empty string (the
     # codebase convention for "not known").
     gene_name_raw = rep.get('gene_name')
@@ -651,13 +653,13 @@ def _lens_ranked_entry(coords, group_rows, by_peptide, genome,
             isinstance(gene_name_raw, float) and pd.isna(gene_name_raw))
         else "")
 
-    start_off, end_off = _mut_offsets_in_context(peptide, pep_context)
+    start_off, end_off = peptide_offsets_in_context(peptide, pep_context)
     if start_off is None:
         logger.debug(
             "Could not locate peptide %r in pep_context %r for variant "
             "%r; skipping (mutation span unknown).",
             peptide, pep_context, coords)
-        return _ExternalVariantEntry()
+        return ExternalVariantEntry()
 
     # Frameshift → the whole downstream tail is novel; combine the
     # variant's neoepitope rows into the maximal mutant span. Frameshift
@@ -695,9 +697,9 @@ def _lens_ranked_entry(coords, group_rows, by_peptide, genome,
             t = t.strip()
             if t and t not in transcript_ids:
                 transcript_ids.append(t)
-    transcripts = _resolve_transcripts(transcript_ids, genome)
+    transcripts = resolve_external_transcripts(transcript_ids, genome)
 
-    entry = _ExternalVariantEntry(
+    entry = ExternalVariantEntry(
         variant=variant,
         had_transcript_ids=bool(transcript_ids),
         resolved_transcript=bool(transcripts),
@@ -1055,28 +1057,21 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
     return ranked_sorted_by_target_score(ranked), dna_vaf_by_variant
 
 
-def _parse_pvacseq_id(vid, genome=None):
-    """Parse a pVACseq aggregate ``ID`` field into a
-    ``(varcode.Variant, alleles_real)`` pair, matching the
-    :func:`_parse_variant_coords` shape used on the LENS path.
+def parse_pvacseq_variant(variant_id, genome=None):
+    """Parse a pVACseq aggregate ``ID`` field into a ``varcode.Variant``.
 
     Common forms in the wild:
       - ``chr1-100000-100001-A-T`` (5-part dashed: contig-start-end-ref-alt)
       - ``chr1-100000-A-T`` (4-part dashed)
       - ``1.123.A.T`` (4-part dotted, legacy)
 
-    All recognized forms supply real ref + alt nucleotides, so
-    ``alleles_real`` is always ``True`` on success. Returns
-    ``(None, False)`` for unrecognized input.
-
-    The shape symmetry with :func:`_parse_variant_coords` lets future
-    code that handles both LENS and pVACseq paths uniformly read a
-    single ``alleles_real`` flag without case analysis.
+    All recognized forms supply real ref + alt nucleotides. Returns ``None``
+    for unrecognized input.
     """
     from varcode import Variant
-    if not vid:
-        return None, False
-    s = str(vid)
+    if not variant_id:
+        return None
+    s = str(variant_id)
     contig = pos_s = ref = alt = None
     if '-' in s:
         parts = s.split('-')
@@ -1090,11 +1085,11 @@ def _parse_pvacseq_id(vid, genome=None):
         if len(parts) == 4:
             contig, pos_s, ref, alt = parts
     if contig is None:
-        return None, False
+        return None
     try:
         pos = int(pos_s)
     except (ValueError, TypeError):
-        return None, False
+        return None
     # Strip the ``chr`` prefix pVACseq emits, same rationale as LENS:
     # pyensembl uses bare contigs and ``normalize_contig_names=False``
     # below means varcode won't strip for us. Keeping the prefix
@@ -1107,8 +1102,8 @@ def _parse_pvacseq_id(vid, genome=None):
             contig=contig, start=pos, ref=ref, alt=alt,
             genome=genome, normalize_contig_names=False)
     except Exception:
-        return None, False
-    return v, True
+        return None
+    return v
 
 
 def _pvacseq_variant_key(row):
@@ -1229,7 +1224,7 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
         # (codebase convention for "not known"). No 'unknown' invention.
         gene = _pvacseq_gene(rep)
 
-        variant, alleles_real = _parse_pvacseq_id(vid, genome=genome)
+        variant = parse_pvacseq_variant(vid, genome=genome)
         if variant is None:
             n_skipped += 1
             logger.debug(
@@ -1261,7 +1256,7 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
         # have real effect context; falls back to [] when the genome
         # isn't plumbed through or the ID can't be resolved.
         transcript_ids = _pvacseq_transcript_ids(rep)
-        transcripts = _resolve_transcripts(transcript_ids, genome)
+        transcripts = resolve_external_transcripts(transcript_ids, genome)
         if transcript_ids:
             n_with_ids += 1
             if transcripts:
@@ -1326,9 +1321,9 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
     return ranked_sorted_by_target_score(ranked), dna_vaf_by_variant
 
 
-def _patient_info_from_external(ranked, source_path, patient_id,
-                                input_label='External report',
-                                predictions=None):
+def patient_info_from_external(ranked, source_path, patient_id,
+                               input_label='External report',
+                               predictions=None):
     """Build a :class:`PatientInfo` from external-input data.
 
     Counts are derived from the ranked output:
@@ -1411,7 +1406,7 @@ def load_external_ranked(args):
 
     ``patient_info`` carries the variant-count metadata template
     reports (ASCII / HTML / PDF) need; counts are proxies derived
-    from the ranked output (see ``_patient_info_from_external``).
+    from the ranked output (see :func:`patient_info_from_external`).
     """
     from .epitope_io import load_lens, load_pvacseq
     patient_id = getattr(args, 'output_patient_id', '') or ''
@@ -1422,7 +1417,7 @@ def load_external_ranked(args):
             predictions, args.input_lens,
             genome=getattr(args, 'genome', None),
             vaccine_peptide_length=vaccine_peptide_length)
-        patient_info = _patient_info_from_external(
+        patient_info = patient_info_from_external(
             ranked, args.input_lens, patient_id,
             input_label='LENS report',
             predictions=predictions)
@@ -1433,7 +1428,7 @@ def load_external_ranked(args):
         ranked, dna_vaf_by_variant = ranked_from_pvacseq_predictions(
             predictions, args.input_pvacseq,
             genome=getattr(args, 'genome', None))
-        patient_info = _patient_info_from_external(
+        patient_info = patient_info_from_external(
             ranked, args.input_pvacseq, patient_id,
             input_label='pVACseq report',
             predictions=predictions)

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -28,33 +28,35 @@ from .varcode_effects import (
 logger = logging.getLogger(__name__)
 
 
-def _find_mutation_region(ref_protein, mut_protein):
+def find_mutation_region(reference_protein, mutant_protein):
+    """Return the differing region between reference and mutant proteins.
+
+    The returned offsets use zero-based, half-open coordinates in the mutant
+    protein. Insertions span their inserted residues; deletions have an empty
+    span at the deletion point.
     """
-    Find the mutated region by diffing reference and mutant protein sequences.
-    Returns (start, end) offsets in the mutant protein (0-based, half-open).
-    """
-    min_len = min(len(ref_protein), len(mut_protein))
+    min_len = min(len(reference_protein), len(mutant_protein))
 
     # Find first difference
     start = min_len
     for i in range(min_len):
-        if ref_protein[i] != mut_protein[i]:
+        if reference_protein[i] != mutant_protein[i]:
             start = i
             break
 
     # Find where sequences re-align from the right
-    ref_i = len(ref_protein)
-    mut_i = len(mut_protein)
+    ref_i = len(reference_protein)
+    mut_i = len(mutant_protein)
     while ref_i > start and mut_i > start:
-        if ref_protein[ref_i - 1] == mut_protein[mut_i - 1]:
+        if reference_protein[ref_i - 1] == mutant_protein[mut_i - 1]:
             ref_i -= 1
             mut_i -= 1
         else:
             break
 
     # Proteins differ only in length (e.g. stop-loss extension)
-    if start == min_len and len(ref_protein) != len(mut_protein):
-        return min_len, len(mut_protein)
+    if start == min_len and len(reference_protein) != len(mutant_protein):
+        return min_len, len(mutant_protein)
 
     return start, mut_i
 
@@ -272,7 +274,7 @@ class MutantProteinFragment(DataclassSerializable):
             return None
 
         # Locate the mutation in the protein
-        mut_start, mut_end = _find_mutation_region(ref_protein, mut_protein)
+        mut_start, mut_end = find_mutation_region(ref_protein, mut_protein)
         if mut_start >= len(mut_protein):
             return None
 

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.31"
+__version__ = "3.1.32"
 
 
 def print_version():


### PR DESCRIPTION
Advances #328.

## Summary
- promote nine externally meaningful parsing, transcript-resolution, reporting, and mutation-region operations to documented public APIs
- expose `ExternalVariantEntry` as the explicit per-variant ingestion result contract
- name peptide/context offset calculation for what it actually computes
- simplify pVACseq variant parsing from a `(Variant, always_true)` tuple to `Variant | None`
- remove the old underscored names rather than retaining compatibility aliases
- bump vaxrank to 3.1.32

## Verification
- `./lint.sh`
- `./test.sh tests/test_external_input.py tests/test_dna_fallback.py` (62 passed)
- `./test.sh` (993 passed)