### PR TITLE
Expose processing and construct operations

### DIFF
--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -291,7 +291,7 @@ def test_ascii_report_renders_coverage_block_in_construction_section():
     section header, per-allele coverage lines, per-antigen
     ``covers A (tier)`` annotations."""
     import io
-    from vaxrank.report import _make_report
+    from vaxrank.report import render_report
 
     template_data = {
         'patient_info': {'Patient ID': 'TEST'},
@@ -332,7 +332,7 @@ def test_ascii_report_renders_coverage_block_in_construction_section():
         },
     }
     f = io.StringIO()
-    _make_report(template_data, f, 'templates/template.txt')
+    render_report(template_data, f, 'templates/template.txt')
     rendered = f.getvalue()
     # Section header.
     assert 'Vaccine construction — mrna' in rendered

--- a/tests/test_junction_swap.py
+++ b/tests/test_junction_swap.py
@@ -499,12 +499,12 @@ def test_assemble_manifest_chosen_uses_canonical_linker_names():
             "Manifest 'chosen' entry %r is not the canonical name" % name)
 
 
-def test_packing_linker_aa_uses_max_candidate_length():
+def test_packing_linker_amino_acids_uses_max_candidate_length():
     """The bin-packer must size junctions against the longest possible
     per-junction substitution, not just the shared linker. Otherwise
     a short shared linker + long candidate could overflow the cap at
     swap time."""
-    from vaxrank.mrna import RNAConstructConfig, _packing_linker_aa
+    from vaxrank.mrna import RNAConstructConfig, packing_linker_amino_acids
     from vaxrank.vaccine_library import get_linker
 
     # Shared linker is short (G2S = 3 aa). Candidate set includes
@@ -515,7 +515,7 @@ def test_packing_linker_aa_uses_max_candidate_length():
         junction_swap_candidates=("G2S", "(G4S)2"),
     )
     shared = get_linker("G2S")
-    packing_aa = _packing_linker_aa(options, shared)
+    packing_aa = packing_linker_amino_acids(options, shared)
     assert len(packing_aa) == 10, (
         "Packer should use max(shared=3, longest_candidate=10) = 10, "
         "got len=%d (%r)" % (len(packing_aa), packing_aa))
@@ -525,7 +525,7 @@ def test_packing_linker_aa_uses_max_candidate_length():
         optimize_linkers=False,
         junction_swap_candidates=("G2S", "(G4S)2"),
     )
-    packing_aa_off = _packing_linker_aa(options_off, shared)
+    packing_aa_off = packing_linker_amino_acids(options_off, shared)
     assert packing_aa_off == "GGS", (
         "With optimizer off, packer should use shared linker "
         "as-is, got %r" % packing_aa_off)

--- a/tests/test_mrna.py
+++ b/tests/test_mrna.py
@@ -23,7 +23,9 @@ from varcode import Variant
 from vaxrank.mrna import (
     RNAConstructConfig,
     assemble_mrna_constructs,
+    build_protein_with_segments,
     codon_optimize,
+    resolve_named_mrna_element,
     summarize_mrna_ranking_decisions,
     write_mrna_outputs,
 )
@@ -187,7 +189,7 @@ def test_ascii_report_renders_mrna_ranking_section():
     """End-to-end: the ASCII report includes a ``mRNA vaccine
     antigen selection`` section when the
     ``mrna_ranking`` template-data field is populated."""
-    from vaxrank.report import _make_report
+    from vaxrank.report import render_report
     import io
 
     template_data = {
@@ -226,7 +228,7 @@ def test_ascii_report_renders_mrna_ranking_section():
         },
     }
     f = io.StringIO()
-    _make_report(template_data, f, 'templates/template.txt')
+    render_report(template_data, f, 'templates/template.txt')
     rendered = f.getvalue()
     # Post-2.25 section header (was "mRNA vaccine antigen selection").
     assert 'Vaccine construction — mrna' in rendered
@@ -243,7 +245,7 @@ def test_ascii_report_renders_mrna_ranking_section():
 def test_ascii_report_skips_construction_section_when_no_modalities():
     """When ``vaccine_constructions`` is empty (no active modality
     or no ranked antigens), no construction sections render."""
-    from vaxrank.report import _make_report
+    from vaxrank.report import render_report
     import io
     template_data = {
         'patient_info': {'Patient ID': 'TEST'},
@@ -257,34 +259,34 @@ def test_ascii_report_skips_construction_section_when_no_modalities():
         'mrna_ranking': None,
     }
     f = io.StringIO()
-    _make_report(template_data, f, 'templates/template.txt')
+    render_report(template_data, f, 'templates/template.txt')
     rendered = f.getvalue()
     assert 'Vaccine construction' not in rendered
 
 
-def test_resolve_named_accepts_dashes_and_case_variants():
+def test_resolve_named_mrna_element_accepts_dashes_and_case_variants():
     """Library keys are written ``HLA_B`` / ``tPA`` / ``IgK`` etc.,
     but users in the field write ``HLA-B`` / ``hla-b`` / ``HLAB``.
