### PR TITLE
Expose CLI orchestration operations

### DIFF
--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -25,7 +25,7 @@ from unittest.mock import MagicMock, patch
 
 from vaxrank.cli import make_vaxrank_arg_parser
 from vaxrank.cli.entry_point import (
-    _resolve_ensembl_release,
+    resolve_ensembl_release,
     configure_logging,
 )
 
@@ -94,7 +94,7 @@ def test_resolve_ensembl_release_sets_genome():
     ) as mock_cls:
         mock_genome = MagicMock()
         mock_cls.return_value = mock_genome
-        _resolve_ensembl_release(args)
+        resolve_ensembl_release(args)
 
     mock_cls.assert_called_once_with(75)
     assert args.genome is mock_genome
@@ -104,7 +104,7 @@ def test_resolve_ensembl_release_noop_when_not_set():
     args = MagicMock()
     args.ensembl_release = None
     args.genome = "GRCh38"
-    _resolve_ensembl_release(args)
+    resolve_ensembl_release(args)
     assert args.genome == "GRCh38"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1597,21 +1597,21 @@ peptide:
 """)
     from vaxrank.cli.arg_parser import parse_vaxrank_args
     from vaxrank.cli.entry_point import (
-        _coalesce_from_config, _construct_config_for_modality,
+        coalesce_config_value, construct_config_for_modality,
     )
     args = parse_vaxrank_args([
         '--input-lens', '/dev/null',
         '--output-csv', '/dev/null',
         '--config', str(cfg),
     ])
-    yaml_kwargs = _construct_config_for_modality(args, 'peptide')
+    yaml_kwargs = construct_config_for_modality(args, 'peptide')
     # Cross-modality default picked up through the merge
     assert yaml_kwargs['max_antigen_length_aa'] == 19
     # Peptide-specific knob picked up through the merge
     assert yaml_kwargs['linker'] == 'AAY'
 
     # CLI default → YAML wins
-    linker = _coalesce_from_config(
+    linker = coalesce_config_value(
         args, 'peptide_linker', yaml_kwargs, 'linker')
     assert linker == 'AAY'
 
@@ -1622,7 +1622,7 @@ peptide:
         '--config', str(cfg),
         '--peptide-linker', 'EAAAK',
     ])
-    yaml_kwargs2 = _construct_config_for_modality(args2, 'peptide')
-    linker2 = _coalesce_from_config(
+    yaml_kwargs2 = construct_config_for_modality(args2, 'peptide')
+    linker2 = coalesce_config_value(
         args2, 'peptide_linker', yaml_kwargs2, 'linker')
     assert linker2 == 'EAAAK'

--- a/tests/test_contig_filtering.py
+++ b/tests/test_contig_filtering.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch, PropertyMock
 
 from varcode import VariantCollection
 
-from vaxrank.cli.entry_point import _filter_unannotatable_variants
+from vaxrank.cli.entry_point import filter_unannotatable_variants
 
 
 def _make_variant(contig, annotatable=True):
@@ -56,7 +56,7 @@ def _make_collection(variants):
 
 def test_empty_collection():
     variants = VariantCollection([])
-    result = _filter_unannotatable_variants(variants)
+    result = filter_unannotatable_variants(variants)
     assert len(result) == 0
 
 
@@ -64,7 +64,7 @@ def test_all_annotatable():
     v1 = _make_variant("1")
     v2 = _make_variant("X")
     collection = _make_collection([v1, v2])
-    result = _filter_unannotatable_variants(collection)
+    result = filter_unannotatable_variants(collection)
     # Should return the original collection unchanged
     assert result is collection
 
@@ -77,7 +77,7 @@ def test_filters_unannotatable_contig():
         "vaxrank.cli.entry_point.VariantCollection",
         side_effect=lambda variants: variants,
     ):
-        result = _filter_unannotatable_variants(
+        result = filter_unannotatable_variants(
             _make_collection([v_ok, v_bad])
         )
     assert len(result) == 1
@@ -94,7 +94,7 @@ def test_filters_multiple_unannotatable_contigs():
         "vaxrank.cli.entry_point.VariantCollection",
         side_effect=lambda variants: variants,
     ):
-        result = _filter_unannotatable_variants(
+        result = filter_unannotatable_variants(
             _make_collection([v1, v2, v3, v4])
         )
     assert len(result) == 2
@@ -107,5 +107,5 @@ def test_chr_prefixed_contigs_kept_if_annotatable():
     v_chr1 = _make_variant("chr1", annotatable=True)
     v_chrX = _make_variant("chrX", annotatable=True)
     collection = _make_collection([v_chr1, v_chrX])
-    result = _filter_unannotatable_variants(collection)
+    result = filter_unannotatable_variants(collection)
     assert result is collection

--- a/tests/test_entry_point_helpers.py
+++ b/tests/test_entry_point_helpers.py
@@ -48,7 +48,7 @@ def _capture_logger(logger_name, level=logging.DEBUG):
         target.setLevel(prev_level)
 
 
-# -- _resolve_mhc_for_linker_optimizer --------------------------------
+# -- resolve_mhc_for_linker_optimizer ----------------------------------
 
 
 def _args_with_inferred_alleles(alleles=None):
@@ -91,7 +91,7 @@ def test_resolve_mhc_defaults_to_mhcflurry_when_predictor_missing(monkeypatch):
     monkeypatch.setattr(mhctools, 'MHCflurry', _stub_ctor)
     args = _args_with_inferred_alleles(['HLA-A*02:01', 'HLA-B*07:02'])
     with _capture_logger('vaxrank.cli.entry_point') as records:
-        predictor, alleles = ep._resolve_mhc_for_linker_optimizer(args)
+        predictor, alleles = ep.resolve_mhc_for_linker_optimizer(args)
     assert isinstance(predictor, _SentinelPredictor)
     assert alleles == ['HLA-A*02:01', 'HLA-B*07:02']
     assert captured['alleles'] == ['HLA-A*02:01', 'HLA-B*07:02']
@@ -120,7 +120,7 @@ def test_resolve_mhc_warns_when_mhcflurry_default_unavailable(monkeypatch):
 
     args = _args_with_inferred_alleles(['HLA-A*02:01'])
     with _capture_logger('vaxrank.cli.entry_point') as records:
-        predictor, alleles = ep._resolve_mhc_for_linker_optimizer(args)
+        predictor, alleles = ep.resolve_mhc_for_linker_optimizer(args)
     assert predictor is None
     assert alleles is None
     msgs = [r.getMessage() for r in records]
@@ -133,10 +133,10 @@ def test_resolve_mhc_warns_when_mhcflurry_default_unavailable(monkeypatch):
 def test_resolve_mhc_no_inputs_at_all():
     """Pipeline path with neither flag set: both come back None and
     the warning explicitly mentions both flags."""
-    from vaxrank.cli.entry_point import _resolve_mhc_for_linker_optimizer
+    from vaxrank.cli.entry_point import resolve_mhc_for_linker_optimizer
     args = SimpleNamespace()  # no inferred alleles either
     with _capture_logger('vaxrank.cli.entry_point') as records:
-        predictor, alleles = _resolve_mhc_for_linker_optimizer(args)
+        predictor, alleles = resolve_mhc_for_linker_optimizer(args)
     assert predictor is None
     assert alleles is None
     msg = ' '.join(r.getMessage() for r in records)
@@ -161,10 +161,27 @@ def test_resolve_mhc_propagates_real_predictor_load_failure(monkeypatch):
     monkeypatch.setattr(ep, 'mhc_binding_predictor_from_args', _kaboom)
     args = SimpleNamespace(_inferred_mhc_alleles_from_lens=['HLA-A*02:01'])
     with pytest.raises(_BadDay):
-        ep._resolve_mhc_for_linker_optimizer(args)
+        ep.resolve_mhc_for_linker_optimizer(args)
 
 
-# -- _log_args_summary -------------------------------------------------
+def test_resolve_target_alleles_uses_cli_then_external_fallback(monkeypatch):
+    from vaxrank.cli import entry_point as ep
+
+    monkeypatch.setattr(
+        ep, 'mhc_alleles_from_args', lambda args: ['HLA-A*02:01'])
+    args = SimpleNamespace(
+        _inferred_mhc_alleles_from_lens=['HLA-B*07:02'])
+    assert ep.resolve_target_alleles(args) == ['HLA-A*02:01']
+
+    def unavailable(args):
+        raise ValueError("no CLI alleles")
+
+    monkeypatch.setattr(ep, 'mhc_alleles_from_args', unavailable)
+    assert ep.resolve_target_alleles(args) == ['HLA-B*07:02']
+    assert ep.resolve_target_alleles(SimpleNamespace()) == []
+
+
+# -- log_args_summary ---------------------------------------------------
 
 
 def _basic_args(**overrides):
@@ -213,10 +230,10 @@ def test_log_args_summary_smoke_no_user_overrides():
     """No CLI overrides → every value matches its default. Without
     ``--verbose`` we should still emit the header but nothing else
     that names a value."""
-    from vaxrank.cli.entry_point import _log_args_summary
+    from vaxrank.cli.entry_point import log_args_summary
     args = _basic_args()
     with _capture_logger('vaxrank.cli.entry_point', logging.INFO) as records:
-        _log_args_summary(args)
+        log_args_summary(args)
     msgs = [r.getMessage() for r in records
             if 'Vaxrank run configuration' in r.getMessage()]
     assert len(msgs) == 1, "Expected exactly one summary log call"
@@ -230,10 +247,10 @@ def test_log_args_summary_smoke_no_user_overrides():
 def test_log_args_summary_surfaces_user_overrides():
     """A user-set value differs from parser default → it gets a
     line. Values that match defaults stay hidden."""
-    from vaxrank.cli.entry_point import _log_args_summary
+    from vaxrank.cli.entry_point import log_args_summary
     args = _basic_args(input_lens='/path/to/file.tsv', vaccine_type=['mrna'])
     with _capture_logger('vaxrank.cli.entry_point', logging.INFO) as records:
-        _log_args_summary(args)
+        log_args_summary(args)
     msg = [r.getMessage() for r in records
            if 'Vaxrank run configuration' in r.getMessage()][0]
     assert 'input_lens' in msg
@@ -246,13 +263,13 @@ def test_log_args_summary_surfaces_user_overrides():
 
 def test_log_args_summary_shows_auto_inferred_block():
     """LENS-path inferred state lives on underscore-prefixed attrs
