### PR TITLE
Finish public API responsibility audit

### DIFF
--- a/tests/test_cancer_driver_gene.py
+++ b/tests/test_cancer_driver_gene.py
@@ -13,10 +13,10 @@
 
 from vaxrank.gene_pathway_check import (
     GenePathwayCheck,
-    _IFNG_RESPONSE_COLUMN_NAME,
-    _CLASS_I_MHC_COLUMN_NAME,
-    _DRIVER_GENE_COLUMN_NAME,
-    _DRIVER_VARIANT_COLUMN_NAME
+    IFNG_RESPONSE_COLUMN_NAME,
+    CLASS_I_MHC_COLUMN_NAME,
+    DRIVER_GENE_COLUMN_NAME,
+    DRIVER_VARIANT_COLUMN_NAME,
 )
 from varcode import Variant
 
@@ -30,12 +30,12 @@ def test_HRAS_G13C_in_cancer_driver_genes():
     eq_(effect.short_description, "p.G13C")
     gene_pathway_check = GenePathwayCheck()
     variant_info = gene_pathway_check.make_variant_dict(HRAS_G13C)
-    assert not variant_info[_IFNG_RESPONSE_COLUMN_NAME]
-    assert not variant_info[_CLASS_I_MHC_COLUMN_NAME]
+    assert not variant_info[IFNG_RESPONSE_COLUMN_NAME]
+    assert not variant_info[CLASS_I_MHC_COLUMN_NAME]
     # even though it's a RAS G13 variant, it's not actually that common
     # and thus didn't make the threshold for our source dataset
-    assert not variant_info[_DRIVER_VARIANT_COLUMN_NAME]
-    assert variant_info[_DRIVER_GENE_COLUMN_NAME]
+    assert not variant_info[DRIVER_VARIANT_COLUMN_NAME]
+    assert variant_info[DRIVER_GENE_COLUMN_NAME]
 
 
 def test_HRAS_G13V_in_cancer_driver_genes_and_variants():
@@ -45,7 +45,7 @@ def test_HRAS_G13V_in_cancer_driver_genes_and_variants():
     eq_(effect.short_description, "p.G13V")
     gene_pathway_check = GenePathwayCheck()
     variant_info = gene_pathway_check.make_variant_dict(HRAS_G13V)
-    assert not variant_info[_IFNG_RESPONSE_COLUMN_NAME]
-    assert not variant_info[_CLASS_I_MHC_COLUMN_NAME]
-    assert variant_info[_DRIVER_VARIANT_COLUMN_NAME]
-    assert variant_info[_DRIVER_GENE_COLUMN_NAME]
+    assert not variant_info[IFNG_RESPONSE_COLUMN_NAME]
+    assert not variant_info[CLASS_I_MHC_COLUMN_NAME]
+    assert variant_info[DRIVER_VARIANT_COLUMN_NAME]
+    assert variant_info[DRIVER_GENE_COLUMN_NAME]

--- a/tests/test_cancer_hotspots.py
+++ b/tests/test_cancer_hotspots.py
@@ -15,11 +15,11 @@ Tests for cancer hotspots lookup module.
 """
 
 from vaxrank.cancer_hotspots import (
+    cancer_hotspots_path,
+    load_cancer_hotspots,
     is_hotspot,
     get_hotspot_info,
     get_hotspot_url,
-    _load_hotspots,
-    _get_hotspots_path,
 )
 
 from .common import eq_, ok_
@@ -32,32 +32,32 @@ from .common import eq_, ok_
 def test_hotspots_path_exists():
     """Test that the hotspots data file path is valid"""
     import os
-    path = _get_hotspots_path()
+    path = cancer_hotspots_path()
     ok_(os.path.exists(path), f"Hotspots file not found at {path}")
 
 
 def test_load_hotspots_returns_dict():
-    """Test that _load_hotspots returns a dictionary"""
-    hotspots = _load_hotspots()
+    """Test that load_cancer_hotspots returns a dictionary."""
+    hotspots = load_cancer_hotspots()
     ok_(isinstance(hotspots, dict))
 
 
 def test_load_hotspots_not_empty():
     """Test that hotspots data is loaded"""
-    hotspots = _load_hotspots()
+    hotspots = load_cancer_hotspots()
     ok_(len(hotspots) > 0, "Hotspots dict should not be empty")
 
 
 def test_load_hotspots_has_expected_count():
     """Test that we have a reasonable number of hotspots"""
-    hotspots = _load_hotspots()
+    hotspots = load_cancer_hotspots()
     # The file has ~3181 lines but ~2739 unique (gene, protein_change) pairs
     ok_(len(hotspots) > 2500, f"Expected >2500 hotspots, got {len(hotspots)}")
 
 
 def test_hotspot_entry_structure():
     """Test that hotspot entries have expected fields"""
-    hotspots = _load_hotspots()
+    hotspots = load_cancer_hotspots()
     # Get any entry
     key, info = next(iter(hotspots.items()))
 
@@ -244,14 +244,14 @@ def test_url_format():
 def test_nonsense_mutation():
     """Test handling of nonsense mutations (stop codon)"""
     # Check if there are any nonsense mutations in the dataset
-    hotspots = _load_hotspots()
+    hotspots = load_cancer_hotspots()
     nonsense_found = any('*' in k[1] for k in hotspots.keys())
     ok_(nonsense_found, "Should have some nonsense mutations in dataset")
 
 
 def test_deletion_mutation():
     """Test that indel mutations are in dataset"""
-    hotspots = _load_hotspots()
+    hotspots = load_cancer_hotspots()
     # Check for DEL or INS mutations
     del_ins_found = any(
         info['mutation_type'] in ('DEL', 'INS')
@@ -265,7 +265,7 @@ def test_deletion_mutation():
 def test_caching_works():
     """Test that the LRU cache is working"""
     # Call multiple times - should use cache
-    hotspots1 = _load_hotspots()
-    hotspots2 = _load_hotspots()
+    hotspots1 = load_cancer_hotspots()
+    hotspots2 = load_cancer_hotspots()
     # Should be the exact same object due to caching
     ok_(hotspots1 is hotspots2)

--- a/tests/test_combined_score_dsl.py
+++ b/tests/test_combined_score_dsl.py
@@ -170,6 +170,16 @@ def test_dsl_unknown_identifier_raises_at_eval_time():
         evaluate_combined_score(tree, vp)
 
 
+def test_combined_score_bindings_exposes_documented_scalar_namespace():
+    from vaxrank.combined_score_dsl import combined_score_bindings
+
+    bindings = combined_score_bindings(_make_vp())
+
+    assert bindings["target_epitope_score"] == pytest.approx(2.5)
+    assert bindings["n_alt_reads"] == pytest.approx(10)
+    assert bindings["expression_score"] == pytest.approx(math.sqrt(10))
+
+
 def test_dsl_parsed_at_construction_time_not_scoring_time():
     """Bad ``combined_score_expr`` should raise when the
     VaccinePeptide is built (config-load surface), not later when