-    ``_resolve_named`` strips dashes and underscores and lowercases
+    ``resolve_named_mrna_element`` strips separators and lowercases
     so all of those resolve to the same entry."""
     from vaxrank.mrna_library import SIGNAL_PEPTIDES, MITDS, UTRS_5P
-    from vaxrank.mrna import _resolve_named
-
-    canonical = _resolve_named(SIGNAL_PEPTIDES, 'HLA_B', 'signal_peptide')
+    canonical = resolve_named_mrna_element(
+        SIGNAL_PEPTIDES, 'HLA_B', 'signal_peptide')
     for variant in ['HLA-B', 'hla_b', 'hla-b', 'HLAB', 'hlab']:
-        assert _resolve_named(
+        assert resolve_named_mrna_element(
             SIGNAL_PEPTIDES, variant, 'signal_peptide') == canonical, variant
     # MITD
-    a_canonical = _resolve_named(MITDS, 'HLA_A', 'mitd')
-    assert _resolve_named(MITDS, 'HLA-A', 'mitd') == a_canonical
-    assert _resolve_named(MITDS, 'hla-a', 'mitd') == a_canonical
+    a_canonical = resolve_named_mrna_element(MITDS, 'HLA_A', 'mitd')
+    assert resolve_named_mrna_element(MITDS, 'HLA-A', 'mitd') == a_canonical
+    assert resolve_named_mrna_element(MITDS, 'hla-a', 'mitd') == a_canonical
     # UTR
-    hbb = _resolve_named(UTRS_5P, 'HBB', '5p_utr')
-    assert _resolve_named(UTRS_5P, 'hbb', '5p_utr') == hbb
+    hbb = resolve_named_mrna_element(UTRS_5P, 'HBB', '5p_utr')
+    assert resolve_named_mrna_element(UTRS_5P, 'hbb', '5p_utr') == hbb
     # Unknown still raises
     import pytest
     with pytest.raises(ValueError, match="Unknown signal_peptide"):
-        _resolve_named(SIGNAL_PEPTIDES, 'NOT_A_REAL_KEY', 'signal_peptide')
+        resolve_named_mrna_element(
+            SIGNAL_PEPTIDES, 'NOT_A_REAL_KEY', 'signal_peptide')
 
 
 def test_codon_optimize_preserves_translation():
@@ -864,12 +866,11 @@ def test_csv_lean_mode_omits_full_rows(tmp_path):
 
 
 def test_dropped_dead_linker_name_param():
-    """_build_protein_with_segments no longer takes a linker_name arg.
+    """build_protein_with_segments no longer takes a linker_name arg.
     Pin the signature so a future regression that re-adds the dead
     parameter is caught immediately."""
     import inspect
-    from vaxrank.mrna import _build_protein_with_segments
-    sig = inspect.signature(_build_protein_with_segments)
+    sig = inspect.signature(build_protein_with_segments)
     assert 'linker_name' not in sig.parameters, (
         "linker_name was a dead parameter and should remain removed; "
         "got params %s" % list(sig.parameters))