-    on args. ``_log_args_summary`` lifts them into a separate
+    on args. ``log_args_summary`` lifts them into a separate
     ``[auto-inferred]`` section."""
-    from vaxrank.cli.entry_point import _log_args_summary
+    from vaxrank.cli.entry_point import log_args_summary
     args = _basic_args()
     args._inferred_mhc_alleles_from_lens = ['HLA-A*02:01']
     with _capture_logger('vaxrank.cli.entry_point', logging.INFO) as records:
-        _log_args_summary(args)
+        log_args_summary(args)
     msg = [r.getMessage() for r in records
            if 'Vaxrank run configuration' in r.getMessage()][0]
     assert 'auto-inferred' in msg
@@ -264,10 +281,10 @@ def test_log_args_summary_verbose_shows_defaults():
     """``--verbose`` flips every key into the visible set, including
     those equal to the parser default. The marker ``(default)``
     annotates them."""
-    from vaxrank.cli.entry_point import _log_args_summary
+    from vaxrank.cli.entry_point import log_args_summary
     args = _basic_args(verbose=True)
     with _capture_logger('vaxrank.cli.entry_point', logging.INFO) as records:
-        _log_args_summary(args)
+        log_args_summary(args)
     msg = [r.getMessage() for r in records
            if 'Vaxrank run configuration' in r.getMessage()][0]
     # Defaults visible with ``(default)`` annotation.
@@ -275,19 +292,19 @@ def test_log_args_summary_verbose_shows_defaults():
     assert '(default)' in msg
 
 
-# -- _auto_populate_output_paths_from_dir -----------------------------
+# -- populate_default_output_paths -------------------------------------
 
 
 def test_auto_populate_pipeline_path_fills_csv_and_json():
     """Pipeline run (no LENS / pVACseq input) with just
     ``--output-dir`` set should auto-fill canonical CSV + JSON
     paths inside the directory."""
-    from vaxrank.cli.entry_point import _auto_populate_output_paths_from_dir
+    from vaxrank.cli.entry_point import populate_default_output_paths
     args = SimpleNamespace(
         output_dir='/tmp/run',
         input_lens=None, input_pvacseq=None,
         output_csv='', output_json_file='')
-    _auto_populate_output_paths_from_dir(args)
+    populate_default_output_paths(args)
     assert args.output_csv == '/tmp/run/ranked_vaccine_peptides.csv'
     assert args.output_json_file == '/tmp/run/ranked_vaccine_peptides.json'
 
@@ -298,12 +315,12 @@ def test_auto_populate_lens_path_fills_neoepitope_csv():
     ``ranked_vaccine_peptides.csv`` so the filename matches the
     content. JSON dump is skipped (the LENS path doesn't build the
     rich in-memory result that --output-json-file serializes)."""
-    from vaxrank.cli.entry_point import _auto_populate_output_paths_from_dir
+    from vaxrank.cli.entry_point import populate_default_output_paths
     args = SimpleNamespace(
         output_dir='/tmp/lens-run',
         input_lens='/path/to/lens.tsv', input_pvacseq=None,
         output_csv='', output_json_file='')
-    _auto_populate_output_paths_from_dir(args)
+    populate_default_output_paths(args)
     assert args.output_csv == '/tmp/lens-run/neoepitope_predictions.csv'
     assert args.output_json_file == ''
 
@@ -311,13 +328,13 @@ def test_auto_populate_lens_path_fills_neoepitope_csv():
 def test_auto_populate_explicit_paths_win():
     """When the user explicitly passes ``--output-csv`` /
     ``--output-json-file``, the auto-fill must not overwrite them."""