@@ -178,15 +188,25 @@ def test_dsl_parsed_at_construction_time_not_scoring_time():
         _make_vp(combined_score_expr='import os')
 
 
-def test_default_expr_is_pre_parsed_at_construction():
+def test_default_expr_is_pre_parsed_at_construction(monkeypatch):
     """When the user doesn't pass ``combined_score_expr``,
     ``__post_init__`` resolves to the default and pre-parses it. The
     AST is the SAME single artifact ``combined_score`` evaluates —
     no separate hardcoded Python branch for the default case."""
     vp = _make_vp(combined_score_expr=None)
     from vaxrank.vaccine_config import DEFAULT_COMBINED_SCORE_EXPR
+    import vaxrank.vaccine_peptide as vaccine_peptide_module
+
     assert vp.combined_score_expr == DEFAULT_COMBINED_SCORE_EXPR
-    assert vp._combined_score_expr_ast is not None
+
+    def fail_on_reparse(_expr):
+        raise AssertionError("unexpected reparse")
+
+    monkeypatch.setattr(
+        vaccine_peptide_module,
+        "parse_combined_score_expr",
+        fail_on_reparse,
+    )
     assert vp.combined_score == pytest.approx(math.sqrt(10) * 2.5)
 
 
@@ -251,25 +271,25 @@ def test_dsl_eval_error_truncates_bindings_in_user_message():
 
 
 def test_dsl_eval_error_warns_when_headline_binding_missing():
-    """Soft contract: ``_bindings_from_vaccine_peptide`` is supposed
-    to populate every entry in ``_HEADLINE_BINDINGS``. If a future
+    """Soft contract: the binding extractor is supposed
+    to populate every entry in ``HEADLINE_BINDINGS``. If a future
     refactor drops one, the user-facing preview shrinks silently —
     surface that through a warning so the maintainer notices."""
     import logging
     from vaxrank.combined_score_dsl import (
-        _HEADLINE_BINDINGS, evaluate_combined_score,
+        HEADLINE_BINDINGS, combined_score_bindings, evaluate_combined_score,
         parse_combined_score_expr)
     import vaxrank.combined_score_dsl as dsl_mod
 
     # Monkeypatch the bindings extractor to drop one headline key.
-    real_extractor = dsl_mod._bindings_from_vaccine_peptide
+    real_extractor = combined_score_bindings
 
     def _stripped(vp):
         b = real_extractor(vp)
-        b.pop(_HEADLINE_BINDINGS[0])  # drop target_epitope_score
+        b.pop(HEADLINE_BINDINGS[0])  # drop target_epitope_score
         return b
 
-    dsl_mod._bindings_from_vaccine_peptide = _stripped
+    dsl_mod.combined_score_bindings = _stripped
     try:
         vp = _make_vp()
         tree = parse_combined_score_expr('log(-1)')
@@ -294,4 +314,4 @@ def test_dsl_eval_error_warns_when_headline_binding_missing():
                 "Expected a warning about the missing headline "
                 "binding; got: %r" % [r.getMessage() for r in warnings])
     finally:
-        dsl_mod._bindings_from_vaccine_peptide = real_extractor
+        dsl_mod.combined_score_bindings = real_extractor

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -720,15 +720,15 @@ def test_resolve_default_methods_stability_plus_affinity():
 
 
 def test_parse_is_cached():
-    """Repeated _parse calls for the same expression should hit the cache
+    """Repeated expression parses should hit the cache
     rather than re-invoking topiary.ranking.parse."""
-    from vaxrank.epitope_dsl import _parse
-    cache_info_before = _parse.cache_info()
+    from vaxrank.epitope_dsl import parse_epitope_expression
+    cache_info_before = parse_epitope_expression.cache_info()
     expr = "affinity['mhcflurry'].logistic(350, 150)"
-    _parse(expr)
-    _parse(expr)
-    _parse(expr)
-    info = _parse.cache_info()
+    parse_epitope_expression(expr)
+    parse_epitope_expression(expr)
+    parse_epitope_expression(expr)
+    info = parse_epitope_expression.cache_info()
     # At least two cache hits from the three calls above
     assert info.hits - cache_info_before.hits >= 2
 

--- a/tests/test_junction_swap.py
+++ b/tests/test_junction_swap.py
@@ -12,12 +12,15 @@
 
 """Tests for per-junction linker optimization (vaxrank issue #247)."""
 
+import warnings
 from types import SimpleNamespace
 
 from vaxrank.junction_swap import (
+    JunctionPredictionWarning,
     JunctionSwapResult,
     junction_kmers,
     optimize_linkers,
+    score_junction_kmers,
 )
 from vaxrank.vaccine_peptide import VaccinePeptide
 
@@ -346,44 +349,34 @@ def test_optimize_default_linker_burden_tracked_in_sweep():
 
 # ---- review-fix coverage -----------------------------------------------------
 
-def test_score_kmers_warn_no_rank_fires_only_once(caplog):
+def test_score_junction_kmers_warns_once_at_repeated_call_site():
     """A predictor that returns predictions without percentile_rank
-    should produce exactly one warning per process — not one per
+    should produce exactly one standard warning per call site — not one per
     junction × candidate."""