@@ -881,12 +882,11 @@ def test_dropped_dead_linker_name_param():
 def test_start_codon_segment_has_named_kind():
     """The pre-2.14 code emitted name=None for the prepended start
     codon segment. Pin that we now use 'start_codon' as the name."""
-    from vaxrank.mrna import _build_protein_with_segments
     from vaxrank.vaccine_library import get_linker
     linker = get_linker("G4S")
     # No signal peptide and antigen doesn't start with M → assembler
     # prepends a start codon segment.
-    _, _, segments = _build_protein_with_segments(
+    _, _, segments = build_protein_with_segments(
         antigen_aas=["KLQGH"], antigen_names=["A"],
         signal_peptide_aa="", signal_peptide_name=None,
         linker=linker, mitd_aa="", mitd_name=None)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -31,8 +31,10 @@ from mhctools.pred import Prediction
 
 from vaxrank.candidate_epitope import CandidateEpitope, Peptide
 from vaxrank.processing import (
-    _component_probs,
     annotate_processing,
+    load_default_processing_predictor,
+    processing_component_probabilities,
+    resolve_peptide_offset,
 )
 
 
@@ -85,13 +87,30 @@ class StubPepsickle:
 # tested there. The only vaxrank-side concern is the out-of-range guard, so
 # that's all we exercise locally.
 
-def test_component_probs_out_of_range_returns_none_tuple():
+def test_processing_component_probabilities_rejects_out_of_range_span():
     """Peptide span extending past the source returns ``(None, None)``
     so the caller can drop the row instead of raising IndexError from
     the mhctools slice helpers."""
-    c_term, max_internal = _component_probs([0.1, 0.2, 0.3], start=2, length=5)
+    c_term, max_internal = processing_component_probabilities(
+        [0.1, 0.2, 0.3], start=2, length=5)
     assert c_term is None
     assert max_internal is None
+
+
+def test_processing_component_probabilities_extracts_requested_span():
+    c_term, max_internal = processing_component_probabilities(
+        [0.1, 0.2, 0.3, 0.4], start=1, length=3)
+
+    assert c_term == 0.4
+    assert max_internal == 0.3
+
+
+def test_resolve_peptide_offset_prefers_nearest_repeated_occurrence():
+    source = "AAAAAXXXAAAAA"
+    context = _ep("AAAAA", source, offset=7)
+
+    assert resolve_peptide_offset(source, "AAAAA", context) == 8
+    assert resolve_peptide_offset(source, "CCCCC", context) is None
 
 
 # ---- Annotation (integration with flat records) ---------------------
@@ -258,15 +277,13 @@ def test_annotate_processing_empty_input_returns_zero():
 # Vaxrank no longer ships its own subprocess launcher — those tests
 # moved upstream alongside the implementation.
 
-def test_load_default_predictor_returns_none_when_mhctools_missing(
+def test_load_default_processing_predictor_handles_missing_mhctools(
         monkeypatch):
-    """When mhctools isn't installed, ``_load_default_predictor`` logs
+    """When mhctools isn't installed, the default factory logs
     a clear warning and returns None so the caller can degrade
     gracefully (no crash, no annotations)."""
     import builtins
     import sys
-    from vaxrank.processing import _load_default_predictor
-
     real_import = builtins.__import__
 
     def _fail_on_mhctools(name, *args, **kwargs):
@@ -276,7 +293,7 @@ def test_load_default_predictor_returns_none_when_mhctools_missing(
 
     monkeypatch.setattr(builtins, '__import__', _fail_on_mhctools)
     monkeypatch.delitem(sys.modules, 'mhctools', raising=False)
-    assert _load_default_predictor() is None
+    assert load_default_processing_predictor() is None
 
 
 # ---- Report integration --------------------------------------------------
@@ -289,7 +306,7 @@ def test_ascii_report_surfaces_each_predictor_in_per_epitope_table():
     VCF/BAM path collapsed via dict-overwrite so this test would
     have only seen one row."""
     import io
-    from vaxrank.report import _make_report
+    from vaxrank.report import render_report
     template_data = {
         'patient_info': {'Patient ID': 'TEST'},
         'package_versions': {},
@@ -326,7 +343,7 @@ def test_ascii_report_surfaces_each_predictor_in_per_epitope_table():
         }],
     }
     f = io.StringIO()