-    from vaxrank.cli.entry_point import _auto_populate_output_paths_from_dir
+    from vaxrank.cli.entry_point import populate_default_output_paths
     args = SimpleNamespace(
         output_dir='/tmp/run',
         input_lens=None, input_pvacseq=None,
         output_csv='/elsewhere/custom.csv',
         output_json_file='/elsewhere/custom.json')
-    _auto_populate_output_paths_from_dir(args)
+    populate_default_output_paths(args)
     assert args.output_csv == '/elsewhere/custom.csv'
     assert args.output_json_file == '/elsewhere/custom.json'
 
@@ -325,11 +342,11 @@ def test_auto_populate_explicit_paths_win():
 def test_auto_populate_no_output_dir_is_a_noop():
     """Without ``--output-dir`` the helper does nothing — the
     operator-passed flags determine output destinations as before."""
-    from vaxrank.cli.entry_point import _auto_populate_output_paths_from_dir
+    from vaxrank.cli.entry_point import populate_default_output_paths
     args = SimpleNamespace(
         output_dir='', input_lens=None, input_pvacseq=None,
         output_csv='', output_json_file='')
-    _auto_populate_output_paths_from_dir(args)
+    populate_default_output_paths(args)
     assert args.output_csv == ''
     assert args.output_json_file == ''
 
@@ -422,22 +439,22 @@ def test_lens_antigen_source_breakdown_orders_snv_indel_first():
 
 def test_confirm_overwrite_noop_for_missing_or_empty_dir(tmp_path):
     """Missing or empty --output-dir needs no confirmation (no exit)."""
-    from vaxrank.cli.entry_point import _confirm_output_dir_overwrite
+    from vaxrank.cli.entry_point import confirm_output_dir_overwrite
     # missing