-    import logging
-
-    from vaxrank.junction_swap import (
-        _reset_score_kmers_warnings,
-        _score_kmers,
-    )
-
     class NoRankPredictor:
         def predict_peptides(self, peptides):
             return [SimpleNamespace(peptide=p, allele="HLA-A*02:01")
                     for p in peptides]
 
-    _reset_score_kmers_warnings()
-    with caplog.at_level(logging.WARNING):
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("default", JunctionPredictionWarning)
         for _ in range(5):
-            _score_kmers(["KLQGHSAPV"], ["HLA-A*02:01"], NoRankPredictor())
-    no_rank_warnings = [r for r in caplog.records
-                        if "usable percentile_rank" in r.message]
+            score_junction_kmers(
+                ["KLQGHSAPV"], ["HLA-A*02:01"], NoRankPredictor()
+            )
+    no_rank_warnings = [
+        item for item in captured
+        if "usable percentile_rank" in str(item.message)
+    ]
     assert len(no_rank_warnings) == 1, (
         "Expected exactly one no-rank warning across 5 calls, got %d"
         % len(no_rank_warnings))
 
 
-def test_score_kmers_warns_when_allele_filter_drops_all(caplog):
+def test_score_junction_kmers_warns_when_allele_filter_drops_all():
     """If the predictor returns only alleles outside the patient set,
-    warn once (the optimizer would otherwise silently pick the first
+    warn once per call site (the optimizer would otherwise silently pick the first
     candidate)."""
-    import logging
-
-    from vaxrank.junction_swap import (
-        _reset_score_kmers_warnings,
-        _score_kmers,
-    )
-
     class WrongAllelePredictor:
         def predict_peptides(self, peptides):
             # Returns only HLA-B*07:02 predictions; caller asks for A*02:01
@@ -391,16 +384,17 @@ def test_score_kmers_warns_when_allele_filter_drops_all(caplog):
                 peptide=p, allele="HLA-B*07:02", percentile_rank=10.0)
                 for p in peptides]
 
-    _reset_score_kmers_warnings()
-    with caplog.at_level(logging.WARNING):
-        rows = _score_kmers(
-            ["KLQGHSAPV"], ["HLA-A*02:01"], WrongAllelePredictor())
-        # Second call must NOT re-emit the warning
-        _score_kmers(
-            ["KLQGHSAPV"], ["HLA-A*02:01"], WrongAllelePredictor())
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("default", JunctionPredictionWarning)
+        for _ in range(2):
+            rows = score_junction_kmers(
+                ["KLQGHSAPV"], ["HLA-A*02:01"], WrongAllelePredictor()
+            )
     assert rows == [], "All predictions filtered out → no rows"
-    filter_warnings = [r for r in caplog.records
-                       if "allele filter dropped all" in r.message]
+    filter_warnings = [
+        item for item in captured
+        if "allele filter dropped all" in str(item.message)
+    ]
     assert len(filter_warnings) == 1, (
         "Expected exactly one allele-filter warning, got %d"
         % len(filter_warnings))

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -378,7 +378,7 @@ def test_epitope_data_renders_one_row_per_predictor_for_same_pep_allele():
         comparators={'wt': Peptide(sequence='SIINFEKL')},
         overlaps_mutation=True, occurs_in_reference=False)
 
-    rows = [creator._epitope_data(epitope, p) for p in (mhcflurry, netmhcpan)]
+    rows = [creator.epitope_data(epitope, p) for p in (mhcflurry, netmhcpan)]
     assert len(rows) == 2
     # Each row preserves its own predictor name + IC50 — no collapsing.
     assert rows[0]['Predictor'] == 'mhcflurry'
@@ -405,13 +405,13 @@ def test_epitope_data_renders_missing_mutant_ic50_placeholder():
             "SIINFEKL", "SSIINFEKL", offset=1, ic50=missing_value,
             percentile_rank=None)
 
-        row = creator._epitope_data(epitope, epitope.best_affinity())
+        row = creator.epitope_data(epitope, epitope.best_affinity())
 
         assert row['IC50'] == 'No prediction'
 
 
 def test_epitope_data_surfaces_processing_columns_when_annotated():
-    """``TemplateDataCreator._epitope_data`` adds three extra
+    """``TemplateDataCreator.epitope_data`` adds three extra
     columns (Processing: C-term, Processing: max internal,
     Processing: combined) when ``include_processing=True`` — the
     values come from the ProcessingPrediction map by joining on
@@ -428,7 +428,7 @@ def test_epitope_data_surfaces_processing_columns_when_annotated():
     creator = TemplateDataCreator.__new__(TemplateDataCreator)
     creator.processing_predictions_by_key = {}
     # Default: legacy 7-column shape (no Processing columns).
-    pre = creator._epitope_data(pred, leaf)
+    pre = creator.epitope_data(pred, leaf)
     assert isinstance(pre, OrderedDict)
     assert 'Processing: C-term' not in pre
     assert 'Processing: combined' not in pre
@@ -439,7 +439,7 @@ def test_epitope_data_surfaces_processing_columns_when_annotated():
         [pred],
         predictor=StubPepsickle({source: [0.1] * 9 + [0.85] + [0.0] * 4}))
     creator.processing_predictions_by_key = by_key
-    post = creator._epitope_data(pred, leaf, include_processing=True)
+    post = creator.epitope_data(pred, leaf, include_processing=True)
     assert 'Processing: C-term' in post
     assert 'Processing: max internal' in post
     assert 'Processing: combined' in post
@@ -561,8 +561,8 @@ def test_epitope_data_header_consistent_when_some_predictions_unannotated():
 
     # When the caller turns include_processing on, BOTH rows have
     # the same key set — table renders cleanly.