-    _make_report(template_data, f, 'templates/template.txt')
+    render_report(template_data, f, 'templates/template.txt')
     rendered = f.getvalue()
     # Both predictors named in the per-epitope ASCII table; same
     # peptide+allele appears twice (one row per predictor).

--- a/vaxrank/mrna.py
+++ b/vaxrank/mrna.py
@@ -225,14 +225,7 @@ class RNAConstruct:
     antigens: list = field(default_factory=list)
 
 
-def _normalize_lookup_key(name):
-    """Strip case + dash/underscore differences for table lookups.
-    Lets users write ``HLA-B`` / ``hla_b`` / ``HLAB`` / ``HLA_B`` for
-    a key the library spells ``HLA_B``."""
-    return str(name).replace('-', '').replace('_', '').lower()
-
-
-def _resolve_named(table, name, kind):
+def resolve_named_mrna_element(table, name, kind):
     """Resolve ``name`` against ``table`` with case + separator
     tolerance. Common biological identifiers (HLA-B, tPA, IgK) are
     written with mixed case and dashes in the literature; the table
@@ -240,9 +233,10 @@ def _resolve_named(table, name, kind):
     accept any sensible spelling."""
     if name in table:
         return table[name]
-    needle = _normalize_lookup_key(name)
+    needle = str(name).replace('-', '').replace('_', '').lower()
     for k, v in table.items():