-    _confirm_output_dir_overwrite(
+    confirm_output_dir_overwrite(
         SimpleNamespace(output_dir=str(tmp_path / "nope"), force_overwrite=False))
     # empty
     (tmp_path / "empty").mkdir()
-    _confirm_output_dir_overwrite(
+    confirm_output_dir_overwrite(
         SimpleNamespace(output_dir=str(tmp_path / "empty"), force_overwrite=False))
 
 
 def test_confirm_overwrite_force_proceeds(tmp_path, caplog):
     """--force-overwrite proceeds into a non-empty dir without prompting."""
-    from vaxrank.cli.entry_point import _confirm_output_dir_overwrite
+    from vaxrank.cli.entry_point import confirm_output_dir_overwrite
     (tmp_path / "f.txt").write_text("x")
     with caplog.at_level(logging.INFO):
-        _confirm_output_dir_overwrite(
+        confirm_output_dir_overwrite(
             SimpleNamespace(output_dir=str(tmp_path), force_overwrite=True))
     assert any('force-overwrite' in r.getMessage() for r in caplog.records)
 
@@ -449,7 +466,7 @@ def test_confirm_overwrite_non_interactive_warns_and_proceeds(
     (tmp_path / "f.txt").write_text("x")
     monkeypatch.setattr(entry_point.sys.stdin, 'isatty', lambda: False)
     with caplog.at_level(logging.WARNING):
-        entry_point._confirm_output_dir_overwrite(
+        entry_point.confirm_output_dir_overwrite(
             SimpleNamespace(output_dir=str(tmp_path), force_overwrite=False))
     assert any('already exists' in r.getMessage() for r in caplog.records)
 
@@ -458,7 +475,7 @@ def test_write_run_summary(tmp_path):
     """The top-level run_summary.txt records inputs, the MHC alleles in
     play (flagged inferred on the external path), antigen counts, and
     where each output landed."""
-    from vaxrank.cli.entry_point import _write_run_summary
+    from vaxrank.cli.entry_point import write_run_summary
     args = SimpleNamespace(
         output_dir=str(tmp_path),
         input_lens='patient.lens.tsv', input_pvacseq=None, vcf=None, bam=None,
@@ -472,7 +489,7 @@ def test_write_run_summary(tmp_path):
         num_somatic_variants=5, num_coding_effect_variants=5,
         num_variants_with_rna_support=4, num_variants_with_vaccine_peptides=5)
 
-    _write_run_summary(args, patient, source='external')
+    write_run_summary(args, patient, source='external')
 
     text = (tmp_path / 'run_summary.txt').read_text()
     assert 'LENS report' in text and 'patient.lens.tsv' in text
@@ -487,7 +504,7 @@ def test_write_run_summary(tmp_path):
 
 def test_write_run_summary_noop_without_output_dir(tmp_path):
     """No --output-dir → no run summary written (ranking-only runs)."""
-    from vaxrank.cli.entry_point import _write_run_summary
+    from vaxrank.cli.entry_point import write_run_summary
     args = SimpleNamespace(output_dir='', input_lens=None, input_pvacseq=None)
-    _write_run_summary(args, None, source='external')
+    write_run_summary(args, None, source='external')
     assert not list(tmp_path.iterdir())

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -1440,19 +1440,19 @@ def test_external_arg_parser_accepts_ensembl_release():
 
 
 def test_external_path_resolves_genome_from_ensembl_release():
-    """End-to-end plumbing: parse + ``_resolve_ensembl_release`` on
+    """End-to-end plumbing: parse + ``resolve_ensembl_release`` on
     an external-input args namespace must leave ``args.genome`` as a
     real ``pyensembl.EnsemblRelease`` so transcript resolution can
     use it."""
     import pyensembl
     from vaxrank.cli.arg_parser import parse_vaxrank_args
-    from vaxrank.cli.entry_point import _resolve_ensembl_release
+    from vaxrank.cli.entry_point import resolve_ensembl_release
     args = parse_vaxrank_args([
         '--input-lens', '/dev/null',
         '--output-csv', '/dev/null',
         '--ensembl-release', '75',
     ])
-    _resolve_ensembl_release(args)
+    resolve_ensembl_release(args)
     assert isinstance(args.genome, pyensembl.EnsemblRelease)
     assert args.genome.release == 75
 

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -16,7 +16,7 @@ Pre-PR-#253: external-input mode hard-short-circuited and the
 construct writers were never reached. These tests pin the new
 architecture: a single shared ``ranked_variants_with_vaccine_peptides``
 intermediate that *both* the VCF/BAM pipeline and the LENS / pVACseq
-loaders produce, then a shared dispatch (``_emit_outputs``) into
+loaders produce, then a shared dispatch (``emit_outputs``) into
 modality-specific construct writers.
 """
 
@@ -763,7 +763,7 @@ def test_lens_warns_when_no_affinity_columns_detected(tmp_path, caplog):
         "Warning should report the detected non-affinity kinds; got %r" % msg
 
 
-# ---- _emit_outputs observability -----------------------------------------
+# ---- emit_outputs observability -------------------------------------------
 
 def _vaccine_args(output_dir, vaccine_type='mrna'):
     """Build a SimpleNamespace covering both peptide and mrna design
@@ -820,7 +820,7 @@ def test_emit_outputs_logs_active_and_fired_dispatch(caplog, tmp_path):
     """The dispatch summary log line is part of the contract — pins
     the active vaccine type(s) and which writers fired."""
     import logging
-    from vaxrank.cli.entry_point import _emit_outputs
+    from vaxrank.cli.entry_point import emit_outputs
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
     report_df, predictions = load_lens(path)
@@ -830,7 +830,7 @@ def test_emit_outputs_logs_active_and_fired_dispatch(caplog, tmp_path):
     args = _mrna_args(out_dir)
     args.input_lens = path  # source-specific label derives from this
     with caplog.at_level(logging.INFO):
-        _emit_outputs(args, ranked, source='external')
+        emit_outputs(args, ranked, source='external')
     dispatch = [r.message for r in caplog.records
                 if 'Vaccine-type dispatch' in r.message]
     assert len(dispatch) == 1
@@ -846,52 +846,52 @@ def test_resolve_vaccine_types_default_and_unknown():
     instead of silently no-opping."""
     import pytest as _pytest
     from types import SimpleNamespace
-    from vaxrank.cli.entry_point import _resolve_vaccine_types
+    from vaxrank.cli.entry_point import resolve_vaccine_types
 
     # Defaults: both modalities active when --vaccine-type isn't set
-    assert _resolve_vaccine_types(SimpleNamespace()) == ['peptide', 'mrna']
-    assert _resolve_vaccine_types(
+    assert resolve_vaccine_types(SimpleNamespace()) == ['peptide', 'mrna']
+    assert resolve_vaccine_types(
         SimpleNamespace(vaccine_type=None)) == ['peptide', 'mrna']
     # Single-string form (caller bypassing argparse)
-    assert _resolve_vaccine_types(
+    assert resolve_vaccine_types(
         SimpleNamespace(vaccine_type='mrna')) == ['mrna']
     # Single-element list narrows to that one type
-    assert _resolve_vaccine_types(
+    assert resolve_vaccine_types(
         SimpleNamespace(vaccine_type=['peptide'])) == ['peptide']
     # Multi-mode + dedup
-    assert _resolve_vaccine_types(
+    assert resolve_vaccine_types(
         SimpleNamespace(vaccine_type=['peptide', 'mrna'])
     ) == ['peptide', 'mrna']
-    assert _resolve_vaccine_types(
+    assert resolve_vaccine_types(
         SimpleNamespace(vaccine_type=['mrna', 'peptide', 'mrna'])
     ) == ['mrna', 'peptide']  # first-occurrence order preserved
     # Unknown
     with _pytest.raises(ValueError, match="Unknown vaccine type"):
-        _resolve_vaccine_types(SimpleNamespace(vaccine_type=['dna']))
+        resolve_vaccine_types(SimpleNamespace(vaccine_type=['dna']))
 
 
 def test_vaccine_target_dir_layout(tmp_path):
     """Single-mode → files land directly in --output-dir; multi-mode
     → per-modality subdirs (so peptide's manifest.json doesn't
     overwrite mrna's)."""
-    from vaxrank.cli.entry_point import _vaccine_target_dir
+    from vaxrank.cli.entry_point import vaccine_target_dir
     base = str(tmp_path / "out")
     # Single-mode flat
-    assert _vaccine_target_dir(base, 'peptide', ['peptide']) == base
+    assert vaccine_target_dir(base, 'peptide', ['peptide']) == base
     # Multi-mode subdirs
-    assert _vaccine_target_dir(base, 'peptide', ['peptide', 'mrna']) == \
+    assert vaccine_target_dir(base, 'peptide', ['peptide', 'mrna']) == \
         os.path.join(base, 'peptide')
-    assert _vaccine_target_dir(base, 'mrna', ['peptide', 'mrna']) == \
+    assert vaccine_target_dir(base, 'mrna', ['peptide', 'mrna']) == \
         os.path.join(base, 'mrna')
     # No --output-dir → no writer fires
-    assert _vaccine_target_dir('', 'peptide', ['peptide']) is None
+    assert vaccine_target_dir('', 'peptide', ['peptide']) is None
 
 
 def test_lens_with_vaccine_type_mrna_writes_three_fastas(tmp_path):
     """End-to-end: --input-lens + --vaccine-type=mrna +
     --output-dir=DIR writes three FASTAs + manifest + mrna-sequence-parts.csv
     directly into DIR (single-mode flat layout)."""
-    from vaxrank.cli.entry_point import _emit_outputs
+    from vaxrank.cli.entry_point import emit_outputs
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
     report_df, predictions = load_lens(path)
@@ -899,7 +899,7 @@ def test_lens_with_vaccine_type_mrna_writes_three_fastas(tmp_path):
 
     out_dir = str(tmp_path / "out")
     args = _mrna_args(out_dir)
-    _emit_outputs(args, ranked, source='external')
+    emit_outputs(args, ranked, source='external')
     assert os.path.isfile(os.path.join(out_dir, "cds.fasta"))
     assert os.path.isfile(os.path.join(out_dir, "no_polyA.fasta"))
     assert os.path.isfile(os.path.join(out_dir, "full.fasta"))
@@ -919,7 +919,7 @@ def test_lens_with_vaccine_type_mrna_writes_three_fastas(tmp_path):
 def test_lens_with_multi_vaccine_type_uses_subdirs(tmp_path):
     """Multi-mode (peptide + mrna) writes into per-modality subdirs
     so canonical filenames don't collide on manifest.json."""
-    from vaxrank.cli.entry_point import _emit_outputs
+    from vaxrank.cli.entry_point import emit_outputs
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
     report_df, predictions = load_lens(path)
@@ -927,7 +927,7 @@ def test_lens_with_multi_vaccine_type_uses_subdirs(tmp_path):
 
     out_dir = str(tmp_path / "out")
     args = _vaccine_args(out_dir, vaccine_type=['peptide', 'mrna'])
-    _emit_outputs(args, ranked, source='external')
+    emit_outputs(args, ranked, source='external')
     # mRNA outputs in DIR/mrna/
     assert os.path.isfile(os.path.join(out_dir, "mrna", "cds.fasta"))
     assert os.path.isfile(os.path.join(out_dir, "mrna", "manifest.json"))
@@ -939,7 +939,7 @@ def test_lens_with_multi_vaccine_type_uses_subdirs(tmp_path):
 
 def test_emit_outputs_skips_writer_when_no_output_dir(tmp_path):
     """No --output-dir → writer no-ops (ranking-only run)."""
-    from vaxrank.cli.entry_point import _emit_outputs
+    from vaxrank.cli.entry_point import emit_outputs
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
     report_df, predictions = load_lens(path)
@@ -948,7 +948,7 @@ def test_emit_outputs_skips_writer_when_no_output_dir(tmp_path):
     out_dir = str(tmp_path / "out")
     args = _mrna_args(out_dir)
     args.output_dir = ''  # no destination → no writer fires
-    _emit_outputs(args, ranked, source='external')
+    emit_outputs(args, ranked, source='external')
     assert not os.path.exists(out_dir), \
         "Without --output-dir, no writer should have fired"
 

--- a/tests/test_nan_robustness.py
+++ b/tests/test_nan_robustness.py
@@ -15,7 +15,7 @@ Two layered guarantees:
    probability in ``score``, not ``value``); the producer must
    normalize these on the way in or every downstream consumer pays.
 
-2. ``cli.entry_point._to_json_nan_tolerant`` renders NaN / Inf as
+2. ``cli.entry_point.serialize_json_nan_tolerant`` renders NaN / Inf as
    JSON ``null`` rather than crashing the writer. Defense in depth:
    even if a future producer leaks a NaN, the whole report doesn't
    get lost on the last step.
@@ -173,18 +173,18 @@ def test_predict_epitopes_does_not_emit_nan_value_for_presentation():
         "pMHC_presentation rows should have value=None, not NaN")
 
 
-# ---- _to_json_nan_tolerant ---------------------------------------------
+# ---- serialize_json_nan_tolerant ---------------------------------------
 
 
 def test_json_writer_renders_nan_as_null():
     """Defense-in-depth: if a NaN slips past the producer guards, the
     JSON writer renders it as ``null`` rather than crashing."""
-    from vaxrank.cli.entry_point import _to_json_nan_tolerant
+    from vaxrank.cli.entry_point import serialize_json_nan_tolerant
 
     payload = {'finite': 1.5, 'nan': float('nan'),
                'inf': float('inf'), 'neg_inf': float('-inf'),
                'nested': {'also_nan': float('nan')}}
-    out = _to_json_nan_tolerant(payload)
+    out = serialize_json_nan_tolerant(payload)
     parsed = json.loads(out)
     assert parsed['finite'] == 1.5
     assert parsed['nan'] is None
@@ -195,20 +195,20 @@ def test_json_writer_renders_nan_as_null():
 
 def test_json_writer_handles_list_of_floats():
     """Lists of floats with embedded NaN also serialize cleanly."""
-    from vaxrank.cli.entry_point import _to_json_nan_tolerant
+    from vaxrank.cli.entry_point import serialize_json_nan_tolerant
 
     payload = {'values': [1.0, float('nan'), 2.0, float('inf')]}
-    parsed = json.loads(_to_json_nan_tolerant(payload))
+    parsed = json.loads(serialize_json_nan_tolerant(payload))
     assert parsed['values'] == [1.0, None, 2.0, None]
 
 
 def test_json_writer_round_trips_real_payload():
     """A finite payload that doesn't trigger the NaN path should
     survive the writer with the same content."""
-    from vaxrank.cli.entry_point import _to_json_nan_tolerant
+    from vaxrank.cli.entry_point import serialize_json_nan_tolerant
 
     payload = {'a': 1, 'b': 'string', 'c': [1, 2, 3], 'd': {'e': 4.5}}
-    parsed = json.loads(_to_json_nan_tolerant(payload))
+    parsed = json.loads(serialize_json_nan_tolerant(payload))
     assert parsed == payload
 
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -471,11 +471,11 @@ def test_manufacturability_default_on_for_peptide_only(monkeypatch):
             '--vaccine-type', *vaccine_type,
         ])
         # main() resolves args.manufacturability based on
-        # _resolve_vaccine_types(args). Run that resolution here.
-        from vaxrank.cli.entry_point import _resolve_vaccine_types
+        # resolve_vaccine_types(args). Run that resolution here.
+        from vaxrank.cli.entry_point import resolve_vaccine_types
         if args.manufacturability is None:
             args.manufacturability = (
-                'peptide' in _resolve_vaccine_types(args))
+                'peptide' in resolve_vaccine_types(args))
         assert args.manufacturability is expected, (
             "vaccine_type=%s: expected manufacturability=%s, got %s"
             % (vaccine_type, expected, args.manufacturability))
@@ -651,7 +651,7 @@ def test_dedup_by_content_when_duplicate_objects(monkeypatch):
     from types import SimpleNamespace
 
     from vaxrank.cli.entry_point import (
-        _annotate_predictions_with_processing,
+        annotate_predictions_with_processing,
     )
     import vaxrank.processing as proc_mod
 
@@ -680,7 +680,7 @@ def test_dedup_by_content_when_duplicate_objects(monkeypatch):
         return real_annotate(pred_list, predictor=stub)
 
     monkeypatch.setattr(proc_mod, 'annotate_processing', _capture)
-    _annotate_predictions_with_processing(ranked, lens_epitopes)
+    annotate_predictions_with_processing(ranked, lens_epitopes)
 
     assert 'list' in captured
     deduped = captured['list']

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -71,7 +71,7 @@ from ..vaf import extract_dna_vaf_by_variant
 logger = logging.getLogger(__name__)
 
 
-def _to_json_nan_tolerant(obj):
+def serialize_json_nan_tolerant(obj):
     """Serialize ``obj`` to a JSON string, rendering NaN/Inf as
     ``null`` rather than raising. Defense-in-depth wrapper around
     ``serializable.to_json``; producers should already be coercing
@@ -82,7 +82,7 @@ def _to_json_nan_tolerant(obj):
     return simplejson.dumps(to_serializable_repr(obj), ignore_nan=True)
 
 
-def _filter_unannotatable_variants(variants):
+def filter_unannotatable_variants(variants):
     """
     Filter out variants whose contigs cannot be resolved by varcode/pyensembl.
 
@@ -124,16 +124,10 @@ def _filter_unannotatable_variants(variants):
     return variants
 
 
-def _has_external_input(args):
-    return bool(
-        getattr(args, 'input_pvacseq', None)
-        or getattr(args, 'input_lens', None))
-
-
-def _annotate_predictions_with_processing(ranked_vaccine_peptides,
-                                          lens_epitopes,
-                                          human_only=False,
-                                          threshold=0.5):
+def annotate_predictions_with_processing(ranked_vaccine_peptides,
+                                         lens_epitopes,
+                                         human_only=False,
+                                         threshold=0.5):
     """Run pepsickle credibility tagging across all CandidateEpitope records.
     Pulls them from BOTH the ranked-vaccine-peptides intermediate
     (one VP per variant; each VP has its own epitopes) AND the
@@ -189,18 +183,10 @@ def _annotate_predictions_with_processing(ranked_vaccine_peptides,
         all_epitopes, human_only=human_only, threshold=threshold)
 
 
-def _epitope_config_from_args_safe(args):
-    from ..epitope_config import EpitopeConfig
-    try:
-        return epitope_config_from_args(args)
-    except Exception:
-        return EpitopeConfig()
-
-
 _DEFAULT_VACCINE_TYPES = ['peptide', 'mrna']
 
 
-def _resolve_vaccine_types(args):
+def resolve_vaccine_types(args):
     """Return the ordered, deduplicated list of active vaccine types.
 
     ``--vaccine-type`` is multi-valued (default
@@ -233,7 +219,7 @@ def _resolve_vaccine_types(args):
     return types
 
 
-def _coalesce_from_config(args, cli_attr, config_kwargs, config_key):
+def coalesce_config_value(args, cli_attr, config_kwargs, config_key):
     """Resolve a single construct knob across CLI flag, YAML config,
     and built-in default. Precedence (highest first):
 
@@ -258,7 +244,7 @@ def _coalesce_from_config(args, cli_attr, config_kwargs, config_key):
     return cli_val       # built-in default
 
 
-def _construct_config_for_modality(args, modality):
+def construct_config_for_modality(args, modality):
     """Return ``extract_construct_kwargs(merged_config, modality)``
     or ``{}`` if the YAML config can't be loaded (e.g. tests that
     bypass the CLI and don't supply a --config attribute, or a path
@@ -282,7 +268,7 @@ def _construct_config_for_modality(args, modality):
         return {}
 
 
-def _vaccine_target_dir(output_dir, vaccine_type, all_active_types):
+def vaccine_target_dir(output_dir, vaccine_type, all_active_types):
     """Where this writer should put its files.
 
     Single-mode runs (one type) write directly into ``output_dir``.
@@ -303,7 +289,11 @@ def _emit_neoepitope_report_external(args, report_df, epitopes):
     """
     if report_df is None or report_df.empty:
         return
-    epitope_config = _epitope_config_from_args_safe(args)
+    from ..epitope_config import EpitopeConfig
+    try:
+        epitope_config = epitope_config_from_args(args)
+    except Exception:
+        epitope_config = EpitopeConfig()
     write_neoepitope_report(
         report_df=report_df,
         epitopes=epitopes,
@@ -334,10 +324,10 @@ def _resolve_axis(args, per_type_attr, shared_attr, fallback):
 def _emit_peptide_constructs(args, ranked, target_dir):
     """Build + write peptide-vaccine constructs. Modality-specific."""
     # YAML overrides for any knob not explicitly passed on the CLI.
-    yaml_kwargs = _construct_config_for_modality(args, 'peptide')
+    yaml_kwargs = construct_config_for_modality(args, 'peptide')
 
     def cfg(cli_attr, yaml_key):
-        return _coalesce_from_config(args, cli_attr, yaml_kwargs, yaml_key)
+        return coalesce_config_value(args, cli_attr, yaml_kwargs, yaml_key)
 
     # Resolve the orthogonal antigen-design axes:
     # per-type override > shared default > config default. The legacy
@@ -380,7 +370,7 @@ def _emit_peptide_constructs(args, ranked, target_dir):
     # coverage tier before bin-packing. No-op when alleles aren't
     # available (e.g. external arg parser without
     # ``--mhc-alleles`` and no LENS-inferred set).
-    target_alleles = _resolve_target_alleles(args)
+    target_alleles = resolve_target_alleles(args)
     constructs = assemble_peptide_constructs(
         ranked, options=peptide_options, target_alleles=target_alleles)
     # Canonical filenames inside the per-modality target directory:
@@ -468,12 +458,12 @@ _ARG_GROUPS = (
 
 # Cached lookup for the section -> keys mapping. Built once at module
 # import; the per-section "(N defaults hidden)" footer in
-# ``_log_args_summary`` reads from here instead of rebuilding the
+# ``log_args_summary`` reads from here instead of rebuilding the
 # dict on every call.
 _ARG_GROUPS_BY_NAME = dict(_ARG_GROUPS)
 
 
-def _log_args_summary(args):
+def log_args_summary(args):
     """Pretty-print the resolved args. Replaces ``logger.info(args)``
     which was a single flat ``Namespace(...)`` dump that scrolled past
     100 keys without grouping. We log:
@@ -556,11 +546,11 @@ def _log_args_summary(args):
     logger.info("\n".join(lines))
 
 
-def _resolve_target_alleles(args):
+def resolve_target_alleles(args):
     """Return the list of patient MHC alleles for coverage-aware
     antigen selection (and for report-time coverage display).
 
-    Resolution mirrors :func:`_resolve_mhc_for_linker_optimizer`:
+    Resolution mirrors :func:`resolve_mhc_for_linker_optimizer`:
 
     * Pipeline path: from ``--mhc-alleles`` on the CLI.
     * External path (LENS / pVACseq): the loader stashes inferred
@@ -583,7 +573,7 @@ def _resolve_target_alleles(args):
     return list(alleles or [])
 
 
-def _resolve_mhc_for_linker_optimizer(args):
+def resolve_mhc_for_linker_optimizer(args):
     """Find a usable (predictor, alleles) pair for the per-junction
     linker optimizer.
 
@@ -687,10 +677,10 @@ def _resolve_mhc_for_linker_optimizer(args):
 
 def _emit_mrna_constructs(args, ranked, target_dir):
     """Build + write mRNA-vaccine constructs. Modality-specific."""
-    yaml_kwargs = _construct_config_for_modality(args, 'mrna')
+    yaml_kwargs = construct_config_for_modality(args, 'mrna')
 
     def cfg(cli_attr, yaml_key):
-        return _coalesce_from_config(args, cli_attr, yaml_kwargs, yaml_key)
+        return coalesce_config_value(args, cli_attr, yaml_kwargs, yaml_key)
 
     junction_candidates_raw = cfg(
         'mrna_junction_candidates', 'junction_candidates') or ''
@@ -742,11 +732,11 @@ def _emit_mrna_constructs(args, ranked, target_dir):
             'mrna_poly_a_segment_linker', 'poly_a_segment_linker'),
     )
     if options.optimize_linkers:
-        mhc_predictor, mhc_alleles = _resolve_mhc_for_linker_optimizer(args)
+        mhc_predictor, mhc_alleles = resolve_mhc_for_linker_optimizer(args)
     else:
         mhc_predictor = None
         mhc_alleles = None
-    target_alleles = _resolve_target_alleles(args)
+    target_alleles = resolve_target_alleles(args)
     constructs = assemble_mrna_constructs(
         ranked, options=options,
         mhc_predictor=mhc_predictor, mhc_alleles=mhc_alleles,
@@ -774,8 +764,8 @@ def _emit_mrna_constructs(args, ranked, target_dir):
 
 
 # Multi-mode dispatch table: vaccine-type → writer.
-# ``_emit_outputs`` iterates over the active types from
-# ``_resolve_vaccine_types`` and fires each writer with its own
+# ``emit_outputs`` iterates over the active types from
+# ``resolve_vaccine_types`` and fires each writer with its own
 # target dir. Adding a new vaccine type means registering it here +
 # extending ``--vaccine-type`` choices in arg_parser.
 _VACCINE_TYPE_DISPATCH = {
@@ -784,21 +774,21 @@ _VACCINE_TYPE_DISPATCH = {
 }
 
 
-def _emit_outputs(args, ranked, source):
+def emit_outputs(args, ranked, source):
     """Single fan-out point for everything downstream of ranking.
 
     ``ranked`` is the shared ``[(Variant, [VaccinePeptide])]``
     intermediate; ``source`` is 'pipeline' (VCF/BAM) or 'external'
     (LENS/pVACseq).
 
-    Active vaccine types come from ``_resolve_vaccine_types``
+    Active vaccine types come from :func:`resolve_vaccine_types`
     (``--vaccine-type`` is multi-valued). Each writer fires when
     ``--output-dir`` is set; single-mode runs land directly in
     ``--output-dir``, multi-mode runs land in per-modality subdirs
     so their canonical filenames (manifest.json, vaccine.fasta, …)
     don't collide.
     """
-    vaccine_types = _resolve_vaccine_types(args)
+    vaccine_types = resolve_vaccine_types(args)
 
     # Rank reports run for both sources; on the external-input path
     # the LENS-native per-(peptide, allele) report already consumed
@@ -838,7 +828,7 @@ def _emit_outputs(args, ranked, source):
             # be noise on top of the dispatch line below. The user
             # sees ``wrote=[]`` and can act on it.
             continue
-        target_dir = _vaccine_target_dir(output_dir, vtype, vaccine_types)
+        target_dir = vaccine_target_dir(output_dir, vtype, vaccine_types)
         # Multi-mode is "all-or-nothing": any writer failure aborts
         # the whole run. Partial output is worse than no output —
         # ending up with a peptide vaccine on disk but no mRNA
@@ -852,7 +842,7 @@ def _emit_outputs(args, ranked, source):
             writer(args, ranked, target_dir)
         except Exception:
             written = [
-                (t, _vaccine_target_dir(output_dir, t, vaccine_types))
+                (t, vaccine_target_dir(output_dir, t, vaccine_types))
                 for t in fired
             ]
             written_desc = (
@@ -901,7 +891,7 @@ _AUTO_OUTPUT_FILENAMES = {
 }
 
 
-def _auto_populate_output_paths_from_dir(args):
+def populate_default_output_paths(args):
     """When ``--output-dir`` is set and the per-format output flags
     are not, default them to canonical filenames inside the
     directory. Lets ``--output-dir DIR`` produce the full bundle
@@ -939,7 +929,7 @@ def _auto_populate_output_paths_from_dir(args):
             ", ".join("%s -> %s" % (a, p) for a, p in filled))
 
 
-def _write_run_summary(args, patient_info, source):
+def write_run_summary(args, patient_info, source):
     """Write a top-level ``run_summary.txt`` in --output-dir.
 
     In multi-vaccine-type runs the constructs live in per-modality
@@ -962,7 +952,7 @@ def _write_run_summary(args, patient_info, source):
             if getattr(args, attr, None):
                 lines.append("  %s: %s" % (label, getattr(args, attr)))
 
-    alleles = _resolve_target_alleles(args)
+    alleles = resolve_target_alleles(args)
     if alleles:
         inferred = getattr(args, '_inferred_mhc_alleles_from_lens', None)
         note = " (inferred from report)" if (
@@ -992,14 +982,14 @@ def _write_run_summary(args, patient_info, source):
         if path:
             lines.append("  %-18s %s" % (
                 label + ":", os.path.relpath(path, output_dir)))
-    vaccine_types = _resolve_vaccine_types(args)
+    vaccine_types = resolve_vaccine_types(args)
     # In the split-report layout (multi-type + reports requested) each
     # modality subdir also holds its own vaccine_report; say so.
     split_reports = len(vaccine_types) > 1 and any(
         getattr(args, a, '') for a in (
             'output_ascii_report', 'output_html_report', 'output_pdf_report'))
     for vtype in vaccine_types:
-        target_dir = _vaccine_target_dir(output_dir, vtype, vaccine_types)
+        target_dir = vaccine_target_dir(output_dir, vtype, vaccine_types)
         if target_dir:
             contents = (
                 "constructs + vaccine_report" if split_reports
@@ -1015,7 +1005,7 @@ def _write_run_summary(args, patient_info, source):
     logger.info("Wrote run summary to %s", summary_path)
 
 
-def _confirm_output_dir_overwrite(args):
+def confirm_output_dir_overwrite(args):
     """Confirm before writing into an existing, non-empty --output-dir.
 
     Interactive (TTY) runs get a ``y/N`` prompt and abort on anything
@@ -1064,7 +1054,7 @@ def configure_logging(args):
                     handler.setLevel(logging.DEBUG)
 
 
-def _resolve_ensembl_release(args):
+def resolve_ensembl_release(args):
     """If --ensembl-release was given, override args.genome with a specific
     pyensembl EnsemblRelease so that varcode/isovar use that release."""
     ensembl_release = getattr(args, 'ensembl_release', None)
@@ -1124,25 +1114,25 @@ def main(args_list=None):
 
     args = parse_vaxrank_args(args_list)
     configure_logging(args)
-    _resolve_ensembl_release(args)
+    resolve_ensembl_release(args)
     # Manufacturability default depends on whether peptide is one of
     # the active vaccine types: those metrics (GRAVY / Cys content /
     # N-terminal Q / Asp-Pro bonds) apply to peptide synthesis but
     # not to mRNA constructs (translated in vivo). Show the section
     # when peptide is being designed; hide it when only mRNA. Users
     # can force either way via the explicit flags. Reuse
-    # ``_resolve_vaccine_types`` so the shape-tolerance and dedup
+    # ``resolve_vaccine_types`` so the shape-tolerance and dedup
     # logic lives in exactly one place.
     if getattr(args, 'manufacturability', None) is None:
-        args.manufacturability = 'peptide' in _resolve_vaccine_types(args)
+        args.manufacturability = 'peptide' in resolve_vaccine_types(args)
     # When ``--output-dir`` is set, auto-fill the canonical
     # CSV / JSON output paths inside the directory so a user
     # who passes just ``--output-dir mydir/`` gets the full
     # bundle (FASTAs + manifest + ranked-peptides CSV +
     # JSON dump) without listing every flag. Explicit
     # ``--output-csv`` / ``--output-json-file`` paths win.
-    _auto_populate_output_paths_from_dir(args)
-    _log_args_summary(args)
+    populate_default_output_paths(args)
+    log_args_summary(args)
 
     # Fail fast when no output path is set, *before* loading inputs or
     # running predictions. Otherwise a long --input-lens run silently
@@ -1150,7 +1140,7 @@ def main(args_list=None):
     # --output-* flag, with no default destination). Applies to both
     # the VCF/BAM pipeline path and the external-input path.
     check_args(args)
-    _confirm_output_dir_overwrite(args)
+    confirm_output_dir_overwrite(args)
 
     # Architecture (post-#252):
     #
@@ -1162,7 +1152,7 @@ def main(args_list=None):
     #   SHARED:  ranked_variants_with_vaccine_peptides
     #
     #   DOWNSTREAM (modality-agnostic reports + peptide / mRNA construct dispatch)
-    #     _emit_outputs(args, ranked, source)
+    #     emit_outputs(args, ranked, source)
     #
     # The external-input path no longer hard-short-circuits — it
     # produces the same shape as the VCF/BAM path so peptide and mRNA
@@ -1179,7 +1169,9 @@ def main(args_list=None):
     # shared template-report block can ``data.get(...)`` either way.
     data = {}
 
-    if _has_external_input(args):
+    if (
+            getattr(args, 'input_pvacseq', None)
+            or getattr(args, 'input_lens', None)):
         loaded = load_external_ranked(args)
         if loaded is None:
             ranked_variants_with_vaccine_peptides = []
@@ -1200,7 +1192,7 @@ def main(args_list=None):
         # ``--mhc-alleles`` being on the CLI. The external arg
         # parser doesn't include the mhctools args, so the predictor
         # still has to come from ``--mhc-predictor`` if set —
-        # ``_resolve_mhc_for_linker_optimizer`` produces a targeted
+        # ``resolve_mhc_for_linker_optimizer`` produces a targeted
         # message when alleles are inferred but predictor is missing.
         if patient_info is not None:
             from ..external_input import LENS_PROVENANCE_MARKER
@@ -1238,13 +1230,13 @@ def main(args_list=None):
     # default; opt-out via --no-processing-aware-annotation.
     processing_predictions_by_key = {}
     if getattr(args, 'processing_aware_annotation', True):
-        _, processing_predictions_by_key = _annotate_predictions_with_processing(
+        _, processing_predictions_by_key = annotate_predictions_with_processing(
             ranked_variants_with_vaccine_peptides, predictions,
             human_only=getattr(args, 'pepsickle_human_only', False),
             threshold=getattr(args, 'pepsickle_threshold', 0.5))
 
-    _emit_outputs(args, ranked_variants_with_vaccine_peptides, source)
-    _write_run_summary(args, patient_info, source)
+    emit_outputs(args, ranked_variants_with_vaccine_peptides, source)
+    write_run_summary(args, patient_info, source)
 
     ########################
     # Template-based reports (PDF / HTML / ASCII)
@@ -1266,19 +1258,19 @@ def main(args_list=None):
     # the selected pool. The selector is the same one
     # ``_emit_*_constructs`` runs at write time, so the report
     # matches what would actually be assembled with --output-dir.
-    target_alleles = _resolve_target_alleles(args)
+    target_alleles = resolve_target_alleles(args)
     vaccine_constructions = {}
     if ranked_variants_with_vaccine_peptides:
         from ..coverage import (
             select_antigens_for_coverage, summarize_construction_decisions,
         )
-        active_types = _resolve_vaccine_types(args)
+        active_types = resolve_vaccine_types(args)
         if 'mrna' in active_types:
             from ..mrna import RNAConstructConfig
-            yaml_kwargs = _construct_config_for_modality(args, 'mrna')
+            yaml_kwargs = construct_config_for_modality(args, 'mrna')
 
             def _mrna_cfg(cli_attr, yaml_key):
-                return _coalesce_from_config(
+                return coalesce_config_value(
                     args, cli_attr, yaml_kwargs, yaml_key)
             mrna_options = RNAConstructConfig(
                 antigens_per_construct=_mrna_cfg(
@@ -1306,10 +1298,10 @@ def main(args_list=None):
             }
         if 'peptide' in active_types:
             from ..peptide import PeptideConstructConfig
-            yaml_kwargs = _construct_config_for_modality(args, 'peptide')
+            yaml_kwargs = construct_config_for_modality(args, 'peptide')
 
             def _pep_cfg(cli_attr, yaml_key):
-                return _coalesce_from_config(
+                return coalesce_config_value(
                     args, cli_attr, yaml_kwargs, yaml_key)
             pep_options = PeptideConstructConfig(
                 antigens_per_construct=_pep_cfg(
@@ -1367,7 +1359,7 @@ def main(args_list=None):
                 template_data=template_data, pdf_report_path=pdf_path,
                 backend=args.pdf_backend)
 
-    active_types = _resolve_vaccine_types(args)
+    active_types = resolve_vaccine_types(args)
     report_output_dir = getattr(args, 'output_dir', '') or ''
     if len(active_types) > 1 and report_output_dir:
         # Split layout (#269): a modality-agnostic core report at the
@@ -1381,7 +1373,7 @@ def main(args_list=None):
             args.output_ascii_report, args.output_html_report,
             args.output_pdf_report)
         for vtype in active_types:
-            target_dir = _vaccine_target_dir(
+            target_dir = vaccine_target_dir(
                 report_output_dir, vtype, active_types)
             if not target_dir:
                 continue
@@ -1420,7 +1412,7 @@ def run_vaxrank_from_parsed_args(args):
     # ``vaccine_peptides.ranking_rules`` should be a no-op tie-break
     # against ManufacturabilityConfig() defaults rather than against
     # user-overridden thresholds that don't apply to mRNA.
-    if 'peptide' in _resolve_vaccine_types(args):
+    if 'peptide' in resolve_vaccine_types(args):
         manufacturability_config = manufacturability_config_from_args(
             args, merged_config=merged_config)
     else:
@@ -1475,7 +1467,7 @@ def run_vaxrank_from_parsed_args(args):
     # We load variants ourselves (instead of run_isovar_from_parsed_args)
     # so we can filter out alt contigs that would crash downstream.
     variants = variant_collection_from_args(args)
-    variants = _filter_unannotatable_variants(variants)
+    variants = filter_unannotatable_variants(variants)
     isovar_results = run_isovar(
         variants=variants,
         alignment_file=alignment_file_from_args(args),
@@ -1542,7 +1534,7 @@ def ranked_vaccine_peptides_with_metadata_from_parsed_args(args):
     logger.info("MHC alleles: %s", mhc_alleles)
 
     all_variants = variant_collection_from_args(args)
-    variants = _filter_unannotatable_variants(all_variants)
+    variants = filter_unannotatable_variants(all_variants)
     logger.info("Variants: %d loaded, %d after filtering invalid contigs",
                 len(all_variants), len(variants))
 
@@ -1610,7 +1602,7 @@ def ranked_vaccine_peptides_with_metadata_from_parsed_args(args):
             # of crashing the whole report. Note: strict JSON doesn't
             # have a NaN literal — simplejson's default behavior is to
             # raise; we explicitly opt into the null representation.
-            f.write(_to_json_nan_tolerant(data))
+            f.write(serialize_json_nan_tolerant(data))
             logger.info('Wrote JSON report data to %s', args.output_json_file)
 
     return data

--- a/vaxrank/modalities.py
+++ b/vaxrank/modalities.py
@@ -10,7 +10,7 @@ knows how to design (today: ``peptide`` and ``mrna``; future:
 
 Every place that needs the list of modalities — CLI ``--vaccine-type``
 choices, the YAML config schema, the dispatch table inside
-``_emit_outputs``, the per-modality config loader — reads from here.
+``emit_outputs``, the per-modality config loader — reads from here.
 Adding a new modality is one entry: register the construct-config
 class. The schema, CLI, and dispatch all pick up the new modality
 automatically.

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.33"
+__version__ = "3.1.34"
 
 
 def print_version():


### PR DESCRIPTION
Advances #328 by removing test coupling to private CLI helpers. Promotes 15 externally meaningful orchestration operations to named public APIs with direct tests, folds two single-use wrappers into their owners, and leaves only four genuinely internal output implementations behind the public emit_outputs boundary. Bumps vaxrank to 3.1.34.\n\nVerification:\n- ./lint.sh\n- ./test.sh (996 passed)\n- focused CLI/helper tests (301 passed)\n- ./run-vaxrank-b16-test-data.sh