-    row_a = creator._epitope_data(annotated, leaf_a, include_processing=True)
-    row_u = creator._epitope_data(unannotated, leaf_u, include_processing=True)
+    row_a = creator.epitope_data(annotated, leaf_a, include_processing=True)
+    row_u = creator.epitope_data(unannotated, leaf_u, include_processing=True)
     assert list(row_a.keys()) == list(row_u.keys()), (
         "Annotated and unannotated rows should share identical "
         "column keys when include_processing=True; got "

--- a/tests/test_reference_proteome.py
+++ b/tests/test_reference_proteome.py
@@ -35,6 +35,7 @@ from vaxrank.reference_proteome import (
     cta_source_gene_ids_for_genome,
     ensembl_dataset_cache_identity,
     oncoref_cta_source_gene_ids,
+    resolve_reference_kmer_lengths,
     self_reference_matches,
 )
 from vaxrank.vaccine_antigen import (
@@ -81,12 +82,22 @@ def create_mock_genome(transcripts, species_name="test_species", release=100):
 # ReferenceProteome Basic Tests
 # =============================================================================
 
+def test_resolve_reference_kmer_lengths_precedence():
+    assert resolve_reference_kmer_lengths(None, None, [11, 9, 10]) == (9, 11)
+    assert resolve_reference_kmer_lengths(8, None, [9, 10]) == (8, 10)
+    assert resolve_reference_kmer_lengths(None, 12, [9, 10]) == (9, 12)
+    assert resolve_reference_kmer_lengths(8, 12, [9, 10]) == (8, 12)
+    assert resolve_reference_kmer_lengths(None, None, None) == (
+        DEFAULT_MIN_KMER_LENGTH,
+        DEFAULT_MAX_KMER_LENGTH,
+    )
+
+
 def test_none_genome():
     """Test ReferenceProteome with None genome"""
     ref = ReferenceProteome(None)
     ok_(not ref.contains("ANYSEQ"))
     ok_(not ref.contains("MADEUP"))
-    eq_(len(ref._kmer_set), 0)
 
 
 def test_contains_basic():

--- a/tests/test_vaccine_peptide_config.py
+++ b/tests/test_vaccine_peptide_config.py
@@ -33,7 +33,7 @@ def _make_fragment(seq="A" * 25, n_alt_reads=9):
     """Minimal duck-typed MutantProteinFragment for VaccinePeptide tests.
 
     Must expose every binding the combined_score DSL evaluator looks up
-    (``_bindings_from_vaccine_peptide``); the DSL is the single path
+    (``combined_score_bindings``); the DSL is the single path
     that produces ``combined_score`` after the 3.1 refactor, including
     for the default expression.
     """

--- a/tests/test_varcode_effects.py
+++ b/tests/test_varcode_effects.py
@@ -118,7 +118,7 @@ def test_report_effect_data_uses_selected_effect_and_shows_outcomes():
     outcomes, _likely, priority = _outcome_set()
     creator = object.__new__(TemplateDataCreator)
 
-    effect_data = creator._effect_data(outcomes, selected_effect=priority)
+    effect_data = creator.effect_data(outcomes, selected_effect=priority)
 
     assert effect_data["Effect type"] == "_PriorityEffect"
     assert effect_data["Transcript name"] == "TX-PRIORITY"

--- a/vaxrank/cancer_hotspots.py
+++ b/vaxrank/cancer_hotspots.py
@@ -24,20 +24,20 @@ from importlib.resources import files
 logger = logging.getLogger(__name__)
 
 
-def _get_hotspots_path():
+def cancer_hotspots_path():
     """Get path to bundled cancer hotspots TSV file."""
     return str(files('vaxrank').joinpath('data/cancer_hotspots_v2.tsv'))
 
 
 @lru_cache(maxsize=1)
-def _load_hotspots():
+def load_cancer_hotspots():
     """
     Load cancer hotspots data into a lookup dictionary.
 
     Returns dict mapping (gene_upper, protein_change) -> hotspot info dict
     """
     hotspots = {}
-    path = _get_hotspots_path()
+    path = cancer_hotspots_path()
 
     if not os.path.exists(path):
         logger.warning("Cancer hotspots file not found at %s", path)
@@ -94,7 +94,7 @@ def is_hotspot(gene_name, protein_change):
     bool
         True if the mutation is a known cancer hotspot
     """
-    hotspots = _load_hotspots()
+    hotspots = load_cancer_hotspots()
 
     # Normalize protein change - strip "p." prefix if present
     if protein_change.startswith('p.'):
@@ -121,7 +121,7 @@ def get_hotspot_info(gene_name, protein_change):
     dict or None
         Hotspot information dict if found, None otherwise
     """
-    hotspots = _load_hotspots()
+    hotspots = load_cancer_hotspots()
 
     # Normalize protein change - strip "p." prefix if present
     if protein_change.startswith('p.'):

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -1248,7 +1248,7 @@ def main(args_list=None):
     # builder has the same shape inputs either way. Antigens whose
     # transcript IDs can't be resolved (release mismatch, ERV, …)
     # render with "—" placeholders rather than crashing — see
-    # ``TemplateDataCreator._effect_data``.
+    # ``TemplateDataCreator.effect_data``.
     if not (args.output_ascii_report or args.output_html_report or args.output_pdf_report):
         return
 

--- a/vaxrank/combined_score_dsl.py
+++ b/vaxrank/combined_score_dsl.py
@@ -98,7 +98,7 @@ logger = logging.getLogger(__name__)
 # (the read counts and mutant-AA count are useful too, but more
 # numerous and less specific; they go in the DEBUG log). Order is
 # the order they appear in the preview.
-_HEADLINE_BINDINGS = (
+HEADLINE_BINDINGS = (
     'target_epitope_score',
     'self_epitope_score',
     'expression_score',
@@ -208,7 +208,7 @@ def combined_score_binding_names(expr_or_tree):
     )
 
 
-def _bindings_from_vaccine_peptide(vp):
+def combined_score_bindings(vp):
     """Read-only namespace of the scalars exposed to the DSL.
 
     Pulls from both the ``VaccinePeptide`` and its
@@ -260,7 +260,7 @@ def evaluate_combined_score(expr_or_tree, vaccine_peptide):
         # Re-render for error messages; stays cheap because this
         # only runs on failure.
         expr_text = ast.unparse(tree)
-    bindings = _bindings_from_vaccine_peptide(vaccine_peptide)
+    bindings = combined_score_bindings(vaccine_peptide)
     namespace = dict(_FUNCTIONS)
     namespace.update(bindings)
     try:
@@ -282,11 +282,11 @@ def evaluate_combined_score(expr_or_tree, vaccine_peptide):
         # whole ranked list and a tight preview keeps the stack
         # readable.
         preview = {
-            k: bindings[k] for k in _HEADLINE_BINDINGS if k in bindings
+            k: bindings[k] for k in HEADLINE_BINDINGS if k in bindings
         }
         missing = [k for k in _REQUIRED_HEADLINE_BINDINGS if k not in bindings]
         if missing:
-            # Soft contract: ``_bindings_from_vaccine_peptide`` is
+            # Soft contract: ``combined_score_bindings`` is
             # supposed to populate every source-agnostic headline binding. If a
             # future refactor renames or drops one, the preview will
             # silently shrink — surface that through a warning so
@@ -295,7 +295,7 @@ def evaluate_combined_score(expr_or_tree, vaccine_peptide):
             logger.warning(
                 "combined_score_expr error preview is missing "
                 "expected headline binding(s) %s; the bindings "
-                "contract from _bindings_from_vaccine_peptide may "
+                "contract from combined_score_bindings may "
                 "have changed.", missing)
         other_count = len(bindings) - len(preview)
         suffix = (

--- a/vaxrank/cta_admission.py
+++ b/vaxrank/cta_admission.py
@@ -38,16 +38,6 @@ class CTAAdmissionError(RuntimeError):
     """Raised when CTA admission evidence cannot be resolved unambiguously."""
 
 
-def _finite_nonnegative(value, label: str) -> float:
-    try:
-        result = float(value)
-    except (TypeError, ValueError) as error:
-        raise ValueError(f"{label} must be numeric") from error
-    if not math.isfinite(result) or result < 0:
-        raise ValueError(f"{label} must be finite and non-negative")
-    return result
-
-
 @dataclass(frozen=True)
 class CTAAdmissionPolicy(DataclassSerializable):
     """Run-specific quantitative tumor-expression admission rule."""
@@ -56,15 +46,17 @@ class CTAAdmissionPolicy(DataclassSerializable):
     expression_unit: str
 
     def __post_init__(self):
-        object.__setattr__(
-            self,
-            "min_tumor_expression",
-            _finite_nonnegative(
-                self.min_tumor_expression, "Minimum tumor expression"
-            ),
-        )
-        if self.min_tumor_expression <= 0:
+        try:
+            minimum = float(self.min_tumor_expression)
+        except (TypeError, ValueError) as error:
+            raise ValueError("Minimum tumor expression must be numeric") from error
+        if not math.isfinite(minimum) or minimum < 0:
+            raise ValueError(
+                "Minimum tumor expression must be finite and non-negative"
+            )
+        if minimum <= 0:
             raise ValueError("Minimum tumor expression must be greater than zero")
+        object.__setattr__(self, "min_tumor_expression", minimum)
         if not self.expression_unit:
             raise ValueError("CTA expression policy requires an explicit unit")
 
@@ -93,9 +85,13 @@ class PatientTumorExpressionEvidence(DataclassSerializable):
                 "Tumor expression requires assay, units, and versioned provenance"
             )
         object.__setattr__(self, "gene_id", gene_id)
-        object.__setattr__(
-            self, "value", _finite_nonnegative(self.value, "Tumor expression")
-        )
+        try:
+            value = float(self.value)
+        except (TypeError, ValueError) as error:
+            raise ValueError("Tumor expression must be numeric") from error
+        if not math.isfinite(value) or value < 0:
+            raise ValueError("Tumor expression must be finite and non-negative")
+        object.__setattr__(self, "value", value)
 
 
 @dataclass(frozen=True)

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -65,7 +65,7 @@ _METHOD_KIND_MAP = {
 
 
 @functools.lru_cache(maxsize=64)
-def _parse(expr):
+def parse_epitope_expression(expr):
     """Parse a DSL string into a topiary node. Cached so the same config's
     ``filter_expr`` / ``score_expr`` aren't re-parsed multiple times within
     one :func:`write_neoepitope_report` call (validator + build_filter_node
@@ -378,9 +378,9 @@ def validate_dsl_against_predictions(cfg, epitopes, *, topiary_df=None):
     """
     nodes = []
     if cfg.filter_expr is not None:
-        nodes.append(_parse(cfg.filter_expr))
+        nodes.append(parse_epitope_expression(cfg.filter_expr))
     if cfg.score_expr is not None:
-        nodes.append(_parse(cfg.score_expr))
+        nodes.append(parse_epitope_expression(cfg.score_expr))
     if not nodes:
         return
 
@@ -475,7 +475,7 @@ def build_filter_node(cfg):
     cutoff mask. Users who want a hard pre-filter must set ``filter_expr``.
     """
     if cfg.filter_expr is not None:
-        return _parse(cfg.filter_expr)
+        return parse_epitope_expression(cfg.filter_expr)
     return None
 
 
@@ -489,5 +489,6 @@ def build_score_node(cfg):
     different mechanism — it is the same DSL machinery applied to a
     well-known formula.
     """
-    return _parse(cfg.score_expr if cfg.score_expr is not None
-                  else default_score_expr(cfg))
+    return parse_epitope_expression(
+        cfg.score_expr if cfg.score_expr is not None else default_score_expr(cfg)
+    )

--- a/vaxrank/gene_pathway_check.py
+++ b/vaxrank/gene_pathway_check.py
@@ -21,10 +21,10 @@ from .varcode_effects import select_varcode_effect_outcome
 _ENSEMBL_GENE_ID_COLUMN_NAME = 'Ensembl Gene ID'
 _MUTATION_COLUMN_NAME = 'Mutation'
 
-_IFNG_RESPONSE_COLUMN_NAME = 'interferon_gamma_response'
-_CLASS_I_MHC_COLUMN_NAME = 'class1_mhc_presentation_pathway'
-_DRIVER_GENE_COLUMN_NAME = 'cancer_driver_gene'
-_DRIVER_VARIANT_COLUMN_NAME = 'cancer_driver_variant'
+IFNG_RESPONSE_COLUMN_NAME = 'interferon_gamma_response'
+CLASS_I_MHC_COLUMN_NAME = 'class1_mhc_presentation_pathway'
+DRIVER_GENE_COLUMN_NAME = 'cancer_driver_gene'
+DRIVER_VARIANT_COLUMN_NAME = 'cancer_driver_variant'
 
 _CURRENT_DIR = dirname(__file__)
 _DATA_DIR = join(_CURRENT_DIR, "data")
@@ -121,20 +121,20 @@ class GenePathwayCheck(object):
             effect_description = ""
             overlapping_gene_ids = []
         variant_dict = OrderedDict()
-        variant_dict[_IFNG_RESPONSE_COLUMN_NAME] = any([
+        variant_dict[IFNG_RESPONSE_COLUMN_NAME] = any([
             gene_id in self.interferon_gamma_response_gene_set
             for gene_id in overlapping_gene_ids
         ])
-        variant_dict[_CLASS_I_MHC_COLUMN_NAME] = any([
+        variant_dict[CLASS_I_MHC_COLUMN_NAME] = any([
             gene_id in self.class1_mhc_presentation_pathway_gene_set
             for gene_id in overlapping_gene_ids
         ])
-        variant_dict[_DRIVER_GENE_COLUMN_NAME] = any([
+        variant_dict[DRIVER_GENE_COLUMN_NAME] = any([
             gene_id in self.cancer_driver_genes_set
             for gene_id in overlapping_gene_ids
         ])
 
-        variant_dict[_DRIVER_VARIANT_COLUMN_NAME] = any([
+        variant_dict[DRIVER_VARIANT_COLUMN_NAME] = any([
             (gene_id, effect_description) in self.cancer_driver_variants_set
             for gene_id in overlapping_gene_ids
         ])

--- a/vaxrank/junction_swap.py
+++ b/vaxrank/junction_swap.py
@@ -31,6 +31,7 @@ Issue: openvax/vaxrank#247.
 """
 
 import logging
+import warnings
 from dataclasses import dataclass, field
 
 from .vaccine_library import JUNCTION_SWAP_CANDIDATES, get_linker
@@ -70,6 +71,10 @@ class JunctionSwapResult:
         return [link.name for link in self.chosen_linker_per_junction]
 
 
+class JunctionPredictionWarning(UserWarning):
+    """A junction predictor cannot provide scores required for optimization."""
+
+
 def junction_kmers(left_aa, linker_aa, right_aa, k_lengths,
                    reference_proteome=None):
     """Enumerate k-mers spanning a single junction.
@@ -107,18 +112,17 @@ def junction_kmers(left_aa, linker_aa, right_aa, k_lengths,
     return out
 
 
-def _score_kmers(kmers, alleles, predictor):
+def score_junction_kmers(kmers, alleles, predictor):
     """Run the predictor and return rows of (kmer, allele, rank).
 
-    Warns once per process when:
+    Uses Python's standard warning filter to warn once per call site when:
       - the predictor returned predictions but none had a usable
         ``percentile_rank`` (e.g. binding-affinity-only mhctools
         wrappers like RandomBindingPredictor), or
       - the predictor returned predictions but the allele filter
         dropped all of them (the optimizer would silently pick the
         first candidate).
-    Each branch warns at most once per process; reset by calling
-    ``_reset_score_kmers_warnings()`` (test-only).
+    Callers can configure repetition through the standard :mod:`warnings` API.
     """
     if not kmers:
         return []
@@ -140,33 +144,27 @@ def _score_kmers(kmers, alleles, predictor):
             continue
         n_with_rank += 1
         rows.append((p.peptide, p.allele, float(rank)))
-    if n_seen and not n_with_rank and not _score_kmers.warned_no_rank:
-        logger.warning(
-            "Junction-swap predictor returned %d predictions but none had "
+    if n_seen and not n_with_rank:
+        warnings.warn(
+            f"Junction-swap predictor returned {n_seen} predictions but none had "
             "a usable percentile_rank field; the optimizer cannot rank "
             "chimeric k-mers and will fall back to the first candidate. "
             "Use mhcflurry-presentation or a predictor that exposes "
-            "percentile rank.", n_seen)
-        _score_kmers.warned_no_rank = True
-    if n_total and not n_seen and not _score_kmers.warned_allele_filter:
-        logger.warning(
-            "Junction-swap predictor returned %d predictions but the "
+            "percentile rank.",
+            JunctionPredictionWarning,
+            stacklevel=2,
+        )
+    if n_total and not n_seen:
+        warnings.warn(
+            f"Junction-swap predictor returned {n_total} predictions but the "
             "allele filter dropped all of them; the optimizer cannot "
             "rank chimeric k-mers and will fall back to the first "
             "candidate. Check that the predictor's configured alleles "
-            "include the patient HLA set.", n_total)
-        _score_kmers.warned_allele_filter = True
+            "include the patient HLA set.",
+            JunctionPredictionWarning,
+            stacklevel=2,
+        )
     return rows
-
-
-_score_kmers.warned_no_rank = False
-_score_kmers.warned_allele_filter = False
-
-
-def _reset_score_kmers_warnings():
-    """Test-only: reset the warn-once flags on _score_kmers."""
-    _score_kmers.warned_no_rank = False
-    _score_kmers.warned_allele_filter = False
 
 
 def _burden_key(rows, rank_strong=RANK_STRONG, rank_mild=RANK_MILD):
@@ -289,7 +287,7 @@ def optimize_linkers(
             kmers = junction_kmers(
                 left_aa, cand.amino_acids, right_aa, k_lengths,
                 reference_proteome=reference_proteome)
-            rows = _score_kmers(kmers, alleles, predictor)
+            rows = score_junction_kmers(kmers, alleles, predictor)
             key = _burden_key(rows, rank_strong, rank_mild)
             per_cand_keys.append(key)
             if best is None or key < best[0]:

--- a/vaxrank/reference_proteome.py
+++ b/vaxrank/reference_proteome.py
@@ -59,18 +59,12 @@ def oncoref_cta_source_gene_ids() -> frozenset[str]:
     )
 
 
-def _is_human_genome(genome) -> bool:
-    if genome is None:
-        return False
+def cta_source_gene_ids_for_genome(genome) -> frozenset[str]:
+    """Human CTA source exclusions, or an empty set for other species."""
     species = getattr(genome, "species", None)
     latin_name = str(getattr(species, "latin_name", ""))
     normalized = latin_name.strip().casefold().replace("_", " ")
-    return normalized in {"homo sapiens", "human"}
-
-
-def cta_source_gene_ids_for_genome(genome) -> frozenset[str]:
-    """Human CTA source exclusions, or an empty set for other species."""
-    if not _is_human_genome(genome):
+    if normalized not in {"homo sapiens", "human"}:
         return frozenset()
     return oncoref_cta_source_gene_ids()
 
@@ -447,7 +441,10 @@ def extract_kmers(sequences, min_len, max_len):
     return kmers
 
 
-def _resolve_kmer_lengths(min_kmer_length, max_kmer_length, epitope_lengths):
+def resolve_reference_kmer_lengths(
+    min_kmer_length, max_kmer_length, epitope_lengths
+):
+    """Resolve an index range from explicit bounds, epitope lengths, or defaults."""
     if epitope_lengths and (min_kmer_length is None or max_kmer_length is None):
         lengths = sorted(epitope_lengths)
         if min_kmer_length is None:
@@ -624,7 +621,7 @@ class ReferenceProteome:
             CandidateEpitope lengths being predicted. Used to derive kmer range
             when min/max not explicitly set.
         """
-        min_kmer_length, max_kmer_length = _resolve_kmer_lengths(
+        min_kmer_length, max_kmer_length = resolve_reference_kmer_lengths(
             min_kmer_length, max_kmer_length, epitope_lengths)
 
         unique_seqs = set(proteins.values())
@@ -665,7 +662,7 @@ class ReferenceProteome:
         min_kmer_length : int, optional
         max_kmer_length : int, optional
         """
-        min_kmer_length, max_kmer_length = _resolve_kmer_lengths(
+        min_kmer_length, max_kmer_length = resolve_reference_kmer_lengths(
             min_kmer_length, max_kmer_length, epitope_lengths)
 
         if genome is None:

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -218,7 +218,7 @@ class TemplateDataCreator(object):
         ])
         return variant_data
 
-    def _effect_data(self, predicted_effect, selected_effect=None):
+    def effect_data(self, predicted_effect, selected_effect=None):
         """OrderedDict with info about the given varcode effect.
 
         ``predicted_effect`` may be ``None`` on external-input paths
@@ -362,7 +362,7 @@ class TemplateDataCreator(object):
                 return p.value
         return None
 
-    def _epitope_data(self, epitope, prediction, include_processing=False):
+    def epitope_data(self, epitope, prediction, include_processing=False):
         """Returns an OrderedDict with epitope data for one
         (CandidateEpitope, mutant Prediction) row.
 
@@ -512,7 +512,7 @@ class TemplateDataCreator(object):
             predicted_effect = mutant_protein_fragment.predicted_effect()
             predicted_effect_outcomes = mutant_protein_fragment.predicted_effect(
                 outcome_selection=OUTCOME_SELECTION_MULTI_OUTCOME)
-            effect_data = self._effect_data(
+            effect_data = self.effect_data(
                 predicted_effect_outcomes,
                 selected_effect=predicted_effect)
 
@@ -569,12 +569,12 @@ class TemplateDataCreator(object):
 
                 for e in vaccine_peptide.target_epitopes:
                     for p in _affinity_leaves(e):
-                        epitopes.append(self._epitope_data(
+                        epitopes.append(self.epitope_data(
                             e, p, include_processing=any_processing))
 
                 for e in vaccine_peptide.self_epitopes:
                     for p in _affinity_leaves(e):
-                        epitope_data = self._epitope_data(e, p)
+                        epitope_data = self.epitope_data(e, p)
                         key_list = ['Allele', 'IC50', 'Sequence']
                         wt_epitopes.append(
                             {key: epitope_data[key] for key in key_list})

--- a/vaxrank/risk_ligand.py
+++ b/vaxrank/risk_ligand.py
@@ -44,21 +44,6 @@ class RiskLigandError(RuntimeError):
     """Raised when a risk-ligand index cannot be built unambiguously."""
 
 
-def _json_native(value):
-    if isinstance(value, dict):
-        return {key: _json_native(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_json_native(item) for item in value]
-    return value
-
-
-def _fingerprint(payload) -> str:
-    encoded = json.dumps(
-        _json_native(payload), sort_keys=True, separators=(",", ":")
-    ).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
-
-
 @dataclass(frozen=True)
 class ResolvedRiskProtein(DataclassSerializable):
     """One distinct risk-protein sequence with all transcript provenance."""
@@ -468,7 +453,7 @@ class PatientHLARiskLigandIndex(DataclassSerializable):
         )
 
     def to_report_dict(self) -> dict:
-        return _json_native(asdict(self))
+        return json.loads(json.dumps(asdict(self)))
 
 
 def resolve_tissue_risk_protein_sequences(
@@ -548,12 +533,15 @@ def resolve_tissue_risk_protein_sequences(
         "policy": asdict(tissue_risk.policy),
         "cta_count": tissue_risk.cta_unfiltered_gene_count,
     }
+    policy_sha256 = hashlib.sha256(json.dumps(
+        policy_payload, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")).hexdigest()
     species = str(getattr(getattr(genome, "species", None), "latin_name", "") or "")
     return RiskProteinSequenceSet(
         resolution_policy=resolution_policy,
         genome_release=str(getattr(genome, "release", "") or ""),
         species=species,
-        tissue_risk_policy_sha256=_fingerprint(policy_payload),
+        tissue_risk_policy_sha256=policy_sha256,
         hpa_source_sha256=tissue_risk.hpa_provenance.source_sha256,
         cta_unfiltered_gene_ids_sha256=(
             tissue_risk.cta_unfiltered_gene_ids_sha256
@@ -765,6 +753,9 @@ def risk_ligand_index_from_prediction_frame(
         "selection_policy": asdict(selection_policy),
         "predictors": sorted(predictor_identities),
     }
+    cache_identity_sha256 = hashlib.sha256(json.dumps(
+        cache_payload, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")).hexdigest()
     provenance = RiskLigandIndexProvenance(
         genome_release=protein_sequences.genome_release,
         species=protein_sequences.species,
@@ -775,7 +766,7 @@ def risk_ligand_index_from_prediction_frame(
             protein_sequences.cta_unfiltered_gene_ids_sha256
         ),
         predictor_identities=tuple(predictor_identities),
-        cache_identity_sha256=_fingerprint(cache_payload),
+        cache_identity_sha256=cache_identity_sha256,
     )
     return PatientHLARiskLigandIndex(
         alleles=normalized_alleles,

--- a/vaxrank/safety_assessment.py
+++ b/vaxrank/safety_assessment.py
@@ -11,6 +11,7 @@ subset that passed an immunogenicity filter.
 
 from __future__ import annotations
 
+import json
 import math
 from dataclasses import asdict, dataclass, field
 from numbers import Integral
@@ -342,7 +343,7 @@ class WindowSafetyAssessment(DataclassSerializable):
 
     def to_report_dict(self) -> dict:
         """Plain JSON-compatible tree without serializer type metadata."""
-        return _json_native(asdict(self))
+        return json.loads(json.dumps(asdict(self)))
 
     def prediction_rows(self) -> list[dict]:
         """Flat, primitive-valued rows for CSV/DataFrame report inputs."""
@@ -487,9 +488,9 @@ class AntigenSafetyAssessment(DataclassSerializable):
         """JSON-compatible evidence tree for safety audit reports."""
         return {
             "window_assessment": self.window_assessment.to_report_dict(),
-            "risk_index_provenance": _json_native(
+            "risk_index_provenance": json.loads(json.dumps(
                 asdict(self.risk_index_provenance)
-            ),
+            )),
             "near_self_assessments": [
                 assessment.to_report_dict()
                 for assessment in self.near_self_assessments
@@ -610,14 +611,6 @@ def assess_antigen_safety(
             comparator=comparator,
         ),
     )
-
-
-def _json_native(value):
-    if isinstance(value, dict):
-        return {key: _json_native(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_json_native(item) for item in value]
-    return value
 
 
 def safety_assessment_from_prediction_frame(

--- a/vaxrank/tissue_risk.py
+++ b/vaxrank/tissue_risk.py
@@ -18,8 +18,8 @@ https://v23.proteinatlas.org/about/help
 from __future__ import annotations
 
 import hashlib
+import json
 from dataclasses import asdict, dataclass, field
-from pathlib import Path
 from typing import Optional
 
 import pandas as pd
@@ -41,27 +41,6 @@ def _text(value) -> str:
     if pd.isna(value):
         return ""
     return str(value).strip()
-
-
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        while chunk := handle.read(1024 * 1024):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _set_fingerprint(values) -> str:
-    payload = "\n".join(sorted(set(values))).encode("utf-8")
-    return hashlib.sha256(payload).hexdigest()
-
-
-def _json_native(value):
-    if isinstance(value, dict):
-        return {key: _json_native(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_json_native(item) for item in value]
-    return value
 
 
 @dataclass(frozen=True)
@@ -205,7 +184,7 @@ class TissueRiskAssessment(DataclassSerializable):
         )
 
     def to_report_dict(self) -> dict:
-        return _json_native(asdict(self))
+        return json.loads(json.dumps(asdict(self)))
 
     def evidence_rows(self) -> list[dict]:
         rows = []
@@ -260,6 +239,10 @@ def build_hpa_reference_provenance() -> HPAReferenceProvenance:
 
     hpa_version = reference_data.DEFAULT_HPA_VERSION
     path = reference_data.ensure(HPA_NORMAL_TISSUE_SOURCE, hpa_version)
+    source_digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            source_digest.update(chunk)
     try:
         verified = reference_data.verify(HPA_NORMAL_TISSUE_SOURCE, hpa_version)
         verification_status = "verified" if verified else "checksum_mismatch"
@@ -273,7 +256,7 @@ def build_hpa_reference_provenance() -> HPAReferenceProvenance:
         hpa_version=hpa_version,
         source_path=str(path),
         source_bytes=path.stat().st_size,
-        source_sha256=_sha256_file(path),
+        source_sha256=source_digest.hexdigest(),
         verification_status=verification_status,
     )
 
@@ -406,6 +389,8 @@ def derive_tissue_risk_proteins(
         coverage=HPAEvidenceCoverage(**counts),
         hpa_provenance=provenance,
         cta_unfiltered_gene_count=len(cta_gene_ids),
-        cta_unfiltered_gene_ids_sha256=_set_fingerprint(cta_gene_ids),
+        cta_unfiltered_gene_ids_sha256=hashlib.sha256(
+            "\n".join(sorted(cta_gene_ids)).encode("utf-8")
+        ).hexdigest(),
         excluded_cta_source_gene_ids=tuple(excluded_cta_gene_ids),
     )

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.34"
+__version__ = "3.1.35"
 
 
 def print_version():


### PR DESCRIPTION
Closes #328.\n\nCompletes the responsibility-based private-helper audit for vaxrank 3.1.35:\n- replaces the final 10 private production symbols imported by tests with public data, DSL, schema, junction-scoring, and reference-index operations\n- exposes combined-score binding extraction plus effect and epitope report-row construction where tests already depended on those contracts\n- replaces junction scorer function attributes and the test-only reset hook with JunctionPredictionWarning and standard Python warning filtering\n- folds duplicated safety JSON/fingerprint, numeric-validation, file-hashing, and species-check glue into the owning operations\n- removes direct test reads of private reference-cache storage\n- retains only single-owner algorithms, format readers, registered callbacks, and cache implementation details as private\n\nVerification:\n- ./lint.sh\n- ./test.sh (998 passed)\n- focused audit tests (251 passed, plus 96 report/reference tests)\n- static inventory: 0 private production imports from tests\n- ./run-vaxrank-b16-test-data.sh