-        if _normalize_lookup_key(k) == needle:
+        normalized_key = str(k).replace('-', '').replace('_', '').lower()
+        if normalized_key == needle:
             return v
     raise ValueError(
         "Unknown %s '%s'. Available: %s" % (
@@ -452,10 +446,10 @@ def _antigen_aa_sequences(ranked_vaccine_peptides, max_antigen_length_aa,
             yield name, window
 
 
-def _build_protein_with_segments(antigen_aas, antigen_names, signal_peptide_aa,
-                                 signal_peptide_name, linker, mitd_aa,
-                                 mitd_name, per_junction_linkers=None,
-                                 pre_mitd_linker=None):
+def build_protein_with_segments(antigen_aas, antigen_names, signal_peptide_aa,
+                                signal_peptide_name, linker, mitd_aa,
+                                mitd_name, per_junction_linkers=None,
+                                pre_mitd_linker=None):
     """Concatenate signal peptide + antigens + linker/MITD into one protein.
 
     Returns ``(protein_str, frozen_segments, aa_segments)`` where:
@@ -560,7 +554,7 @@ def build_poly_a(options):
     return "A" * first + options.poly_a_segment_linker + "A" * rest
 
 
-def _packing_linker_aa(options, linker):
+def packing_linker_amino_acids(options, linker):
     """Linker AA string the packer should bill against, sized to the
     longest possible per-junction substitution.
 
@@ -594,10 +588,10 @@ def _pack_constructs(antigen_pairs, options, signal_peptide_aa, linker,
     swap step at assembly time can never exceed the cap by picking a
     candidate longer than the shared linker.
     """
-    linker_aa = _packing_linker_aa(options, linker)
+    linker_aa = packing_linker_amino_acids(options, linker)
     # When there is no signal peptide, the assembler prepends an ATG to the
     # CDS body if the first antigen doesn't already start with M (see
-    # _build_protein_with_segments). Reserve 3 nt up-front to keep packing
+    # build_protein_with_segments). Reserve 3 nt up-front to keep packing
     # honest.
     start_codon_nt = 3 if not signal_peptide_aa else 0
     fixed_overhead_nt = (
@@ -721,8 +715,8 @@ def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
                 if id(item) not in head_keys]
         ranked_vaccine_peptides = head + tail
     signal_peptide_aa = (
-        _resolve_named(SIGNAL_PEPTIDES, options.signal_peptide,
-                       'signal peptide')
+        resolve_named_mrna_element(
+            SIGNAL_PEPTIDES, options.signal_peptide, 'signal peptide')
         if options.signal_peptide else ""
     )
     # Natural secretory signal peptides start with the initial M (it's the
@@ -734,9 +728,13 @@ def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
             "Signal peptide '%s' does not start with M; the resulting CDS "
             "would have no start codon." % options.signal_peptide)
     linker = get_linker(options.linker)
-    mitd_aa = _resolve_named(MITDS, options.mitd, 'MITD') if options.include_mitd else ""
-    utr_5p_dna = _resolve_named(UTRS_5P, options.utr_5p, "5' UTR")
-    utr_3p_dna = _resolve_named(UTRS_3P, options.utr_3p, "3' UTR")
+    mitd_aa = (
+        resolve_named_mrna_element(MITDS, options.mitd, 'MITD')
+        if options.include_mitd else "")
+    utr_5p_dna = resolve_named_mrna_element(
+        UTRS_5P, options.utr_5p, "5' UTR")
+    utr_3p_dna = resolve_named_mrna_element(
+        UTRS_3P, options.utr_3p, "3' UTR")
 
     antigens = list(_antigen_aa_sequences(
         ranked_vaccine_peptides,
@@ -837,7 +835,7 @@ def assemble_mrna_constructs(ranked_vaccine_peptides, options=None,
                         'note': "default linker beat or tied all candidates",
                     }
 
-        protein, frozen_segments, aa_segments = _build_protein_with_segments(
+        protein, frozen_segments, aa_segments = build_protein_with_segments(
             antigen_aas, names, signal_peptide_aa, options.signal_peptide,
             linker, mitd_aa,
             options.mitd if options.include_mitd else None,

--- a/vaxrank/processing.py
+++ b/vaxrank/processing.py
@@ -95,7 +95,7 @@ PEPSICKLE_PREDICTOR_NAME = 'pepsickle'
 # IndexError, so we range-check first and return ``(None, None)`` to mean
 # "no signal" upstream.
 
-def _component_probs(seq_probs, start, length):
+def processing_component_probabilities(seq_probs, start, length):
     """Return ``(c_term, max_internal)`` for a peptide at
     ``seq_probs[start:start+length]``, or ``(None, None)`` when the
     span doesn't fit. Both components come straight from the public
@@ -109,32 +109,11 @@ def _component_probs(seq_probs, start, length):
     return c_term, max_internal
 
 
-def _closest_occurrence(source, peptide, declared_offset):
-    """Offset of ``peptide`` in ``source`` closest to ``declared_offset``,
-    or ``None`` if not found.
-
-    Bias toward the declared offset so repeated peptides (homopolymer
-    tracts, short ligands appearing in multiple loops) don't snap to
-    position 0 when the upstream loader recorded a later occurrence.
-    """
-    if not peptide or not source:
-        return None
-    best = None
-    best_drift = None
-    pos = source.find(peptide)
-    while pos >= 0:
-        drift = abs(pos - declared_offset)
-        if best_drift is None or drift < best_drift:
-            best, best_drift = pos, drift
-        pos = source.find(peptide, pos + 1)
-    return best
-
-
 # ----------------------------------------------------------------------------
 # Pepsickle invocation (delegates to mhctools' built-in subprocess isolation)
 # ----------------------------------------------------------------------------
 
-def _load_default_predictor(human_only=False, threshold=0.5):
+def load_default_processing_predictor(human_only=False, threshold=0.5):
     """Construct an ``mhctools.Pepsickle`` with subprocess isolation
     on, or return ``None`` if mhctools / pepsickle isn't installed.
 
@@ -225,7 +204,7 @@ def annotate_processing(epitopes, predictor=None,
     # uses mhctools' built-in subprocess isolation; the test-seam
     # path uses whatever object the caller passed in.
     if predictor is None:
-        predictor = _load_default_predictor(
+        predictor = load_default_processing_predictor(
             human_only=human_only, threshold=threshold)
         if predictor is None:
             return 0, processing_predictions
@@ -283,13 +262,13 @@ def annotate_processing(epitopes, predictor=None,
             peptide = e.sequence or ''
             if not peptide:
                 continue
-            offset = _resolve_peptide_offset(source, peptide, e)
+            offset = resolve_peptide_offset(source, peptide, e)
             if offset is None:
                 n_skipped_peptide_not_in_context += 1
                 if len(skipped_examples) < 3:
                     skipped_examples.append((peptide, source))
                 continue
-            c_term, max_internal = _component_probs(
+            c_term, max_internal = processing_component_probabilities(
                 seq_probs, offset, len(peptide))
             if c_term is None:
                 continue
@@ -342,7 +321,7 @@ def annotate_processing(epitopes, predictor=None,
     return n_annotated, processing_predictions
 
 
-def _resolve_peptide_offset(source, peptide, mutant_ctx):
+def resolve_peptide_offset(source, peptide, mutant_context):
     """Locate the peptide's offset within its source.
 
     Trust the mutant ``Peptide.offset`` first; re-locate via
@@ -354,12 +333,19 @@ def _resolve_peptide_offset(source, peptide, mutant_ctx):
 
     Returns the offset (int) or None when the peptide isn't in the source.
     """
-    declared = mutant_ctx.offset or 0
+    declared = mutant_context.offset or 0
     length = len(peptide)
     if (declared + length <= len(source)
             and source[declared:declared + length] == peptide):
         return declared
-    found = _closest_occurrence(source, peptide, declared)
+    found = None
+    best_drift = None
+    position = source.find(peptide)
+    while position >= 0:
+        drift = abs(position - declared)
+        if best_drift is None or drift < best_drift:
+            found, best_drift = position, drift
+        position = source.find(peptide, position + 1)
     if found is None:
         return None
     drift = abs(found - declared)

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -644,10 +644,11 @@ class TemplateDataCreator(object):
         return self.template_data
 
 
-def _make_report(
+def render_report(
         template_data,
         file_handle,
         template_path):
+    """Render one packaged Jinja template into an open text stream."""
     template = JINJA_ENVIRONMENT.get_template(template_path)
     report = template.render(template_data)
     file_handle.write(report)
@@ -656,14 +657,14 @@ def make_ascii_report(
         template_data,
         ascii_report_path):
     with open(ascii_report_path, "w") as f:
-        _make_report(template_data, f, 'templates/template.txt')
+        render_report(template_data, f, 'templates/template.txt')
     logger.info('Wrote ASCII report to %s', ascii_report_path)
 
 def make_html_report(
         template_data,
         html_report_path):
     with open(html_report_path, "w") as f:
-        _make_report(template_data, f, 'templates/template.html')
+        render_report(template_data, f, 'templates/template.html')
     logger.info('Wrote HTML report to %s', html_report_path)
 
 def _pdf_via_pdfkit(html_path, pdf_report_path):
@@ -697,7 +698,7 @@ def make_pdf_report(
         pdf_report_path,
         backend='pdfkit'):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.html') as f:
-        _make_report(template_data, f, 'templates/template.html')
+        render_report(template_data, f, 'templates/template.html')
         f.flush()
 
         if backend == 'pdfkit':

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.32"
+__version__ = "3.1.33"
 
 
 def print_version():


### PR DESCRIPTION
Advances #328.

## Summary
- expose public processing-component, peptide-offset, and default-predictor operations
- inline the one-owner closest-occurrence search instead of preserving a trivial private helper
- expose report rendering as a tested stream-oriented API
- expose mRNA element resolution, segmented protein construction, and conservative linker sizing
- fold the trivial private mRNA lookup-key normalizer into its public owner
- remove all superseded underscored names without aliases
- bump vaxrank to 3.1.33

## Verification
- `./lint.sh`
- focused processing/mRNA/junction/report tests (100 passed)
- `./test.sh` (995 passed)
- `bash ./run-vaxrank-b16-test-data.sh` (passed; all report formats generated)