### PR TITLE
Give external inputs one parse, one identity, and one construct rule

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.16.0,<6.0.0
+topiary>=5.17.1,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,6 +10,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Fixtures must never carry a real dependency version. A literal that looks
+# like one invites the next person to "keep it current", which is how an
+# oncoref version pin ended up asserted in test_cta_admission and broke on
+# every upstream bump. This sentinel is obviously not a real release.
+STUB_ONCOREF_VERSION = "0.0.0-test"
+
+
 def ok_(a, s=None):
     if s is None:
         assert a

--- a/tests/test_cta_admission.py
+++ b/tests/test_cta_admission.py
@@ -3,6 +3,8 @@ import json
 import pandas as pd
 import pytest
 
+from tests.common import STUB_ONCOREF_VERSION
+
 from vaxrank.cta_admission import (
     CTA_REASON_CANONICAL_EXPRESSION_PASS,
     CTA_REASON_EXPLICIT_OVERRIDE,
@@ -59,7 +61,14 @@ def _frame():
     return pd.DataFrame(rows)
 
 
+# These tests stub oncoref's data, so they stub its version too. Asserting
+# the real installed version pinned the suite to one release of a dependency
+# it does not otherwise care about, and every oncoref bump broke this test.
+# What is worth asserting is that the recorded provenance comes from
+# ``oncoref.__version__`` rather than being fabricated — which a sentinel
+# checks and a literal cannot.
 def _patch_oncoref(monkeypatch, *, frame=None, canonical=None, unfiltered=None):
+    monkeypatch.setattr("oncoref.__version__", STUB_ONCOREF_VERSION)
     monkeypatch.setattr(
         "oncoref.cta.cta_evidence", lambda: _frame() if frame is None else frame
     )
@@ -118,7 +127,7 @@ def test_canonical_cta_at_expression_threshold_is_admitted(monkeypatch):
         PRAME, HELD_OUT, OTHER_CTA
     }))
     assert result.reference_evidence.canonical_default
-    assert result.reference_evidence.oncoref_version == "1.8.174"
+    assert result.reference_evidence.oncoref_version == STUB_ONCOREF_VERSION
     records = result.antigen.tumor_specificity.evidence_records
     assert [record.evidence_kind for record in records] == [
         "oncoref_cta_membership", "patient_tumor_expression"

--- a/tests/test_entry_point_helpers.py
+++ b/tests/test_entry_point_helpers.py
@@ -361,17 +361,18 @@ def test_lens_funnel_summarizes_input_composition():
     in one block (so the operator isn't left correlating drop counts
     across multiple lines)."""
     import os
-    from vaxrank.epitope_io import load_lens
-    from vaxrank.external_input import ranked_from_lens_predictions
+    from vaxrank.epitope_io import read_lens_report
+    from vaxrank.external_input import lens_ranking_result
     from .testing_helpers import data_path
 
     lens_path = data_path("epitope_fixtures/lens_example.tsv")
     if not os.path.exists(lens_path):
         pytest.skip("lens_example.tsv fixture not found")
 
-    _df, predictions = load_lens(lens_path)
+    _loaded = read_lens_report(lens_path)
+    predictions = list(_loaded.epitopes)
     with _capture_logger('vaxrank.external_input', logging.INFO) as records:
-        ranked_from_lens_predictions(predictions, lens_path)
+        lens_ranking_result(_loaded, predictions)
 
     funnel = [r.getMessage() for r in records
               if 'LENS load funnel' in r.getMessage()]
@@ -393,17 +394,18 @@ def test_lens_antigen_source_breakdown_orders_snv_indel_first():
     pure-alphabetical."""
     import os
     import re
-    from vaxrank.epitope_io import load_lens
-    from vaxrank.external_input import ranked_from_lens_predictions
+    from vaxrank.epitope_io import read_lens_report
+    from vaxrank.external_input import lens_ranking_result
     from .testing_helpers import data_path
 
     lens_path = data_path("epitope_fixtures/lens_example.tsv")
     if not os.path.exists(lens_path):
         pytest.skip("lens_example.tsv fixture not found")
 
-    _df, predictions = load_lens(lens_path)
+    _loaded = read_lens_report(lens_path)
+    predictions = list(_loaded.epitopes)
     with _capture_logger('vaxrank.external_input', logging.INFO) as records:
-        ranked_from_lens_predictions(predictions, lens_path)
+        lens_ranking_result(_loaded, predictions)
 
     msgs = [
         r.getMessage() for r in records

--- a/tests/test_entry_point_helpers.py
+++ b/tests/test_entry_point_helpers.py
@@ -379,7 +379,7 @@ def test_lens_funnel_summarizes_input_composition():
         "Expected exactly one consolidated funnel line; got %d" % len(funnel))
     msg = funnel[0]
     assert 'rows in:' in msg
-    assert 'candidate epitopes scored' in msg
+    assert 'candidate epitopes eligible for construct ranking' in msg
     # The old per-stage lines must be gone (no double-counting).
     assert not any('LENS report contains' in r.getMessage() for r in records)
     assert not any(

--- a/tests/test_epitope_dsl.py
+++ b/tests/test_epitope_dsl.py
@@ -487,3 +487,104 @@ def test_allele_free_evidence_is_projected_onto_patient_alleles():
         EpitopeConfig(score_expr="processing[mhcflurry].score"))
     assert set(scored.per_allele_scores) == set(alleles)
     assert scored.epitope_score > 0
+
+
+def test_pipeline_and_external_frames_each_group_on_their_own_identity():
+    """Both frame shapes name their group keys; neither is left to inference.
+
+    What topiary infers has changed twice (sample_name being prepended, then
+    the 5.17.1 group-index fixes). A frame whose grouping shifts underneath it
+    merges candidates that are not the same candidate, so vaxrank states the
+    identity for each shape instead of relying on the default.
+    """
+    import pandas as pd
+
+    from vaxrank.epitope_dsl import (
+        PIPELINE_GROUP_COLUMNS, PREDICTION_GROUP_COLUMNS,
+        prediction_group_columns,
+    )
+
+    common = {"peptide": ["SIINFEKL"], "peptide_offset": [0],
+              "allele": ["HLA-A*02:01"]}
+    # A TopiaryPredictor frame: identity is the source sequence name.
+    pipeline = pd.DataFrame({**common, "source_sequence_name": ["ovalbumin"]})
+    assert prediction_group_columns(pipeline) == list(PIPELINE_GROUP_COLUMNS)
+
+    # A vaxrank / external-reader frame: identity is the provenance key, and
+    # it wins even when a source name is also present.
+    external = pd.DataFrame({
+        **common, "source_sequence_name": ["ovalbumin"],
+        "prediction_id": ["lens:abc"]})
+    assert prediction_group_columns(external) == list(
+        PREDICTION_GROUP_COLUMNS)
+
+    # Neither identity present: refuse rather than group on sequence alone.
+    with pytest.raises(ValueError, match="no usable score-group identity"):
+        prediction_group_columns(pd.DataFrame(common))
+
+
+def test_kind_support_is_forwarded_to_the_dsl():
+    """A caller holding a predictor must not make topiary guess.
+
+    ``mhc_dependence`` guards resolve from kind_support when supplied and by
+    scanning rows otherwise. vaxrank's pipeline path holds the predictor that
+    knows the answer, so leaving it unset made every such guard a guess —
+    the same defect topiary fixed on its own --filter-by path.
+    """
+    from unittest import mock
+
+    import pandas as pd
+    import topiary.ranking
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import score_predictions
+
+    df = pd.DataFrame([{
+        "prediction_id": "p1", "source_sequence_name": "ctx",
+        "peptide": "SIINFEKL", "peptide_offset": 0, "peptide_length": 8,
+        "allele": "HLA-A*02:01", "n_flank": "", "c_flank": "",
+        "prediction_method_name": "mhcflurry", "predictor_version": "2.1.1",
+        "kind": "pMHC_affinity", "value": 50.0, "affinity": 50.0,
+        "percentile_rank": 0.4, "score": 0.0,
+    }])
+    support = {"mhcflurry": {
+        "pMHC_affinity": {"mhc_dependence": "single_allele",
+                          "mhc_class": "I"}}}
+
+    real_context = topiary.ranking.EvalContext
+    seen = {}
+
+    def spy(frame, **kwargs):
+        seen.update(kwargs)
+        return real_context(frame, **kwargs)
+
+    with mock.patch.object(topiary.ranking, "EvalContext", spy):
+        scores = score_predictions(
+            [], EpitopeConfig(), topiary_df=df, kind_support=support)
+
+    assert seen["kind_support"] is support
+    # The group identity is named too, not inferred.
+    assert seen["group_keys"][0] == "prediction_id"
+    assert len(scores) == 1
+
+
+def test_external_readers_leave_kind_support_unset():
+    """No predictor means no kind_support — absent, not fabricated."""
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import read_lens_report
+
+    import tempfile
+    import os
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "lens.tsv")
+        with open(path, "w") as handle:
+            handle.write(
+                "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\n"
+                "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\n")
+        report = read_lens_report(path, epitope_config=EpitopeConfig())
+
+    # Scores still land; dependence resolves from the rows, which is correct
+    # for a frame no predictor produced.
+    [epitope] = report.epitopes
+    assert epitope.per_allele_scores

--- a/tests/test_epitope_dsl.py
+++ b/tests/test_epitope_dsl.py
@@ -443,3 +443,47 @@ def test_epitopes_to_topiary_df_schema_pinned():
     by_peptide = df.set_index('peptide')['peptide_offset'].to_dict()
     assert by_peptide['SIINFEKL'] == 4
     assert by_peptide['SIINFEKM'] == 12
+
+
+def test_allele_free_evidence_is_projected_onto_patient_alleles():
+    """Processing-only evidence must still produce per-allele scores.
+
+    topiary 5.18's ``peptide_view()`` broadcasts an allele-free value across
+    allele groups that already exist, but a peptide whose only evidence is
+    allele-free has no such groups — its single group is keyed on an empty
+    allele, and the patient's genotype is not in the frame at all
+    (openvax/topiary#182). Dropping this projection in favor of
+    ``peptide_view()`` would silently score such candidates 0 and drop them,
+    which is the failure mode of vaxrank#295.
+    """
+    from mhctools.pred import Prediction
+
+    from vaxrank.candidate_epitope import CandidateEpitope
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import (
+        attach_per_allele_scores, epitopes_to_topiary_df,
+    )
+
+    alleles = ("HLA-A*02:01", "HLA-B*07:02")
+    epitope = CandidateEpitope(
+        sequence="SIINFEKL", source_sequence="XXSIINFEKLXX", offset=2,
+        prediction_id="processing-only",
+        patient_alleles=alleles,
+        predictions=(Prediction(
+            kind="antigen_processing", predictor_name="mhcflurry",
+            predictor_version="2.1.1", allele="", peptide="SIINFEKL",
+            value=None, score=0.77),))
+
+    # The canonical leaf stays allele-free on the object ...
+    [leaf] = epitope.predictions_for("antigen_processing", predictor="mhcflurry")
+    assert leaf.allele == ""
+
+    # ... and is projected onto both patient alleles in the evaluation frame.
+    frame = epitopes_to_topiary_df([epitope])
+    assert set(frame["allele"]) == set(alleles)
+
+    [scored] = attach_per_allele_scores(
+        [epitope],
+        EpitopeConfig(score_expr="processing[mhcflurry].score"))
+    assert set(scored.per_allele_scores) == set(alleles)
+    assert scored.epitope_score > 0

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -204,6 +204,56 @@ def test_native_reload_rejects_missing_explicit_prediction_score(tmp_path):
         load_predictions(path)
 
 
+def test_native_roundtrip_preserves_complete_wt_prediction(tmp_path):
+    """WT leaves retain the same complete provenance as mutant leaves."""
+    mutant = Prediction(
+        kind="pMHC_affinity",
+        predictor_name="mhcflurry",
+        predictor_version="2.1.1",
+        allele="HLA-A*02:01",
+        peptide="SIINFEKL",
+        value=50.0,
+        score=0.91,
+        percentile_rank=0.5,
+    )
+    wt_prediction = Prediction(
+        kind="pMHC_affinity",
+        predictor_name="mhcflurry",
+        predictor_version="2.1.1",
+        allele="HLA-A*02:01",
+        peptide="SIINFEKM",
+        value=500.0,
+        score=0.42,
+        percentile_rank=4.8,
+        tcr="CASSWTYEQYF",
+        n_flank="NN",
+        c_flank="CC",
+        source_sequence_name="WT_TRANSCRIPT_1",
+        offset=17,
+    )
+    original = CandidateEpitope(
+        sequence="SIINFEKL",
+        source_sequence="AASIINFEKLLL",
+        offset=2,
+        predictions=(mutant,),
+        comparators={
+            COMPARATOR_WT: Peptide(
+                sequence="SIINFEKM",
+                predictions=(wt_prediction,),
+            ),
+        },
+        patient_alleles=("HLA-A*02:01",),
+        per_allele_scores={"HLA-A*02:01": 0.91},
+    )
+
+    path = tmp_path / "complete-wt.csv"
+    save_predictions([original], path)
+    reloaded = load_predictions(path)[0]
+
+    assert reloaded.wt is not None
+    assert reloaded.wt.predictions_flat() == (wt_prediction,)
+
+
 # ── pVACseq import ───────────────────────────────────────────────────────────
 
 def test_load_pvacseq():

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -24,6 +24,7 @@ from vaxrank.epitope_io import (
     epitope_prediction_rows,
     predictions_to_dataframe,
     save_predictions,
+    lens_epitope_position,
     load_predictions,
     load_pvacseq,
     load_lens,
@@ -31,6 +32,15 @@ from vaxrank.epitope_io import (
 )
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data", "epitope_fixtures")
+
+
+def test_lens_epitope_position_uses_source_context_and_offset():
+    assert lens_epitope_position(
+        "SIINFEKL", "AASIINFEKLLL") == (
+            "SIINFEKL", "AASIINFEKLLL", 2)
+    assert lens_epitope_position("SIINFEKL", "") == (
+        "SIINFEKL", "", 0)
+    assert lens_epitope_position("SIINFEKL", "UNRELATED") is None
 
 
 def _make_prediction(allele="HLA-A*02:01", peptide_sequence="SIINFEKL",

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -2088,3 +2088,72 @@ def test_neoepitope_core_row_shared_contract():
         score=0.5)
     assert scored["Score"] == 0.5
     assert scored["Predicted mutant pMHC affinity"] == ""
+
+
+def test_native_roundtrip_preserves_targetability_and_self_reference(tmp_path):
+    """Safety decisions must survive a save/load cycle.
+
+    ``overlaps_targetable`` and ``self_reference_match`` both fall back to the
+    permissive legacy behavior when absent, so dropping them on write did not
+    fail loudly — it silently re-admitted a held-out epitope as a vaccine
+    target on reload.
+    """
+    from mhctools.pred import Prediction
+
+    from vaxrank.candidate_epitope import (
+        SOURCE_CLASS_MUTATION, CandidateEpitope,
+    )
+    from vaxrank.epitope_io import load_predictions, save_predictions
+    from vaxrank.vaccine_antigen import SelfReferenceMatch
+
+    prediction = Prediction(
+        kind="pMHC_affinity", predictor_name="mhcflurry",
+        predictor_version="2.1.1", allele="HLA-A*02:01",
+        peptide="SIINFEKL", value=50.0, score=0.9, percentile_rank=0.4)
+    epitope = CandidateEpitope(
+        sequence="SIINFEKL", n_flank="AAA", c_flank="CCC",
+        source_sequence="XXSIINFEKLXX", source_name="ENST00000123456",
+        offset=2, predictions=(prediction,),
+        source_class=SOURCE_CLASS_MUTATION, overlaps_mutation=True,
+        overlaps_targetable=False,
+        self_reference_match=SelfReferenceMatch(
+            peptide="SIINFEKL", occurs=False, antigen_kind="CTA",
+            excluded_gene_ids=("ENSG00000141510",),
+            genome_release="GRCh38"),
+        patient_alleles=("HLA-A*02:01",), prediction_id="pid-1",
+        per_allele_scores={"HLA-A*02:01": 0.9})
+
+    path = tmp_path / "native.csv"
+    save_predictions([epitope], path)
+    [reloaded] = load_predictions(path)
+
+    assert reloaded.overlaps_targetable is False
+    assert reloaded.is_targetable is False
+    assert reloaded.self_reference_match == epitope.self_reference_match
+    assert reloaded.occurs_in_self_reference is False
+    # Flanks drive processing predictors; a reload without them cannot
+    # reproduce the scores of the file it read.
+    assert (reloaded.n_flank, reloaded.c_flank) == ("AAA", "CCC")
+    assert reloaded.source_name == "ENST00000123456"
+
+
+def test_native_roundtrip_keeps_undecided_targetability_undecided(tmp_path):
+    """A blank cell reloads as "no decision", never as False."""
+    from mhctools.pred import Prediction
+
+    from vaxrank.candidate_epitope import CandidateEpitope
+    from vaxrank.epitope_io import load_predictions, save_predictions
+
+    epitope = CandidateEpitope(
+        sequence="SIINFEKL", source_sequence="SIINFEKL", offset=0,
+        predictions=(Prediction(
+            kind="pMHC_affinity", predictor_name="mhcflurry",
+            predictor_version="2.1.1", allele="HLA-A*02:01",
+            peptide="SIINFEKL", value=50.0, score=0.9),),
+        prediction_id="pid-2")
+    path = tmp_path / "undecided.csv"
+    save_predictions([epitope], path)
+    [reloaded] = load_predictions(path)
+
+    assert reloaded.overlaps_targetable is None
+    assert reloaded.is_targetable is True

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -525,6 +525,76 @@ def test_load_lens_preserves_allele_independent_processing_once():
     assert all(epitope.per_allele_scores)
 
 
+def test_lens_processing_dsl_scores_every_patient_allele(tmp_path):
+    """Canonical processing evidence participates in allele-scoped DSL groups."""
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import (
+        attach_per_allele_scores,
+        epitopes_to_topiary_df,
+    )
+
+    path = tmp_path / "multi-allele-processing.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\n"
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t60\t0.8\n")
+
+    _, epitopes = load_lens(path)
+    assert len(epitopes) == 1
+    epitope = epitopes[0]
+    processing = epitope.predictions_for(
+        "antigen_processing", predictor="mhcflurry")
+    assert len(processing) == 1
+    assert processing[0].allele == ""
+
+    topiary_df = epitopes_to_topiary_df(epitopes)
+    processing_rows = topiary_df[
+        topiary_df["kind"] == "antigen_processing"]
+    assert set(processing_rows["allele"]) == {
+        "HLA-A*02:01", "HLA-B*07:02"}
+
+    scored = attach_per_allele_scores(
+        epitopes,
+        EpitopeConfig(score_expr="processing[mhcflurry].score"))
+    assert scored[0].per_allele_scores == {
+        "HLA-A*02:01": pytest.approx(0.8),
+        "HLA-B*07:02": pytest.approx(0.8),
+    }
+
+
+def test_lens_context_scores_merge_by_source_position(tmp_path):
+    """Equal peptide/allele rows retain context-specific integrated scores."""
+    from vaxrank.epitope_config import EpitopeConfig
+
+    path = tmp_path / "context-specific-scores.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.pres_score\tmhcflurry_2.1.1.proc_score\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLAA\t50\t0.2\t0.3\n"
+        "SIINFEKL\tHLA-A02:01\tYYYYSIINFEKLZ\t60\t0.9\t0.8\n")
+
+    report_df, epitopes = load_lens(path)
+    assert list(report_df["Source sequence name"]) == [
+        "XXSIINFEKLAA", "YYYYSIINFEKLZ"]
+    assert list(report_df["Peptide offset"]) == [2, 4]
+
+    csv_path = tmp_path / "scored.csv"
+    write_neoepitope_report(
+        report_df,
+        epitopes,
+        csv_report_path=str(csv_path),
+        epitope_config=EpitopeConfig(score_expr=(
+            "presentation[mhcflurry].score + "
+            "processing[mhcflurry].score")),
+    )
+
+    import pandas as pd
+    result = pd.read_csv(csv_path).set_index("Source sequence name")
+    assert result.loc["XXSIINFEKLAA", "vaxrank_score"] == pytest.approx(0.5)
+    assert result.loc["YYYYSIINFEKLZ", "vaxrank_score"] == pytest.approx(1.7)
+
+
 def test_load_lens_rejects_conflicting_processing_scores(tmp_path):
     """An allele-independent score may repeat, but may not disagree."""
     path = tmp_path / "conflicting-processing.tsv"

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -21,6 +21,7 @@ from mhctools.pred import Prediction
 
 from vaxrank.candidate_epitope import COMPARATOR_WT, CandidateEpitope, Peptide
 from vaxrank.epitope_io import (
+    epitope_prediction_rows,
     predictions_to_dataframe,
     save_predictions,
     load_predictions,
@@ -130,6 +131,77 @@ def test_roundtrip_preserves_values(tmp_path):
     assert _first_leaf(loaded).percentile_rank == pytest.approx(1.23)
     assert loaded.occurs_in_reference is True
     assert loaded.offset == 5
+
+
+def test_native_roundtrip_preserves_evidence_only_predictions(tmp_path):
+    """Native exports retain every evidence kind and its scoring provenance."""
+    predictions = (
+        Prediction(
+            kind="pMHC_presentation",
+            predictor_name="mhcflurry",
+            predictor_version="2.1.1",
+            allele="HLA-A*02:01",
+            peptide="SIINFEKL",
+            value=None,
+            score=0.85,
+            percentile_rank=0.28,
+            tcr="CASSIRSSYEQYF",
+            n_flank="AA",
+            c_flank="LL",
+            source_sequence_name="GENE1",
+            offset=2,
+        ),
+        Prediction(
+            kind="antigen_processing",
+            predictor_name="mhcflurry",
+            predictor_version="2.1.1",
+            allele="",
+            peptide="SIINFEKL",
+            value=None,
+            score=0.73,
+            percentile_rank=None,
+        ),
+    )
+    original = CandidateEpitope(
+        sequence="SIINFEKL",
+        source_sequence="XXSIINFEKLXX",
+        offset=2,
+        predictions=predictions,
+        patient_alleles=("HLA-A*02:01", "HLA-B*07:02"),
+        per_allele_scores={
+            "HLA-A*02:01": 1.58,
+            "HLA-B*07:02": 0.73,
+        },
+    )
+
+    rows = epitope_prediction_rows(original)
+    assert [row["prediction_kind"] for row in rows] == [
+        "antigen_processing", "pMHC_presentation"]
+
+    path = tmp_path / "evidence-only.csv"
+    save_predictions([original], path)
+    exported = predictions_to_dataframe([original])
+    assert len(exported) == 2
+    assert set(exported["prediction_kind"]) == {
+        "antigen_processing", "pMHC_presentation"}
+
+    loaded = load_predictions(path)
+    assert len(loaded) == 1
+    reloaded = loaded[0]
+    assert reloaded.patient_alleles == original.patient_alleles
+    assert reloaded.per_allele_scores == original.per_allele_scores
+    assert reloaded.predictions_flat() == original.predictions_flat()
+
+
+def test_native_reload_rejects_missing_explicit_prediction_score(tmp_path):
+    """New native rows never turn missing scientific evidence into zero."""
+    path = tmp_path / "missing-score.csv"
+    dataframe = predictions_to_dataframe([_make_prediction()])
+    dataframe.loc[0, "prediction_score"] = None
+    dataframe.to_csv(path, index=False)
+
+    with pytest.raises(ValueError, match="missing prediction_score"):
+        load_predictions(path)
 
 
 # ── pVACseq import ───────────────────────────────────────────────────────────

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -954,8 +954,17 @@ def test_lens_context_scores_merge_by_source_position(tmp_path):
     assert result.loc["YYYYSIINFEKLZ", "vaxrank_score"] == pytest.approx(1.7)
 
 
-def test_load_lens_rejects_conflicting_processing_scores(tmp_path):
-    """An allele-independent score may repeat, but may not disagree."""
+def test_load_lens_reports_conflicting_processing_scores_without_aborting(
+        tmp_path, caplog):
+    """A disagreement is surfaced, not fatal.
+
+    An allele-independent score repeated across allele rows should agree —
+    it depends on peptide and flanks, not on MHC. When it doesn't, aborting
+    the load gives the operator nothing to act on and costs them the whole
+    run; the usual cause is a file printing one value at two precisions.
+    """
+    import logging
+
     path = tmp_path / "conflicting-processing.tsv"
     path.write_text(
         "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
@@ -963,8 +972,47 @@ def test_load_lens_rejects_conflicting_processing_scores(tmp_path):
         "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\n"
         "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t60\t0.4\n")
 
-    with pytest.raises(ValueError, match="Conflicting LENS processing"):
-        read_lens_report(path)
+    with caplog.at_level(logging.WARNING):
+        report = read_lens_report(path)
+
+    [epitope] = report.epitopes
+    [processing] = epitope.predictions_for(
+        "antigen_processing", predictor="mhcflurry")
+    # First-seen wins, so the result is deterministic in file order.
+    assert processing.score == pytest.approx(0.8)
+    assert epitope.patient_alleles == ("HLA-A*02:01", "HLA-B*07:02")
+
+    warning = "\n".join(
+        record.getMessage()
+        for record in caplog.records if record.levelno >= logging.WARNING)
+    assert "processing" in warning
+    # The operator needs the peptide and both values to chase it upstream.
+    assert "SIINFEKL" in warning
+    assert "0.8" in warning and "0.4" in warning
+
+
+def test_load_lens_tolerates_reprinted_processing_scores(tmp_path, caplog):
+    """The same value at two precisions is not a disagreement."""
+    import logging
+
+    path = tmp_path / "reprinted-processing.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\n"
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t60\t0.8000\n")
+
+    with caplog.at_level(logging.WARNING):
+        report = read_lens_report(path)
+
+    [epitope] = report.epitopes
+    [processing] = epitope.predictions_for(
+        "antigen_processing", predictor="mhcflurry")
+    assert processing.score == pytest.approx(0.8)
+    assert not [
+        record for record in caplog.records
+        if record.levelno >= logging.WARNING
+        and "processing score" in record.getMessage()]
 
 
 def test_epitope_report_surfaces_integrated_mhcflurry_axes():

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -344,11 +344,10 @@ def test_pvacseq_source_keyed_filtered_scores_do_not_broadcast(tmp_path):
 # ── LENS import ──────────────────────────────────────────────────────────────
 
 def test_load_lens_emits_one_epitope_per_position_with_multi_predictor_leaves():
-    """load_lens groups all per-(allele, predictor) predictions for one
+    """load_lens groups all per-(allele, predictor, kind) predictions for one
     ``(peptide, source, offset)`` position into a single CandidateEpitope.
-    The fixture has 3 rows × 2 predictors = 6 leaf Predictions
-    spread across 3 Epitopes (the adapter dedups by position), and
-    3 report rows."""
+    The fixture has three report rows and each CandidateEpitope carries
+    separate MHCflurry affinity/presentation plus netMHCpan affinity leaves."""
     path = os.path.join(DATA_DIR, "lens_example.tsv")
     report_df, epitopes = load_lens(path)
     assert len(epitopes) == 3
@@ -364,6 +363,14 @@ def test_load_lens_emits_one_epitope_per_position_with_multi_predictor_leaves():
         ms = {p.predictor_name for p in e.predictions_flat()}
         assert ms == {"mhcflurry", "netmhcpan"}
     assert report_df["Predictors used"].iloc[0] == "mhcflurry,netmhcpan"
+    assert report_df["%ile rank"].iloc[0] == pytest.approx(0.45)
+    assert report_df["mhcflurry affinity percentile rank"].iloc[0] == \
+        pytest.approx(0.45)
+    assert report_df["mhcflurry presentation score"].iloc[0] == \
+        pytest.approx(0.85)
+    assert report_df[
+        "mhcflurry presentation percentile rank"].iloc[0] == \
+        pytest.approx(0.28)
 
     # Find the SVVGSSSSS CandidateEpitope and inspect its mhcflurry leaf.
     e = next(
@@ -373,8 +380,14 @@ def test_load_lens_emits_one_epitope_per_position_with_multi_predictor_leaves():
     assert mhcf.allele == "HLA-A*02:01"  # 'HLA-A02:01' normalized
     assert mhcf.peptide == "SVVGSSSSS"
     assert mhcf.value == pytest.approx(95.4)
-    assert mhcf.percentile_rank == pytest.approx(0.28)  # mhcflurry pres_perc
+    assert mhcf.percentile_rank == pytest.approx(0.45)  # mhcflurry aff_perc
     assert mhcf.predictor_version == "2.1.1"
+    presentation = e.predictions_for(
+        'pMHC_presentation', predictor='mhcflurry')[0]
+    assert presentation.allele == "HLA-A*02:01"
+    assert presentation.value is None
+    assert presentation.score == pytest.approx(0.85)
+    assert presentation.percentile_rank == pytest.approx(0.28)
     # wt_ic50 is now derived from mhcflurry_agretopicity (= MT/WT ratio).
     # Fixture row: mhcflurry IC50 = 95.4, agretopicity = 0.020 → WT ≈ 4770.
     # Only mhcflurry leaf gets a WT pair (matches that tool's IC50 scale).
@@ -461,6 +474,104 @@ def test_load_lens_detects_netmhcstabpan():
     assert methods == {"mhcflurry", "netmhcpan", "netmhcstabpan"}
     # Stability value column is labeled with its unit
     assert "netmhcstabpan value (hours)" in report_df.columns
+    # Older LENS output can carry pres_perc without pres_score. Preserve
+    # the percentile leaf with a neutral score instead of dropping it.
+    presentation = epitopes[0].predictions_for(
+        "pMHC_presentation", predictor="mhcflurry")[0]
+    assert presentation.score == 0.0
+    assert presentation.percentile_rank is not None
+
+
+def test_load_lens_preserves_mhcflurry_axes_for_coverage_and_dsl():
+    """Affinity and presentation remain distinct clinical evidence.
+
+    This pins the #265 failure mode: ``pres_perc`` must not overwrite
+    ``aff_perc``, and the presentation axis must independently drive
+    coverage and Topiary DSL scoring.
+    """
+    from vaxrank.coverage import compute_coverage
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import score_predictions
+
+    path = os.path.join(DATA_DIR, "lens_example.tsv")
+    _, epitopes = load_lens(path)
+    epitope = next(e for e in epitopes if e.sequence == "SVVGSSSSS")
+
+    coverage = compute_coverage([epitope], ["HLA-A*02:01"])["HLA-A*02:01"]
+    # Coverage aggregates the best affinity evidence across models;
+    # netMHCpan's 0.30 beats MHCflurry's independently preserved 0.45.
+    assert coverage.best_affinity_pct == pytest.approx(0.30)
+    assert coverage.best_presentation_pct == pytest.approx(0.28)
+
+    scores = score_predictions(
+        [epitope],
+        EpitopeConfig(score_expr="presentation[mhcflurry].score"))
+    assert list(scores) == [pytest.approx(0.85)]
+
+
+def test_load_lens_preserves_allele_independent_processing_once():
+    """Repeated LENS allele rows yield one canonical processing leaf."""
+    path = os.path.join(
+        DATA_DIR, "real_lens_subsets", "lens_v1.9_real_subset.tsv")
+    report_df, epitopes = load_lens(path)
+    epitope = epitopes[0]
+    processing = epitope.predictions_for(
+        "antigen_processing", predictor="mhcflurry")
+
+    assert len(processing) == 1
+    assert processing[0].allele == ""
+    assert processing[0].score == pytest.approx(
+        report_df["mhcflurry processing score"].iloc[0])
+    assert all(epitope.per_allele_scores)
+
+
+def test_load_lens_rejects_conflicting_processing_scores(tmp_path):
+    """An allele-independent score may repeat, but may not disagree."""
+    path = tmp_path / "conflicting-processing.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\n"
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t60\t0.4\n")
+
+    with pytest.raises(ValueError, match="Conflicting LENS processing"):
+        load_lens(path)
+
+
+def test_epitope_report_surfaces_integrated_mhcflurry_axes():
+    """Clinical rows distinguish integrated MHCflurry and pepsickle scores.
+
+    Mixed-predictor tables retain identical columns; the netMHCpan affinity
+    row gets explicit placeholders because those integrated axes came from
+    MHCflurry rather than netMHCpan.
+    """
+    from vaxrank.report import TemplateDataCreator
+
+    path = os.path.join(
+        DATA_DIR, "real_lens_subsets", "lens_v1.4_real_subset.tsv")
+    _, epitopes = load_lens(path)
+    epitope = epitopes[0]
+    mhcflurry_affinity = epitope.predictions_for(
+        "pMHC_affinity", predictor="mhcflurry")[0]
+    netmhcpan_affinity = epitope.predictions_for(
+        "pMHC_affinity", predictor="netmhcpan")[0]
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = {}
+
+    mhcflurry_row = creator.epitope_data(
+        epitope, mhcflurry_affinity,
+        include_additional_prediction_axes=True)
+    netmhcpan_row = creator.epitope_data(
+        epitope, netmhcpan_affinity,
+        include_additional_prediction_axes=True)
+
+    assert mhcflurry_row["Presentation score"] != "—"
+    assert mhcflurry_row["Presentation %ile"] != "—"
+    assert mhcflurry_row["Integrated processing score"] != "—"
+    assert netmhcpan_row["Presentation score"] == "—"
+    assert netmhcpan_row["Presentation %ile"] == "—"
+    assert netmhcpan_row["Integrated processing score"] == "—"
+    assert tuple(mhcflurry_row) == tuple(netmhcpan_row)
 
 
 # ── DSL integration for external inputs ──────────────────────────────────────
@@ -1160,9 +1271,9 @@ def test_real_lens_v15_emits_both_affinity_predictors():
     leaves = _leaves(epitopes)
     methods = {p.predictor_name for p in leaves}
     assert methods == {"mhcflurry", "netmhcpan"}
-    # Each CandidateEpitope spawns up to N leaves (N = detected count); NA
-    # cells produce fewer.
-    assert len(leaves) <= 2 * len(report_df)
+    # MHCflurry contributes affinity + presentation + processing while
+    # netMHCpan contributes affinity. NA cells produce fewer leaves.
+    assert len(leaves) <= 4 * len(report_df)
     predictors_used = report_df["Predictors used"].iloc[0]
     assert predictors_used.startswith("mhcflurry")
 
@@ -1174,8 +1285,13 @@ def test_real_lens_v19_is_mhcflurry_only():
     leaves = _leaves(epitopes)
     methods = {p.predictor_name for p in leaves}
     assert methods == {"mhcflurry"}
-    # Real data has HLA alleles in the un-asterisked form; loader normalizes.
-    assert all(p.allele.startswith("HLA-") and "*" in p.allele for p in leaves)
+    # Real data has HLA alleles in the un-asterisked form; loader normalizes
+    # every allele-specific leaf. Processing is intentionally allele-less.
+    allele_specific = [p for p in leaves if p.allele]
+    assert all(
+        p.allele.startswith("HLA-") and "*" in p.allele
+        for p in allele_specific)
+    assert any(p.kind == "antigen_processing" and not p.allele for p in leaves)
 
 
 def test_real_lens_dsl_scoring_all_versions(tmp_path):
@@ -1263,7 +1379,8 @@ def test_lens_dsl_stability_and_affinity_combined(tmp_path):
     report_df, epitopes = load_lens(path)
     leaves = [p for e in epitopes for p in e.predictions_flat()]
     kinds_seen = {p.kind for p in leaves}
-    assert kinds_seen == {"pMHC_affinity", "pMHC_stability"}
+    assert kinds_seen == {
+        "pMHC_affinity", "pMHC_presentation", "pMHC_stability"}
 
     cfg = EpitopeConfig(
         score_expr=(

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -563,6 +563,105 @@ def test_lens_processing_dsl_scores_every_patient_allele(tmp_path):
     }
 
 
+def test_lens_processing_only_rows_preserve_alleles_scores_and_report_rows(
+        tmp_path):
+    """Processing-only LENS evidence stays allele-scoped end to end."""
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import (
+        attach_per_allele_scores,
+        epitopes_to_topiary_df,
+    )
+    from vaxrank.report import TemplateDataCreator, epitope_report_row_inputs
+
+    path = tmp_path / "processing-only.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t\t0.8\n"
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t\t0.8\n")
+
+    report_df, epitopes = load_lens(path)
+    assert len(epitopes) == 1
+    epitope = epitopes[0]
+    assert epitope.patient_alleles == (
+        "HLA-A*02:01", "HLA-B*07:02")
+    processing = epitope.predictions_for(
+        "antigen_processing", predictor="mhcflurry")
+    assert len(processing) == 1
+    assert processing[0].allele == ""
+
+    topiary_df = epitopes_to_topiary_df(epitopes)
+    assert set(topiary_df["allele"]) == {
+        "HLA-A*02:01", "HLA-B*07:02"}
+    config = EpitopeConfig(
+        score_expr="processing[mhcflurry].score")
+    scored = attach_per_allele_scores(epitopes, config)
+    assert scored[0].per_allele_scores == {
+        "HLA-A*02:01": pytest.approx(0.8),
+        "HLA-B*07:02": pytest.approx(0.8),
+    }
+
+    csv_path = tmp_path / "scored.csv"
+    write_neoepitope_report(
+        report_df,
+        epitopes,
+        csv_report_path=str(csv_path),
+        epitope_config=config,
+    )
+    import pandas as pd
+    assert list(pd.read_csv(csv_path)["vaxrank_score"]) == [0.8, 0.8]
+
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = {}
+    row_inputs = epitope_report_row_inputs(scored[0])
+    rows = [
+        creator.epitope_data(
+            scored[0], row_input.prediction,
+            allele=row_input.allele,
+            include_additional_prediction_axes=True)
+        for row_input in row_inputs
+    ]
+    assert [row["Allele"] for row in rows] == ["A*02:01", "B*07:02"]
+    assert [row["Score"] for row in rows] == ["0.8", "0.8"]
+    assert all(row["Integrated processing score"] == "0.800" for row in rows)
+
+
+def test_lens_presentation_only_candidate_has_a_template_report_row(tmp_path):
+    """Presentation evidence anchors a table row when affinity is absent."""
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import attach_per_allele_scores
+    from vaxrank.report import TemplateDataCreator, epitope_report_row_inputs
+
+    path = tmp_path / "presentation-only.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.pres_score\tmhcflurry_2.1.1.pres_perc\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t\t0.85\t0.28\n")
+
+    _, epitopes = load_lens(path)
+    config = EpitopeConfig(
+        score_expr="presentation[mhcflurry].score")
+    epitope = attach_per_allele_scores(epitopes, config)[0]
+    row_inputs = epitope_report_row_inputs(epitope)
+    assert len(row_inputs) == 1
+    assert row_inputs[0].prediction.kind == "pMHC_presentation"
+    assert row_inputs[0].allele == "HLA-A*02:01"
+
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = {}
+    row = creator.epitope_data(
+        epitope,
+        row_inputs[0].prediction,
+        allele=row_inputs[0].allele,
+        include_additional_prediction_axes=True,
+    )
+    assert row["Allele"] == "A*02:01"
+    assert row["Score"] == "0.85"
+    assert row["IC50"] == "No prediction"
+    assert row["Presentation score"] == "0.850"
+    assert row["Presentation %ile"] == "0.280"
+
+
 def test_lens_context_scores_merge_by_source_position(tmp_path):
     """Equal peptide/allele rows retain context-specific integrated scores."""
     from vaxrank.epitope_config import EpitopeConfig

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -56,6 +56,16 @@ def test_external_prediction_key_is_legible_stable_and_round_trippable():
     assert ExternalPredictionKey.from_identifier(identifier) == key
     assert key.construct_identifier != key.identifier
 
+    # Annotation is carried but deliberately excluded from the identity:
+    # which gene a report named first is presentation, and folding it in
+    # would make two rows describing one candidate into two candidates.
+    annotated = dataclasses.replace(
+        key, primary_gene_name="GENE2", primary_transcript_id="ENST2")
+    assert annotated.identifier == identifier
+    # So a reconstructed key carries the identity but not that annotation —
+    # equality holds against the un-annotated key, not the annotated one.
+    assert ExternalPredictionKey.from_identifier(identifier) != annotated
+
 
 def test_native_round_trip_preserves_external_prediction_identity(tmp_path):
     key = ExternalPredictionKey(

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -30,8 +30,56 @@ from vaxrank.epitope_io import (
     load_lens,
     write_neoepitope_report,
 )
+from vaxrank.external_prediction import ExternalPredictionKey
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data", "epitope_fixtures")
+
+
+def test_external_prediction_key_is_legible_stable_and_round_trippable():
+    key = ExternalPredictionKey(
+        source_format="lens",
+        variant_id="chr1:1000",
+        antigen_source="SNV",
+        gene_ids=("ENSG2", "ENSG1"),
+        gene_names=("GENE2", "GENE1"),
+        transcript_ids=("ENST2", "ENST1"),
+        peptide="SIINFEKL",
+        source_sequence="AASIINFEKLLL",
+        offset=2,
+    )
+
+    identifier = key.identifier
+
+    assert '"variant_id":"chr1:1000"' in identifier
+    assert '"gene_ids":["ENSG1","ENSG2"]' in identifier
+    assert ExternalPredictionKey.from_identifier(identifier) == key
+    assert key.construct_identifier != key.identifier
+
+
+def test_native_round_trip_preserves_external_prediction_identity(tmp_path):
+    key = ExternalPredictionKey(
+        source_format="lens",
+        variant_id="chr1:1000",
+        gene_names=("GENE1",),
+        transcript_ids=("ENST1",),
+        peptide="SIINFEKL",
+        source_sequence="AASIINFEKLLL",
+        offset=2,
+    )
+    original = _make_prediction()
+    original = CandidateEpitope.from_peptide(
+        original,
+        comparators=original.comparators,
+        source_class=original.source_class,
+        overlaps_mutation=original.overlaps_mutation,
+        prediction_id=key.identifier,
+    )
+
+    path = tmp_path / "external-provenance.csv"
+    save_predictions([original], path)
+    reloaded = load_predictions(path)[0]
+
+    assert reloaded.prediction_id == key.identifier
 
 
 def test_lens_epitope_position_uses_source_context_and_offset():
@@ -468,9 +516,17 @@ def test_pvacseq_source_keyed_filtered_scores_do_not_broadcast(tmp_path):
         epitope_config=cfg)
 
     result = pd.read_csv(csv_path)
-    by_source = result.set_index("Source sequence name")["vaxrank_score"]
-    assert by_source["chr1-154590262-T-A"] == pytest.approx(76.11)
-    assert by_source["chr2-200000-G-C"] == 0.0
+    by_source = result.set_index("Source sequence name")
+    assert by_source.loc[
+        "chr1-154590262-T-A", "vaxrank_score"] == pytest.approx(76.11)
+    assert by_source.loc[
+        "chr1-154590262-T-A", "vaxrank_filter_passed"]
+    assert pd.isna(by_source.loc[
+        "chr2-200000-G-C", "vaxrank_score"])
+    assert not by_source.loc[
+        "chr2-200000-G-C", "vaxrank_filter_passed"]
+    assert by_source.loc[
+        "chr2-200000-G-C", "vaxrank_exclusion_reason"] == "dsl_filter"
 
 
 # ── LENS import ──────────────────────────────────────────────────────────────
@@ -1330,9 +1386,9 @@ def test_filter_plus_score_expr_both_bracketed(tmp_path):
     assert (result["vaxrank_score"] > 0).any()
 
 
-def test_filter_expr_drops_all_groups_yields_zero_scores(tmp_path):
-    """A filter that matches no rows should produce a report with all
-    scores = 0 (not crash)."""
+def test_filter_expr_drops_all_groups_marks_audit_rows_without_fake_scores(
+        tmp_path):
+    """Filtered audit rows are explicit and never acquire synthetic zeros."""
     from vaxrank.epitope_config import EpitopeConfig
     from vaxrank.epitope_io import write_neoepitope_report
 
@@ -1345,7 +1401,32 @@ def test_filter_expr_drops_all_groups_yields_zero_scores(tmp_path):
         report_df, preds, csv_report_path=str(csv_path), epitope_config=cfg)
     import pandas as pd
     result = pd.read_csv(csv_path)
-    assert (result["vaxrank_score"] == 0).all()
+    assert result["vaxrank_score"].isna().all()
+    assert not result["vaxrank_filter_passed"].any()
+    assert not result["vaxrank_rank_eligible"].any()
+    assert set(result["vaxrank_exclusion_reason"]) == {"dsl_filter"}
+
+
+def test_report_distinguishes_below_minimum_from_dsl_filter(tmp_path):
+    """A real score below the ranking gate remains visible and classified."""
+    from vaxrank.epitope_config import EpitopeConfig
+
+    path = os.path.join(DATA_DIR, "lens_example.tsv")
+    report_df, preds = load_lens(path)
+    csv_path = tmp_path / "below-minimum.csv"
+    write_neoepitope_report(
+        report_df,
+        preds,
+        csv_report_path=str(csv_path),
+        epitope_config=EpitopeConfig(min_epitope_score=2.0),
+    )
+    import pandas as pd
+    result = pd.read_csv(csv_path)
+
+    assert result["vaxrank_score"].notna().all()
+    assert result["vaxrank_filter_passed"].all()
+    assert not result["vaxrank_rank_eligible"].any()
+    assert set(result["vaxrank_exclusion_reason"]) == {"min_epitope_score"}
 
 
 def test_mixed_bracketed_and_unqualified_evaluates_cleanly(tmp_path):

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -662,6 +662,61 @@ def test_lens_presentation_only_candidate_has_a_template_report_row(tmp_path):
     assert row["Presentation %ile"] == "0.280"
 
 
+def test_lens_report_anchors_mixed_evidence_per_allele_and_predictor(tmp_path):
+    """Each allele/predictor gets its strongest available report anchor."""
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import attach_per_allele_scores
+    from vaxrank.report import TemplateDataCreator, epitope_report_row_inputs
+
+    path = tmp_path / "mixed-evidence.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.pres_score\tmhcflurry_2.1.1.proc_score\t"
+        "netmhcpan_4.1.aff_nm\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\t0.7\t\n"
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t\t0.6\t0.7\t75\n"
+        "SIINFEKL\tHLA-C07:02\tXXSIINFEKLXX\t\t\t0.7\t\n")
+
+    _, epitopes = load_lens(path)
+    epitope = attach_per_allele_scores(
+        epitopes,
+        EpitopeConfig(score_expr="processing[mhcflurry].score"),
+    )[0]
+    row_inputs = epitope_report_row_inputs(epitope)
+    assert [
+        (row.allele, row.prediction.predictor_name, row.prediction.kind)
+        for row in row_inputs
+    ] == [
+        ("HLA-A*02:01", "mhcflurry", "pMHC_affinity"),
+        ("HLA-B*07:02", "netmhcpan", "pMHC_affinity"),
+        ("HLA-B*07:02", "mhcflurry", "pMHC_presentation"),
+        ("HLA-C*07:02", "mhcflurry", "antigen_processing"),
+    ]
+
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = {}
+    report_rows = [
+        creator.epitope_data(
+            epitope,
+            row_input.prediction,
+            allele=row_input.allele,
+            include_additional_prediction_axes=True,
+        )
+        for row_input in row_inputs
+    ]
+    by_key = {
+        (row["Allele"], row["Predictor"]): row for row in report_rows}
+    assert by_key[("A*02:01", "mhcflurry")]["IC50"] == "50.00 nM"
+    assert by_key[("A*02:01", "mhcflurry")][
+        "Presentation score"] == "0.800"
+    assert by_key[("B*07:02", "netmhcpan")]["IC50"] == "75.00 nM"
+    assert by_key[("B*07:02", "mhcflurry")][
+        "Presentation score"] == "0.600"
+    assert by_key[("C*07:02", "mhcflurry")][
+        "Integrated processing score"] == "0.700"
+    assert all(row["Score"] == "0.7" for row in report_rows)
+
+
 def test_lens_context_scores_merge_by_source_position(tmp_path):
     """Equal peptide/allele rows retain context-specific integrated scores."""
     from vaxrank.epitope_config import EpitopeConfig

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -14,6 +14,7 @@
 Tests for epitope_io: serialization, deserialization, and external imports.
 """
 
+import dataclasses
 import os
 
 import pytest
@@ -26,8 +27,8 @@ from vaxrank.epitope_io import (
     save_predictions,
     lens_epitope_position,
     load_predictions,
-    load_pvacseq,
-    load_lens,
+    read_pvacseq_report,
+    read_lens_report,
     write_neoepitope_report,
 )
 from vaxrank.external_prediction import ExternalPredictionKey
@@ -316,7 +317,8 @@ def test_native_roundtrip_preserves_complete_wt_prediction(tmp_path):
 
 def test_load_pvacseq():
     path = os.path.join(DATA_DIR, "pvacseq_example.tsv")
-    report_df, epitopes = load_pvacseq(path)
+    _loaded = read_pvacseq_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     # One CandidateEpitope per pVACseq row (each row has its own peptide).
     assert len(epitopes) == 3
     assert len(report_df) == 3
@@ -352,7 +354,8 @@ def test_load_pvacseq_populates_per_allele_scores():
     ranking as 'no epitopes for peptide'. Pin both ends: scores are
     non-empty and (for binding-affinity rows) non-zero."""
     path = os.path.join(DATA_DIR, "pvacseq_example.tsv")
-    _, epitopes = load_pvacseq(path)
+    _loaded = read_pvacseq_report(path)
+    epitopes = list(_loaded.epitopes)
     assert epitopes
     # Every epitope has scores keyed by its actual allele(s).
     for e in epitopes:
@@ -372,7 +375,7 @@ def test_load_pvacseq_missing_columns(tmp_path):
     bad_file = tmp_path / "bad.tsv"
     bad_file.write_text("Gene\tAA Change\nTP53\tG245S\n")
     with pytest.raises(ValueError, match="Could not detect pVACseq format"):
-        load_pvacseq(bad_file)
+        read_pvacseq_report(bad_file)
 
 
 def _write_pvacseq_all_epitopes_fixture(tmp_path):
@@ -460,7 +463,8 @@ def _write_pvacseq_duplicate_peptide_fixture(tmp_path):
 
 def test_load_pvacseq_all_epitopes_flavor(tmp_path):
     path = _write_pvacseq_all_epitopes_fixture(tmp_path)
-    report_df, epitopes = load_pvacseq(path)
+    _loaded = read_pvacseq_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
 
     assert len(report_df) == 3
     # Same source + peptide groups the two AERMGFTVV alleles together.
@@ -483,7 +487,8 @@ def test_pvacseq_all_epitopes_per_algorithm_column_scores(tmp_path):
     import pandas as pd
 
     path = _write_pvacseq_all_epitopes_fixture(tmp_path)
-    report_df, epitopes = load_pvacseq(path)
+    _loaded = read_pvacseq_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     csv_path = tmp_path / "scored.csv"
     cfg = EpitopeConfig(score_expr="pvacseq_mhcflurry_ic50_mt")
 
@@ -505,7 +510,8 @@ def test_pvacseq_source_keyed_filtered_scores_do_not_broadcast(tmp_path):
     import pandas as pd
 
     path = _write_pvacseq_duplicate_peptide_fixture(tmp_path)
-    report_df, epitopes = load_pvacseq(path)
+    _loaded = read_pvacseq_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     csv_path = tmp_path / "filtered.csv"
     cfg = EpitopeConfig(
         filter_expr="tumor_dna_vaf > 0.5",
@@ -537,7 +543,8 @@ def test_load_lens_emits_one_epitope_per_position_with_multi_predictor_leaves():
     The fixture has three report rows and each CandidateEpitope carries
     separate MHCflurry affinity/presentation plus netMHCpan affinity leaves."""
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     assert len(epitopes) == 3
     assert len(report_df) == 3
 
@@ -592,7 +599,8 @@ def test_load_lens_populates_per_allele_scores():
     the LENS loader must populate per_allele_scores so downstream
     ranking doesn't drop every variant as zero-scoring."""
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    _, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    epitopes = list(_loaded.epitopes)
     assert epitopes
     for e in epitopes:
         assert e.per_allele_scores, (
@@ -606,7 +614,7 @@ def test_load_lens_report_display_uses_canonical_predictor():
     netmhcpan > alphabetical). Per-predictor raw values land in
     individual columns alongside."""
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, _ = load_lens(path)
+    report_df = read_lens_report(path).report_df
     # Display value = mhcflurry 95.4 nM (canonical)
     assert "95.40 nM" in report_df["Predicted mutant pMHC affinity"].iloc[0]
     # Both raw-value columns present
@@ -617,7 +625,8 @@ def test_load_lens_report_display_uses_canonical_predictor():
 def test_load_lens_mhcflurry_only_v19():
     """A v1.9-dev style file (no netmhcpan cols) emits only mhcflurry rows."""
     path = os.path.join(DATA_DIR, "lens_v1.9_mhcflurry_only.tsv")
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     assert len(epitopes) == 3
     leaves = [p for e in epitopes for p in e.predictions_flat()]
     methods = {p.predictor_name for p in leaves}
@@ -641,7 +650,7 @@ def test_load_lens_missing_required_columns(tmp_path):
     bad_file = tmp_path / "bad.tsv"
     bad_file.write_text("gene_name\tpos\nTP53\t5\n")
     with pytest.raises(ValueError, match="missing required columns"):
-        load_lens(bad_file)
+        read_lens_report(bad_file)
 
 
 def test_load_lens_no_predictor_columns(tmp_path):
@@ -650,13 +659,14 @@ def test_load_lens_no_predictor_columns(tmp_path):
     bad_file.write_text(
         "peptide\tallele\tgene_name\nSIINFEKL\tHLA-A*02:01\tOVA\n")
     with pytest.raises(ValueError, match="no recognized predictor"):
-        load_lens(bad_file)
+        read_lens_report(bad_file)
 
 
 def test_load_lens_detects_netmhcstabpan():
     """netmhcstabpan columns are detected as a pMHC_stability predictor."""
     path = os.path.join(DATA_DIR, "lens_v1.4_with_stability.tsv")
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     leaves = [p for e in epitopes for p in e.predictions_flat()]
     methods = {p.predictor_name for p in leaves}
     assert methods == {"mhcflurry", "netmhcpan", "netmhcstabpan"}
@@ -682,7 +692,8 @@ def test_load_lens_preserves_mhcflurry_axes_for_coverage_and_dsl():
     from vaxrank.epitope_dsl import score_predictions
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    _, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    epitopes = list(_loaded.epitopes)
     epitope = next(e for e in epitopes if e.sequence == "SVVGSSSSS")
 
     coverage = compute_coverage([epitope], ["HLA-A*02:01"])["HLA-A*02:01"]
@@ -701,7 +712,8 @@ def test_load_lens_preserves_allele_independent_processing_once():
     """Repeated LENS allele rows yield one canonical processing leaf."""
     path = os.path.join(
         DATA_DIR, "real_lens_subsets", "lens_v1.9_real_subset.tsv")
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     epitope = epitopes[0]
     processing = epitope.predictions_for(
         "antigen_processing", predictor="mhcflurry")
@@ -728,7 +740,8 @@ def test_lens_processing_dsl_scores_every_patient_allele(tmp_path):
         "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\n"
         "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t60\t0.8\n")
 
-    _, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    epitopes = list(_loaded.epitopes)
     assert len(epitopes) == 1
     epitope = epitopes[0]
     processing = epitope.predictions_for(
@@ -768,7 +781,8 @@ def test_lens_processing_only_rows_preserve_alleles_scores_and_report_rows(
         "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t\t0.8\n"
         "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t\t0.8\n")
 
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     assert len(epitopes) == 1
     epitope = epitopes[0]
     assert epitope.patient_alleles == (
@@ -826,7 +840,8 @@ def test_lens_presentation_only_candidate_has_a_template_report_row(tmp_path):
         "mhcflurry_2.1.1.pres_score\tmhcflurry_2.1.1.pres_perc\n"
         "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t\t0.85\t0.28\n")
 
-    _, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    epitopes = list(_loaded.epitopes)
     config = EpitopeConfig(
         score_expr="presentation[mhcflurry].score")
     epitope = attach_per_allele_scores(epitopes, config)[0]
@@ -865,7 +880,8 @@ def test_lens_report_anchors_mixed_evidence_per_allele_and_predictor(tmp_path):
         "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t\t0.6\t0.7\t75\n"
         "SIINFEKL\tHLA-C07:02\tXXSIINFEKLXX\t\t\t0.7\t\n")
 
-    _, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    epitopes = list(_loaded.epitopes)
     epitope = attach_per_allele_scores(
         epitopes,
         EpitopeConfig(score_expr="processing[mhcflurry].score"),
@@ -916,7 +932,8 @@ def test_lens_context_scores_merge_by_source_position(tmp_path):
         "SIINFEKL\tHLA-A02:01\tXXSIINFEKLAA\t50\t0.2\t0.3\n"
         "SIINFEKL\tHLA-A02:01\tYYYYSIINFEKLZ\t60\t0.9\t0.8\n")
 
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     assert list(report_df["Source sequence name"]) == [
         "XXSIINFEKLAA", "YYYYSIINFEKLZ"]
     assert list(report_df["Peptide offset"]) == [2, 4]
@@ -947,7 +964,7 @@ def test_load_lens_rejects_conflicting_processing_scores(tmp_path):
         "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t60\t0.4\n")
 
     with pytest.raises(ValueError, match="Conflicting LENS processing"):
-        load_lens(path)
+        read_lens_report(path)
 
 
 def test_epitope_report_surfaces_integrated_mhcflurry_axes():
@@ -961,7 +978,8 @@ def test_epitope_report_surfaces_integrated_mhcflurry_axes():
 
     path = os.path.join(
         DATA_DIR, "real_lens_subsets", "lens_v1.4_real_subset.tsv")
-    _, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    epitopes = list(_loaded.epitopes)
     epitope = epitopes[0]
     mhcflurry_affinity = epitope.predictions_for(
         "pMHC_affinity", predictor="mhcflurry")[0]
@@ -995,7 +1013,8 @@ def test_default_methods_resolves_multi_model_affinity(tmp_path):
     from vaxrank.epitope_config import EpitopeConfig
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
 
     # Explicit default = netmhcpan → score reflects netmhcpan affinity.
     cfg = EpitopeConfig(default_methods={"pMHC_affinity": "netmhcpan"})
@@ -1027,7 +1046,8 @@ def test_default_methods_rejects_unknown_method(tmp_path):
     from vaxrank.epitope_config import EpitopeConfig
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     cfg = EpitopeConfig(default_methods={"pMHC_affinity": "mhcnuggets"})
     with pytest.raises(ValueError, match="default_methods.*mhcnuggets"):
         write_neoepitope_report(
@@ -1043,7 +1063,8 @@ def test_default_methods_partial_qualification_mixed_kinds(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_v1.4_with_stability.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     # Formula: affinity qualified (netmhcpan), stability unqualified.
     # default_methods settles the stability kind.
     cfg = EpitopeConfig(
@@ -1069,7 +1090,8 @@ def test_default_methods_partial_qualification_auto_picks_stability(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_v1.4_with_stability.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     # Only one stability method (netmhcstabpan) in this fixture, so
     # auto-pick is trivial but tests the path.
     cfg = EpitopeConfig(
@@ -1094,7 +1116,8 @@ def test_filter_expr_unqualified_on_multi_method_data(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     # fixture's mhcflurry affinities: 95.4, 180.2, 310.5. Cut at 200 keeps
     # 2 rows; with netmhcpan as the default, cut at 200 would keep rows
     # with IC50 < 200 from netmhcpan: 76.11, 120.50 (2 rows).
@@ -1132,7 +1155,8 @@ def test_resolve_default_methods_noop_on_single_method_data():
         epitopes_to_topiary_df, resolve_default_methods)
 
     path = os.path.join(DATA_DIR, "lens_v1.9_mhcflurry_only.tsv")
-    _, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    preds = list(_loaded.epitopes)
     df = epitopes_to_topiary_df(preds)
     assert resolve_default_methods(EpitopeConfig(), df) == {}
 
@@ -1145,7 +1169,8 @@ def test_resolve_default_methods_auto_picks_canonical():
         epitopes_to_topiary_df, resolve_default_methods)
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    _, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    preds = list(_loaded.epitopes)
     df = epitopes_to_topiary_df(preds)
     assert resolve_default_methods(EpitopeConfig(), df) == {
         "pMHC_affinity": "mhcflurry"}
@@ -1158,7 +1183,8 @@ def test_resolve_default_methods_user_override_wins():
         epitopes_to_topiary_df, resolve_default_methods)
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    _, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    preds = list(_loaded.epitopes)
     df = epitopes_to_topiary_df(preds)
     cfg = EpitopeConfig(default_methods={"pMHC_affinity": "netmhcpan"})
     assert resolve_default_methods(cfg, df) == {"pMHC_affinity": "netmhcpan"}
@@ -1176,29 +1202,31 @@ def test_default_methods_works_on_synthetic_main_pipeline_frame(tmp_path):
 
     # Build a minimal topiary-shaped frame with two models per group —
     # exactly what we'd get from a multi-model TopiaryPredictor in the
-    # main pipeline, no LENS loader involved.
+    # main pipeline, no LENS loader involved. ``prediction_id`` is present
+    # because ``epitopes_to_topiary_df`` always emits it: the score group is
+    # an explicit identity, never inferred from the sequence.
     df = pd.DataFrame([
         # group 1: SIINFEKL × HLA-A*02:01, two affinity predictors
-        {"sample_name": "", "source_sequence_name": "ovalbumin",
+        {"prediction_id": "ovalbumin", "source_sequence_name": "ovalbumin",
          "peptide": "SIINFEKL", "peptide_offset": 5, "peptide_length": 8,
          "allele": "HLA-A*02:01", "n_flank": "", "c_flank": "",
          "prediction_method_name": "mhcflurry", "predictor_version": "2.1.1",
          "kind": "pMHC_affinity", "value": 80.0, "affinity": 80.0,
          "percentile_rank": 0.4, "score": 0.0},
-        {"sample_name": "", "source_sequence_name": "ovalbumin",
+        {"prediction_id": "ovalbumin", "source_sequence_name": "ovalbumin",
          "peptide": "SIINFEKL", "peptide_offset": 5, "peptide_length": 8,
          "allele": "HLA-A*02:01", "n_flank": "", "c_flank": "",
          "prediction_method_name": "netmhcpan", "predictor_version": "4.1b",
          "kind": "pMHC_affinity", "value": 120.0, "affinity": 120.0,
          "percentile_rank": 0.7, "score": 0.0},
         # group 2: another peptide+allele
-        {"sample_name": "", "source_sequence_name": "p53",
+        {"prediction_id": "p53", "source_sequence_name": "p53",
          "peptide": "STPPPGTRV", "peptide_offset": 10, "peptide_length": 9,
          "allele": "HLA-B*07:02", "n_flank": "", "c_flank": "",
          "prediction_method_name": "mhcflurry", "predictor_version": "2.1.1",
          "kind": "pMHC_affinity", "value": 250.0, "affinity": 250.0,
          "percentile_rank": 1.5, "score": 0.0},
-        {"sample_name": "", "source_sequence_name": "p53",
+        {"prediction_id": "p53", "source_sequence_name": "p53",
          "peptide": "STPPPGTRV", "peptide_offset": 10, "peptide_length": 9,
          "allele": "HLA-B*07:02", "n_flank": "", "c_flank": "",
          "prediction_method_name": "netmhcpan", "predictor_version": "4.1b",
@@ -1233,7 +1261,8 @@ def test_resolve_default_methods_stability_plus_affinity():
         epitopes_to_topiary_df, resolve_default_methods)
 
     path = os.path.join(DATA_DIR, "lens_v1.4_with_stability.tsv")
-    _, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    preds = list(_loaded.epitopes)
     df = epitopes_to_topiary_df(preds)
     resolved = resolve_default_methods(EpitopeConfig(), df)
     # pMHC_affinity has mhcflurry + netmhcpan → needs default
@@ -1263,7 +1292,8 @@ def test_default_methods_mixed_valid_and_invalid_fails_fast(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_v1.4_with_stability.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     cfg = EpitopeConfig(default_methods={
         "pMHC_affinity": "mhcflurry",      # valid
         "pMHC_stability": "doesnotexist",  # invalid
@@ -1283,7 +1313,8 @@ def test_report_columns_expose_all_detected_predictors(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     cfg = EpitopeConfig(
         score_expr="affinity['mhcflurry'].logistic(350, 150)")
     csv_path = tmp_path / "out.csv"
@@ -1303,7 +1334,8 @@ def test_predictor_version_in_epitope_prediction_from_lens():
     """Every LENS-loaded leaf ``Prediction`` should carry the sniffed
     predictor version, so version-qualified DSL refs resolve."""
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    _, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    epitopes = list(_loaded.epitopes)
     leaves = [p for e in epitopes for p in e.predictions_flat()]
     by_method = {p.predictor_name: p.predictor_version for p in leaves}
     assert by_method["mhcflurry"] == "2.1.1"
@@ -1317,7 +1349,8 @@ def test_dsl_version_mismatch_validation_error(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     cfg = EpitopeConfig(
         score_expr="affinity['mhcflurry', '0.0.0'].logistic(350, 150)")
     with pytest.raises(ValueError, match="predictor version '0.0.0'"):
@@ -1342,7 +1375,8 @@ def test_validate_default_methods_no_defaults_is_noop():
     from vaxrank.epitope_dsl import (
         epitopes_to_topiary_df, validate_default_methods)
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    _, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    preds = list(_loaded.epitopes)
     df = epitopes_to_topiary_df(preds)
     validate_default_methods(EpitopeConfig(), df)  # no raise
 
@@ -1356,7 +1390,8 @@ def test_validate_default_methods_catches_typo_on_single_method_kind(tmp_path):
         epitopes_to_topiary_df, validate_default_methods)
     # Single-model fixture (v1.9 mhcflurry-only).
     path = os.path.join(DATA_DIR, "lens_v1.9_mhcflurry_only.tsv")
-    _, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    preds = list(_loaded.epitopes)
     df = epitopes_to_topiary_df(preds)
     cfg = EpitopeConfig(default_methods={"pMHC_affinity": "bogus"})
     with pytest.raises(ValueError,
@@ -1371,7 +1406,8 @@ def test_filter_plus_score_expr_both_bracketed(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     cfg = EpitopeConfig(
         filter_expr="affinity['netmhcpan'] <= 500",
         score_expr="affinity['mhcflurry'].logistic(350, 150)",
@@ -1393,7 +1429,8 @@ def test_filter_expr_drops_all_groups_marks_audit_rows_without_fake_scores(
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     # No affinity < 0 anywhere.
     cfg = EpitopeConfig(filter_expr="affinity <= 0")
     csv_path = tmp_path / "out.csv"
@@ -1412,7 +1449,8 @@ def test_report_distinguishes_below_minimum_from_dsl_filter(tmp_path):
     from vaxrank.epitope_config import EpitopeConfig
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     csv_path = tmp_path / "below-minimum.csv"
     write_neoepitope_report(
         report_df,
@@ -1438,7 +1476,8 @@ def test_mixed_bracketed_and_unqualified_evaluates_cleanly(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     # Brackets netmhcpan AND references affinity unqualified. Default
     # auto-picks mhcflurry for unqualified refs. Result: netmhcpan_value +
     # mhcflurry_value per row, evaluated cleanly.
@@ -1461,7 +1500,8 @@ def test_pvacseq_single_method_per_group_has_no_ambiguity(tmp_path):
     unambiguous — the default node should score without error."""
     from vaxrank.epitope_io import write_neoepitope_report
     path = os.path.join(DATA_DIR, "pvacseq_example.tsv")
-    report_df, preds = load_pvacseq(path)
+    _loaded = read_pvacseq_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     csv_path = tmp_path / "out.csv"
     # Default EpitopeConfig, no default_methods set.
     write_neoepitope_report(
@@ -1483,7 +1523,8 @@ def test_unknown_column_in_lens_file_is_ignored(tmp_path):
         "random_non_matching_col\n"
         "SIINFEKL\tHLA-A*02:01\t100.0\t0.5\t42\thello\n"
     )
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    epitopes = list(_loaded.epitopes)
     assert len(epitopes) == 1
     leaf = _first_leaf(epitopes[0])
     assert leaf.predictor_name == "mhcflurry"
@@ -1496,7 +1537,8 @@ def test_default_methods_auto_picked_when_unset(tmp_path, caplog):
     import logging
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     cfg = EpitopeConfig()  # no default_methods
 
     with caplog.at_level(logging.INFO, logger="vaxrank.epitope_dsl"):
@@ -1537,33 +1579,64 @@ def test_load_predictions_empty_string_fields_become_empty_not_nan(tmp_path):
     assert leaf.predictor_version == ""
 
 
-def test_write_neoepitope_report_broadcasts_score_across_duplicate_rows(tmp_path):
-    """Real-world LENS / pVACseq files emit the same (peptide, allele)
-    pair from multiple sources (alternative transcripts, homologous
-    regions, multiple variants). The writer broadcasts the same score
-    across each duplicate row instead of raising — per-source provenance
-    lives in other columns."""
+def test_write_neoepitope_report_scores_duplicate_peptides_per_source(tmp_path):
+    """The same (peptide, allele) from two sources gets two scores, not one.
+
+    Real LENS / pVACseq files emit identical peptide-allele pairs from
+    alternative transcripts, homologous regions, and distinct variants. Those
+    are different biological candidates with different evidence, so each row
+    joins on its own prediction identity. Broadcasting one score across them —
+    the pre-identity behavior — silently attributed one source's evidence to
+    another.
+    """
+    import pandas as pd
+    from vaxrank.epitope_io import write_neoepitope_report
+
+    report_df = pd.DataFrame([
+        {'Allele': 'HLA-A*02:01', 'Mutant peptide sequence': 'SIINFEKL',
+         'Genomic variant': 'chr1:100', 'Gene name': 'GENEA',
+         'Prediction identity': 'src-a', 'Peptide offset': 2},
+        {'Allele': 'HLA-A*02:01', 'Mutant peptide sequence': 'SIINFEKL',
+         'Genomic variant': 'chr2:200', 'Gene name': 'GENEB',
+         'Prediction identity': 'src-b', 'Peptide offset': 2},
+    ])
+    # Same peptide and allele, different sources, different affinities.
+    preds = [
+        dataclasses.replace(
+            _make_prediction(peptide_sequence='SIINFEKL',
+                             allele='HLA-A*02:01', ic50=50.0),
+            prediction_id='src-a'),
+        dataclasses.replace(
+            _make_prediction(peptide_sequence='SIINFEKL',
+                             allele='HLA-A*02:01', ic50=4000.0),
+            prediction_id='src-b'),
+    ]
+    csv_path = tmp_path / "out.csv"
+    write_neoepitope_report(report_df, preds, csv_report_path=str(csv_path))
+    result = pd.read_csv(csv_path)
+
+    assert len(result) == 2
+    assert sorted(result['Genomic variant'].tolist()) == [
+        'chr1:100', 'chr2:200']
+    by_source = dict(zip(result['Prediction identity'],
+                         result['vaxrank_score']))
+    # The strong binder scores above the weak one; neither borrows the other's.
+    assert by_source['src-a'] > by_source['src-b']
+
+
+def test_write_neoepitope_report_requires_prediction_identity(tmp_path):
+    """A frame without identity columns is refused, not silently broadcast."""
     import pandas as pd
     from vaxrank.epitope_io import write_neoepitope_report
 
     report_df = pd.DataFrame([
         {'Allele': 'HLA-A*02:01', 'Mutant peptide sequence': 'SIINFEKL',
          'Genomic variant': 'chr1:100', 'Gene name': 'GENEA'},
-        {'Allele': 'HLA-A*02:01', 'Mutant peptide sequence': 'SIINFEKL',
-         'Genomic variant': 'chr2:200', 'Gene name': 'GENEB'},  # same (pep, allele)
     ])
-    preds = [_make_prediction(peptide_sequence='SIINFEKL', allele='HLA-A*02:01')]
-    csv_path = tmp_path / "out.csv"
-    write_neoepitope_report(report_df, preds, csv_report_path=str(csv_path))
-    result = pd.read_csv(csv_path)
-    # Both source rows preserved with their per-source provenance
-    assert len(result) == 2
-    assert sorted(result['Genomic variant'].tolist()) == ['chr1:100', 'chr2:200']
-    # Same vaxrank_score broadcast to both
-    scores = result['vaxrank_score'].unique()
-    assert len(scores) == 1, (
-        "Expected the same score on both duplicate-(peptide, allele) "
-        "rows; got %r" % scores.tolist())
+    preds = [_make_prediction()]
+    with pytest.raises(ValueError, match="Prediction identity"):
+        write_neoepitope_report(
+            report_df, preds, csv_report_path=str(tmp_path / "out.csv"))
 
 
 def test_lens_dsl_combines_both_predictors(tmp_path):
@@ -1572,7 +1645,8 @@ def test_lens_dsl_combines_both_predictors(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
 
     # 50/50 blend of the two predictors' logistic-normalized affinity scores
     cfg = EpitopeConfig(
@@ -1598,7 +1672,8 @@ def test_lens_dsl_validation_catches_missing_predictor(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_v1.9_mhcflurry_only.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
 
     cfg = EpitopeConfig(
         score_expr="affinity['netmhcpan'].logistic(350, 150)"
@@ -1616,7 +1691,8 @@ def test_lens_dsl_validation_catches_missing_kind(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_v1.9_mhcflurry_only.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     cfg = EpitopeConfig(score_expr="stability['netmhcstabpan'].value")
     with pytest.raises(ValueError, match="references kind 'pMHC_stability'"):
         write_neoepitope_report(
@@ -1631,7 +1707,8 @@ def test_lens_dsl_validation_catches_missing_version(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_v1.9_mhcflurry_only.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     cfg = EpitopeConfig(
         score_expr="affinity['mhcflurry', '9.9.9'].logistic(350, 150)"
     )
@@ -1648,7 +1725,8 @@ def test_lens_dsl_version_qualified_formula(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     leaves = [p for e in epitopes for p in e.predictions_flat()]
     # Every LENS leaf should carry predictor_version from columns.
     assert all(p.predictor_version for p in leaves)
@@ -1687,7 +1765,8 @@ def test_real_lens_v14_detects_all_three_predictors():
     three should be detected and emit leaf predictions inside the
     loaded Epitopes."""
     path = os.path.join(REAL_LENS_DIR, "lens_v1.4_real_subset.tsv")
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     leaves = _leaves(epitopes)
     methods = {p.predictor_name for p in leaves}
     assert methods == {"mhcflurry", "netmhcpan", "netmhcstabpan"}
@@ -1704,7 +1783,8 @@ def test_real_lens_v15_emits_both_affinity_predictors():
     per-predictor predictions inside each CandidateEpitope. Canonical
     'mhcflurry' drives the report's display columns."""
     path = os.path.join(REAL_LENS_DIR, "lens_v1.5_real_subset.tsv")
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     leaves = _leaves(epitopes)
     methods = {p.predictor_name for p in leaves}
     assert methods == {"mhcflurry", "netmhcpan"}
@@ -1718,7 +1798,8 @@ def test_real_lens_v15_emits_both_affinity_predictors():
 def test_real_lens_v19_is_mhcflurry_only():
     """v1.9-dev emits only mhcflurry (netMHCpan was dropped)."""
     path = os.path.join(REAL_LENS_DIR, "lens_v1.9_real_subset.tsv")
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    epitopes = list(_loaded.epitopes)
     leaves = _leaves(epitopes)
     methods = {p.predictor_name for p in leaves}
     assert methods == {"mhcflurry"}
@@ -1752,7 +1833,8 @@ def test_real_lens_dsl_scoring_all_versions(tmp_path):
     import pandas as pd
     for name, cfg in cases:
         path = os.path.join(REAL_LENS_DIR, name)
-        report_df, preds = load_lens(path)
+        _loaded = read_lens_report(path)
+        report_df, preds = _loaded.report_df, list(_loaded.epitopes)
         csv_path = tmp_path / f"{name}.csv"
         write_neoepitope_report(
             report_df, preds, csv_report_path=str(csv_path),
@@ -1770,7 +1852,8 @@ def test_real_lens_v14_stability_formula(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(REAL_LENS_DIR, "lens_v1.4_real_subset.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     cfg = EpitopeConfig(score_expr=(
         "affinity['mhcflurry'].logistic(350, 150) * 0.7 + "
         "(stability['netmhcstabpan'].value / 24).clip(0, 1) * 0.3"))
@@ -1789,7 +1872,8 @@ def test_real_lens_version_qualified_auto_detects(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(REAL_LENS_DIR, "lens_v1.5_real_subset.tsv")
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     leaves = _leaves(epitopes)
     versions = {(p.predictor_name, p.predictor_version) for p in leaves}
     # Real v1.5.1 file: mhcflurry 2.1.1 + netmhcpan 4.1b
@@ -1813,7 +1897,8 @@ def test_lens_dsl_stability_and_affinity_combined(tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
 
     path = os.path.join(DATA_DIR, "lens_v1.4_with_stability.tsv")
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     leaves = [p for e in epitopes for p in e.predictions_flat()]
     kinds_seen = {p.kind for p in leaves}
     assert kinds_seen == {
@@ -1842,7 +1927,8 @@ def _assert_default_scores_match_legacy(cfg, path, tmp_path):
     from vaxrank.epitope_io import write_neoepitope_report
     from tests._legacy_score_reference import legacy_score_one as _legacy_score_one
 
-    report_df, epitopes = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     # Auto-picked default for pMHC_affinity is mhcflurry — that's what
     # resolves unqualified Affinity refs in topiary's EvalContext.
     legacy_scores = {}
@@ -1896,7 +1982,8 @@ def test_default_scoring_matches_legacy(tmp_path):
 
 def test_write_neoepitope_report_csv(tmp_path):
     path = os.path.join(DATA_DIR, "pvacseq_example.tsv")
-    report_df, preds = load_pvacseq(path)
+    _loaded = read_pvacseq_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     csv_path = tmp_path / "report.csv"
     write_neoepitope_report(report_df, preds, csv_report_path=str(csv_path))
     assert csv_path.exists()
@@ -1912,7 +1999,8 @@ def test_write_neoepitope_report_csv(tmp_path):
 
 def test_write_neoepitope_report_xlsx(tmp_path):
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, preds = load_lens(path)
+    _loaded = read_lens_report(path)
+    report_df, preds = _loaded.report_df, list(_loaded.epitopes)
     xlsx_path = tmp_path / "report.xlsx"
     write_neoepitope_report(report_df, preds, excel_report_path=str(xlsx_path))
     assert xlsx_path.exists()

--- a/tests/test_epitope_prediction.py
+++ b/tests/test_epitope_prediction.py
@@ -310,3 +310,36 @@ def test_mhc_predictor_error(mouse_genome):
         genome=mouse_genome)
 
     eq_(0, len(epitope_predictions))
+
+
+def test_allele_free_leaf_does_not_become_a_per_allele_score():
+    """Processing evidence scores the peptide, not an extra allele.
+
+    ``per_allele_scores`` is summed into ``epitope_score``, and its contract
+    is explicitly per patient allele. Writing an allele-free leaf's score
+    under '' inflated the candidate's score as though it had one more allele.
+    """
+    import pytest
+    from mhctools.pred import Prediction
+
+    from vaxrank.candidate_epitope import candidate_epitopes_from_rows
+
+    def leaf(allele, kind):
+        return Prediction(
+            kind=kind, predictor_name="mhcflurry", predictor_version="2.1.1",
+            allele=allele, peptide="SIINFEKL", value=50.0, score=0.7)
+
+    [epitope] = candidate_epitopes_from_rows([
+        {"peptide": "SIINFEKL", "source": "AASIINFEKLAA", "offset": 2,
+         "prediction_id": "", "wt": None, "allele_score": 0.9,
+         "mutant": leaf("HLA-A*02:01", "pMHC_affinity")},
+        {"peptide": "SIINFEKL", "source": "AASIINFEKLAA", "offset": 2,
+         "prediction_id": "", "wt": None, "allele_score": 0.7,
+         "mutant": leaf("", "antigen_processing")},
+    ])
+
+    assert epitope.per_allele_scores == {"HLA-A*02:01": 0.9}
+    assert epitope.epitope_score == pytest.approx(0.9)
+    # The evidence itself is still on the candidate, just not as an allele.
+    assert len(epitope.predictions_for(
+        "antigen_processing", predictor="mhcflurry")) == 1

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -319,6 +319,44 @@ def test_real_lens_fixture_runs_end_to_end_via_cli(fixture_path, tmp_path):
     assert xlsx_path.exists(), f"XLSX not written for {fixture_path}"
 
 
+def test_cli_applies_external_score_config_before_ranking(
+        tmp_path, monkeypatch):
+    """Configured evidence-only scores drive ranking, not just CSV output."""
+    from vaxrank.cli import entry_point
+
+    lens_path = tmp_path / "processing-only.tsv"
+    lens_path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\tsnv_alt_allele\tgene_name\n"
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLLL\t\t0.8\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\n")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "epitopes:\n"
+        "  score_expr: processing[mhcflurry].score\n")
+    csv_path = tmp_path / "neoepitopes.csv"
+    captured = {}
+
+    def capture_ranked(_args, ranked, source):
+        captured["ranked"] = ranked
+        captured["source"] = source
+
+    monkeypatch.setattr(entry_point, "emit_outputs", capture_ranked)
+    entry_point.main([
+        "--input-lens", str(lens_path),
+        "--config", str(config_path),
+        "--output-csv", str(csv_path),
+        "--no-processing-aware-annotation",
+    ])
+
+    assert captured["source"] == "external"
+    vaccine_peptide = captured["ranked"][0][1][0]
+    assert vaccine_peptide.target_epitope_score == pytest.approx(0.8)
+    assert vaccine_peptide.target_epitopes[0].per_allele_scores == {
+        "HLA-A*02:01": pytest.approx(0.8)}
+
+
 def test_real_lens_fixtures_present():
     """Pin that the fixture directory has the expected coverage:
     one fixture per known LENS version + one with stop-codon

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -575,6 +575,123 @@ def test_external_filter_does_not_cross_lens_source_contexts(tmp_path):
         "AASIINFEKLLL")
 
 
+def test_external_filter_does_not_cross_identical_lens_contexts(tmp_path):
+    """Variant provenance, not sequence context, controls eligibility."""
+    from types import SimpleNamespace
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.external_input import load_external_ranked
+
+    lens_path = tmp_path / "identical-context.tsv"
+    lens_path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "antigen_source\tvariant_coords\tsnv_ref_allele\t"
+        "snv_alt_allele\tgene_name\tgene_id\ttranscript_id\n"
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLLL\t50\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\tENSG1\tENST1\n"
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLLL\t500\tSNV\t"
+        "chr1:2000\tG\t[C]\tGENE2\tENSG2\tENST2\n")
+    args = SimpleNamespace(
+        input_lens=str(lens_path),
+        input_pvacseq=None,
+        output_patient_id="",
+        vaccine_peptide_length=25,
+        genome=None,
+    )
+
+    ranked, report, loaded, _patient_info, _vafs = load_external_ranked(
+        args,
+        epitope_config=EpitopeConfig(filter_expr="affinity <= 100"),
+    )
+
+    assert len(report) == 2
+    assert len(loaded) == 2
+    assert loaded[0].prediction_id != loaded[1].prediction_id
+    assert len(ranked) == 1
+    assert ranked[0][0].start == 1000
+
+
+def test_lens_representative_uses_configured_dsl_score(tmp_path):
+    """The selected construct context is the highest DSL-scored context."""
+    from types import SimpleNamespace
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.external_input import load_external_ranked
+
+    lens_path = tmp_path / "presentation-ranked.tsv"
+    lens_path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.pres_score\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\tsnv_alt_allele\tgene_name\ttranscript_id\n"
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLLL\t50\t0.1\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\tENST1\n"
+        "LATEKSRWS\tHLA-A02:01\tGGLATEKSRWSTT\t500\t0.9\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\tENST1\n")
+    args = SimpleNamespace(
+        input_lens=str(lens_path),
+        input_pvacseq=None,
+        output_patient_id="",
+        vaccine_peptide_length=25,
+        genome=None,
+    )
+
+    ranked, _report, _loaded, _patient_info, _vafs = load_external_ranked(
+        args,
+        epitope_config=EpitopeConfig(
+            score_expr="presentation[mhcflurry].score"),
+    )
+
+    vaccine_peptide = ranked[0][1][0]
+    assert vaccine_peptide.amino_acids == "GGLATEKSRWSTT"
+    assert [e.sequence for e in vaccine_peptide.target_epitopes] == [
+        "LATEKSRWS"]
+    assert vaccine_peptide.target_epitope_score == pytest.approx(0.9)
+
+
+def test_lens_input_summary_reduces_all_rows_before_construct_checks(
+        tmp_path, monkeypatch):
+    """Input facts survive an unconstructable affinity-winning row."""
+    from types import SimpleNamespace
+
+    from vaxrank import external_input
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.external_input import load_external_ranked
+
+    monkeypatch.setattr(
+        external_input,
+        "resolve_external_transcripts",
+        lambda transcript_ids, _genome: [object()] if transcript_ids else [],
+    )
+    lens_path = tmp_path / "all-row-summary.tsv"
+    lens_path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "antigen_source\tvariant_coords\tsnv_ref_allele\t"
+        "snv_alt_allele\tgene_name\ttranscript_id\t"
+        "rna_reads_covering_genomic_origin\t"
+        "rna_reads_covering_genomic_origin_with_peptide_cds\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\t\t0\t0\n"
+        "LATEKSRWS\tHLA-A02:01\tGGLATEKSRWSTT\t500\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\tENST1\t10\t3\n")
+    args = SimpleNamespace(
+        input_lens=str(lens_path),
+        input_pvacseq=None,
+        output_patient_id="",
+        vaccine_peptide_length=25,
+        genome=None,
+    )
+
+    _ranked, _report, _loaded, patient_info, _vafs = load_external_ranked(
+        args,
+        epitope_config=EpitopeConfig(filter_expr="affinity <= 0"),
+    )
+
+    assert patient_info.num_somatic_variants == 1
+    assert patient_info.num_coding_effect_variants == 1
+    assert patient_info.num_variants_with_rna_support == 1
+    assert patient_info.num_variants_with_vaccine_peptides == 0
+
+
 def test_pvacseq_filter_excluding_every_group_produces_no_ranked_vaccine():
     """The shared external filtering contract also applies to pVACseq."""
     from types import SimpleNamespace
@@ -607,6 +724,88 @@ def test_pvacseq_filter_excluding_every_group_produces_no_ranked_vaccine():
     assert patient_info.num_somatic_variants == 3
     assert patient_info.num_coding_effect_variants == 0
     assert patient_info.num_variants_with_rna_support == 3
+    assert patient_info.num_variants_with_vaccine_peptides == 0
+
+
+def write_multi_peptide_pvacseq_fixture(path):
+    """Write one pVACseq variant with score axes that disagree."""
+    header = (
+        "ID\tIndex\tA*02:01\tGene\tAA Change\tNum Passing Transcripts\t"
+        "Best Peptide\tBest Transcript\tAllele\tIC50 MT\tIC50 WT\t"
+        "%ile MT\t%ile WT\tRNA Expr\tRNA VAF\tRNA Depth\tDNA VAF\t"
+        "Tier\tRef Match\tEvaluation\n")
+    path.write_text(
+        header
+        + "chr1-1000-1001-A-T\t1.GENE1.ENST1.missense.1A/T\t1\t"
+        "GENE1\tA1T\t1\tSIINFEKL\t\tHLA-A*02:01\t50\t5000\t"
+        "0.1\t10\t1\t0\t0\t0.4\tPass\tFalse\tPending\n"
+        + "chr1-1000-1001-A-T\t1.GENE1.ENST2.missense.1A/T\t1\t"
+        "GENE1\tA1T\t1\tLATEKSRWS\tENST2\tHLA-A*02:01\t500\t5000\t"
+        "1.0\t10\t1\t0.2\t100\t0.4\tPass\tFalse\tPending\n")
+    return path
+
+
+def test_pvacseq_representative_uses_configured_dsl_score(tmp_path):
+    """pVACseq construct selection consumes the same score as ranking."""
+    from types import SimpleNamespace
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.external_input import load_external_ranked
+
+    path = write_multi_peptide_pvacseq_fixture(
+        tmp_path / "multi-peptide-pvacseq.tsv")
+    args = SimpleNamespace(
+        input_lens=None,
+        input_pvacseq=str(path),
+        output_patient_id="",
+        vaccine_peptide_length=25,
+        genome=None,
+    )
+
+    ranked, _report, _loaded, _patient_info, _vafs = load_external_ranked(
+        args,
+        epitope_config=EpitopeConfig(score_expr="affinity.value"),
+    )
+
+    vaccine_peptide = ranked[0][1][0]
+    assert vaccine_peptide.amino_acids == "LATEKSRWS"
+    assert [e.sequence for e in vaccine_peptide.target_epitopes] == [
+        "LATEKSRWS"]
+    assert vaccine_peptide.target_epitope_score == pytest.approx(500.0)
+
+
+def test_pvacseq_input_summary_reduces_all_rows_before_selection(
+        tmp_path, monkeypatch):
+    """pVACseq RNA/transcript facts are unions over the raw variant rows."""
+    from types import SimpleNamespace
+
+    from vaxrank import external_input
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.external_input import load_external_ranked
+
+    monkeypatch.setattr(
+        external_input,
+        "resolve_external_transcripts",
+        lambda transcript_ids, _genome: [object()] if transcript_ids else [],
+    )
+    path = write_multi_peptide_pvacseq_fixture(
+        tmp_path / "multi-row-summary-pvacseq.tsv")
+    args = SimpleNamespace(
+        input_lens=None,
+        input_pvacseq=str(path),
+        output_patient_id="",
+        vaccine_peptide_length=25,
+        genome=None,
+    )
+
+    _ranked, _report, _loaded, patient_info, _vafs = load_external_ranked(
+        args,
+        epitope_config=EpitopeConfig(filter_expr="affinity <= 0"),
+    )
+
+    assert patient_info.num_somatic_variants == 1
+    assert patient_info.num_coding_effect_variants == 1
+    assert patient_info.num_variants_with_rna_support == 1
     assert patient_info.num_variants_with_vaccine_peptides == 0
 
 
@@ -978,7 +1177,11 @@ def test_pvacseq_all_epitopes_to_ranked_vaccine_peptides(tmp_path):
     assert (variant.contig, variant.start, variant.ref, variant.alt) == (
         "1", 154590262, "T", "A")
     assert vaccine_peptides[0].mutant_protein_fragment.gene_name == "ADAR"
-    assert len(vaccine_peptides[0].epitopes) == 2
+    # pVACseq has no longer source window that can honestly contain both
+    # minimal epitopes. The default DSL chooses AERMGFTVV; evidence from the
+    # other peptide cannot inflate this construct's target score.
+    assert [e.sequence for e in vaccine_peptides[0].epitopes] == [
+        "AERMGFTVV"]
     assert dna_vaf_by_variant[variant] == pytest.approx(0.302)
 
 
@@ -1009,27 +1212,13 @@ def test_pvacseq_duplicate_peptides_stay_variant_scoped(tmp_path):
 
 # ---- LENS scoring-column edge cases --------------------------------------
 
-def test_lens_warns_when_no_affinity_columns_detected(tmp_path, caplog):
-    """When no pMHC_affinity predictor is detected, the
-    representative-peptide pick is degenerate (every row ties at
-    (2, 0.0); file-order first row "wins"). Pin that we warn
-    instead of silently picking arbitrarily.
-
-    Today this can be triggered by a stability-only LENS file
-    (netmhcstabpan present without mhcflurry/netmhcpan). It can also
-    fire if LENS ever adds tools whose ``kind`` is something other
-    than ``pMHC_affinity`` (presentation-only, cleavage,
-    immunogenicity, etc.) and the registry classifies them
-    accordingly. The warning is kind-agnostic — it reports the
-    detected kinds in its message.
-    """
+def test_lens_without_affinity_uses_dsl_score_without_fallback_warning(
+        tmp_path, caplog):
+    """Non-affinity evidence no longer triggers a raw-affinity fallback."""
     import logging
     from vaxrank.epitope_io import load_lens
     from vaxrank.external_input import ranked_from_lens_predictions
 
-    # Stability-only fixture (the only "no affinity" case the
-    # current registry can produce). If new predictor kinds are added
-    # to _LENS_PREDICTOR_REGISTRY, add fixtures here covering them.
     no_aff = tmp_path / "no_affinity.tsv"
     no_aff.write_text(
         "allele\tpeptide\tnetmhcstabpan_1.0.halflife_hours\t"
@@ -1042,16 +1231,11 @@ def test_lens_warns_when_no_affinity_columns_detected(tmp_path, caplog):
     _, predictions = load_lens(str(no_aff))
     with caplog.at_level(logging.WARNING):
         ranked, _dna_vaf = ranked_from_lens_predictions(predictions, str(no_aff))
-    # Still produces output (the file-order representative)
+    # The configured/default DSL is now the sole representative selector.
     assert len(ranked) == 1
-    # Warning was emitted, mentions the detected non-affinity kinds
-    msg = next(
-        (r.message for r in caplog.records
-         if "no pMHC_affinity scoring columns" in r.message), None)
-    assert msg is not None, \
-        "Expected a warn-once for LENS input lacking affinity predictors"
-    assert "pMHC_stability" in msg, \
-        "Warning should report the detected non-affinity kinds; got %r" % msg
+    assert not any(
+        "no pMHC_affinity scoring columns" in record.message
+        for record in caplog.records)
 
 
 # ---- emit_outputs observability -------------------------------------------

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -1657,3 +1657,62 @@ def test_external_prediction_key_rejects_an_impossible_position():
         ExternalPredictionKey(
             source_format="lens", peptide="SIINFEKL",
             source_sequence="XXSIINFEKLXX", offset=0)
+
+
+def test_vaccine_config_reaches_external_construct_assembly(tmp_path):
+    """``vaccine_peptides:`` config must apply to LENS runs, not just VCF ones.
+
+    It was resolved only inside ``run_vaxrank_from_parsed_args`` — the
+    pipeline-only entry point — so external runs silently used a hard-coded
+    25-aa window and kept every epitope regardless of configuration.
+    """
+    from types import SimpleNamespace
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.external_input import load_external_ranked
+    from vaxrank.vaccine_config import VaccineConfig
+
+    context = (
+        "MAAAAAAAAA" "SIINFEKLQQ" "CCCCCCCCCC" "DDDDDDDDDD" "EEEEEEEEEE"
+        "FFFFFFFFFF" "GGGGGGGGGG" "YLLPAIVHIW" "HHHHHHHHHH")
+    path = tmp_path / "config_lens.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\tsnv_alt_allele\tgene_name\ttranscript_id\t"
+        "mhcflurry_2.1.1.aff\n"
+        f"YLLPAIVHI\tHLA-A02:01\t{context}\tSNV\tchr1:100\tC\t[T]\tG\tENST1\t15\n"
+        f"YLLPAIVHIW\tHLA-B07:02\t{context}\tSNV\tchr1:100\tC\t[T]\tG\tENST1\t30\n")
+
+    def run(length, keep):
+        args = SimpleNamespace(
+            input_lens=str(path), input_pvacseq=None,
+            output_patient_id="", genome=None)
+        ranked, *_ = load_external_ranked(
+            args,
+            epitope_config=EpitopeConfig(),
+            vaccine_config=VaccineConfig(
+                preferred_peptide_length=length,
+                min_peptide_length=length,
+                max_peptide_length=length,
+                num_target_epitopes_to_keep=keep))
+        return ranked[0][1][0]
+
+    assert len(run(25, 0).amino_acids) == 25
+    assert len(run(41, 0).amino_acids) == 41
+
+    # num_target_epitopes_to_keep was never forwarded at all.
+    assert len(run(41, 0).target_epitopes) == 2
+    assert [e.sequence for e in run(41, 1).target_epitopes] == ["YLLPAIVHI"]
+
+
+def test_external_input_parser_accepts_vaccine_peptide_flags():
+    """The flags were rejected as unknown, not merely ignored."""
+    from vaxrank.cli.arg_parser import external_input_arg_parser
+
+    args = external_input_arg_parser().parse_args([
+        "--input-lens", "x.tsv",
+        "--vaccine-peptide-length", "31",
+        "--num-epitopes-per-vaccine-peptide", "2",
+    ])
+    assert args.vaccine_peptide_length == 31
+    assert args.num_epitopes_per_vaccine_peptide == 2

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -47,6 +47,7 @@ def test_external_variant_entry_defaults_describe_an_empty_result():
     assert entry.resolved_transcript is False
     assert entry.annotation is None
     assert entry.dna_vaf is None
+    assert entry.has_rna_support is False
     assert entry.unparseable is False
 
 
@@ -443,24 +444,76 @@ def test_external_filter_prunes_ranked_groups_but_preserves_patient_genotype(
     assert processing[0].allele == ""
 
 
-def test_external_filter_excluding_every_group_produces_no_ranked_vaccine(
+def test_external_minimum_score_prunes_all_ranking_state_for_rejected_allele(
         tmp_path):
+    """A below-threshold allele cannot survive through the score map."""
+    from types import SimpleNamespace
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.external_input import load_external_ranked
+
+    lens_path = tmp_path / "mixed-presentation.tsv"
+    lens_path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.pres_score\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\tsnv_alt_allele\tgene_name\n"
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLLL\t\t0.8\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\n"
+        "SIINFEKL\tHLA-B07:02\tAASIINFEKLLL\t\t0.2\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\n")
+    args = SimpleNamespace(
+        input_lens=str(lens_path),
+        input_pvacseq=None,
+        output_patient_id="",
+        vaccine_peptide_length=25,
+        genome=None,
+    )
+    config = EpitopeConfig(
+        score_expr="presentation[mhcflurry].score",
+        min_epitope_score=0.5,
+    )
+
+    ranked, _report, loaded, _patient_info, _vafs = load_external_ranked(
+        args, epitope_config=config)
+
+    assert loaded[0].per_allele_scores == {
+        "HLA-A*02:01": pytest.approx(0.8),
+        "HLA-B*07:02": pytest.approx(0.2),
+    }
+    target = ranked[0][1][0].target_epitopes[0]
+    assert target.patient_alleles == ("HLA-A*02:01",)
+    assert target.per_allele_scores == {
+        "HLA-A*02:01": pytest.approx(0.8)}
+    assert target.epitope_score == pytest.approx(0.8)
+
+
+def test_external_filter_excluding_every_group_produces_no_ranked_vaccine(
+        tmp_path, monkeypatch):
     """A hard Topiary filter cannot leave zero-scored construct targets."""
     from types import SimpleNamespace
 
     from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank import external_input
     from vaxrank.external_input import (
         LENS_PROVENANCE_MARKER,
         load_external_ranked,
+    )
+
+    monkeypatch.setattr(
+        external_input,
+        "resolve_external_transcripts",
+        lambda transcript_ids, _genome: [object()] if transcript_ids else [],
     )
 
     lens_path = tmp_path / "fully-filtered.tsv"
     lens_path.write_text(
         "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
         "antigen_source\tvariant_coords\tsnv_ref_allele\t"
-        "snv_alt_allele\tgene_name\n"
+        "snv_alt_allele\tgene_name\ttranscript_id\t"
+        "rna_reads_covering_genomic_origin\t"
+        "rna_reads_covering_genomic_origin_with_peptide_cds\n"
         "SIINFEKL\tHLA-A02:01\tAASIINFEKLLL\t50\tSNV\t"
-        "chr1:1000\tA\t[T]\tGENE1\n")
+        "chr1:1000\tA\t[T]\tGENE1\tENST1\t10\t3\n")
     args = SimpleNamespace(
         input_lens=str(lens_path),
         input_pvacseq=None,
@@ -478,6 +531,10 @@ def test_external_filter_excluding_every_group_produces_no_ranked_vaccine(
     assert loaded[0].per_allele_scores == {}
     assert patient_info.mhc_alleles == [
         "HLA-A*02:01", LENS_PROVENANCE_MARKER]
+    assert patient_info.num_somatic_variants == 1
+    assert patient_info.num_coding_effect_variants == 1
+    assert patient_info.num_variants_with_rna_support == 1
+    assert patient_info.num_variants_with_vaccine_peptides == 0
 
 
 def test_external_filter_does_not_cross_lens_source_contexts(tmp_path):
@@ -547,6 +604,10 @@ def test_pvacseq_filter_excluding_every_group_produces_no_ranked_vaccine():
         for epitope in loaded
         for allele in epitope.patient_alleles
     }
+    assert patient_info.num_somatic_variants == 3
+    assert patient_info.num_coding_effect_variants == 0
+    assert patient_info.num_variants_with_rna_support == 3
+    assert patient_info.num_variants_with_vaccine_peptides == 0
 
 
 def test_real_lens_fixtures_present():

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -1207,7 +1207,15 @@ def test_pvacseq_duplicate_peptides_stay_variant_scoped(tmp_path):
         epitopes = vaccine_peptides[0].epitopes
         assert len(epitopes) == 1
         assert epitopes[0].sequence == "AERMGFTVV"
-        assert epitopes[0].source_sequence == expected_source
+        # Variant provenance lives in ``source_name``. ``source_sequence`` is
+        # an amino-acid window and must stay one: pVACseq ships no source
+        # context, so the peptide is its own window. Storing the variant
+        # string there made construct assembly slice a variant *name*.
+        assert epitopes[0].source_name == expected_source
+        assert epitopes[0].source_sequence == "AERMGFTVV"
+        assert (
+            vaccine_peptides[0].mutant_protein_fragment.amino_acids
+            == epitopes[0].source_sequence)
 
 
 # ---- LENS scoring-column edge cases --------------------------------------
@@ -1517,3 +1525,135 @@ def test_log_varcode_agreement(caplog):
     with caplog.at_level(logging.INFO, logger='vaxrank.external_input'):
         log_varcode_agreement([(None, None, 'x')], 'LENS')
     assert not any('varcode' in r.getMessage() for r in caplog.records)
+
+
+# ---- identity / evidence separation regressions --------------------------
+
+def _write_pvacseq_all_epitopes_with_index(tmp_path):
+    """all_epitopes flavor carrying BOTH an Index and genomic coordinates."""
+    path = tmp_path / "pvacseq_all_epitopes_indexed.tsv"
+    columns = [
+        "Index", "Chromosome", "Start", "Stop", "Reference", "Variant",
+        "Transcript", "Variant Type", "Mutation", "Gene Name", "HLA Allele",
+        "Mutation Position", "MT Epitope Seq", "WT Epitope Seq",
+        "Median MT IC50 Score", "Median WT IC50 Score",
+        "Median MT Percentile", "Median WT Percentile",
+        "Tumor DNA Depth", "Tumor DNA VAF", "Tumor RNA Depth",
+        "Tumor RNA VAF", "Gene Expression", "Transcript Expression",
+    ]
+    row = [
+        "ADAR.ENST00000368474.9.missense.806E/V",
+        "chr1", "154590262", "154590263", "T", "A",
+        "ENST00000368474.9", "missense", "E806V", "ADAR",
+        "HLA-B*45:01", "5", "AERMGFTVV", "AERMGFTEV",
+        "76.11", "61.80", "0.10", "0.12",
+        "1233", "0.302", "1233", "0.348", "131.832", "84.961",
+    ]
+    path.write_text("\t".join(columns) + "\n" + "\t".join(row) + "\n")
+    return path
+
+
+def test_pvacseq_index_and_coordinates_both_yield_a_ranked_construct(tmp_path):
+    """An ``Index`` column must not cost the run its vaccine peptides.
+
+    topiary normalizes ``variant`` from ``Index`` when that column exists, so
+    an identity derived from genomic coordinates never joins. Aligning the
+    identity is only half the fix: the ``Index`` string carries no
+    coordinates, so the genomic variant has to come from the coordinate
+    columns independently.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import epitopes_for_ranking
+    from vaxrank.epitope_io import read_pvacseq_report
+    from vaxrank.external_input import pvacseq_ranking_result
+
+    path = _write_pvacseq_all_epitopes_with_index(tmp_path)
+    config = EpitopeConfig()
+    report = read_pvacseq_report(path, epitope_config=config)
+    assert len(report.epitopes) == 1
+
+    result = pvacseq_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+    assert len(result.ranked) == 1
+    variant, vaccine_peptides = result.ranked[0]
+    # Genomic placement comes from the coordinate columns, not the Index.
+    assert (variant.contig, variant.start, variant.ref, variant.alt) == (
+        "1", 154590262, "T", "A")
+    assert vaccine_peptides[0].amino_acids == "AERMGFTVV"
+
+
+def test_lens_construct_excludes_epitopes_outside_its_window(tmp_path):
+    """Only epitopes inside the synthesized peptide may score it.
+
+    A LENS ``pep_context`` can be far longer than the vaccine peptide. The
+    construct window is centered on the mutation, so a neoepitope elsewhere in
+    the context is not in the peptide that would be synthesized and must not
+    contribute to ``target_epitope_score`` or appear in its report table.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import epitopes_for_ranking
+    from vaxrank.epitope_io import read_lens_report
+    from vaxrank.external_input import lens_ranking_result
+
+    context = (
+        "MAAAAAAAAA" "SIINFEKLQQ" "CCCCCCCCCC" "DDDDDDDDDD" "EEEEEEEEEE"
+        "FFFFFFFFFF" "GGGGGGGGGG" "YLLPAIVHIW" "HHHHHHHHHH")
+    path = tmp_path / "lens_long_context.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\tsnv_alt_allele\tgene_name\ttranscript_id\t"
+        "mhcflurry_2.1.1.aff\n"
+        f"SIINFEKL\tHLA-A02:01\t{context}\tSNV\tchr1:100\tC\t[T]\tG\tENST1\t20\n"
+        f"YLLPAIVHI\tHLA-A02:01\t{context}\tSNV\tchr1:100\tC\t[T]\tG\tENST1\t15\n")
+
+    config = EpitopeConfig()
+    report = read_lens_report(path, epitope_config=config)
+    result = lens_ranking_result(
+        report,
+        epitopes_for_ranking(list(report.epitopes), config),
+        vaccine_peptide_length=25)
+
+    assert len(result.ranked) == 1
+    vaccine_peptide = result.ranked[0][1][0]
+    assert len(vaccine_peptide.amino_acids) == 25
+    for epitope in vaccine_peptide.epitopes:
+        assert epitope.sequence in vaccine_peptide.amino_acids
+        # Offsets must be rebased into the window they now describe.
+        assert epitope.source_sequence == vaccine_peptide.amino_acids
+        assert (
+            vaccine_peptide.amino_acids[
+                epitope.offset:epitope.offset + len(epitope.sequence)]
+            == epitope.sequence)
+    assert vaccine_peptide.target_epitope_score == pytest.approx(
+        sum(e.epitope_score for e in vaccine_peptide.target_epitopes))
+
+
+def test_lens_whitespace_in_pep_context_does_not_split_an_identity(tmp_path):
+    """One normalization vocabulary, so a stray space cannot fork a group."""
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import read_lens_report
+
+    path = tmp_path / "lens_whitespace.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\tsnv_alt_allele\tgene_name\tmhcflurry_2.1.1.aff\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\tSNV\tchr1:100\tC\t[T]\tG\t20\n"
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX \tSNV\tchr1:100\tC\t[T]\tG\t25\n")
+
+    report = read_lens_report(path, epitope_config=EpitopeConfig())
+    assert len(report.epitopes) == 1
+    assert report.epitopes[0].patient_alleles == (
+        "HLA-A*02:01", "HLA-B*07:02")
+    # The identity index is what construct ranking joins against; it must not
+    # raise on rows that only differ by whitespace.
+    assert len(report.records_with_epitopes(list(report.epitopes))) == 2
+
+
+def test_external_prediction_key_rejects_an_impossible_position():
+    """The key is a join target, so its position fields must be real."""
+    from vaxrank.external_prediction import ExternalPredictionKey
+
+    with pytest.raises(ValueError, match="not at offset"):
+        ExternalPredictionKey(
+            source_format="lens", peptide="SIINFEKL",
+            source_sequence="XXSIINFEKLXX", offset=0)

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -357,6 +357,127 @@ def test_cli_applies_external_score_config_before_ranking(
         "HLA-A*02:01": pytest.approx(0.8)}
 
 
+def test_external_filter_prunes_ranked_groups_but_preserves_patient_genotype(
+        tmp_path):
+    """Topiary filtering controls targets without redefining the patient."""
+    from types import SimpleNamespace
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.external_input import (
+        LENS_PROVENANCE_MARKER,
+        load_external_ranked,
+    )
+
+    lens_path = tmp_path / "partially-filtered.tsv"
+    lens_path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\t"
+        "snv_alt_allele\tgene_name\n"
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLLL\t50\t0.7\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\n"
+        "SIINFEKL\tHLA-B07:02\tAASIINFEKLLL\t500\t0.7\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\n")
+    args = SimpleNamespace(
+        input_lens=str(lens_path),
+        input_pvacseq=None,
+        output_patient_id="",
+        vaccine_peptide_length=25,
+        genome=None,
+    )
+
+    ranked, _report, loaded, patient_info, _vafs = load_external_ranked(
+        args,
+        epitope_config=EpitopeConfig(filter_expr="affinity <= 100"),
+    )
+
+    # Genotype comes from the complete input membership, before filtering.
+    assert loaded[0].patient_alleles == (
+        "HLA-A*02:01", "HLA-B*07:02")
+    assert patient_info.mhc_alleles == [
+        "HLA-A*02:01", "HLA-B*07:02", LENS_PROVENANCE_MARKER]
+
+    # The filtered B*07:02 group cannot enter ranking, coverage, or design.
+    target = ranked[0][1][0].target_epitopes[0]
+    assert target.patient_alleles == ("HLA-A*02:01",)
+    assert target.per_allele_scores.keys() == {"HLA-A*02:01"}
+    assert {
+        p.allele for p in target.predictions_flat() if p.allele
+    } == {"HLA-A*02:01"}
+    processing = target.predictions_for(
+        "antigen_processing", predictor="mhcflurry")
+    assert len(processing) == 1
+    assert processing[0].allele == ""
+
+
+def test_external_filter_excluding_every_group_produces_no_ranked_vaccine(
+        tmp_path):
+    """A hard Topiary filter cannot leave zero-scored construct targets."""
+    from types import SimpleNamespace
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.external_input import (
+        LENS_PROVENANCE_MARKER,
+        load_external_ranked,
+    )
+
+    lens_path = tmp_path / "fully-filtered.tsv"
+    lens_path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "antigen_source\tvariant_coords\tsnv_ref_allele\t"
+        "snv_alt_allele\tgene_name\n"
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLLL\t50\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\n")
+    args = SimpleNamespace(
+        input_lens=str(lens_path),
+        input_pvacseq=None,
+        output_patient_id="",
+        vaccine_peptide_length=25,
+        genome=None,
+    )
+
+    ranked, _report, loaded, patient_info, _vafs = load_external_ranked(
+        args,
+        epitope_config=EpitopeConfig(filter_expr="affinity <= 0"),
+    )
+
+    assert ranked == []
+    assert loaded[0].per_allele_scores == {}
+    assert patient_info.mhc_alleles == [
+        "HLA-A*02:01", LENS_PROVENANCE_MARKER]
+
+
+def test_pvacseq_filter_excluding_every_group_produces_no_ranked_vaccine():
+    """The shared external filtering contract also applies to pVACseq."""
+    from types import SimpleNamespace
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.external_input import load_external_ranked
+
+    path = os.path.join(DATA_DIR, "pvacseq_example.tsv")
+    args = SimpleNamespace(
+        input_lens=None,
+        input_pvacseq=path,
+        output_patient_id="",
+        vaccine_peptide_length=25,
+        genome=None,
+    )
+
+    ranked, _report, loaded, patient_info, _vafs = load_external_ranked(
+        args,
+        epitope_config=EpitopeConfig(filter_expr="affinity <= 0"),
+    )
+
+    assert ranked == []
+    assert loaded
+    assert all(epitope.per_allele_scores == {} for epitope in loaded)
+    assert set(patient_info.mhc_alleles[:-1]) == {
+        allele
+        for epitope in loaded
+        for allele in epitope.patient_alleles
+    }
+
+
 def test_real_lens_fixtures_present():
     """Pin that the fixture directory has the expected coverage:
     one fixture per known LENS version + one with stop-codon

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -1751,3 +1751,87 @@ def test_external_input_parser_accepts_vaccine_peptide_flags():
     ])
     assert args.vaccine_peptide_length == 31
     assert args.num_epitopes_per_vaccine_peptide == 2
+
+
+# ---- code-review regressions ---------------------------------------------
+
+def test_construct_is_labelled_with_the_row_s_own_gene_not_the_alphabetical_one(
+        tmp_path):
+    """A vaccine peptide must carry the gene the report named for its row.
+
+    ``gene_names`` is sorted so two rows listing the same genes in different
+    orders resolve to one identity — which makes ``gene_names[0]``
+    alphabetical, not primary. Labelling constructs from it put the wrong
+    gene on every template report and produced spurious varcode
+    gene-disagreement warnings.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import epitopes_for_ranking
+    from vaxrank.epitope_io import read_lens_report
+    from vaxrank.external_input import lens_ranking_result
+
+    path = tmp_path / "gene_precedence.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\tsnv_alt_allele\tgene_name\t"
+        "all_gene_names_encoding_peptide\ttranscript_id\t"
+        "all_transcript_ids_encoding_peptide\tmhcflurry_2.1.1.aff\n"
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLAA\tSNV\tchr17:7577120\tC\t[T]\t"
+        "TP53\tATXN7,TP53\tENST00000269305\t"
+        "ENST00000000233,ENST00000269305\t20\n")
+
+    config = EpitopeConfig()
+    report = read_lens_report(path, epitope_config=config)
+    key = report.records[0].key
+    # The identity keeps both, sorted, so row order cannot fork it ...
+    assert key.gene_names == ("ATXN7", "TP53")
+    # ... while the row's own naming is preserved separately.
+    assert key.primary_gene_name == "TP53"
+    assert key.ordered_transcript_ids[0] == "ENST00000269305"
+    # Annotation must stay out of the identity, or two rows naming the same
+    # genes in different orders would become different candidates.
+    assert "primary_gene_name" not in key.identifier
+
+    result = lens_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+    fragment = result.ranked[0][1][0].mutant_protein_fragment
+    assert fragment.gene_name == "TP53"
+
+
+def test_lens_read_counts_come_from_one_row(tmp_path):
+    """Counts must describe one observation, not per-field maxima.
+
+    Maximizing each field independently can assemble a tuple no row ever
+    reported — total from a deep row, alt from a shallow one — and
+    n_alt_reads feeds the combined-score DSL, so an incoherent count
+    reorders the construct ranking.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import epitopes_for_ranking
+    from vaxrank.epitope_io import read_lens_report
+    from vaxrank.external_input import lens_ranking_result
+
+    path = tmp_path / "counts.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\tsnv_alt_allele\tgene_name\t"
+        "rna_reads_covering_genomic_origin\t"
+        "rna_reads_covering_genomic_origin_with_peptide_cds\t"
+        "mhcflurry_2.1.1.aff\n"
+        # deep coverage, few supporting reads
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLAA\tSNV\tchr1:100\tC\t[T]\tG\t"
+        "100\t5\t20\n"
+        # shallow coverage, many supporting reads
+        "SIINFEKL\tHLA-B07:02\tAASIINFEKLAA\tSNV\tchr1:100\tC\t[T]\tG\t"
+        "10\t9\t25\n")
+
+    config = EpitopeConfig()
+    report = read_lens_report(path, epitope_config=config)
+    result = lens_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+    fragment = result.ranked[0][1][0].mutant_protein_fragment
+
+    # The best-supported row wins outright: (10, 9), never the cross-product
+    # (100, 9) that no row reported.
+    assert (fragment.n_overlapping_reads, fragment.n_alt_reads) == (10, 9)
+    assert fragment.n_ref_reads == 1

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -357,6 +357,39 @@ def test_cli_applies_external_score_config_before_ranking(
         "HLA-A*02:01": pytest.approx(0.8)}
 
 
+def test_external_ranking_applies_default_minimum_epitope_score(tmp_path):
+    """Zero-score evidence stays auditable but cannot become a target."""
+    from types import SimpleNamespace
+
+    from vaxrank.external_input import (
+        LENS_PROVENANCE_MARKER,
+        load_external_ranked,
+    )
+
+    lens_path = tmp_path / "processing-only.tsv"
+    lens_path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\tsnv_alt_allele\tgene_name\n"
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLLL\t\t0.8\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\n")
+    args = SimpleNamespace(
+        input_lens=str(lens_path),
+        input_pvacseq=None,
+        output_patient_id="",
+        vaccine_peptide_length=25,
+        genome=None,
+    )
+
+    ranked, report, loaded, patient_info, _vafs = load_external_ranked(args)
+
+    assert ranked == []
+    assert len(report) == 1
+    assert loaded[0].per_allele_scores == {"HLA-A*02:01": 0.0}
+    assert patient_info.mhc_alleles == [
+        "HLA-A*02:01", LENS_PROVENANCE_MARKER]
+
+
 def test_external_filter_prunes_ranked_groups_but_preserves_patient_genotype(
         tmp_path):
     """Topiary filtering controls targets without redefining the patient."""
@@ -445,6 +478,44 @@ def test_external_filter_excluding_every_group_produces_no_ranked_vaccine(
     assert loaded[0].per_allele_scores == {}
     assert patient_info.mhc_alleles == [
         "HLA-A*02:01", LENS_PROVENANCE_MARKER]
+
+
+def test_external_filter_does_not_cross_lens_source_contexts(tmp_path):
+    """A shared sequence cannot transfer eligibility between variants."""
+    from types import SimpleNamespace
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.external_input import load_external_ranked
+
+    lens_path = tmp_path / "shared-peptide.tsv"
+    lens_path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "antigen_source\tvariant_coords\tsnv_ref_allele\t"
+        "snv_alt_allele\tgene_name\n"
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLLL\t50\tSNV\t"
+        "chr1:1000\tA\t[T]\tGENE1\n"
+        "SIINFEKL\tHLA-A02:01\tGGSIINFEKLTT\t500\tSNV\t"
+        "chr1:2000\tG\t[C]\tGENE2\n")
+    args = SimpleNamespace(
+        input_lens=str(lens_path),
+        input_pvacseq=None,
+        output_patient_id="",
+        vaccine_peptide_length=25,
+        genome=None,
+    )
+
+    ranked, report, loaded, _patient_info, _vafs = load_external_ranked(
+        args,
+        epitope_config=EpitopeConfig(filter_expr="affinity <= 100"),
+    )
+
+    assert len(report) == 2
+    assert len(loaded) == 2
+    assert len(ranked) == 1
+    variant, vaccine_peptides = ranked[0]
+    assert variant.start == 1000
+    assert vaccine_peptides[0].target_epitopes[0].source_sequence == (
+        "AASIINFEKLLL")
 
 
 def test_pvacseq_filter_excluding_every_group_produces_no_ranked_vaccine():

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -26,12 +26,13 @@ import os
 
 import pytest
 
-from vaxrank.epitope_io import load_lens
+from vaxrank.epitope_io import read_lens_report
 from vaxrank.external_input import (
+    ExternalConstructOptions,
     ExternalVariantEntry,
     peptide_offsets_in_context,
     parse_lens_variant_coordinates,
-    ranked_from_lens_predictions,
+    lens_ranking_result,
 )
 
 DATA_DIR = os.path.join(
@@ -284,8 +285,10 @@ def test_real_lens_v19_subset_produces_ranked_entries():
     produces a non-empty ranked list end-to-end."""
     path = os.path.join(
         DATA_DIR, "real_lens_subsets", "lens_v1.9_real_subset.tsv")
-    report_df, predictions = load_lens(path)
-    ranked, _dna_vaf = ranked_from_lens_predictions(predictions, path)
+    _loaded = read_lens_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = lens_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
     # The fixture has at least one parseable variant_coords row.
     # Pre-fix: 0. Now: > 0.
     assert len(ranked) > 0, (
@@ -832,8 +835,10 @@ def test_lens_pep_context_with_stop_codon_truncates():
     path = os.path.join(
         DATA_DIR, "real_lens_subsets",
         "lens_v1.9_with_stop_codons.tsv")
-    report_df, predictions = load_lens(path)
-    ranked, _dna_vaf = ranked_from_lens_predictions(predictions, path)
+    _loaded = read_lens_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = lens_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
     # No fragment carries a '*' or a non-standard residue.
     for _, peptides in ranked:
         for vp in peptides:
@@ -894,8 +899,10 @@ def test_lens_picks_strongest_binder_when_multiple_rows_per_variant():
     of binding strength. This test pins the fix.
     """
     path = os.path.join(DATA_DIR, "lens_multi_row_per_variant.tsv")
-    report_df, predictions = load_lens(path)
-    ranked, _dna_vaf = ranked_from_lens_predictions(predictions, path)
+    _loaded = read_lens_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = lens_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
     assert len(ranked) == 1, (
         "Fixture has one variant with 3 peptides; got %d entries" % len(ranked))
     _, peptides = ranked[0]
@@ -917,10 +924,13 @@ def test_patient_info_from_external_proxy_counts():
     from vaxrank.external_input import patient_info_from_external
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, predictions = load_lens(path)
-    ranked, _dna_vaf = ranked_from_lens_predictions(predictions, path)
+    _loaded = read_lens_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = lens_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
     info = patient_info_from_external(
-        ranked, path, patient_id='Pt-X', input_label='LENS report')
+        ranked, path, 'Pt-X', _ranking.input_summary,
+        input_label='LENS report')
     assert info.patient_id == 'Pt-X'
     # PatientInfo on the external path no longer overloads
     # ``vcf_paths`` (LENS files aren't VCFs); the explicit
@@ -928,9 +938,10 @@ def test_patient_info_from_external_proxy_counts():
     assert info.vcf_paths == []
     assert info.inputs == [('LENS report', path)]
     assert info.bam_path is None
-    # All ranked variants are counted as somatic (LENS antigen-only
-    # files don't carry pre-pipeline silent variants).
-    assert info.num_somatic_variants == len(ranked)
+    # Input composition comes from the parse, not from the ranked output:
+    # every variant the file produced antigens for, before filtering.
+    assert info.num_somatic_variants == (
+        _ranking.input_summary.num_somatic_variants)
     # Without --ensembl-release the test fixture won't resolve
     # transcripts; coding-effect count drops to 0.
     assert info.num_coding_effect_variants == 0
@@ -943,7 +954,9 @@ def test_patient_info_from_external_proxy_counts():
 def test_patient_info_from_external_empty_ranked():
     """No ranked variants → all counts zero, no crash."""
     from vaxrank.external_input import patient_info_from_external
-    info = patient_info_from_external([], '/tmp/empty.tsv', patient_id='')
+    from vaxrank.external_input import ExternalInputSummary
+    info = patient_info_from_external(
+        [], '/tmp/empty.tsv', '', ExternalInputSummary())
     assert info.num_somatic_variants == 0
     assert info.num_coding_effect_variants == 0
     assert info.num_variants_with_rna_support == 0
@@ -1017,8 +1030,10 @@ def test_lens_to_ranked_vaccine_peptides_round_trip():
     peptides should produce one entry per unique variant, each
     carrying the pep_context as the antigen fragment."""
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, epitopes = load_lens(path)
-    ranked, _dna_vaf = ranked_from_lens_predictions(epitopes, path)
+    _loaded = read_lens_report(path)
+    epitopes = list(_loaded.epitopes)
+    _ranking = lens_ranking_result(_loaded, epitopes)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
     assert len(ranked) == 3, (
         "LENS fixture has 3 unique variants; got %d" % len(ranked))
     # Each ranked entry: (Variant, [VaccinePeptide])
@@ -1043,8 +1058,10 @@ def test_lens_drives_mrna_construct_assembly_end_to_end():
     from vaxrank.mrna import RNAConstructConfig, assemble_mrna_constructs
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, predictions = load_lens(path)
-    ranked, _dna_vaf = ranked_from_lens_predictions(predictions, path)
+    _loaded = read_lens_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = lens_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
     assert ranked, "Expected non-empty ranked list from LENS fixture"
 
     options = RNAConstructConfig(
@@ -1075,8 +1092,10 @@ def test_lens_drives_peptide_construct_assembly_end_to_end():
         PeptideConstructConfig, assemble_peptide_constructs)
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, predictions = load_lens(path)
-    ranked, _dna_vaf = ranked_from_lens_predictions(predictions, path)
+    _loaded = read_lens_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = lens_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
 
     options = PeptideConstructConfig(mode='slp')
     constructs = assemble_peptide_constructs(ranked, options=options)
@@ -1094,12 +1113,14 @@ def test_pvacseq_to_ranked_vaccine_peptides_round_trip():
     untested and the ID parser only handled dotted form, producing
     an empty ranked list end-to-end.
     """
-    from vaxrank.epitope_io import load_pvacseq
-    from vaxrank.external_input import ranked_from_pvacseq_predictions
+    from vaxrank.epitope_io import read_pvacseq_report
+    from vaxrank.external_input import pvacseq_ranking_result
 
     path = os.path.join(DATA_DIR, "pvacseq_example.tsv")
-    report_df, predictions = load_pvacseq(path)
-    ranked, _dna_vaf = ranked_from_pvacseq_predictions(predictions, path)
+    _loaded = read_pvacseq_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = pvacseq_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
     assert len(ranked) == 3, (
         "pVACseq fixture has 3 unique variants; got %d" % len(ranked))
     genes = sorted(
@@ -1139,13 +1160,15 @@ def test_pvacseq_drives_mrna_construct_assembly_end_to_end():
     """End-to-end: pVACseq report → ranked → mRNA constructs (mirror
     of the LENS end-to-end test). Pre-fix this produced zero
     constructs because the ranked list was empty."""
-    from vaxrank.epitope_io import load_pvacseq
-    from vaxrank.external_input import ranked_from_pvacseq_predictions
+    from vaxrank.epitope_io import read_pvacseq_report
+    from vaxrank.external_input import pvacseq_ranking_result
     from vaxrank.mrna import RNAConstructConfig, assemble_mrna_constructs
 
     path = os.path.join(DATA_DIR, "pvacseq_example.tsv")
-    _, predictions = load_pvacseq(path)
-    ranked, _dna_vaf = ranked_from_pvacseq_predictions(predictions, path)
+    _loaded = read_pvacseq_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = pvacseq_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
     assert ranked
 
     options = RNAConstructConfig(
@@ -1164,13 +1187,14 @@ def test_pvacseq_drives_mrna_construct_assembly_end_to_end():
 def test_pvacseq_all_epitopes_to_ranked_vaccine_peptides(tmp_path):
     """all_epitopes flavor uses MT Epitope Seq + chr/ref/alt columns."""
     from tests.test_epitope_io import _write_pvacseq_all_epitopes_fixture
-    from vaxrank.epitope_io import load_pvacseq
-    from vaxrank.external_input import ranked_from_pvacseq_predictions
+    from vaxrank.epitope_io import read_pvacseq_report
+    from vaxrank.external_input import pvacseq_ranking_result
 
     path = _write_pvacseq_all_epitopes_fixture(tmp_path)
-    _, predictions = load_pvacseq(path)
-    ranked, dna_vaf_by_variant = ranked_from_pvacseq_predictions(
-        predictions, path)
+    _loaded = read_pvacseq_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = pvacseq_ranking_result(_loaded, predictions)
+    ranked, dna_vaf_by_variant = _ranking.ranked, _ranking.dna_vaf_by_variant
 
     assert len(ranked) == 1
     variant, vaccine_peptides = ranked[0]
@@ -1188,13 +1212,14 @@ def test_pvacseq_all_epitopes_to_ranked_vaccine_peptides(tmp_path):
 def test_pvacseq_duplicate_peptides_stay_variant_scoped(tmp_path):
     """Identical peptides from different pVACseq variants must not mix."""
     from tests.test_epitope_io import _write_pvacseq_duplicate_peptide_fixture
-    from vaxrank.epitope_io import load_pvacseq
-    from vaxrank.external_input import ranked_from_pvacseq_predictions
+    from vaxrank.epitope_io import read_pvacseq_report
+    from vaxrank.external_input import pvacseq_ranking_result
 
     path = _write_pvacseq_duplicate_peptide_fixture(tmp_path)
-    _, predictions = load_pvacseq(path)
-    ranked, _dna_vaf_by_variant = ranked_from_pvacseq_predictions(
-        predictions, path)
+    _loaded = read_pvacseq_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = pvacseq_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf_by_variant = _ranking.ranked, _ranking.dna_vaf_by_variant
 
     assert len(ranked) == 2
     expected_source_by_variant = {
@@ -1224,8 +1249,8 @@ def test_lens_without_affinity_uses_dsl_score_without_fallback_warning(
         tmp_path, caplog):
     """Non-affinity evidence no longer triggers a raw-affinity fallback."""
     import logging
-    from vaxrank.epitope_io import load_lens
-    from vaxrank.external_input import ranked_from_lens_predictions
+    from vaxrank.epitope_io import read_lens_report
+    from vaxrank.external_input import lens_ranking_result
 
     no_aff = tmp_path / "no_affinity.tsv"
     no_aff.write_text(
@@ -1236,9 +1261,11 @@ def test_lens_without_affinity_uses_dsl_score_without_fallback_warning(
         "HLA-A02:01\tSVVGSSSSS\t12.5\t0.5\tSNV\t245\t"
         "chr17:7675088\tC\t[T]\tTP53\t42.5\tAASVVGSSSSSGTR\n")
 
-    _, predictions = load_lens(str(no_aff))
+    _loaded = read_lens_report(str(no_aff))
+    predictions = list(_loaded.epitopes)
     with caplog.at_level(logging.WARNING):
-        ranked, _dna_vaf = ranked_from_lens_predictions(predictions, str(no_aff))
+        _ranking = lens_ranking_result(_loaded, predictions)
+        ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
     # The configured/default DSL is now the sole representative selector.
     assert len(ranked) == 1
     assert not any(
@@ -1306,8 +1333,10 @@ def test_emit_outputs_logs_active_and_fired_dispatch(caplog, tmp_path):
     from vaxrank.cli.entry_point import emit_outputs
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, predictions = load_lens(path)
-    ranked, _dna_vaf = ranked_from_lens_predictions(predictions, path)
+    _loaded = read_lens_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = lens_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
 
     out_dir = str(tmp_path / "out")
     args = _mrna_args(out_dir)
@@ -1377,8 +1406,10 @@ def test_lens_with_vaccine_type_mrna_writes_three_fastas(tmp_path):
     from vaxrank.cli.entry_point import emit_outputs
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, predictions = load_lens(path)
-    ranked, _dna_vaf = ranked_from_lens_predictions(predictions, path)
+    _loaded = read_lens_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = lens_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
 
     out_dir = str(tmp_path / "out")
     args = _mrna_args(out_dir)
@@ -1405,8 +1436,10 @@ def test_lens_with_multi_vaccine_type_uses_subdirs(tmp_path):
     from vaxrank.cli.entry_point import emit_outputs
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, predictions = load_lens(path)
-    ranked, _dna_vaf = ranked_from_lens_predictions(predictions, path)
+    _loaded = read_lens_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = lens_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
 
     out_dir = str(tmp_path / "out")
     args = _vaccine_args(out_dir, vaccine_type=['peptide', 'mrna'])
@@ -1425,8 +1458,10 @@ def test_emit_outputs_skips_writer_when_no_output_dir(tmp_path):
     from vaxrank.cli.entry_point import emit_outputs
 
     path = os.path.join(DATA_DIR, "lens_example.tsv")
-    report_df, predictions = load_lens(path)
-    ranked, _dna_vaf = ranked_from_lens_predictions(predictions, path)
+    _loaded = read_lens_report(path)
+    predictions = list(_loaded.epitopes)
+    _ranking = lens_ranking_result(_loaded, predictions)
+    ranked, _dna_vaf = _ranking.ranked, _ranking.dna_vaf_by_variant
 
     out_dir = str(tmp_path / "out")
     args = _mrna_args(out_dir)
@@ -1611,7 +1646,7 @@ def test_lens_construct_excludes_epitopes_outside_its_window(tmp_path):
     result = lens_ranking_result(
         report,
         epitopes_for_ranking(list(report.epitopes), config),
-        vaccine_peptide_length=25)
+        options=ExternalConstructOptions(vaccine_peptide_length=25))
 
     assert len(result.ranked) == 1
     vaccine_peptide = result.ranked[0][1][0]

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -410,6 +410,19 @@ def test_epitope_data_renders_missing_mutant_ic50_placeholder():
         assert row['IC50'] == 'No prediction'
 
 
+def test_epitope_data_renders_missing_dsl_score_as_unavailable():
+    """An absent per-allele score must not silently become zero."""
+    from vaxrank.report import TemplateDataCreator
+
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = {}
+    epitope = _ep("SIINFEKL", "SSIINFEKL", offset=1)
+
+    row = creator.epitope_data(epitope, epitope.best_affinity())
+
+    assert row['Score'] == '—'
+
+
 def test_epitope_data_surfaces_processing_columns_when_annotated():
     """``TemplateDataCreator.epitope_data`` adds three extra
     columns (Processing: C-term, Processing: max internal,

--- a/tests/test_risk_ligand.py
+++ b/tests/test_risk_ligand.py
@@ -3,6 +3,8 @@ from types import SimpleNamespace
 
 import pandas as pd
 import pytest
+
+from tests.common import STUB_ONCOREF_VERSION
 from topiary import TopiaryPredictor
 
 from vaxrank.risk_ligand import (
@@ -59,7 +61,7 @@ def _tissue_risk():
             cta_source_rows_excluded=0,
         ),
         hpa_provenance=HPAReferenceProvenance(
-            oncoref_version="1.8.174",
+            oncoref_version=STUB_ONCOREF_VERSION,
             oncoref_data_version="5.23.17",
             oncoref_source_matrix_version="5.22.10",
             source_name="hpa_normal_tissue",

--- a/tests/test_tissue_risk.py
+++ b/tests/test_tissue_risk.py
@@ -4,6 +4,8 @@ import json
 import pandas as pd
 import pytest
 
+from tests.common import STUB_ONCOREF_VERSION
+
 from vaxrank.tissue_risk import (
     DEFAULT_HPA_LEVELS,
     DEFAULT_HPA_RELIABILITIES,
@@ -18,7 +20,7 @@ from vaxrank.tissue_risk import (
 
 def _provenance(verification_status="verified"):
     return HPAReferenceProvenance(
-        oncoref_version="1.8.174",
+        oncoref_version=STUB_ONCOREF_VERSION,
         oncoref_data_version="5.23.17",
         oncoref_source_matrix_version="5.22.10",
         source_name="hpa_normal_tissue",

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -700,6 +700,8 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
       ``patient_alleles``            iterable[str], optional — alleles
                                      explicitly associated with this input
                                      row even when ``mutant.allele`` is empty.
+      ``per_allele_scores``          mapping[str, float], optional — scores
+                                     already evaluated by the configured DSL.
 
     Semantics:
 
@@ -749,6 +751,13 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
             slot['patient_alleles'].add(row['mutant'].allele)
         slot['patient_alleles'].update(
             allele for allele in (row.get('patient_alleles') or ()) if allele)
+        for allele, score in (row.get('per_allele_scores') or {}).items():
+            score = float(score)
+            existing_score = slot['per_allele_scores'].get(allele)
+            if existing_score is not None and existing_score != score:
+                raise ValueError(
+                    "Conflicting per-allele scores for one candidate epitope")
+            slot['per_allele_scores'][allele] = score
         slot['overlaps_mutation'] |= bool(row.get('overlaps_mutation', False))
         overlaps_targetable = row.get('overlaps_targetable')
         if overlaps_targetable is not None:

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -534,6 +534,12 @@ class CandidateEpitope(Peptide):
     # allele-less.
     patient_alleles: tuple[str, ...] = ()
 
+    # Stable identity supplied by external prediction loaders. It encodes
+    # variant, gene/transcript, peptide context, peptide, and offset; see
+    # ``ExternalPredictionKey``. Empty for native pipeline predictions, whose
+    # position identity remains ``(source_sequence, sequence, offset)``.
+    prediction_id: str = ""
+
     # Per-allele score for this epitope as computed by the configured
     # :class:`~vaxrank.epitope_config.EpitopeConfig` ``score_expr``
     # (see :mod:`vaxrank.epitope_dsl`). Keys are allele names exactly
@@ -592,9 +598,22 @@ class CandidateEpitope(Peptide):
     def __hash__(self) -> int:
         # Inherited from Peptide in spirit, but ``@dataclass(frozen=True)``
         # regenerates ``__hash__`` on every subclass — and ours would
-        # include the mutable ``comparators`` dict. Re-define here to
-        # keep the same position-identity hash as the parent.
-        return hash((self.sequence, self.source_sequence, self.offset))
+        # include the mutable ``comparators`` dict. External candidates add
+        # their provenance ID to the normal peptide-position identity.
+        position = (self.sequence, self.source_sequence, self.offset)
+        if not self.prediction_id:
+            return hash(position)
+        return hash((self.prediction_id,) + position)
+
+    @property
+    def prediction_group_source(self) -> str:
+        """First component of the Topiary score-group identity."""
+        return self.prediction_id or self.source_sequence or self.sequence
+
+    @property
+    def prediction_group_key(self) -> tuple[str, str, int]:
+        """Exact source/peptide/offset identity used for score joins."""
+        return self.prediction_group_source, self.sequence, self.offset
 
     # Convenience: most call sites today read the WT alongside the
     # candidate. Common-case shortcut.
@@ -644,6 +663,7 @@ class CandidateEpitope(Peptide):
             occurs_in_non_CTA_reference=self.occurs_in_non_CTA_reference,
             self_reference_match=self.self_reference_match,
             patient_alleles=self.patient_alleles,
+            prediction_id=self.prediction_id,
             per_allele_scores=dict(self.per_allele_scores))
 
     @classmethod
@@ -675,8 +695,8 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
 
     Producers (``predict_epitopes``, LENS / pVACseq loaders) iterate
     row-shaped inputs (topiary frame, TSV) and build a flat list of
-    row dicts; this function groups them by ``(peptide, source,
-    offset)`` and emits one ``CandidateEpitope`` per group, in
+    row dicts; this function groups them by ``(prediction_id, peptide,
+    source, offset)`` and emits one ``CandidateEpitope`` per group, in
     first-seen order.
 
     Each row is a mapping with the following keys:
@@ -684,6 +704,7 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
       ``peptide``    str             — candidate peptide sequence
       ``source``     str             — source protein / transcript window
       ``offset``     int             — peptide offset within ``source``
+      ``prediction_id`` str, optional — complete external provenance key
       ``mutant``     Prediction      — leaf prediction for one (allele,
                                        predictor, version) cell
       ``wt``         Prediction|None — parallel WT prediction, optional
@@ -722,13 +743,15 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
     groups: dict = {}
     for row in rows:
         peptide = row['peptide']
-        key = (peptide, row['source'], row['offset'])
+        prediction_id = row.get('prediction_id') or ''
+        key = (prediction_id, peptide, row['source'], row['offset'])
         slot = groups.get(key)
         if slot is None:
             slot = {
                 'peptide': peptide,
                 'source': row['source'],
                 'offset': row['offset'],
+                'prediction_id': prediction_id,
                 'mutant_preds': [],
                 'wt_preds': [],
                 'wt_peptide': None,
@@ -816,6 +839,7 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
             occurs_in_non_CTA_reference=slot['occurs_in_non_CTA_reference'],
             self_reference_match=slot['self_reference_match'],
             patient_alleles=tuple(sorted(slot['patient_alleles'])),
+            prediction_id=slot['prediction_id'],
             per_allele_scores=dict(slot['per_allele_scores']),
         ))
     return out

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -526,6 +526,14 @@ class CandidateEpitope(Peptide):
     # raw-reference behavior for legacy files and external-input loaders.
     self_reference_match: Optional["SelfReferenceMatch"] = None
 
+    # Patient alleles for which this candidate has input evidence. This is
+    # usually identical to the non-empty alleles on prediction leaves, but
+    # must be retained separately for allele-independent evidence such as
+    # antigen processing. External formats like LENS repeat that evidence on
+    # one row per patient allele while the canonical Prediction remains
+    # allele-less.
+    patient_alleles: tuple[str, ...] = ()
+
     # Per-allele score for this epitope as computed by the configured
     # :class:`~vaxrank.epitope_config.EpitopeConfig` ``score_expr``
     # (see :mod:`vaxrank.epitope_dsl`). Keys are allele names exactly
@@ -537,6 +545,23 @@ class CandidateEpitope(Peptide):
     # from here and never recompute — the DSL is the single source
     # of truth.
     per_allele_scores: dict = field(default_factory=dict)
+
+    def __post_init__(self):
+        """Normalize predictions and retain every explicitly known allele."""
+        super().__post_init__()
+        alleles = {
+            allele
+            for allele in self.patient_alleles
+            if allele
+        }
+        alleles.update(
+            prediction.allele
+            for prediction in self.predictions_flat()
+            if prediction.allele
+        )
+        alleles.update(
+            allele for allele in self.per_allele_scores if allele)
+        object.__setattr__(self, 'patient_alleles', tuple(sorted(alleles)))
 
     @property
     def epitope_score(self) -> float:
@@ -618,6 +643,7 @@ class CandidateEpitope(Peptide):
             occurs_in_reference=self.occurs_in_reference,
             occurs_in_non_CTA_reference=self.occurs_in_non_CTA_reference,
             self_reference_match=self.self_reference_match,
+            patient_alleles=self.patient_alleles,
             per_allele_scores=dict(self.per_allele_scores))
 
     @classmethod
@@ -671,6 +697,9 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
                                      value as ``occurs_in_reference``.
       ``self_reference_match``       SelfReferenceMatch|None — explicit
                                      antigen-aware exact-self result.
+      ``patient_alleles``            iterable[str], optional — alleles
+                                     explicitly associated with this input
+                                     row even when ``mutant.allele`` is empty.
 
     Semantics:
 
@@ -707,6 +736,7 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
                 'occurs_in_reference': False,
                 'occurs_in_non_CTA_reference': False,
                 'self_reference_match': None,
+                'patient_alleles': set(),
                 # Accumulator for per-allele DSL scores. Same allele
                 # may appear in multiple rows (different predictors);
                 # all rows for one allele share the same score by
@@ -715,6 +745,10 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
             }
             groups[key] = slot
         slot['mutant_preds'].append(row['mutant'])
+        if row['mutant'].allele:
+            slot['patient_alleles'].add(row['mutant'].allele)
+        slot['patient_alleles'].update(
+            allele for allele in (row.get('patient_alleles') or ()) if allele)
         slot['overlaps_mutation'] |= bool(row.get('overlaps_mutation', False))
         overlaps_targetable = row.get('overlaps_targetable')
         if overlaps_targetable is not None:
@@ -772,6 +806,7 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
             occurs_in_reference=slot['occurs_in_reference'],
             occurs_in_non_CTA_reference=slot['occurs_in_non_CTA_reference'],
             self_reference_match=slot['self_reference_match'],
+            patient_alleles=tuple(sorted(slot['patient_alleles'])),
             per_allele_scores=dict(slot['per_allele_scores']),
         ))
     return out

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -703,6 +703,12 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
 
       ``peptide``    str             — candidate peptide sequence
       ``source``     str             — source protein / transcript window
+      ``source_name`` str, optional  — human-readable name of that window
+                                       (transcript, variant, contig …)
+      ``n_flank`` / ``c_flank``      str, optional — residues flanking the
+                                       peptide in its source protein; carried
+                                       because processing predictors score
+                                       them
       ``offset``     int             — peptide offset within ``source``
       ``prediction_id`` str, optional — complete external provenance key
       ``mutant``     Prediction      — leaf prediction for one (allele,
@@ -750,6 +756,9 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
             slot = {
                 'peptide': peptide,
                 'source': row['source'],
+                'source_name': row.get('source_name') or '',
+                'n_flank': row.get('n_flank') or '',
+                'c_flank': row.get('c_flank') or '',
                 'offset': row['offset'],
                 'prediction_id': prediction_id,
                 'mutant_preds': [],
@@ -829,6 +838,9 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
         out.append(CandidateEpitope(
             sequence=slot['peptide'],
             source_sequence=slot['source'],
+            source_name=slot['source_name'],
+            n_flank=slot['n_flank'],
+            c_flank=slot['c_flank'],
             offset=slot['offset'],
             predictions=tuple(slot['mutant_preds']),
             comparators=comparators,

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -813,9 +813,21 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
                     "Conflicting self-reference matches for one candidate epitope"
                 )
             slot['self_reference_match'] = self_reference_match
-        if 'allele_score' in row:
-            slot['per_allele_scores'][row['mutant'].allele] = float(
-                row['allele_score'])
+        if 'allele_score' in row and row['mutant'].allele:
+            # Allele-free leaves (antigen_processing, proteasome_cleavage)
+            # carry a score for the peptide, not for an allele. Writing it
+            # under '' would put a non-allele entry in a map whose contract
+            # is explicitly per patient allele, and epitope_score sums the
+            # map — so the candidate would score its processing evidence as
+            # if it were an extra allele. attach_per_allele_scores applies
+            # the same rule on the loader path.
+            allele = row['mutant'].allele
+            score = float(row['allele_score'])
+            existing = slot['per_allele_scores'].get(allele)
+            if existing is not None and existing != score:
+                raise ValueError(
+                    "Conflicting per-allele scores for one candidate epitope")
+            slot['per_allele_scores'][allele] = score
         wt = row.get('wt')
         if wt is not None and wt.peptide and wt.peptide == peptide:
             # Self-WT: comparing the candidate against itself is meaningless.

--- a/vaxrank/cells.py
+++ b/vaxrank/cells.py
@@ -145,5 +145,16 @@ def first_text(row, *names) -> str:
 
 
 def first_number(row, *names, default=None):
-    """:func:`first` coerced through :func:`number`."""
-    return number(first(row, *names), default=default)
+    """Return the first value among *names* that parses as a number.
+
+    Note the rule: a present-but-unparseable cell does *not* stop the search.
+    A report that writes ``rna_vaf='high'`` and ``tumor_rna_vaf=0.3`` has one
+    usable number, and both the ranking path and the report path must find
+    the same one — reading "first non-missing, then coerce" in one place and
+    "first that coerces" in another is how the two disagreed about a row.
+    """
+    for name in names:
+        parsed = number(row.get(name))
+        if parsed is not None:
+            return parsed
+    return default

--- a/vaxrank/cells.py
+++ b/vaxrank/cells.py
@@ -1,0 +1,149 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The single normalization vocabulary for tabular input cells.
+
+Every reader of an external report (LENS, pVACseq) and of vaxrank's own
+native epitope files funnels cell values through these functions. There is
+deliberately *one* answer to "is this cell missing", "what is this cell as
+text", and "what is this cell as a number", because a prediction identity
+built with one answer must join against an identity built with another.
+
+The historical failure mode this replaces: ``epitope_io._safe_str`` did not
+strip whitespace while ``external_prediction.external_text`` did, so a single
+trailing space in a LENS ``pep_context`` produced two different identities for
+the same row and aborted the run with an opaque duplicate-identity error.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+# Cell text that means "no value" regardless of the producing tool. Compared
+# case-insensitively after stripping.
+MISSING_TEXT = frozenset({"", "na", "n/a", "nan", "none", "null", "."})
+
+_TRUE_TEXT = frozenset({"true", "t", "yes", "y", "1"})
+_FALSE_TEXT = frozenset({"false", "f", "no", "n", "0"})
+
+
+def missing(value) -> bool:
+    """True when a cell carries no value.
+
+    Covers ``None``, pandas/numpy NA sentinels, and the textual spellings in
+    :data:`MISSING_TEXT` that TSV producers use interchangeably.
+    """
+    if value is None:
+        return True
+    try:
+        if bool(pd.isna(value)):
+            return True
+    except (TypeError, ValueError):
+        # Array-likes and exotic objects are not scalar-missing.
+        pass
+    if isinstance(value, str):
+        return value.strip().lower() in MISSING_TEXT
+    return False
+
+
+def text(value) -> str:
+    """Return a cell as stripped text, or ``""`` when it is missing."""
+    if missing(value):
+        return ""
+    return str(value).strip()
+
+
+def values(*cells) -> tuple[str, ...]:
+    """Return the sorted unique comma/semicolon-delimited values of *cells*.
+
+    External reports pack multi-valued annotations (gene IDs, transcript IDs)
+    into one cell with either separator, and different rows list them in
+    different orders. Sorting and de-duplicating here is what lets those rows
+    resolve to one identity.
+    """
+    result = set()
+    for cell in cells:
+        cell_text = text(cell)
+        if not cell_text:
+            continue
+        for comma_part in cell_text.split(","):
+            for part in comma_part.split(";"):
+                part = part.strip()
+                if part:
+                    result.add(part)
+    return tuple(sorted(result))
+
+
+def number(value, default=None):
+    """Return a cell as ``float``, or *default* when missing/unparseable."""
+    if missing(value):
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def integer(value, default=0) -> int:
+    """Return a cell as a rounded ``int``, or *default* when unusable.
+
+    Read counts and depths arrive as floats, as float-formatted strings, or
+    not at all. A missing count is *default* (normally ``0``, an honest "no
+    signal") rather than a fabricated stand-in.
+    """
+    parsed = number(value)
+    if parsed is None:
+        return default
+    try:
+        return int(round(parsed))
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def boolean(value, default=False) -> bool:
+    """Return a cell as ``bool``, honoring the usual TSV spellings."""
+    if missing(value):
+        return default
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in _TRUE_TEXT:
+            return True
+        if lowered in _FALSE_TEXT:
+            return False
+        return default
+    return bool(value)
+
+
+def first(row, *names):
+    """Return the first present, non-missing value among *names* in *row*.
+
+    The ordering of *names* is a documented precedence, not an accident:
+    when one logical field is spelled differently across report flavors,
+    every reader must consult the spellings in the same order or the two
+    readers disagree about what the row says.
+    """
+    for name in names:
+        value = row.get(name)
+        if not missing(value):
+            return value
+    return None
+
+
+def first_text(row, *names) -> str:
+    """:func:`first` coerced through :func:`text`."""
+    return text(first(row, *names))
+
+
+def first_number(row, *names, default=None):
+    """:func:`first` coerced through :func:`number`."""
+    return number(first(row, *names), default=default)

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -985,6 +985,11 @@ def external_input_arg_parser():
              "By default pyensembl picks the most recent locally installed "
              "release. Match the release LENS / pVACseq used.")
     add_output_args(arg_parser)
+    # Vaccine-peptide options apply to external inputs exactly as they do to
+    # the VCF pipeline: the construct window, how many target epitopes it
+    # keeps, and how it is scored are all vaccine-design decisions, not
+    # properties of where the predictions came from.
+    add_vaccine_peptide_args(arg_parser)
     # Template reports (ASCII / HTML / PDF) work on this path too once
     # transcripts are resolved (#268). The supplemental + optional groups
     # contribute the namespace shape ``TemplateDataCreator`` expects

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -439,7 +439,8 @@ def add_output_args(arg_parser):
         "--output-epitopes",
         default="",
         help="Path to save epitope predictions as a TSV/CSV file (format inferred "
-             "from extension). This file can later be loaded with --input-epitopes.")
+             "from extension). Written as a record of what was predicted; "
+             "there is no CLI flag to load one back yet (openvax/vaxrank#346).")
 
     output_args_group.add_argument(
         "--output-isovar-csv",

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -1171,8 +1171,29 @@ def main(args_list=None):
         merged_config = load_vaxrank_config(args)
         epitope_config = epitope_config_from_args(
             args, merged_config=merged_config)
+        # ``vaccine_peptides:`` config used to be resolved only inside
+        # ``run_vaxrank_from_parsed_args`` — the pipeline-only entry point —
+        # so peptide length, epitope retention, the combined-score
+        # expression, and manufacturability thresholds silently did nothing
+        # on LENS / pVACseq runs. Resolve them here too and hand them to the
+        # loader, which passes them to construct assembly.
+        vaccine_config = vaccine_config_from_args(
+            args, merged_config=merged_config)
+        if 'peptide' in resolve_vaccine_types(args):
+            manufacturability_config = manufacturability_config_from_args(
+                args, merged_config=merged_config)
+        else:
+            manufacturability_config = None
+        args.vaccine_peptide_length = vaccine_config.preferred_peptide_length
+        args.num_epitopes_per_vaccine_peptide = (
+            vaccine_config.num_target_epitopes_to_keep)
+        args.max_vaccine_peptides_per_variant = (
+            vaccine_config.max_vaccine_peptides_per_variant)
         loaded = load_external_ranked(
-            args, epitope_config=epitope_config)
+            args,
+            epitope_config=epitope_config,
+            vaccine_config=vaccine_config,
+            manufacturability_config=manufacturability_config)
         if loaded is None:
             ranked_variants_with_vaccine_peptides = []
         else:

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -282,18 +282,14 @@ def vaccine_target_dir(output_dir, vaccine_type, all_active_types):
     return output_dir
 
 
-def _emit_neoepitope_report_external(args, report_df, epitopes):
+def emit_external_neoepitope_report(
+        args, report_df, epitopes, epitope_config):
     """LENS / pVACseq specific report path: writes the per-(peptide,
     allele) neoepitope CSV / XLSX. Independent from the modality
     dispatch — these are *report* outputs, not vaccine-design outputs.
     """
     if report_df is None or report_df.empty:
         return
-    from ..epitope_config import EpitopeConfig
-    try:
-        epitope_config = epitope_config_from_args(args)
-    except Exception:
-        epitope_config = EpitopeConfig()
     write_neoepitope_report(
         report_df=report_df,
         epitopes=epitopes,
@@ -792,7 +788,7 @@ def emit_outputs(args, ranked, source):
 
     # Rank reports run for both sources; on the external-input path
     # the LENS-native per-(peptide, allele) report already consumed
-    # ``--output-csv`` (via _emit_neoepitope_report_external) so the
+    # ``--output-csv`` (via emit_external_neoepitope_report) so the
     # rank-report writer would collide — skip it there.
     if (args.output_csv or args.output_xlsx_report) and source != 'external':
         make_csv_report(
@@ -1172,7 +1168,11 @@ def main(args_list=None):
     if (
             getattr(args, 'input_pvacseq', None)
             or getattr(args, 'input_lens', None)):
-        loaded = load_external_ranked(args)
+        merged_config = load_vaxrank_config(args)
+        epitope_config = epitope_config_from_args(
+            args, merged_config=merged_config)
+        loaded = load_external_ranked(
+            args, epitope_config=epitope_config)
         if loaded is None:
             ranked_variants_with_vaccine_peptides = []
         else:
@@ -1210,7 +1210,8 @@ def main(args_list=None):
                     len(alleles), ", ".join(alleles))
         # Per-(peptide, allele) CSV / XLSX report is unique to the
         # external-input path; emit it before the shared dispatch.
-        _emit_neoepitope_report_external(args, report_df, predictions)
+        emit_external_neoepitope_report(
+            args, report_df, predictions, epitope_config)
         # Template reports want a dict here, not a Namespace —
         # ``vars(args)`` matches the pipeline path's
         # ``data['args']`` shape.

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -76,7 +76,7 @@ def parse_epitope_expression(expr):
     return parse(expr)
 
 
-def _kind_for_method(method_name):
+def prediction_kind_for_method(method_name):
     """Topiary Kind string for a prediction_method_name.
 
     Unknown methods default to pMHC_affinity so that a plain

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -350,6 +350,55 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None):
     ]
 
 
+def epitopes_after_dsl_filter(epitopes):
+    """Materialize the prediction groups retained by the Topiary DSL.
+
+    :func:`attach_per_allele_scores` records one key for every retained
+    peptide-allele group, including groups whose configured score is exactly
+    zero. This function uses that membership—not the numeric score—as the
+    authoritative filter result and returns ranking-only copies containing
+    those allele-scoped mutant and comparator leaves.
+
+    The input objects remain unchanged and retain their complete
+    ``patient_alleles`` membership. Callers must infer the patient genotype
+    from that pre-filter collection; filtering target evidence must never
+    redefine which alleles the patient has.
+    """
+    from dataclasses import replace
+
+    retained_epitopes = []
+    for epitope in epitopes:
+        retained_alleles = set(epitope.per_allele_scores)
+        if not retained_alleles:
+            continue
+        retained_predictions = tuple(
+            prediction
+            for prediction in epitope.predictions_flat()
+            if not prediction.allele
+            or prediction.allele in retained_alleles
+        )
+        if not retained_predictions:
+            continue
+        retained_comparators = {}
+        for name, comparator in epitope.comparators.items():
+            retained_comparators[name] = replace(
+                comparator,
+                predictions=tuple(
+                    prediction
+                    for prediction in comparator.predictions_flat()
+                    if not prediction.allele
+                    or prediction.allele in retained_alleles
+                ),
+            )
+        retained_epitopes.append(replace(
+            epitope,
+            predictions=retained_predictions,
+            comparators=retained_comparators,
+            patient_alleles=tuple(sorted(retained_alleles)),
+        ))
+    return retained_epitopes
+
+
 def collect_dsl_references(node):
     """Walk a parsed DSL node and collect its external-data references.
 

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -404,6 +404,10 @@ def epitopes_for_ranking(epitopes, cfg=None):
             predictions=retained_predictions,
             comparators=retained_comparators,
             patient_alleles=tuple(sorted(retained_alleles)),
+            per_allele_scores={
+                allele: epitope.per_allele_scores[allele]
+                for allele in sorted(retained_alleles)
+            },
         ))
     return retained_epitopes
 

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -78,7 +78,7 @@ PIPELINE_GROUP_COLUMNS = (
 
 
 # Method name -> topiary Kind for external-input predictions (LENS / pVACseq
-# import). Listed methods come from ``load_lens`` / ``load_pvacseq``;
+# import). Listed methods come from the external report readers;
 # anything not in this map is assumed to be a pMHC_affinity predictor.
 _METHOD_KIND_MAP = {
     "mhcflurry": "pMHC_affinity",
@@ -366,7 +366,7 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
     :class:`~vaxrank.candidate_epitope.CandidateEpitope` instances with
     each one's ``per_allele_scores`` populated.
 
-    External-input loaders (``load_pvacseq`` / ``load_lens``) build
+    External report readers (``read_pvacseq_report`` / ``read_lens_report``) build
     unscored CandidateEpitopes from a TSV. The upstream pipeline path
     populates ``per_allele_scores`` inside ``predict_epitopes`` from the
     DSL eval; this helper is the equivalent step for the loader path so

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -319,7 +319,12 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None):
     by_position: dict[tuple, dict[str, float]] = {}
     for idx, val in score_series.items():
         src_name, peptide, offset, allele = idx
-        by_position.setdefault((src_name, peptide, offset), {})[allele] = float(val)
+        # Allele-independent processing predictions use ``allele=''``.
+        # They belong in the nested prediction model, but never in a map
+        # whose public contract is explicitly per patient allele.
+        if allele:
+            by_position.setdefault(
+                (src_name, peptide, offset), {})[allele] = float(val)
     return [
         replace(
             e,

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -19,8 +19,8 @@ Two entry points:
   to drop rows wholesale before scoring.
 
 - :func:`build_score_node` — returns a numeric ``DSLNode`` whose ``.eval(ctx)``
-  produces a ``pd.Series`` indexed by ``(source_sequence_name, peptide,
-  peptide_offset, allele)`` group tuples.
+  produces a ``pd.Series`` indexed by exact prediction identity, peptide,
+  peptide offset, and allele for current vaxrank frames.
 
 When ``filter_expr`` / ``score_expr`` are set on the config, each is parsed
 via :func:`topiary.ranking.parse`. When absent the nodes are built directly
@@ -49,6 +49,15 @@ import pandas as pd
 
 
 logger = logging.getLogger(__name__)
+
+
+PREDICTION_ID_COLUMN = "prediction_id"
+PREDICTION_GROUP_COLUMNS = (
+    PREDICTION_ID_COLUMN,
+    "peptide",
+    "peptide_offset",
+    "allele",
+)
 
 
 # Method name -> topiary Kind for external-input predictions (LENS / pVACseq
@@ -134,7 +143,7 @@ def epitopes_to_topiary_df(epitopes):
     rows = []
     for e in epitopes:
         ctx = e
-        source_name = ctx.source_sequence or ctx.sequence
+        prediction_id = ctx.prediction_group_source
         predictions = ctx.predictions_flat()
         patient_alleles = ctx.patient_alleles
         for p in predictions:
@@ -149,7 +158,8 @@ def epitopes_to_topiary_df(epitopes):
             )
             for allele in evaluation_alleles:
                 rows.append({
-                    "source_sequence_name": source_name,
+                    PREDICTION_ID_COLUMN: prediction_id,
+                    "source_sequence_name": ctx.source_sequence or ctx.sequence,
                     "peptide": p.peptide,
                     "peptide_offset": ctx.offset,
                     "peptide_length": len(p.peptide),
@@ -165,6 +175,49 @@ def epitopes_to_topiary_df(epitopes):
                     "score": p.score,
                 })
     return pd.DataFrame(rows)
+
+
+def prediction_group_columns(topiary_df):
+    """Return explicit score-group columns when prediction IDs are present.
+
+    Topiary's inferred grouping is retained for legacy frames. External and
+    vaxrank-generated frames use the stable prediction ID so two biological
+    sources can never be joined merely because their sequences are equal.
+    """
+    if all(column in topiary_df.columns for column in PREDICTION_GROUP_COLUMNS):
+        return list(PREDICTION_GROUP_COLUMNS)
+    return None
+
+
+def filter_prediction_groups(topiary_df, node, default_methods=None):
+    """Apply a Topiary filter using vaxrank's explicit prediction identity.
+
+    Topiary issue #175 tracks adding ``group_keys`` directly to
+    ``apply_filter``; until then its public ``EvalContext`` supplies the same
+    DSL evaluation with an explicit group index here.
+    """
+    from topiary.ranking import EvalContext, apply_filter
+
+    if node is None or topiary_df.empty:
+        return topiary_df.reset_index(drop=True)
+    group_columns = prediction_group_columns(topiary_df)
+    if group_columns is None:
+        return apply_filter(
+            topiary_df, node, default_methods=default_methods)
+
+    context = EvalContext(
+        topiary_df,
+        group_keys=group_columns,
+        default_methods=default_methods,
+        filter_context=True,
+    )
+    values = node.eval(context).reindex(context.group_index)
+    nonmissing = values.dropna()
+    if not nonmissing.map(pd.api.types.is_bool).all():
+        raise TypeError("Filter expression must evaluate to booleans")
+    passing = set(values.fillna(False).astype(bool).loc[lambda x: x].index)
+    keep = context.row_group_tuples().isin(passing)
+    return topiary_df[keep].reset_index(drop=True)
 
 
 # Priority order for auto-picking a canonical method when the user hasn't
@@ -250,15 +303,14 @@ def validate_default_methods(cfg, topiary_df):
 def score_predictions(epitopes, cfg, *, topiary_df=None):
     """Score external-input epitopes using the configured Topiary DSL.
 
-    Returns a ``pandas.Series`` of per-(peptide, allele) scores indexed
-    by the group-key MultiIndex topiary uses internally
-    (``source_sequence_name, peptide, peptide_offset, allele``). Callers
-    merge this back onto their report DataFrame.
+    Returns a ``pandas.Series`` of per-(peptide, allele) scores. Current
+    vaxrank frames use ``(prediction_id, peptide, peptide_offset, allele)``;
+    legacy caller-supplied frames retain Topiary's inferred group keys.
 
     Multi-model data (e.g. both MHCflurry and netMHCpan for
     ``pMHC_affinity``) is handled via topiary's
-    ``EvalContext(default_methods=...)`` and
-    ``apply_filter(default_methods=...)``: unqualified DSL references
+    ``EvalContext(default_methods=...)`` and the same context for filtering:
+    unqualified DSL references
     resolve to the per-Kind default (user-specified via
     ``cfg.default_methods`` or auto-picked canonical), while bracketed
     references like ``Affinity['netmhcpan']`` still pick up their
@@ -272,7 +324,7 @@ def score_predictions(epitopes, cfg, *, topiary_df=None):
     :func:`epitopes_to_topiary_df`) rather than rebuilding from
     ``epitopes``.
     """
-    from topiary.ranking import EvalContext, apply_filter
+    from topiary.ranking import EvalContext
 
     df = (epitopes_to_topiary_df(epitopes)
           if topiary_df is None else topiary_df)
@@ -284,12 +336,17 @@ def score_predictions(epitopes, cfg, *, topiary_df=None):
 
     filter_node = build_filter_node(cfg)
     if filter_node is not None:
-        df = apply_filter(df, filter_node, default_methods=resolved)
+        df = filter_prediction_groups(
+            df, filter_node, default_methods=resolved)
         if df.empty:
             return pd.Series(dtype=float)
 
     score_node = build_score_node(cfg)
-    ctx = EvalContext(df, default_methods=resolved)
+    ctx = EvalContext(
+        df,
+        group_keys=prediction_group_columns(df),
+        default_methods=resolved,
+    )
     return (
         score_node.eval(ctx)
         .reindex(ctx.group_index)
@@ -326,11 +383,9 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None):
     if cfg is None:
         cfg = EpitopeConfig()
     score_series = score_predictions(epitopes, cfg, topiary_df=topiary_df)
-    # score_series is keyed by topiary's group columns. For the rebuilt
-    # vaxrank frame the first key mirrors ``epitopes_to_topiary_df``;
-    # for a supplied loader frame (pVACseq) it matches that loader's
-    # source/variant grouping. ``CandidateEpitope.source_sequence`` is
-    # set to the same key by those loaders.
+    # score_series is keyed by the explicit prediction ID when available,
+    # followed by peptide, offset, and allele. Legacy frames retain Topiary's
+    # inferred first group column.
     by_position: dict[tuple, dict[str, float]] = {}
     for idx, val in score_series.items():
         src_name, peptide, offset, allele = idx
@@ -344,8 +399,7 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None):
         replace(
             e,
             per_allele_scores=by_position.get(
-                (e.source_sequence or e.sequence, e.sequence, e.offset),
-                {}))
+                e.prediction_group_key, {}))
         for e in epitopes
     ]
 

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -113,9 +113,12 @@ def epitopes_to_topiary_df(epitopes):
     :class:`topiary.ranking.EvalContext` and
     :func:`topiary.ranking.apply_filter`.
 
-    One row per leaf ``mhctools.Prediction`` in each CandidateEpitope's mutant
-    context — a single CandidateEpitope can emit N rows (one per allele x
-    predictor x kind). When multiple predictions share a (peptide,
+    One row per allele-scoped leaf ``mhctools.Prediction`` in each
+    CandidateEpitope's mutant context. Allele-independent antigen-processing
+    evidence is projected into every allele group in this evaluation view while
+    remaining one canonical leaf on the CandidateEpitope. A single
+    CandidateEpitope can therefore emit N rows (one per allele x predictor x
+    kind). When multiple predictions share a (peptide,
     allele) pair (e.g. MHCflurry and netMHCpan rows from a LENS file),
     DSL expressions can select between them via
     ``affinity['mhcflurry']`` / ``affinity['netmhcpan']``, and when
@@ -132,23 +135,38 @@ def epitopes_to_topiary_df(epitopes):
     for e in epitopes:
         ctx = e
         source_name = ctx.source_sequence or ctx.sequence
-        for p in ctx.predictions_flat():
-            rows.append({
-                "source_sequence_name": source_name,
-                "peptide": p.peptide,
-                "peptide_offset": ctx.offset,
-                "peptide_length": len(p.peptide),
-                "allele": p.allele,
-                "n_flank": ctx.n_flank,
-                "c_flank": ctx.c_flank,
-                "prediction_method_name": p.predictor_name,
-                "predictor_version": p.predictor_version or "",
-                "kind": p.kind,
-                "value": p.value,
-                "affinity": p.value,
-                "percentile_rank": p.percentile_rank,
-                "score": p.score,
-            })
+        predictions = ctx.predictions_flat()
+        patient_alleles = tuple(sorted({
+            prediction.allele for prediction in predictions
+            if prediction.allele
+        }))
+        for p in predictions:
+            evaluation_alleles = (
+                patient_alleles
+                if (
+                    p.kind == "antigen_processing"
+                    and not p.allele
+                    and patient_alleles
+                )
+                else (p.allele,)
+            )
+            for allele in evaluation_alleles:
+                rows.append({
+                    "source_sequence_name": source_name,
+                    "peptide": p.peptide,
+                    "peptide_offset": ctx.offset,
+                    "peptide_length": len(p.peptide),
+                    "allele": allele,
+                    "n_flank": ctx.n_flank,
+                    "c_flank": ctx.c_flank,
+                    "prediction_method_name": p.predictor_name,
+                    "predictor_version": p.predictor_version or "",
+                    "kind": p.kind,
+                    "value": p.value,
+                    "affinity": p.value,
+                    "percentile_rank": p.percentile_rank,
+                    "score": p.score,
+                })
     return pd.DataFrame(rows)
 
 

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -350,14 +350,15 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None):
     ]
 
 
-def epitopes_after_dsl_filter(epitopes):
-    """Materialize the prediction groups retained by the Topiary DSL.
+def epitopes_for_ranking(epitopes, cfg=None):
+    """Materialize external prediction groups eligible for ranking.
 
     :func:`attach_per_allele_scores` records one key for every retained
-    peptide-allele group, including groups whose configured score is exactly
-    zero. This function uses that membership—not the numeric score—as the
-    authoritative filter result and returns ranking-only copies containing
-    those allele-scoped mutant and comparator leaves.
+    peptide-allele group. This function applies the configured
+    ``min_epitope_score`` to those retained groups and returns ranking-only
+    copies containing the eligible allele-scoped mutant and comparator
+    leaves. Groups below the minimum remain on the input objects for audit
+    reporting but cannot become vaccine targets.
 
     The input objects remain unchanged and retain their complete
     ``patient_alleles`` membership. Callers must infer the patient genotype
@@ -365,10 +366,18 @@ def epitopes_after_dsl_filter(epitopes):
     redefine which alleles the patient has.
     """
     from dataclasses import replace
+    from .epitope_config import EpitopeConfig
+
+    if cfg is None:
+        cfg = EpitopeConfig()
 
     retained_epitopes = []
     for epitope in epitopes:
-        retained_alleles = set(epitope.per_allele_scores)
+        retained_alleles = {
+            allele
+            for allele, score in epitope.per_allele_scores.items()
+            if score >= cfg.min_epitope_score
+        }
         if not retained_alleles:
             continue
         retained_predictions = tuple(

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -136,10 +136,7 @@ def epitopes_to_topiary_df(epitopes):
         ctx = e
         source_name = ctx.source_sequence or ctx.sequence
         predictions = ctx.predictions_flat()
-        patient_alleles = tuple(sorted({
-            prediction.allele for prediction in predictions
-            if prediction.allele
-        }))
+        patient_alleles = ctx.patient_alleles
         for p in predictions:
             evaluation_alleles = (
                 patient_alleles

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -52,8 +52,25 @@ logger = logging.getLogger(__name__)
 
 
 PREDICTION_ID_COLUMN = "prediction_id"
+
+# Vaxrank works with two frame shapes, each with its own identity column.
+# Both are named explicitly rather than left to topiary's inference: what
+# inference keys on has changed twice (sample_name being prepended, then the
+# group-index fixes in 5.17.1), and a frame whose grouping shifts underneath
+# it merges candidates that are not the same candidate.
 PREDICTION_GROUP_COLUMNS = (
+    # Frames vaxrank builds from CandidateEpitope objects, and external
+    # report readers. Identity is the complete provenance key.
     PREDICTION_ID_COLUMN,
+    "peptide",
+    "peptide_offset",
+    "allele",
+)
+PIPELINE_GROUP_COLUMNS = (
+    # Frames a TopiaryPredictor produces directly. There is one protein
+    # fragment per variant, so the source sequence name *is* the identity;
+    # these rows never carry a prediction_id.
+    "source_sequence_name",
     "peptide",
     "peptide_offset",
     "allele",
@@ -178,20 +195,24 @@ def epitopes_to_topiary_df(epitopes):
 def prediction_group_columns(topiary_df):
     """Return the explicit score-group columns for a vaxrank frame.
 
-    Every frame vaxrank builds carries all four. Naming them beats letting
-    topiary infer, because inference keys on ``source_sequence_name`` — so two
-    biological sources would join merely because their sequences are equal.
+    Picks by which identity column the frame carries: ``prediction_id`` for
+    frames vaxrank built or an external reader produced, otherwise the
+    predictor's own ``source_sequence_name``. A frame carrying neither has no
+    identity to group on and is rejected rather than silently grouped by
+    sequence, which would merge two biological sources whose peptides happen
+    to be equal.
     """
-    missing = [
-        column for column in PREDICTION_GROUP_COLUMNS
-        if column not in topiary_df.columns]
-    if missing:
-        raise ValueError(
-            "Prediction frame is missing score-group column(s) %s. Frames "
-            "must come from epitopes_to_topiary_df or an external report "
-            "reader, both of which supply the complete identity."
-            % ", ".join(missing))
-    return list(PREDICTION_GROUP_COLUMNS)
+    columns = set(topiary_df.columns)
+    for candidate in (PREDICTION_GROUP_COLUMNS, PIPELINE_GROUP_COLUMNS):
+        if set(candidate) <= columns:
+            return list(candidate)
+    raise ValueError(
+        "Prediction frame carries no usable score-group identity. Expected "
+        "%s (vaxrank-built or external-reader frames) or %s (frames from a "
+        "TopiaryPredictor); got columns %s."
+        % (", ".join(PREDICTION_GROUP_COLUMNS),
+           ", ".join(PIPELINE_GROUP_COLUMNS),
+           ", ".join(sorted(columns)) or "(none)"))
 
 
 
@@ -275,7 +296,8 @@ def validate_default_methods(cfg, topiary_df):
                 f"(available for {kind}: {sorted(available)})")
 
 
-def score_predictions(epitopes, cfg, *, topiary_df=None):
+def score_predictions(epitopes, cfg, *, topiary_df=None,
+                      kind_support=None):
     """Score external-input epitopes using the configured Topiary DSL.
 
     Returns a ``pandas.Series`` of per-(peptide, allele) scores, indexed by
@@ -297,6 +319,12 @@ def score_predictions(epitopes, cfg, *, topiary_df=None):
     Pass ``topiary_df`` to reuse an already-built frame (see
     :func:`epitopes_to_topiary_df`) rather than rebuilding from
     ``epitopes``.
+
+    ``kind_support`` is topiary's per-(model, kind) MHC context, used to
+    resolve ``mhc_dependence`` guards. Callers holding a
+    ``TopiaryPredictor`` should forward its property; external report
+    readers have no predictor and correctly leave it ``None``, in which
+    case topiary resolves dependence from the rows.
     """
     from topiary.ranking import EvalContext, apply_filter
 
@@ -313,7 +341,8 @@ def score_predictions(epitopes, cfg, *, topiary_df=None):
         df = apply_filter(
             df, filter_node,
             group_keys=prediction_group_columns(df),
-            default_methods=resolved)
+            default_methods=resolved,
+            kind_support=kind_support)
         if df.empty:
             return pd.Series(dtype=float)
 
@@ -322,6 +351,7 @@ def score_predictions(epitopes, cfg, *, topiary_df=None):
         df,
         group_keys=prediction_group_columns(df),
         default_methods=resolved,
+        kind_support=kind_support,
     )
     return (
         score_node.eval(ctx)
@@ -330,7 +360,8 @@ def score_predictions(epitopes, cfg, *, topiary_df=None):
     )
 
 
-def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None):
+def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
+                             kind_support=None):
     """Score ``epitopes`` via the configured DSL and return a new list of
     :class:`~vaxrank.candidate_epitope.CandidateEpitope` instances with
     each one's ``per_allele_scores`` populated.
@@ -358,7 +389,8 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None):
         return epitopes
     if cfg is None:
         cfg = EpitopeConfig()
-    score_series = score_predictions(epitopes, cfg, topiary_df=topiary_df)
+    score_series = score_predictions(
+        epitopes, cfg, topiary_df=topiary_df, kind_support=kind_support)
     # score_series is keyed by prediction ID, peptide, offset, and allele.
     by_position: dict[tuple, dict[str, float]] = {}
     for idx, val in score_series.items():

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -122,6 +122,22 @@ def epitopes_to_topiary_df(epitopes):
     are NOT emitted as rows. The DSL frame is mutant-only by
     convention — comparator data stays on the CandidateEpitope for display.
     """
+    # Allele-independent evidence is projected into every patient allele here
+    # while remaining one canonical leaf on the CandidateEpitope. topiary
+    # 5.18's ``peptide_view()`` broadcasts an allele-free value across the
+    # allele groups that already exist, which covers a peptide that also has
+    # affinity rows — but two gaps keep this projection necessary:
+    #
+    #   openvax/topiary#182 — a peptide whose *only* evidence is allele-free
+    #     has one group, keyed on an empty allele. The patient's genotype is
+    #     not in the frame, so per-allele scores cannot be produced and the
+    #     candidate scores 0 and is dropped. LENS emits such rows.
+    #   openvax/topiary#183 — an allele-free row is its own group, so any
+    #     filter predicated on an allele-scoped kind removes it; a later
+    #     ``peptide_view()`` in the score expression then reads NaN.
+    #
+    # Do not delete this projection in favor of ``peptide_view()`` until both
+    # are closed; the failure is silent in both cases.
     rows = []
     for e in epitopes:
         ctx = e
@@ -349,7 +365,9 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None):
         src_name, peptide, offset, allele = idx
         # Allele-independent processing predictions use ``allele=''``.
         # They belong in the nested prediction model, but never in a map
-        # whose public contract is explicitly per patient allele.
+        # whose public contract is explicitly per patient allele. This
+        # filter stays even once openvax/topiary#182 lands: an unprojected
+        # allele-free row still produces an empty-allele group.
         if allele:
             by_position.setdefault(
                 (src_name, peptide, offset), {})[allele] = float(val)

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -97,24 +97,6 @@ def prediction_kind_for_method(method_name):
     return _METHOD_KIND_MAP.get(str(method_name).lower(), "pMHC_affinity")
 
 
-def drop_empty_sample_name(df):
-    """Drop ``sample_name`` when topiary emits it with no real values.
-
-    Topiary 5.16.2+ prepends ``sample_name`` to the group index whenever
-    the column is present with any non-NaN value — and topiary's
-    ``predict_*`` methods now always emit the column filled with empty
-    strings, which count as non-NaN. Vaxrank is single-sample and would
-    rather keep the group key 4-wide than carry a placeholder level
-    through every downstream lookup.
-    """
-    if "sample_name" not in df.columns:
-        return df
-    has_real_value = (
-        df["sample_name"].dropna().astype(str).str.strip().ne("").any())
-    if has_real_value:
-        return df
-    return df.drop(columns=["sample_name"])
-
 
 def epitopes_to_topiary_df(epitopes):
     """Convert a list of :class:`vaxrank.candidate_epitope.CandidateEpitope` into the
@@ -178,46 +160,23 @@ def epitopes_to_topiary_df(epitopes):
 
 
 def prediction_group_columns(topiary_df):
-    """Return explicit score-group columns when prediction IDs are present.
+    """Return the explicit score-group columns for a vaxrank frame.
 
-    Topiary's inferred grouping is retained for legacy frames. External and
-    vaxrank-generated frames use the stable prediction ID so two biological
-    sources can never be joined merely because their sequences are equal.
+    Every frame vaxrank builds carries all four. Naming them beats letting
+    topiary infer, because inference keys on ``source_sequence_name`` — so two
+    biological sources would join merely because their sequences are equal.
     """
-    if all(column in topiary_df.columns for column in PREDICTION_GROUP_COLUMNS):
-        return list(PREDICTION_GROUP_COLUMNS)
-    return None
+    missing = [
+        column for column in PREDICTION_GROUP_COLUMNS
+        if column not in topiary_df.columns]
+    if missing:
+        raise ValueError(
+            "Prediction frame is missing score-group column(s) %s. Frames "
+            "must come from epitopes_to_topiary_df or an external report "
+            "reader, both of which supply the complete identity."
+            % ", ".join(missing))
+    return list(PREDICTION_GROUP_COLUMNS)
 
-
-def filter_prediction_groups(topiary_df, node, default_methods=None):
-    """Apply a Topiary filter using vaxrank's explicit prediction identity.
-
-    Topiary issue #175 tracks adding ``group_keys`` directly to
-    ``apply_filter``; until then its public ``EvalContext`` supplies the same
-    DSL evaluation with an explicit group index here.
-    """
-    from topiary.ranking import EvalContext, apply_filter
-
-    if node is None or topiary_df.empty:
-        return topiary_df.reset_index(drop=True)
-    group_columns = prediction_group_columns(topiary_df)
-    if group_columns is None:
-        return apply_filter(
-            topiary_df, node, default_methods=default_methods)
-
-    context = EvalContext(
-        topiary_df,
-        group_keys=group_columns,
-        default_methods=default_methods,
-        filter_context=True,
-    )
-    values = node.eval(context).reindex(context.group_index)
-    nonmissing = values.dropna()
-    if not nonmissing.map(pd.api.types.is_bool).all():
-        raise TypeError("Filter expression must evaluate to booleans")
-    passing = set(values.fillna(False).astype(bool).loc[lambda x: x].index)
-    keep = context.row_group_tuples().isin(passing)
-    return topiary_df[keep].reset_index(drop=True)
 
 
 # Priority order for auto-picking a canonical method when the user hasn't
@@ -303,9 +262,8 @@ def validate_default_methods(cfg, topiary_df):
 def score_predictions(epitopes, cfg, *, topiary_df=None):
     """Score external-input epitopes using the configured Topiary DSL.
 
-    Returns a ``pandas.Series`` of per-(peptide, allele) scores. Current
-    vaxrank frames use ``(prediction_id, peptide, peptide_offset, allele)``;
-    legacy caller-supplied frames retain Topiary's inferred group keys.
+    Returns a ``pandas.Series`` of per-(peptide, allele) scores, indexed by
+    ``(prediction_id, peptide, peptide_offset, allele)``.
 
     Multi-model data (e.g. both MHCflurry and netMHCpan for
     ``pMHC_affinity``) is handled via topiary's
@@ -324,7 +282,7 @@ def score_predictions(epitopes, cfg, *, topiary_df=None):
     :func:`epitopes_to_topiary_df`) rather than rebuilding from
     ``epitopes``.
     """
-    from topiary.ranking import EvalContext
+    from topiary.ranking import EvalContext, apply_filter
 
     df = (epitopes_to_topiary_df(epitopes)
           if topiary_df is None else topiary_df)
@@ -336,8 +294,10 @@ def score_predictions(epitopes, cfg, *, topiary_df=None):
 
     filter_node = build_filter_node(cfg)
     if filter_node is not None:
-        df = filter_prediction_groups(
-            df, filter_node, default_methods=resolved)
+        df = apply_filter(
+            df, filter_node,
+            group_keys=prediction_group_columns(df),
+            default_methods=resolved)
         if df.empty:
             return pd.Series(dtype=float)
 
@@ -383,9 +343,7 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None):
     if cfg is None:
         cfg = EpitopeConfig()
     score_series = score_predictions(epitopes, cfg, topiary_df=topiary_df)
-    # score_series is keyed by the explicit prediction ID when available,
-    # followed by peptide, offset, and allele. Legacy frames retain Topiary's
-    # inferred first group column.
+    # score_series is keyed by prediction ID, peptide, offset, and allele.
     by_position: dict[tuple, dict[str, float]] = {}
     for idx, val in score_series.items():
         src_name, peptide, offset, allele = idx

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -809,6 +809,8 @@ def load_lens(path):
             row=row,
             allele=allele,
             peptide=peptide,
+            source_sequence_name=pep_context or str(peptide),
+            peptide_offset=offset,
             detected=detected,
             display_pred=display_pred,
             chosen_tools=[d.tool for d in chosen],
@@ -838,8 +840,8 @@ def load_lens(path):
     return report_df, epitopes
 
 
-def _build_lens_report_row(row, allele, peptide, detected, display_pred,
-                           chosen_tools):
+def _build_lens_report_row(row, allele, peptide, source_sequence_name,
+                           peptide_offset, detected, display_pred, chosen_tools):
     """Assemble one row of the LENS neoepitope report DataFrame.
 
     ``display_pred`` (if not None) drives the legacy Affinity / %ile
@@ -875,6 +877,8 @@ def _build_lens_report_row(row, allele, peptide, detected, display_pred,
         '%ile rank': display_percentile,
         'Agretopicity': display_agretopicity,
         'TPM': _safe_float(row.get("tpm")),
+        'Source sequence name': source_sequence_name,
+        'Peptide offset': peptide_offset,
     })
     # Every detected predictor gets a raw-value column so users can see
     # per-tool signals side-by-side in the report, even if not chosen

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -683,6 +683,11 @@ def read_pvacseq_report(path, epitope_config=None):
 # to know which metric is the "value" and which are percentile ranks.
 _LENS_COLUMN_RE = re.compile(r"^([A-Za-z][A-Za-z0-9]*)_(\d[\w.]*)\.(.+)$")
 
+# Two printings of one processing score are "the same value" below this.
+# Wide enough to absorb a file that writes 0.8 on one row and 0.8000 on the
+# next, tight enough that a genuinely different score still gets reported.
+PROCESSING_SCORE_TOLERANCE = 1e-9
+
 # Registry describing how each LENS-emitted predictor maps into the Topiary
 # DSL. ``kind`` is the topiary prediction Kind (pMHC_affinity etc.).
 # ``value_cols`` and ``percentile_cols`` are LENS metric suffixes in
@@ -918,6 +923,9 @@ def read_lens_report(path, epitope_config=None):
     # constructs, or pepsickle); summarized once after the loop.
     n_dropped_peptide_context_mismatch = 0
     mismatch_examples = []
+    # (peptide, tool, kept score, conflicting score) for allele rows that
+    # disagreed about an allele-independent processing score.
+    processing_conflicts = []
     for row in rows:
         peptide = cells.text(row.get("peptide"))
         if not peptide:
@@ -1054,10 +1062,18 @@ def read_lens_report(path, epitope_config=None):
                 if processing_key in processing_rows_by_position:
                     processing_row = processing_rows_by_position[
                         processing_key]
-                    if processing_row['mutant'].score != processing_score:
-                        raise ValueError(
-                            "Conflicting LENS processing scores for one "
-                            "peptide position and predictor")
+                    kept = processing_row['mutant'].score
+                    if abs(kept - processing_score) > PROCESSING_SCORE_TOLERANCE:
+                        # The repeats *should* be identical — same peptide,
+                        # same flanks, no MHC involved — so a real difference
+                        # is worth surfacing. It is not worth aborting the
+                        # run over: the usual cause is a file printing the
+                        # same value at two precisions, and there is no way
+                        # for an operator to act on a hard failure here.
+                        # Keep the first-seen value (deterministic in file
+                        # order) and report the disagreement once at the end.
+                        processing_conflicts.append(
+                            (peptide, d.tool, kept, processing_score))
                     processing_row['patient_alleles'].add(allele)
                 else:
                     processing_row = {
@@ -1094,6 +1110,18 @@ def read_lens_report(path, epitope_config=None):
             display_pred=display_pred,
             chosen_tools=[d.tool for d in chosen],
         ))
+
+    if processing_conflicts:
+        ex_peptide, ex_tool, ex_kept, ex_other = processing_conflicts[0]
+        logger.warning(
+            "%d peptide/predictor pair(s) reported different %s processing "
+            "scores across their allele rows. That score depends on peptide "
+            "and flanks, not on MHC, so the repeats should agree; most often "
+            "the file printed one value at two precisions. Kept the "
+            "first-seen value. Example: peptide %s, %s scored %r on one row "
+            "and %r on another.",
+            len(processing_conflicts), ex_tool, ex_peptide, ex_tool,
+            ex_kept, ex_other)
 
     if n_dropped_peptide_context_mismatch:
         ex_peptide, ex_context = mismatch_examples[0]

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -449,12 +449,19 @@ _LENS_COLUMN_RE = re.compile(r"^([A-Za-z][A-Za-z0-9]*)_(\d[\w.]*)\.(.+)$")
 # Registry describing how each LENS-emitted predictor maps into the Topiary
 # DSL. ``kind`` is the topiary prediction Kind (pMHC_affinity etc.).
 # ``value_cols`` and ``percentile_cols`` are LENS metric suffixes in
-# preference order — the first present metric wins.
+# preference order — the first present metric wins. MHCflurry's integrated
+# model contributes two additional kinds: allele-specific presentation and
+# allele-independent antigen processing. Their columns stay attached to the
+# same detected tool/version so the loader can emit all three canonical
+# mhctools prediction kinds.
 _LENS_PREDICTOR_REGISTRY = {
     "mhcflurry": {
         "kind": "pMHC_affinity",
         "value_cols": ("aff",),
-        "percentile_cols": ("pres_perc", "aff_perc"),
+        "percentile_cols": ("aff_perc",),
+        "presentation_score_cols": ("pres_score",),
+        "presentation_percentile_cols": ("pres_perc",),
+        "processing_score_cols": ("proc_score",),
     },
     "netmhcpan": {
         "kind": "pMHC_affinity",
@@ -475,7 +482,9 @@ class DetectedPredictor:
     ``value_col`` is the LENS column carrying the predicted value
     (IC50 for affinity, half-life hours for stability). The other
     ``*_col`` attributes are ``None`` when that signal isn't emitted
-    for the detected ``(tool, version)``.
+    for the detected ``(tool, version)``. MHCflurry presentation and
+    processing columns are modeled separately rather than overloading
+    its affinity percentile.
     """
     tool: str
     version: str
@@ -483,6 +492,9 @@ class DetectedPredictor:
     value_col: str
     percentile_col: str | None = None
     agretopicity_col: str | None = None
+    presentation_score_col: str | None = None
+    presentation_percentile_col: str | None = None
+    processing_score_col: str | None = None
 
 
 def detect_lens_predictors(columns):
@@ -515,6 +527,15 @@ def detect_lens_predictors(columns):
             continue
         percentile_col = next(
             (metrics[m] for m in spec["percentile_cols"] if m in metrics), None)
+        presentation_score_col = next(
+            (metrics[m] for m in spec.get("presentation_score_cols", ())
+             if m in metrics), None)
+        presentation_percentile_col = next(
+            (metrics[m] for m in spec.get(
+                "presentation_percentile_cols", ()) if m in metrics), None)
+        processing_score_col = next(
+            (metrics[m] for m in spec.get("processing_score_cols", ())
+             if m in metrics), None)
         # Agretopicity columns aren't versioned (just "<tool>_agretopicity"),
         # so we look them up directly on the full column set.
         agretopicity_col = f"{tool}_agretopicity"
@@ -527,6 +548,9 @@ def detect_lens_predictors(columns):
             value_col=value_col,
             percentile_col=percentile_col,
             agretopicity_col=agretopicity_col,
+            presentation_score_col=presentation_score_col,
+            presentation_percentile_col=presentation_percentile_col,
+            processing_score_col=processing_score_col,
         ))
     # Deterministic order: tool name alphabetical
     detected.sort(key=lambda d: (d.tool, d.version))
@@ -565,8 +589,9 @@ def load_lens(path):
     LENS column schemas vary across versions (v1.4, v1.5, v1.9+); we sniff
     which predictors a given file actually emits rather than requiring a
     fixed schema. Internally we build one flat per-(peptide, allele,
-    detected predictor) record per row, then group them into ``CandidateEpitope``
-    objects keyed by ``(peptide, source_sequence, offset)`` so Topiary
+    detected predictor, prediction kind) record per row, then group them
+    into ``CandidateEpitope`` objects keyed by
+    ``(peptide, source_sequence, offset)`` so Topiary
     DSL expressions can combine multi-predictor predictions via
     ``affinity['mhcflurry']`` / ``affinity['netmhcpan']`` or use an
     unqualified ``affinity`` fallback via the epitope config's
@@ -582,8 +607,10 @@ def load_lens(path):
         Report-ready DataFrame (one row per peptide × allele).
     list of CandidateEpitope
         One ``CandidateEpitope`` per ``(peptide, source_sequence, offset)``
-        group, each carrying its per-(allele, predictor)
-        ``mhctools.Prediction`` records inside ``epitope``.
+        group, each carrying its per-(allele, predictor, kind)
+        ``mhctools.Prediction`` records inside ``epitope``. MHCflurry
+        inputs may carry distinct ``pMHC_affinity``, ``pMHC_presentation``,
+        and allele-independent ``antigen_processing`` leaves.
     """
     # low_memory=False avoids mixed-dtype warnings — LENS reports have many
     # optional columns that are mostly NA for a given antigen type.
@@ -618,6 +645,7 @@ def load_lens(path):
 
     epitope_rows = []
     report_rows = []
+    processing_scores_by_position = {}
     # Rows whose peptide isn't a substring of a non-empty pep_context —
     # peptide and pep_context came from different isoforms / annotation
     # snapshots upstream. Dropped here (not carried into the report,
@@ -659,53 +687,120 @@ def load_lens(path):
             continue
         offset = pep_context.find(str(peptide)) if pep_context else 0
         row_added = False
+        shared_epitope_fields = {
+            'peptide': str(peptide),
+            'source': pep_context,
+            'offset': offset,
+            'source_class': SOURCE_CLASS_MUTATION,
+            # LENS pre-curates rows as neoepitopes and pre-filters
+            # against the patient reference proteome — both flags
+            # are structurally true for any surviving row.
+            'overlaps_mutation': True,
+            'occurs_in_reference': False,
+            'occurs_in_non_CTA_reference': False,
+        }
         for d in chosen:
             value = _safe_float(row.get(d.value_col))
-            if value is None:
-                continue
             percentile_rank = (
                 _safe_float(row.get(d.percentile_col))
                 if d.percentile_col else None)
             # Derive WT IC50 from agretopicity, only for the
             # mhcflurry-affinity predictor (the value matches that
             # tool's IC50 scale). Other predictors leave wt_ic50=None.
-            wt_ic50 = None
-            if (d.tool == "mhcflurry" and d.kind == "pMHC_affinity"
-                    and agretopicity is not None and agretopicity > 0):
-                wt_ic50 = value / agretopicity
-            mutant = Prediction(
-                kind=d.kind, predictor_name=d.tool,
-                predictor_version=d.version, allele=allele,
-                peptide=str(peptide), value=value, score=0.0,
-                percentile_rank=percentile_rank,
-            )
-            wt = None
-            if wt_ic50 is not None:
-                # LENS doesn't emit a WT peptide column — pass an
-                # empty string. ``candidate_epitopes_from_rows`` keeps
-                # the WT context (anonymous-WT signal) because wt_ic50
-                # is non-None even though the sequence is unknown.
-                wt = Prediction(
+            if value is not None:
+                wt_ic50 = None
+                if (d.tool == "mhcflurry" and d.kind == "pMHC_affinity"
+                        and agretopicity is not None and agretopicity > 0):
+                    wt_ic50 = value / agretopicity
+                mutant = Prediction(
                     kind=d.kind, predictor_name=d.tool,
                     predictor_version=d.version, allele=allele,
-                    peptide="", value=wt_ic50, score=0.0,
-                    percentile_rank=None,
+                    peptide=str(peptide), value=value, score=0.0,
+                    percentile_rank=percentile_rank,
                 )
-            epitope_rows.append({
-                'peptide': str(peptide),
-                'source': pep_context,
-                'offset': offset,
-                'mutant': mutant,
-                'wt': wt,
-                'source_class': SOURCE_CLASS_MUTATION,
-                # LENS pre-curates rows as neoepitopes and pre-filters
-                # against the patient reference proteome — both flags
-                # are structurally true for any surviving row.
-                'overlaps_mutation': True,
-                'occurs_in_reference': False,
-                'occurs_in_non_CTA_reference': False,
-            })
-            row_added = True
+                wt = None
+                if wt_ic50 is not None:
+                    # LENS doesn't emit a WT peptide column — pass an
+                    # empty string. ``candidate_epitopes_from_rows`` keeps
+                    # the WT context (anonymous-WT signal) because wt_ic50
+                    # is non-None even though the sequence is unknown.
+                    wt = Prediction(
+                        kind=d.kind, predictor_name=d.tool,
+                        predictor_version=d.version, allele=allele,
+                        peptide="", value=wt_ic50, score=0.0,
+                        percentile_rank=None,
+                    )
+                epitope_rows.append({
+                    **shared_epitope_fields,
+                    'mutant': mutant,
+                    'wt': wt,
+                })
+                row_added = True
+
+            presentation_score = (
+                _safe_float(row.get(d.presentation_score_col))
+                if d.presentation_score_col else None)
+            presentation_percentile = (
+                _safe_float(row.get(d.presentation_percentile_col))
+                if d.presentation_percentile_col else None)
+            if (presentation_score is not None
+                    or presentation_percentile is not None):
+                # mhctools represents MHCflurry presentation as its own
+                # allele-specific kind. ``Prediction.score`` is required;
+                # retain a percentile-only legacy row with a neutral 0.0
+                # score rather than discarding the percentile evidence.
+                epitope_rows.append({
+                    **shared_epitope_fields,
+                    'mutant': Prediction(
+                        kind="pMHC_presentation",
+                        predictor_name=d.tool,
+                        predictor_version=d.version,
+                        allele=allele,
+                        peptide=str(peptide),
+                        value=None,
+                        score=(
+                            presentation_score
+                            if presentation_score is not None else 0.0),
+                        percentile_rank=presentation_percentile,
+                    ),
+                    'wt': None,
+                })
+                row_added = True
+
+            processing_score = (
+                _safe_float(row.get(d.processing_score_col))
+                if d.processing_score_col else None)
+            if processing_score is not None:
+                # MHCflurry processing depends on peptide + flanks, not MHC.
+                # LENS repeats it on every allele row, while mhctools emits
+                # one allele-less prediction per peptide position. Preserve
+                # that canonical shape and reject inconsistent repeats.
+                processing_key = (
+                    str(peptide), pep_context, offset, d.tool, d.version)
+                if processing_key in processing_scores_by_position:
+                    if processing_scores_by_position[
+                            processing_key] != processing_score:
+                        raise ValueError(
+                            "Conflicting LENS processing scores for one "
+                            "peptide position and predictor")
+                else:
+                    processing_scores_by_position[
+                        processing_key] = processing_score
+                    epitope_rows.append({
+                        **shared_epitope_fields,
+                        'mutant': Prediction(
+                            kind="antigen_processing",
+                            predictor_name=d.tool,
+                            predictor_version=d.version,
+                            allele="",
+                            peptide=str(peptide),
+                            value=None,
+                            score=processing_score,
+                            percentile_rank=None,
+                        ),
+                        'wt': None,
+                    })
+                row_added = True
 
         if not row_added:
             continue
@@ -789,6 +884,18 @@ def _build_lens_report_row(row, allele, peptide, detected, display_pred,
         unit = unit_by_kind.get(d.kind, "")
         label = f"{d.tool} value ({unit})" if unit else f"{d.tool} value"
         out[label] = _safe_float(row.get(d.value_col))
+        if d.kind == "pMHC_affinity" and d.percentile_col:
+            out[f"{d.tool} affinity percentile rank"] = _safe_float(
+                row.get(d.percentile_col))
+        if d.presentation_score_col:
+            out[f"{d.tool} presentation score"] = _safe_float(
+                row.get(d.presentation_score_col))
+        if d.presentation_percentile_col:
+            out[f"{d.tool} presentation percentile rank"] = _safe_float(
+                row.get(d.presentation_percentile_col))
+        if d.processing_score_col:
+            out[f"{d.tool} processing score"] = _safe_float(
+                row.get(d.processing_score_col))
     return out
 
 

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -22,8 +22,8 @@ All loader functions emit ``list[vaxrank.candidate_epitope.CandidateEpitope]``;
 the flat per-(peptide, allele, predictor) row shape lives only inside
 the CSV / DataFrame layer for round-trip fidelity. Loaders feed each
 row to :func:`~vaxrank.candidate_epitope.candidate_epitopes_from_rows`,
-which groups by ``(peptide, source, offset)`` into ``CandidateEpitope``
-objects at the end.
+which groups native rows by position and external rows by their complete
+``ExternalPredictionKey`` identity into ``CandidateEpitope`` objects.
 """
 
 import json
@@ -36,6 +36,7 @@ import pandas as pd
 from mhctools.pred import Prediction
 
 from .epitope_dsl import prediction_kind_for_method
+from .external_prediction import ExternalPredictionKey
 from .candidate_epitope import (
     SOURCE_CLASS_MUTATION, candidate_epitopes_from_rows,
 )
@@ -56,6 +57,7 @@ VAXRANK_COLUMNS = [
     "source_class",
     "overlaps_mutation",
     "source_sequence",
+    "prediction_id",
     "offset",
     "occurs_in_reference",
     "occurs_in_non_CTA_reference",
@@ -131,6 +133,7 @@ def epitope_prediction_rows(epitope):
             "source_class": epitope.source_class,
             "overlaps_mutation": epitope.overlaps_mutation,
             "source_sequence": epitope.source_sequence,
+            "prediction_id": epitope.prediction_id,
             "offset": epitope.offset,
             "occurs_in_reference": epitope.occurs_in_reference,
             "occurs_in_non_CTA_reference": epitope.occurs_in_non_CTA_reference,
@@ -333,6 +336,7 @@ def load_predictions(path):
         rows.append({
             'peptide': peptide,
             'source': string_or_empty(row.get("source_sequence", "")),
+            'prediction_id': string_or_empty(row.get("prediction_id", "")),
             'offset': int(row.get("offset", 0)),
             'mutant': mutant,
             'wt': wt,
@@ -466,6 +470,7 @@ def _topiary_pvacseq_to_epitope_rows(df):
         epitope_rows.append({
             'peptide': peptide,
             'source': _topiary_group_source(row),
+            'prediction_id': _safe_str(row.get("prediction_id")),
             'offset': int(_safe_float(row.get("peptide_offset")) or 0),
             'mutant': mutant,
             'wt': wt,
@@ -503,6 +508,7 @@ def _build_pvacseq_report_row(row):
         'RNA VAF': rna_vaf,
         'DNA VAF': dna_vaf,
         '%ile MT': _safe_float(row.get("percentile_rank")),
+        'Prediction identity': _safe_str(row.get("prediction_id")),
         'Source sequence name': _topiary_group_source(row),
         'Peptide offset': int(_safe_float(row.get("peptide_offset")) or 0),
         'MHC class': _safe_str(row.get("mhc_class")),
@@ -539,13 +545,21 @@ def load_pvacseq(path, epitope_config=None):
         vaxrank_score
     list of CandidateEpitope
         One ``vaxrank.candidate_epitope.CandidateEpitope`` per unique
-        ``(peptide, source_sequence, offset)`` group.
+        external prediction identity.
     """
     from topiary import read_pvacseq
 
     from .epitope_dsl import drop_empty_sample_name
     result = read_pvacseq(path)
     topiary_df = drop_empty_sample_name(result.df)
+    topiary_df = topiary_df.copy()
+    topiary_df["prediction_id"] = [
+        key.identifier if key is not None else ""
+        for key in (
+            ExternalPredictionKey.from_pvacseq_row(row)
+            for _, row in topiary_df.iterrows()
+        )
+    ]
     epitope_rows, n_rows = _topiary_pvacseq_to_epitope_rows(topiary_df)
     report_rows = [
         _build_pvacseq_report_row(row)
@@ -774,8 +788,8 @@ def load_lens(path, epitope_config=None):
     which predictors a given file actually emits rather than requiring a
     fixed schema. Internally we build one flat per-(peptide, allele,
     detected predictor, prediction kind) record per row, then group them
-    into ``CandidateEpitope`` objects keyed by
-    ``(peptide, source_sequence, offset)`` so Topiary
+    into ``CandidateEpitope`` objects keyed by complete variant, gene,
+    transcript, and peptide-position provenance so Topiary
     DSL expressions can combine multi-predictor predictions via
     ``affinity['mhcflurry']`` / ``affinity['netmhcpan']`` or use an
     unqualified ``affinity`` fallback via the epitope config's
@@ -794,8 +808,8 @@ def load_lens(path, epitope_config=None):
     pandas.DataFrame
         Report-ready DataFrame (one row per peptide × allele).
     list of CandidateEpitope
-        One ``CandidateEpitope`` per ``(peptide, source_sequence, offset)``
-        group, each carrying its per-(allele, predictor, kind)
+        One ``CandidateEpitope`` per external prediction identity, each
+        carrying its per-(allele, predictor, kind)
         ``mhctools.Prediction`` records inside ``epitope``. MHCflurry
         inputs may carry distinct ``pMHC_affinity``, ``pMHC_presentation``,
         and allele-independent ``antigen_processing`` leaves.
@@ -875,10 +889,15 @@ def load_lens(path, epitope_config=None):
                 mismatch_examples.append((peptide, pep_context))
             continue
         peptide, pep_context, offset = position
+        prediction_key = ExternalPredictionKey.from_lens_row(row)
+        if prediction_key is None:
+            continue
+        prediction_id = prediction_key.identifier
         row_added = False
         shared_epitope_fields = {
             'peptide': str(peptide),
             'source': pep_context,
+            'prediction_id': prediction_id,
             'offset': offset,
             'source_class': SOURCE_CLASS_MUTATION,
             # LENS pre-curates rows as neoepitopes and pre-filters
@@ -965,7 +984,7 @@ def load_lens(path, epitope_config=None):
                 # one allele-less prediction per peptide position. Preserve
                 # that canonical shape and reject inconsistent repeats.
                 processing_key = (
-                    str(peptide), pep_context, offset, d.tool, d.version)
+                    prediction_id, d.tool, d.version)
                 if processing_key in processing_rows_by_position:
                     processing_row = processing_rows_by_position[
                         processing_key]
@@ -1002,6 +1021,7 @@ def load_lens(path, epitope_config=None):
             row=row,
             allele=allele,
             peptide=peptide,
+            prediction_id=prediction_id,
             source_sequence_name=pep_context or str(peptide),
             peptide_offset=offset,
             detected=detected,
@@ -1033,8 +1053,9 @@ def load_lens(path, epitope_config=None):
     return report_df, epitopes
 
 
-def _build_lens_report_row(row, allele, peptide, source_sequence_name,
-                           peptide_offset, detected, display_pred, chosen_tools):
+def _build_lens_report_row(row, allele, peptide, prediction_id,
+                           source_sequence_name, peptide_offset, detected,
+                           display_pred, chosen_tools):
     """Assemble one row of the LENS neoepitope report DataFrame.
 
     ``display_pred`` (if not None) drives the legacy Affinity / %ile
@@ -1065,6 +1086,7 @@ def _build_lens_report_row(row, allele, peptide, source_sequence_name,
         mutant_affinity=display_value, wt_peptide='', wt_affinity=None,
         gene_name=gene, variant=variant_pos)
     out.update({
+        'Prediction identity': prediction_id,
         'Antigen source': antigen_source,
         'Predictors used': ','.join(chosen_tools),
         '%ile rank': display_percentile,
@@ -1135,7 +1157,7 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
         (one row per (peptide, allele) pair).
     epitopes : list of CandidateEpitope
         Output of ``load_lens`` / ``load_pvacseq`` — one CandidateEpitope per
-        unique ``(peptide, source, offset)``.
+        complete external prediction identity.
     excel_report_path : str, optional
     csv_report_path : str, optional
     epitope_config : EpitopeConfig, optional
@@ -1158,24 +1180,17 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
     peptide_col = 'Mutant peptide sequence'
     allele_col = 'Allele'
 
-    # The score-merge below keys by (peptide, allele) and broadcasts the
-    # score back across every matching report_df row. Real-world LENS
-    # files emit the same (peptide, allele) pair from multiple sources
-    # (alternative transcripts, homologous regions, multiple variants)
-    # — that's expected, not an error. Each row retains its own source
-    # provenance (variant_coords, gene_name, transcript) and gets the
-    # same score, which is the correct behavior for a per-row report.
-    # The duplicate count is only useful when chasing a downstream
-    # row-count mismatch — log at DEBUG, not INFO.
+    # Duplicate peptide/allele pairs are expected across variants and
+    # transcripts. Current external loaders join them by Prediction identity;
+    # legacy frames without that column retain their historical broadcast.
     if len(report_df) > 0 and logger.isEnabledFor(logging.DEBUG):
         dup_count = int(report_df.duplicated(
             subset=[peptide_col, allele_col]).sum())
         if dup_count:
             logger.debug(
                 "report_df has %d duplicate (peptide, allele) row(s) "
-                "from multi-source input; the same score broadcasts "
-                "across each duplicate. Per-source provenance is "
-                "preserved by the other columns.", dup_count)
+                "from multi-source input; explicit prediction identities "
+                "keep current-format scores source-specific.", dup_count)
 
     # Build the topiary DataFrame once and share it between validator and
     # scorer. pVACseq import keeps the loader-produced frame in
@@ -1193,12 +1208,10 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
     score_series = score_predictions(
         epitopes, epitope_config, topiary_df=topiary_df)
 
-    # score_series is indexed by topiary's group key
-    # (source/variant, peptide, peptide_offset, allele). pVACseq reports
-    # carry that source key through for precise alignment. If an exact
-    # source-keyed row is absent, it was filtered out and must stay at 0.
-    # Older LENS-shaped reports lack source/offset columns and keep the
-    # legacy (peptide, allele) broadcast.
+    # score_series is indexed by the stable prediction identity, peptide,
+    # offset, and allele for current external loaders. If an exact row is
+    # absent, the DSL filtered it out. Legacy report frames without an
+    # explicit identity retain their source-position or peptide fallback.
     scores_by_key = {}
     scores_by_pair = {}
     for idx_tuple, score in score_series.items():
@@ -1207,27 +1220,49 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
         scores_by_pair[(peptide, allele)] = score
 
     report_df = report_df.copy()
+    identity_col = 'Prediction identity'
     source_col = 'Source sequence name'
     offset_col = 'Peptide offset'
+    join_col = (
+        identity_col if identity_col in report_df.columns else source_col)
     has_source_keys = (
-        source_col in report_df.columns and offset_col in report_df.columns)
+        join_col in report_df.columns and offset_col in report_df.columns)
     scores = []
+    filter_passed = []
+    rank_eligible = []
+    exclusion_reasons = []
     for _, row in report_df.iterrows():
-        score = None
+        score_key = None
         if has_source_keys:
             offset = _safe_float(row.get(offset_col))
             if offset is not None:
-                score = scores_by_key.get((
-                    row.get(source_col), row[peptide_col], int(offset),
-                    row[allele_col]))
-            if score is None:
-                score = 0.0
+                score_key = (
+                    row.get(join_col), row[peptide_col], int(offset),
+                    row[allele_col])
+            passed = score_key in scores_by_key
+            score = scores_by_key.get(score_key)
         else:
-            score = scores_by_pair.get((row[peptide_col], row[allele_col]), 0.0)
-        scores.append(round(float(score), 6))
+            score_key = (row[peptide_col], row[allele_col])
+            passed = score_key in scores_by_pair
+            score = scores_by_pair.get(score_key)
+        eligible = (
+            passed
+            and score is not None
+            and float(score) >= epitope_config.min_epitope_score
+        )
+        scores.append(round(float(score), 6) if passed else None)
+        filter_passed.append(passed)
+        rank_eligible.append(eligible)
+        exclusion_reasons.append(
+            "" if eligible else (
+                "dsl_filter" if not passed else "min_epitope_score"))
     report_df.insert(2, 'vaxrank_score', scores)
+    report_df.insert(3, 'vaxrank_filter_passed', filter_passed)
+    report_df.insert(4, 'vaxrank_rank_eligible', rank_eligible)
+    report_df.insert(5, 'vaxrank_exclusion_reason', exclusion_reasons)
 
-    report_df = report_df.sort_values('vaxrank_score', ascending=False)
+    report_df = report_df.sort_values(
+        'vaxrank_score', ascending=False, na_position='last')
     report_df.insert(0, 'rank', range(1, len(report_df) + 1))
 
     if csv_report_path:

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -1135,7 +1135,7 @@ def read_lens_report(path, epitope_config=None):
 
     report_df = pd.DataFrame(report_rows) if report_rows else pd.DataFrame()
     epitopes = candidate_epitopes_from_rows(epitope_rows)
-    # See load_pvacseq for the parallel rationale: the 3.1 refactor moved
+    # See read_pvacseq_report for the parallel rationale: the 3.1 refactor moved
     # per-(peptide, allele) scoring to the DSL and stored the result on
     # CandidateEpitope.per_allele_scores. Loaders must populate it or
     # downstream ranking sees zero-scored epitopes and drops everything.
@@ -1254,17 +1254,17 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
     Parameters
     ----------
     report_df : pandas.DataFrame
-        Report-ready DataFrame from load_pvacseq or load_lens
+        Report-ready DataFrame from an external report reader
         (one row per (peptide, allele) pair).
     epitopes : list of CandidateEpitope
-        Output of ``load_lens`` / ``load_pvacseq`` — one CandidateEpitope per
+        Output of ``read_lens_report`` / ``read_pvacseq_report`` — one per
         complete external prediction identity.
     excel_report_path : str, optional
     csv_report_path : str, optional
     epitope_config : EpitopeConfig, optional
     topiary_df : pandas.DataFrame, optional
         Pre-built topiary long-form rows to use for DSL validation and
-        scoring. ``load_pvacseq`` stores this on ``report_df.attrs`` so
+        scoring. ``read_pvacseq_report`` stores this on ``report_df.attrs`` so
         pVACseq annotation columns remain available to custom DSL
         expressions.
     """

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -645,7 +645,7 @@ def load_lens(path):
 
     epitope_rows = []
     report_rows = []
-    processing_scores_by_position = {}
+    processing_rows_by_position = {}
     # Rows whose peptide isn't a substring of a non-empty pep_context —
     # peptide and pep_context came from different isoforms / annotation
     # snapshots upstream. Dropped here (not carried into the report,
@@ -777,16 +777,16 @@ def load_lens(path):
                 # that canonical shape and reject inconsistent repeats.
                 processing_key = (
                     str(peptide), pep_context, offset, d.tool, d.version)
-                if processing_key in processing_scores_by_position:
-                    if processing_scores_by_position[
-                            processing_key] != processing_score:
+                if processing_key in processing_rows_by_position:
+                    processing_row = processing_rows_by_position[
+                        processing_key]
+                    if processing_row['mutant'].score != processing_score:
                         raise ValueError(
                             "Conflicting LENS processing scores for one "
                             "peptide position and predictor")
+                    processing_row['patient_alleles'].add(allele)
                 else:
-                    processing_scores_by_position[
-                        processing_key] = processing_score
-                    epitope_rows.append({
+                    processing_row = {
                         **shared_epitope_fields,
                         'mutant': Prediction(
                             kind="antigen_processing",
@@ -799,7 +799,11 @@ def load_lens(path):
                             percentile_rank=None,
                         ),
                         'wt': None,
-                    })
+                        'patient_alleles': {allele},
+                    }
+                    processing_rows_by_position[
+                        processing_key] = processing_row
+                    epitope_rows.append(processing_row)
                 row_added = True
 
         if not row_added:

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -37,7 +37,11 @@ from mhctools.pred import Prediction
 
 from . import cells
 from .epitope_dsl import prediction_kind_for_method
-from .external_prediction import ExternalPredictionKey
+from .external_prediction import (
+    _PVACSEQ_DNA_VAF_COLUMNS,
+    _PVACSEQ_RNA_VAF_COLUMNS,
+    ExternalPredictionKey,
+)
 from .external_report import (
     GENOMIC_VARIANT_COLUMN, ExternalRecord, ExternalReport,
 )
@@ -437,14 +441,6 @@ def neoepitope_core_row(allele, mutant_peptide, mutant_affinity,
     return row
 
 
-def _first_float(*values):
-    for value in values:
-        coerced = cells.number(value)
-        if coerced is not None:
-            return coerced
-    return None
-
-
 def _topiary_group_source(row):
     """Source key matching topiary.ranking.EvalContext grouping."""
     return (
@@ -520,12 +516,13 @@ def _topiary_pvacseq_to_epitope_rows(rows):
 
 def _build_pvacseq_report_row(row):
     """Build one user-facing report row from a topiary pVACseq row."""
-    rna_expr = _first_float(
-        row.get("rna_transcript_expression"),
-        row.get("transcript_expression"),
-        row.get("gene_expression"))
-    rna_vaf = _first_float(row.get("rna_vaf"), row.get("tumor_rna_vaf"))
-    dna_vaf = _first_float(row.get("dna_vaf"), row.get("tumor_dna_vaf"))
+    # Same helper, same precedence, as the ranking path uses for these
+    # fields — so the report and the ranking cannot disagree about a row.
+    rna_expr = cells.first_number(
+        row, "rna_transcript_expression", "transcript_expression",
+        "gene_expression")
+    rna_vaf = cells.first_number(row, *_PVACSEQ_RNA_VAF_COLUMNS)
+    dna_vaf = cells.first_number(row, *_PVACSEQ_DNA_VAF_COLUMNS)
     out = neoepitope_core_row(
         allele=cells.text(row.get("allele")),
         mutant_peptide=cells.text(row.get("peptide")),
@@ -1309,9 +1306,11 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
         epitopes, epitope_config, topiary_df=topiary_df)
 
     # score_series is indexed by the stable prediction identity, peptide,
-    # offset, and allele for current external loaders. If an exact row is
-    # absent, the DSL filtered it out. Legacy report frames without an
-    # explicit identity retain their source-position or peptide fallback.
+    # offset, and allele. If an exact row is absent, the DSL filtered it out.
+    # There is no (peptide, allele) fallback: it broadcast one source's score
+    # onto every row sharing a sequence, which is the merge the identity
+    # exists to prevent. A frame without the identity columns is refused
+    # below rather than silently broadcast.
     scores_by_key = {}
     for idx_tuple, score in score_series.items():
         prediction_id, peptide, offset, allele = idx_tuple

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -500,7 +500,12 @@ def _topiary_pvacseq_to_epitope_rows(rows):
             'source': peptide,
             'source_name': _topiary_group_source(row),
             'prediction_id': cells.text(row.get("prediction_id")),
-            'offset': int(cells.number(row.get("peptide_offset")) or 0),
+            # 0, not the frame's peptide_offset, and for the same reason
+            # ExternalPredictionKey.from_pvacseq_row pins it: the peptide is
+            # its own source window, so it sits at offset 0 of that window.
+            # Reading a source-protein offset here would let the epitope and
+            # the identity that names it disagree about the same position.
+            'offset': 0,
             'mutant': mutant,
             'wt': wt,
             'source_class': SOURCE_CLASS_MUTATION,

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -35,8 +35,12 @@ from dataclasses import dataclass
 import pandas as pd
 from mhctools.pred import Prediction
 
+from . import cells
 from .epitope_dsl import prediction_kind_for_method
 from .external_prediction import ExternalPredictionKey
+from .external_report import (
+    GENOMIC_VARIANT_COLUMN, ExternalRecord, ExternalReport,
+)
 from .candidate_epitope import (
     SOURCE_CLASS_MUTATION, candidate_epitopes_from_rows,
 )
@@ -56,7 +60,18 @@ VAXRANK_COLUMNS = [
     "prediction_method_name",
     "source_class",
     "overlaps_mutation",
+    # Targetability and the antigen-aware exact-self result are *decisions*,
+    # not raw inputs: a reload that dropped them silently re-admitted
+    # held-out epitopes as vaccine targets, because both fields fall back to
+    # the permissive legacy behavior when absent.
+    "overlaps_targetable",
+    "self_reference_match",
     "source_sequence",
+    "source_name",
+    # Flanking residues drive processing/cleavage predictors, so a reload
+    # without them cannot reproduce the scores of the file it read.
+    "n_flank",
+    "c_flank",
     "prediction_id",
     "offset",
     "occurs_in_reference",
@@ -132,7 +147,14 @@ def epitope_prediction_rows(epitope):
             "prediction_method_name": p.predictor_name,
             "source_class": epitope.source_class,
             "overlaps_mutation": epitope.overlaps_mutation,
+            "overlaps_targetable": epitope.overlaps_targetable,
+            "self_reference_match": (
+                epitope.self_reference_match.to_json()
+                if epitope.self_reference_match is not None else ""),
             "source_sequence": epitope.source_sequence,
+            "source_name": epitope.source_name,
+            "n_flank": epitope.n_flank,
+            "c_flank": epitope.c_flank,
             "prediction_id": epitope.prediction_id,
             "offset": epitope.offset,
             "occurs_in_reference": epitope.occurs_in_reference,
@@ -333,11 +355,29 @@ def load_predictions(path):
             json.loads(per_allele_scores_raw)
             if per_allele_scores_raw else {})
         occurs_in_ref = bool(row.get("occurs_in_reference", False))
+        # ``overlaps_targetable`` is tri-state: True / False / "producer did
+        # not decide". A blank cell must reload as None, not as False.
+        targetable_raw = row.get("overlaps_targetable")
+        overlaps_targetable = (
+            None if cells.missing(targetable_raw)
+            else cells.boolean(targetable_raw))
+        self_reference_raw = string_or_empty(
+            row.get("self_reference_match", ""))
+        self_reference_match = None
+        if self_reference_raw:
+            from .vaccine_antigen import SelfReferenceMatch
+            self_reference_match = SelfReferenceMatch.from_json(
+                self_reference_raw)
         rows.append({
             'peptide': peptide,
             'source': string_or_empty(row.get("source_sequence", "")),
+            'source_name': string_or_empty(row.get("source_name", "")),
+            'n_flank': string_or_empty(row.get("n_flank", "")),
+            'c_flank': string_or_empty(row.get("c_flank", "")),
             'prediction_id': string_or_empty(row.get("prediction_id", "")),
             'offset': int(row.get("offset", 0)),
+            'overlaps_targetable': overlaps_targetable,
+            'self_reference_match': self_reference_match,
             'mutant': mutant,
             'wt': wt,
             'source_class': string_or_empty(
@@ -356,22 +396,12 @@ def load_predictions(path):
 
 # ── pVACseq import ───────────────────────────────────────────────────────────
 
-def _is_missing(val):
-    """True for scalar missing values from pandas / pVACseq TSVs."""
-    if val is None:
-        return True
-    try:
-        return bool(pd.isna(val))
-    except (TypeError, ValueError):
-        return False
-
-
 def _format_nm(value):
     # Missing affinity → blank, consistent with every other missing
     # value in the neoepitope CSVs (see _build_lens_report_row). A
     # blank cell in a "Predicted … affinity" column reads as "not
     # predicted" without mixing a string sentinel into numeric data.
-    value = _safe_float(value)
+    value = cells.number(value)
     return '%.2f nM' % value if value is not None else ''
 
 
@@ -414,7 +444,7 @@ def neoepitope_core_row(allele, mutant_peptide, mutant_affinity,
 
 def _first_float(*values):
     for value in values:
-        coerced = _safe_float(value)
+        coerced = cells.number(value)
         if coerced is not None:
             return coerced
     return None
@@ -423,30 +453,30 @@ def _first_float(*values):
 def _topiary_group_source(row):
     """Source key matching topiary.ranking.EvalContext grouping."""
     return (
-        _safe_str(row.get("variant"))
-        or _safe_str(row.get("source_sequence_name"))
-        or _safe_str(row.get("peptide"))
+        cells.text(row.get("variant"))
+        or cells.text(row.get("source_sequence_name"))
+        or cells.text(row.get("peptide"))
     )
 
 
-def _topiary_pvacseq_to_epitope_rows(df):
+def _topiary_pvacseq_to_epitope_rows(rows):
     """Convert topiary.read_pvacseq long-form rows to CandidateEpitope rows."""
     epitope_rows = []
     n_rows = 0
-    for _, row in df.iterrows():
-        peptide = _safe_str(row.get("peptide"))
-        allele = _safe_str(row.get("allele"))
-        value = _safe_float(row.get("value"))
+    for row in rows:
+        peptide = cells.text(row.get("peptide"))
+        allele = cells.text(row.get("allele"))
+        value = cells.number(row.get("value"))
         if not peptide or not allele or value is None:
             continue
 
-        method = _safe_str(row.get("prediction_method_name")) or "pvacseq"
-        version = _safe_str(row.get("predictor_version"))
+        method = cells.text(row.get("prediction_method_name")) or "pvacseq"
+        version = cells.text(row.get("predictor_version"))
         kind = (
-            _safe_str(row.get("kind"))
+            cells.text(row.get("kind"))
             or prediction_kind_for_method(method))
-        percentile_rank = _safe_float(row.get("percentile_rank"))
-        score = _safe_float(row.get("score"))
+        percentile_rank = cells.number(row.get("percentile_rank"))
+        score = cells.number(row.get("score"))
         mutant = Prediction(
             kind=kind, predictor_name=method, predictor_version=version,
             allele=allele, peptide=peptide, value=value,
@@ -455,30 +485,38 @@ def _topiary_pvacseq_to_epitope_rows(df):
         )
 
         wt = None
-        wt_value = _safe_float(row.get("wt_value"))
+        wt_value = cells.number(row.get("wt_value"))
         if wt_value is not None:
-            wt_method = _safe_str(row.get("wt_prediction_method_name")) or method
-            wt_version = _safe_str(row.get("wt_predictor_version")) or version
+            wt_method = cells.text(row.get("wt_prediction_method_name")) or method
+            wt_version = cells.text(row.get("wt_predictor_version")) or version
             wt = Prediction(
                 kind=kind, predictor_name=wt_method,
                 predictor_version=wt_version, allele=allele,
-                peptide=_safe_str(row.get("wt_peptide")),
+                peptide=cells.text(row.get("wt_peptide")),
                 value=wt_value, score=0.0,
-                percentile_rank=_safe_float(row.get("wt_percentile_rank")),
+                percentile_rank=cells.number(row.get("wt_percentile_rank")),
             )
 
         epitope_rows.append({
             'peptide': peptide,
-            'source': _topiary_group_source(row),
-            'prediction_id': _safe_str(row.get("prediction_id")),
-            'offset': int(_safe_float(row.get("peptide_offset")) or 0),
+            # pVACseq ships no source-protein context, so the peptide *is*
+            # its own source window — the same thing the prediction identity
+            # records. The variant string is provenance and belongs in
+            # ``source_name``; storing it in ``source_sequence`` made a
+            # non-sequence look like a sequence, and any consumer that
+            # sliced that window (construct assembly does) got a fragment of
+            # the variant's *name* back.
+            'source': peptide,
+            'source_name': _topiary_group_source(row),
+            'prediction_id': cells.text(row.get("prediction_id")),
+            'offset': int(cells.number(row.get("peptide_offset")) or 0),
             'mutant': mutant,
             'wt': wt,
             'source_class': SOURCE_CLASS_MUTATION,
-            'overlaps_mutation': _safe_bool(
+            'overlaps_mutation': cells.boolean(
                 row.get("contains_mutant_residues"), default=True),
-            'occurs_in_reference': _safe_bool(row.get("pvacseq_ref_match")),
-            'occurs_in_non_CTA_reference': _safe_bool(
+            'occurs_in_reference': cells.boolean(row.get("pvacseq_ref_match")),
+            'occurs_in_non_CTA_reference': cells.boolean(
                 row.get("pvacseq_ref_match")),
         })
         n_rows += 1
@@ -494,35 +532,76 @@ def _build_pvacseq_report_row(row):
     rna_vaf = _first_float(row.get("rna_vaf"), row.get("tumor_rna_vaf"))
     dna_vaf = _first_float(row.get("dna_vaf"), row.get("tumor_dna_vaf"))
     out = neoepitope_core_row(
-        allele=_safe_str(row.get("allele")),
-        mutant_peptide=_safe_str(row.get("peptide")),
+        allele=cells.text(row.get("allele")),
+        mutant_peptide=cells.text(row.get("peptide")),
         mutant_affinity=row.get("value"),
-        wt_peptide=_safe_str(row.get("wt_peptide")),
+        wt_peptide=cells.text(row.get("wt_peptide")),
         wt_affinity=row.get("wt_value"),
-        gene_name=_safe_str(row.get("gene")),
-        variant=_safe_str(row.get("variant")))
+        gene_name=cells.text(row.get("gene")),
+        variant=cells.text(row.get("variant")))
     out.update({
-        'Tier': _safe_str(row.get("pvacseq_tier")),
-        'Ref Match': _safe_bool(row.get("pvacseq_ref_match")),
+        'Tier': cells.text(row.get("pvacseq_tier")),
+        'Ref Match': cells.boolean(row.get("pvacseq_ref_match")),
         'RNA Expr': rna_expr,
         'RNA VAF': rna_vaf,
         'DNA VAF': dna_vaf,
-        '%ile MT': _safe_float(row.get("percentile_rank")),
-        'Prediction identity': _safe_str(row.get("prediction_id")),
+        '%ile MT': cells.number(row.get("percentile_rank")),
+        'Prediction identity': cells.text(row.get("prediction_id")),
         'Source sequence name': _topiary_group_source(row),
-        'Peptide offset': int(_safe_float(row.get("peptide_offset")) or 0),
-        'MHC class': _safe_str(row.get("mhc_class")),
-        'Contains mutant residues': _safe_bool(
+        'Peptide offset': int(cells.number(row.get("peptide_offset")) or 0),
+        'MHC class': cells.text(row.get("mhc_class")),
+        'Contains mutant residues': cells.boolean(
             row.get("contains_mutant_residues"), default=True),
     })
     for col, value in row.items():
         if col.startswith("pvacseq_") and col not in {
                 "pvacseq_ref_match", "pvacseq_tier"}:
-            out[col] = _safe_float(value)
+            out[col] = cells.number(value)
     return out
 
 
-def load_pvacseq(path, epitope_config=None):
+# pVACseq's all_epitopes flavor carries both a row key (``Index``) and genomic
+# coordinates. ``topiary.read_pvacseq`` prefers ``Index`` for its ``variant``
+# column and does not carry the coordinate columns through — so the identity
+# survives the normalization and the genome position does not. Construct
+# ranking needs the position, so we recover it here, at load, keyed by the
+# same identity topiary produced. This is the only place the raw TSV is
+# consulted, and what it recovers is stated rather than assumed.
+_PVACSEQ_COORDINATE_COLUMNS = ("Chromosome", "Start", "Reference", "Variant")
+
+
+def pvacseq_genomic_coordinates(path):
+    """Map each pVACseq row identity to its ``chrom-start-ref-alt`` string.
+
+    Returns an empty map for flavors that ship no coordinate columns (the
+    aggregated flavor encodes the position in its ``ID`` instead).
+    """
+    from .external_prediction import pvacseq_variant_id
+    try:
+        header = pd.read_csv(path, sep="\t", nrows=0)
+    except (ValueError, OSError):
+        return {}
+    if not set(_PVACSEQ_COORDINATE_COLUMNS) <= set(header.columns):
+        return {}
+    id_columns = [
+        column for column in ("Index", "ID")
+        if column in header.columns]
+    frame = pd.read_csv(
+        path, sep="\t", low_memory=False,
+        usecols=list(_PVACSEQ_COORDINATE_COLUMNS) + id_columns)
+    coordinates = {}
+    for _, raw in frame.iterrows():
+        row = dict(raw)
+        variant_id = pvacseq_variant_id(row)
+        if not variant_id:
+            continue
+        parts = [cells.text(row.get(c)) for c in _PVACSEQ_COORDINATE_COLUMNS]
+        if all(parts):
+            coordinates.setdefault(variant_id, "-".join(parts))
+    return coordinates
+
+
+def read_pvacseq_report(path, epitope_config=None):
     """
     Import a pVACseq TSV and return a neoepitope report DataFrame ready
     for output.
@@ -553,18 +632,34 @@ def load_pvacseq(path, epitope_config=None):
     result = read_pvacseq(path)
     topiary_df = drop_empty_sample_name(result.df)
     topiary_df = topiary_df.copy()
-    topiary_df["prediction_id"] = [
-        key.identifier if key is not None else ""
-        for key in (
-            ExternalPredictionKey.from_pvacseq_row(row)
-            for _, row in topiary_df.iterrows()
-        )
-    ]
-    epitope_rows, n_rows = _topiary_pvacseq_to_epitope_rows(topiary_df)
+
+    # Topiary has already normalized both pVACseq flavors onto one column
+    # vocabulary (``variant``, ``gene``, ``transcript``, ``rna_depth`` /
+    # ``tumor_rna_depth``, …). Every later stage reads these rows, never the
+    # raw TSV — so an identity built here and an identity used for construct
+    # ranking are the same object rather than two derivations that have to be
+    # kept in agreement.
+    rows = [dict(row) for _, row in topiary_df.iterrows()]
+    coordinates = pvacseq_genomic_coordinates(path)
+    records = []
+    prediction_ids = []
+    for row in rows:
+        genomic = coordinates.get(cells.text(row.get("variant")))
+        if genomic:
+            row[GENOMIC_VARIANT_COLUMN] = genomic
+        key = ExternalPredictionKey.from_pvacseq_row(row)
+        prediction_ids.append(key.identifier if key is not None else "")
+        if key is not None:
+            records.append(ExternalRecord(key=key, row=row))
+    topiary_df["prediction_id"] = prediction_ids
+    for row, prediction_id in zip(rows, prediction_ids):
+        row["prediction_id"] = prediction_id
+
+    epitope_rows, n_rows = _topiary_pvacseq_to_epitope_rows(rows)
     report_rows = [
         _build_pvacseq_report_row(row)
-        for _, row in topiary_df.iterrows()
-        if _safe_str(row.get("peptide")) and _safe_str(row.get("allele"))
+        for row in rows
+        if cells.text(row.get("peptide")) and cells.text(row.get("allele"))
     ]
 
     report_df = pd.DataFrame(report_rows) if report_rows else pd.DataFrame()
@@ -576,43 +671,14 @@ def load_pvacseq(path, epitope_config=None):
     logger.info(
         "Loaded %d epitope(s) (%d row(s), %s flavor) from pVACseq file %s",
         len(epitopes), n_rows, result.extra.get("pvacseq_format"), path)
-    return report_df, epitopes
-
-
-# ── Shared cell-coercion helpers ─────────────────────────────────────────────
-
-def _safe_str(val):
-    """Coerce a cell to str, mapping NaN/None/'NA' to empty string."""
-    if _is_missing(val):
-        return ""
-    s = str(val)
-    if s == "NA":
-        return ""
-    return s
-
-
-def _safe_float(val):
-    """Convert to float, returning None for NaN/missing."""
-    if _is_missing(val):
-        return None
-    try:
-        return float(val)
-    except (ValueError, TypeError):
-        return None
-
-
-def _safe_bool(val, default=False):
-    """Coerce common TSV boolean spellings; missing values use *default*."""
-    if _is_missing(val):
-        return default
-    if isinstance(val, str):
-        lowered = val.strip().lower()
-        if lowered in {"true", "t", "yes", "y", "1"}:
-            return True
-        if lowered in {"false", "f", "no", "n", "0"}:
-            return False
-        return default
-    return bool(val)
+    return ExternalReport(
+        source_format="pvacseq",
+        path=str(path),
+        report_df=report_df,
+        epitopes=tuple(epitopes),
+        records=tuple(records),
+        rows=tuple(rows),
+    )
 
 
 # ── LENS import ──────────────────────────────────────────────────────────────
@@ -766,8 +832,8 @@ def lens_epitope_position(peptide, peptide_context):
     represented by an empty source and offset zero; a peptide that does not
     occur in a non-empty context has no valid position and returns ``None``.
     """
-    peptide = _safe_str(peptide)
-    peptide_context = _safe_str(peptide_context)
+    peptide = cells.text(peptide)
+    peptide_context = cells.text(peptide_context)
     if not peptide:
         return None
     if peptide_context:
@@ -779,7 +845,7 @@ def lens_epitope_position(peptide, peptide_context):
     return peptide, peptide_context, offset
 
 
-def load_lens(path, epitope_config=None):
+def read_lens_report(path, epitope_config=None):
     """
     Import a LENS report TSV and return a neoepitope report DataFrame
     plus a list of ``vaxrank.candidate_epitope.CandidateEpitope`` objects.
@@ -845,6 +911,11 @@ def load_lens(path, epitope_config=None):
         _pick_canonical_predictor(affinity_preds) if affinity_preds else None)
     chosen = list(detected)
 
+    # One materialization of the source rows. Construct ranking consumes
+    # these same dicts, so LENS evidence columns (read counts, VAF, alleles)
+    # never require a second read of the file.
+    rows = [dict(row) for _, row in df.iterrows()]
+    records = []
     epitope_rows = []
     report_rows = []
     processing_rows_by_position = {}
@@ -854,8 +925,8 @@ def load_lens(path, epitope_config=None):
     # constructs, or pepsickle); summarized once after the loop.
     n_dropped_peptide_context_mismatch = 0
     mismatch_examples = []
-    for _, row in df.iterrows():
-        peptide = _safe_str(row.get("peptide"))
+    for row in rows:
+        peptide = cells.text(row.get("peptide"))
         if not peptide:
             continue
 
@@ -870,7 +941,7 @@ def load_lens(path, epitope_config=None):
         # way to recover wildtype affinity from a LENS row, since
         # LENS doesn't emit a WT IC50 column directly. Computed
         # once per row (shared across detected predictors).
-        agretopicity = _safe_float(row.get("mhcflurry_agretopicity"))
+        agretopicity = cells.number(row.get("mhcflurry_agretopicity"))
         # Locate the neoepitope inside its surrounding context once per
         # row (pep_context is a row-level column, not per-predictor).
         # LENS centers the peptide within pep_context but doesn't emit
@@ -881,7 +952,7 @@ def load_lens(path, epitope_config=None):
         # a fabricated offset downstream into the report, constructs,
         # and pepsickle. An empty pep_context is a different case (no
         # SLP window at all): keep it, offset 0, bare-neoepitope fallback.
-        pep_context = _safe_str(row.get("pep_context"))
+        pep_context = cells.text(row.get("pep_context"))
         position = lens_epitope_position(peptide, pep_context)
         if position is None:
             n_dropped_peptide_context_mismatch += 1
@@ -893,6 +964,8 @@ def load_lens(path, epitope_config=None):
         if prediction_key is None:
             continue
         prediction_id = prediction_key.identifier
+        row["prediction_id"] = prediction_id
+        records.append(ExternalRecord(key=prediction_key, row=row))
         row_added = False
         shared_epitope_fields = {
             'peptide': str(peptide),
@@ -908,9 +981,9 @@ def load_lens(path, epitope_config=None):
             'occurs_in_non_CTA_reference': False,
         }
         for d in chosen:
-            value = _safe_float(row.get(d.value_col))
+            value = cells.number(row.get(d.value_col))
             percentile_rank = (
-                _safe_float(row.get(d.percentile_col))
+                cells.number(row.get(d.percentile_col))
                 if d.percentile_col else None)
             # Derive WT IC50 from agretopicity, only for the
             # mhcflurry-affinity predictor (the value matches that
@@ -946,10 +1019,10 @@ def load_lens(path, epitope_config=None):
                 row_added = True
 
             presentation_score = (
-                _safe_float(row.get(d.presentation_score_col))
+                cells.number(row.get(d.presentation_score_col))
                 if d.presentation_score_col else None)
             presentation_percentile = (
-                _safe_float(row.get(d.presentation_percentile_col))
+                cells.number(row.get(d.presentation_percentile_col))
                 if d.presentation_percentile_col else None)
             if (presentation_score is not None
                     or presentation_percentile is not None):
@@ -976,7 +1049,7 @@ def load_lens(path, epitope_config=None):
                 row_added = True
 
             processing_score = (
-                _safe_float(row.get(d.processing_score_col))
+                cells.number(row.get(d.processing_score_col))
                 if d.processing_score_col else None)
             if processing_score is not None:
                 # MHCflurry processing depends on peptide + flanks, not MHC.
@@ -1050,7 +1123,24 @@ def load_lens(path, epitope_config=None):
     logger.info(
         "Loaded %d epitope(s) (%d row(s) × %d predictor(s)) from %s",
         len(epitopes), len(report_df), len(chosen), path)
-    return report_df, epitopes
+    return ExternalReport(
+        source_format="lens",
+        path=str(path),
+        report_df=report_df,
+        epitopes=tuple(epitopes),
+        records=tuple(records),
+        rows=tuple(rows),
+    )
+
+
+def load_lens(path, epitope_config=None):
+    """Back-compat view of :func:`read_lens_report` as ``(df, epitopes)``."""
+    return read_lens_report(path, epitope_config=epitope_config).loaded
+
+
+def load_pvacseq(path, epitope_config=None):
+    """Back-compat view of :func:`read_pvacseq_report` as ``(df, epitopes)``."""
+    return read_pvacseq_report(path, epitope_config=epitope_config).loaded
 
 
 def _build_lens_report_row(row, allele, peptide, prediction_id,
@@ -1062,21 +1152,21 @@ def _build_lens_report_row(row, allele, peptide, prediction_id,
     columns; every *detected* predictor's raw value is also exposed as
     '<Tool> value (nM/hours)' so downstream DSL / scripts can see both.
     """
-    antigen_source = _safe_str(row.get("antigen_source"))
-    gene = _safe_str(row.get("gene_name"))
-    variant_pos = _safe_str(row.get("variant_coords"))
+    antigen_source = cells.text(row.get("antigen_source"))
+    gene = cells.text(row.get("gene_name"))
+    variant_pos = cells.text(row.get("variant_coords"))
     if not variant_pos:
-        variant_pos = _safe_str(row.get("mut_aa_pos"))
+        variant_pos = cells.text(row.get("mut_aa_pos"))
     if not variant_pos:
-        variant_pos = _safe_str(row.get("origin_descriptor"))
+        variant_pos = cells.text(row.get("origin_descriptor"))
 
     display_value = (
-        _safe_float(row.get(display_pred.value_col)) if display_pred else None)
+        cells.number(row.get(display_pred.value_col)) if display_pred else None)
     display_percentile = (
-        _safe_float(row.get(display_pred.percentile_col))
+        cells.number(row.get(display_pred.percentile_col))
         if display_pred and display_pred.percentile_col else None)
     display_agretopicity = (
-        _safe_float(row.get(display_pred.agretopicity_col))
+        cells.number(row.get(display_pred.agretopicity_col))
         if display_pred and display_pred.agretopicity_col else None)
 
     # Shared core columns (WT affinity isn't predicted on the import
@@ -1091,7 +1181,7 @@ def _build_lens_report_row(row, allele, peptide, prediction_id,
         'Predictors used': ','.join(chosen_tools),
         '%ile rank': display_percentile,
         'Agretopicity': display_agretopicity,
-        'TPM': _safe_float(row.get("tpm")),
+        'TPM': cells.number(row.get("tpm")),
         'Source sequence name': source_sequence_name,
         'Peptide offset': peptide_offset,
     })
@@ -1102,18 +1192,18 @@ def _build_lens_report_row(row, allele, peptide, prediction_id,
     for d in detected:
         unit = unit_by_kind.get(d.kind, "")
         label = f"{d.tool} value ({unit})" if unit else f"{d.tool} value"
-        out[label] = _safe_float(row.get(d.value_col))
+        out[label] = cells.number(row.get(d.value_col))
         if d.kind == "pMHC_affinity" and d.percentile_col:
-            out[f"{d.tool} affinity percentile rank"] = _safe_float(
+            out[f"{d.tool} affinity percentile rank"] = cells.number(
                 row.get(d.percentile_col))
         if d.presentation_score_col:
-            out[f"{d.tool} presentation score"] = _safe_float(
+            out[f"{d.tool} presentation score"] = cells.number(
                 row.get(d.presentation_score_col))
         if d.presentation_percentile_col:
-            out[f"{d.tool} presentation percentile rank"] = _safe_float(
+            out[f"{d.tool} presentation percentile rank"] = cells.number(
                 row.get(d.presentation_percentile_col))
         if d.processing_score_col:
-            out[f"{d.tool} processing score"] = _safe_float(
+            out[f"{d.tool} processing score"] = cells.number(
                 row.get(d.processing_score_col))
     return out
 
@@ -1234,7 +1324,7 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
     for _, row in report_df.iterrows():
         score_key = None
         if has_source_keys:
-            offset = _safe_float(row.get(offset_col))
+            offset = cells.number(row.get(offset_col))
             if offset is not None:
                 score_key = (
                     row.get(join_col), row[peptide_col], int(offset),

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -218,13 +218,8 @@ def predictions_to_dataframe(epitopes):
 
     Parameters
     ----------
-    epitopes : list of CandidateEpitope, dict, or iterable
-        Most callers pass a plain ``list[CandidateEpitope]``. A ``dict`` is
-        accepted for back-compat with pre-3.0 call sites that keyed
-        an ordered map by ``(peptide, allele)`` — the values are used.
+    epitopes : iterable of CandidateEpitope
     """
-    if isinstance(epitopes, dict):
-        epitopes = list(epitopes.values())
     rows = []
     for e in epitopes:
         rows.extend(epitope_prediction_rows(e))
@@ -628,10 +623,8 @@ def read_pvacseq_report(path, epitope_config=None):
     """
     from topiary import read_pvacseq
 
-    from .epitope_dsl import drop_empty_sample_name
     result = read_pvacseq(path)
-    topiary_df = drop_empty_sample_name(result.df)
-    topiary_df = topiary_df.copy()
+    topiary_df = result.df.copy()
 
     # Topiary has already normalized both pVACseq flavors onto one column
     # vocabulary (``variant``, ``gene``, ``transcript``, ``rna_depth`` /
@@ -1133,16 +1126,6 @@ def read_lens_report(path, epitope_config=None):
     )
 
 
-def load_lens(path, epitope_config=None):
-    """Back-compat view of :func:`read_lens_report` as ``(df, epitopes)``."""
-    return read_lens_report(path, epitope_config=epitope_config).loaded
-
-
-def load_pvacseq(path, epitope_config=None):
-    """Back-compat view of :func:`read_pvacseq_report` as ``(df, epitopes)``."""
-    return read_pvacseq_report(path, epitope_config=epitope_config).loaded
-
-
 def _build_lens_report_row(row, allele, peptide, prediction_id,
                            source_sequence_name, peptide_offset, detected,
                            display_pred, chosen_tools):
@@ -1271,8 +1254,7 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
     allele_col = 'Allele'
 
     # Duplicate peptide/allele pairs are expected across variants and
-    # transcripts. Current external loaders join them by Prediction identity;
-    # legacy frames without that column retain their historical broadcast.
+    # transcripts; the identity join keeps their scores distinct.
     if len(report_df) > 0 and logger.isEnabledFor(logging.DEBUG):
         dup_count = int(report_df.duplicated(
             subset=[peptide_col, allele_col]).sum())
@@ -1280,7 +1262,7 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
             logger.debug(
                 "report_df has %d duplicate (peptide, allele) row(s) "
                 "from multi-source input; explicit prediction identities "
-                "keep current-format scores source-specific.", dup_count)
+                "keep their scores source-specific.", dup_count)
 
     # Build the topiary DataFrame once and share it between validator and
     # scorer. pVACseq import keeps the loader-produced frame in
@@ -1303,38 +1285,34 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
     # absent, the DSL filtered it out. Legacy report frames without an
     # explicit identity retain their source-position or peptide fallback.
     scores_by_key = {}
-    scores_by_pair = {}
     for idx_tuple, score in score_series.items():
-        source_name, peptide, offset, allele = idx_tuple
-        scores_by_key[(source_name, peptide, int(offset), allele)] = score
-        scores_by_pair[(peptide, allele)] = score
+        prediction_id, peptide, offset, allele = idx_tuple
+        scores_by_key[(prediction_id, peptide, int(offset), allele)] = score
 
     report_df = report_df.copy()
     identity_col = 'Prediction identity'
-    source_col = 'Source sequence name'
     offset_col = 'Peptide offset'
-    join_col = (
-        identity_col if identity_col in report_df.columns else source_col)
-    has_source_keys = (
-        join_col in report_df.columns and offset_col in report_df.columns)
+    missing = [
+        column for column in (identity_col, offset_col)
+        if column not in report_df.columns]
+    if missing:
+        raise ValueError(
+            "Neoepitope report frame is missing %s. Scores join on the exact "
+            "prediction identity; a (peptide, allele) fallback would "
+            "broadcast one source's score onto another source that happens "
+            "to share a sequence." % " and ".join(missing))
     scores = []
     filter_passed = []
     rank_eligible = []
     exclusion_reasons = []
     for _, row in report_df.iterrows():
-        score_key = None
-        if has_source_keys:
-            offset = cells.number(row.get(offset_col))
-            if offset is not None:
-                score_key = (
-                    row.get(join_col), row[peptide_col], int(offset),
-                    row[allele_col])
-            passed = score_key in scores_by_key
-            score = scores_by_key.get(score_key)
-        else:
-            score_key = (row[peptide_col], row[allele_col])
-            passed = score_key in scores_by_pair
-            score = scores_by_pair.get(score_key)
+        offset = cells.number(row.get(offset_col))
+        score_key = (
+            (row.get(identity_col), row[peptide_col], int(offset),
+             row[allele_col])
+            if offset is not None else None)
+        passed = score_key in scores_by_key
+        score = scores_by_key.get(score_key)
         eligible = (
             passed
             and score is not None

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -81,9 +81,15 @@ VAXRANK_COLUMNS = [
     # Generic WT fields parallel the mutant prediction fields. The legacy
     # ``wt_ic50`` column remains populated for affinity consumers.
     "wt_prediction_kind",
+    "wt_prediction_peptide",
     "wt_prediction_value",
     "wt_prediction_score",
     "wt_percentile_rank",
+    "wt_prediction_tcr",
+    "wt_prediction_n_flank",
+    "wt_prediction_c_flank",
+    "wt_prediction_source_sequence_name",
+    "wt_prediction_offset",
 ]
 
 
@@ -147,6 +153,8 @@ def epitope_prediction_rows(epitope):
             ),
             "wt_prediction_kind": (
                 wt_prediction.kind if wt_prediction is not None else ""),
+            "wt_prediction_peptide": (
+                wt_prediction.peptide if wt_prediction is not None else ""),
             "wt_prediction_value": (
                 wt_prediction.value if wt_prediction is not None else None),
             "wt_prediction_score": (
@@ -154,6 +162,17 @@ def epitope_prediction_rows(epitope):
             "wt_percentile_rank": (
                 wt_prediction.percentile_rank
                 if wt_prediction is not None else None),
+            "wt_prediction_tcr": (
+                wt_prediction.tcr if wt_prediction is not None else ""),
+            "wt_prediction_n_flank": (
+                wt_prediction.n_flank if wt_prediction is not None else ""),
+            "wt_prediction_c_flank": (
+                wt_prediction.c_flank if wt_prediction is not None else ""),
+            "wt_prediction_source_sequence_name": (
+                wt_prediction.source_sequence_name
+                if wt_prediction is not None else None),
+            "wt_prediction_offset": (
+                wt_prediction.offset if wt_prediction is not None else None),
         })
     unpaired_wt = [
         prediction
@@ -276,10 +295,23 @@ def load_predictions(path):
             wt = Prediction(
                 kind=wt_kind, predictor_name=method,
                 predictor_version=version, allele=allele,
-                peptide=wt_peptide,
+                peptide=(
+                    string_or_empty(row.get("wt_prediction_peptide"))
+                    or wt_peptide),
                 value=optional_float(row.get("wt_prediction_value")),
                 score=wt_score,
                 percentile_rank=optional_float(row.get("wt_percentile_rank")),
+                tcr=string_or_empty(row.get("wt_prediction_tcr", "")),
+                n_flank=string_or_empty(
+                    row.get("wt_prediction_n_flank", "")),
+                c_flank=string_or_empty(
+                    row.get("wt_prediction_c_flank", "")),
+                source_sequence_name=(
+                    string_or_empty(
+                        row.get("wt_prediction_source_sequence_name"))
+                    or None),
+                offset=int(optional_float(
+                    row.get("wt_prediction_offset")) or 0),
             )
         elif wt_ic50 is not None:
             wt = Prediction(

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -26,6 +26,7 @@ which groups by ``(peptide, source, offset)`` into ``CandidateEpitope``
 objects at the end.
 """
 
+import json
 import logging
 import os
 import re
@@ -34,7 +35,7 @@ from dataclasses import dataclass
 import pandas as pd
 from mhctools.pred import Prediction
 
-from .epitope_dsl import _kind_for_method
+from .epitope_dsl import prediction_kind_for_method
 from .candidate_epitope import (
     SOURCE_CLASS_MUTATION, candidate_epitopes_from_rows,
 )
@@ -59,35 +60,66 @@ VAXRANK_COLUMNS = [
     "occurs_in_reference",
     "occurs_in_non_CTA_reference",
     "predictor_version",
+    # Generic prediction fields. The legacy ``ic50`` column remains above
+    # for compatibility, but cannot represent presentation, processing, or
+    # any future non-affinity kind.
+    "prediction_kind",
+    "prediction_peptide",
+    "prediction_value",
+    "prediction_score",
+    "prediction_tcr",
+    "prediction_n_flank",
+    "prediction_c_flank",
+    "prediction_source_sequence_name",
+    "prediction_offset",
+    # Explicit input-allele membership is necessary for canonical
+    # allele-independent processing predictions.
+    "patient_alleles",
+    # Preserve the exact configured DSL result so a native reload does not
+    # silently revert to an unrelated default scoring formula.
+    "per_allele_scores",
+    # Generic WT fields parallel the mutant prediction fields. The legacy
+    # ``wt_ic50`` column remains populated for affinity consumers.
+    "wt_prediction_kind",
+    "wt_prediction_value",
+    "wt_prediction_score",
+    "wt_percentile_rank",
 ]
 
 
-def _epitope_to_rows(epitope):
-    """Flatten one ``CandidateEpitope`` to per-(predictor, allele) row dicts
-    matching :data:`VAXRANK_COLUMNS`. Drives ``predictions_to_dataframe``
-    and ``save_predictions``."""
+def epitope_prediction_rows(epitope):
+    """Serialize one candidate to one native row per mutant prediction.
+
+    Every prediction kind is emitted. Affinity values are duplicated into
+    the legacy ``ic50`` column for compatibility; the generic prediction
+    columns retain the kind, value, normalized score, percentile, and
+    provenance needed to reconstruct the original ``Prediction`` records.
+    """
     wt = epitope.wt
     wt_peptide_sequence = wt.sequence if wt is not None else ""
-    # Build (allele, predictor_name) -> wt_ic50 lookup so each per-allele
-    # candidate row gets paired with its matching WT IC50, if any.
-    wt_ic50_by_key = {}
+    wt_by_key = {}
     if wt is not None:
         for p in wt.predictions_flat():
-            if p.kind == 'pMHC_affinity' and p.value is not None:
-                wt_ic50_by_key.setdefault((p.allele, p.predictor_name), p.value)
+            key = (
+                p.kind, p.predictor_name, p.predictor_version, p.allele)
+            wt_by_key.setdefault(key, []).append(p)
     rows = []
     for p in epitope.predictions_flat():
-        if p.kind != 'pMHC_affinity':
-            # The vaxrank-native CSV format only carries affinity rows;
-            # presentation / stability / processing live elsewhere.
-            continue
-        wt_ic50 = wt_ic50_by_key.get((p.allele, p.predictor_name))
+        key = (p.kind, p.predictor_name, p.predictor_version, p.allele)
+        matching_wt = wt_by_key.get(key, [])
+        wt_prediction = matching_wt.pop(0) if matching_wt else None
         rows.append({
             "allele": p.allele,
             "peptide_sequence": epitope.sequence,
             "wt_peptide_sequence": wt_peptide_sequence,
-            "ic50": p.value,
-            "wt_ic50": wt_ic50,
+            "ic50": p.value if p.kind == "pMHC_affinity" else None,
+            "wt_ic50": (
+                wt_prediction.value
+                if (
+                    wt_prediction is not None
+                    and wt_prediction.kind == "pMHC_affinity"
+                )
+                else None),
             "percentile_rank": p.percentile_rank,
             "prediction_method_name": p.predictor_name,
             "source_class": epitope.source_class,
@@ -97,14 +129,48 @@ def _epitope_to_rows(epitope):
             "occurs_in_reference": epitope.occurs_in_reference,
             "occurs_in_non_CTA_reference": epitope.occurs_in_non_CTA_reference,
             "predictor_version": p.predictor_version,
+            "prediction_kind": p.kind,
+            "prediction_peptide": p.peptide,
+            "prediction_value": p.value,
+            "prediction_score": p.score,
+            "prediction_tcr": p.tcr,
+            "prediction_n_flank": p.n_flank,
+            "prediction_c_flank": p.c_flank,
+            "prediction_source_sequence_name": p.source_sequence_name,
+            "prediction_offset": p.offset,
+            "patient_alleles": json.dumps(
+                list(epitope.patient_alleles), separators=(",", ":")),
+            "per_allele_scores": json.dumps(
+                epitope.per_allele_scores,
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            "wt_prediction_kind": (
+                wt_prediction.kind if wt_prediction is not None else ""),
+            "wt_prediction_value": (
+                wt_prediction.value if wt_prediction is not None else None),
+            "wt_prediction_score": (
+                wt_prediction.score if wt_prediction is not None else None),
+            "wt_percentile_rank": (
+                wt_prediction.percentile_rank
+                if wt_prediction is not None else None),
         })
+    unpaired_wt = [
+        prediction
+        for predictions in wt_by_key.values()
+        for prediction in predictions
+    ]
+    if unpaired_wt:
+        raise ValueError(
+            "Cannot serialize WT predictions without matching mutant "
+            "prediction leaves; refusing to lose comparator evidence")
     return rows
 
 
 def predictions_to_dataframe(epitopes):
     """Convert a collection of ``CandidateEpitope`` objects to a flat DataFrame
-    matching :data:`VAXRANK_COLUMNS` — one row per leaf
-    ``pMHC_affinity`` prediction.
+    matching :data:`VAXRANK_COLUMNS` — one row per mutant prediction leaf,
+    regardless of prediction kind.
 
     Parameters
     ----------
@@ -117,7 +183,7 @@ def predictions_to_dataframe(epitopes):
         epitopes = list(epitopes.values())
     rows = []
     for e in epitopes:
-        rows.extend(_epitope_to_rows(e))
+        rows.extend(epitope_prediction_rows(e))
     return pd.DataFrame(rows, columns=VAXRANK_COLUMNS)
 
 
@@ -134,59 +200,120 @@ def save_predictions(epitopes, path):
 
 
 def load_predictions(path):
-    """Load a vaxrank-native CSV/TSV file and return ``list[CandidateEpitope]``."""
+    """Load a vaxrank-native CSV/TSV file.
+
+    Files written before generic prediction columns were introduced remain
+    supported as affinity-only inputs. New-format rows must carry an explicit
+    prediction kind and score; missing scientific values are not converted to
+    implicit zeros.
+    """
     sep = "\t" if str(path).endswith(".tsv") else ","
     df = pd.read_csv(path, sep=sep)
 
-    def _str_or_empty(val):
+    def string_or_empty(val):
         if val is None or (isinstance(val, float) and pd.isna(val)):
             return ""
         return str(val)
 
+    def optional_float(val):
+        if val is None or pd.isna(val):
+            return None
+        return float(val)
+
+    has_generic_predictions = "prediction_kind" in df.columns
+
     rows = []
     for _, row in df.iterrows():
-        wt_ic50 = row.get("wt_ic50")
-        if pd.isna(wt_ic50):
-            wt_ic50 = None
-        percentile_rank = row.get("percentile_rank")
-        if pd.isna(percentile_rank):
-            percentile_rank = None
+        wt_ic50 = optional_float(row.get("wt_ic50"))
+        percentile_rank = optional_float(row.get("percentile_rank"))
         peptide = row["peptide_sequence"]
-        wt_peptide = _str_or_empty(row.get("wt_peptide_sequence", ""))
-        method = _str_or_empty(row.get("prediction_method_name", ""))
-        version = _str_or_empty(row.get("predictor_version", ""))
-        allele = row["allele"]
-        kind = _kind_for_method(method)
+        wt_peptide = string_or_empty(row.get("wt_peptide_sequence", ""))
+        method = string_or_empty(row.get("prediction_method_name", ""))
+        version = string_or_empty(row.get("predictor_version", ""))
+        allele = string_or_empty(row.get("allele", ""))
+        if has_generic_predictions:
+            kind = string_or_empty(row.get("prediction_kind"))
+            if not kind:
+                raise ValueError(
+                    "Native epitope row is missing prediction_kind")
+            score = optional_float(row.get("prediction_score"))
+            if score is None:
+                raise ValueError(
+                    "Native epitope row is missing prediction_score")
+            value = optional_float(row.get("prediction_value"))
+            prediction_peptide = string_or_empty(
+                row.get("prediction_peptide")) or peptide
+        else:
+            # Legacy files only represented affinity IC50 and did not retain
+            # normalized scores. Keep that historical 0.0 compatibility
+            # behavior only when the generic schema is entirely absent.
+            kind = prediction_kind_for_method(method)
+            score = 0.0
+            value = float(row["ic50"])
+            prediction_peptide = peptide
         mutant = Prediction(
             kind=kind, predictor_name=method, predictor_version=version,
-            allele=allele, peptide=peptide, value=float(row["ic50"]),
-            score=0.0,
+            allele=allele, peptide=prediction_peptide, value=value,
+            score=score,
             percentile_rank=(
                 float(percentile_rank) if percentile_rank is not None
                 else None),
+            tcr=string_or_empty(row.get("prediction_tcr", "")),
+            n_flank=string_or_empty(row.get("prediction_n_flank", "")),
+            c_flank=string_or_empty(row.get("prediction_c_flank", "")),
+            source_sequence_name=(
+                string_or_empty(row.get("prediction_source_sequence_name"))
+                or None),
+            offset=int(optional_float(row.get("prediction_offset")) or 0),
         )
         wt = None
-        if wt_ic50 is not None:
+        wt_kind = string_or_empty(row.get("wt_prediction_kind", ""))
+        if wt_kind:
+            wt_score = optional_float(row.get("wt_prediction_score"))
+            if wt_score is None:
+                raise ValueError(
+                    "Native epitope row is missing wt_prediction_score")
+            wt = Prediction(
+                kind=wt_kind, predictor_name=method,
+                predictor_version=version, allele=allele,
+                peptide=wt_peptide,
+                value=optional_float(row.get("wt_prediction_value")),
+                score=wt_score,
+                percentile_rank=optional_float(row.get("wt_percentile_rank")),
+            )
+        elif wt_ic50 is not None:
             wt = Prediction(
                 kind=kind, predictor_name=method,
                 predictor_version=version, allele=allele,
-                peptide=wt_peptide, value=float(wt_ic50), score=0.0,
+                peptide=wt_peptide, value=wt_ic50, score=0.0,
                 percentile_rank=None,
             )
+        patient_alleles_raw = string_or_empty(row.get("patient_alleles", ""))
+        patient_alleles = (
+            tuple(json.loads(patient_alleles_raw))
+            if patient_alleles_raw else ())
+        per_allele_scores_raw = string_or_empty(
+            row.get("per_allele_scores", ""))
+        per_allele_scores = (
+            json.loads(per_allele_scores_raw)
+            if per_allele_scores_raw else {})
         occurs_in_ref = bool(row.get("occurs_in_reference", False))
         rows.append({
             'peptide': peptide,
-            'source': _str_or_empty(row.get("source_sequence", "")),
+            'source': string_or_empty(row.get("source_sequence", "")),
             'offset': int(row.get("offset", 0)),
             'mutant': mutant,
             'wt': wt,
-            'source_class': _str_or_empty(row.get("source_class", "")) or None,
+            'source_class': string_or_empty(
+                row.get("source_class", "")) or None,
             'overlaps_mutation': bool(row.get("overlaps_mutation", True)),
             'occurs_in_reference': occurs_in_ref,
             # Fall back to raw occurs_in_reference when the CSV is
             # from a pre-3.0 producer that didn't emit this column.
             'occurs_in_non_CTA_reference': bool(
                 row.get("occurs_in_non_CTA_reference", occurs_in_ref)),
+            'patient_alleles': patient_alleles,
+            'per_allele_scores': per_allele_scores,
         })
     return candidate_epitopes_from_rows(rows)
 
@@ -279,7 +406,9 @@ def _topiary_pvacseq_to_epitope_rows(df):
 
         method = _safe_str(row.get("prediction_method_name")) or "pvacseq"
         version = _safe_str(row.get("predictor_version"))
-        kind = _safe_str(row.get("kind")) or _kind_for_method(method)
+        kind = (
+            _safe_str(row.get("kind"))
+            or prediction_kind_for_method(method))
         percentile_rank = _safe_float(row.get("percentile_rank"))
         score = _safe_float(row.get("score"))
         mutant = Prediction(
@@ -355,7 +484,7 @@ def _build_pvacseq_report_row(row):
     return out
 
 
-def load_pvacseq(path):
+def load_pvacseq(path, epitope_config=None):
     """
     Import a pVACseq TSV and return a neoepitope report DataFrame ready
     for output.
@@ -366,6 +495,8 @@ def load_pvacseq(path):
     Parameters
     ----------
     path : str or Path
+    epitope_config : EpitopeConfig, optional
+        Effective DSL configuration to evaluate before returning candidates.
 
     Returns
     -------
@@ -394,7 +525,8 @@ def load_pvacseq(path):
     report_df.attrs["topiary_df"] = topiary_df
     epitopes = candidate_epitopes_from_rows(epitope_rows)
     from .epitope_dsl import attach_per_allele_scores
-    epitopes = attach_per_allele_scores(epitopes, topiary_df=topiary_df)
+    epitopes = attach_per_allele_scores(
+        epitopes, epitope_config, topiary_df=topiary_df)
     logger.info(
         "Loaded %d epitope(s) (%d row(s), %s flavor) from pVACseq file %s",
         len(epitopes), n_rows, result.extra.get("pvacseq_format"), path)
@@ -581,7 +713,7 @@ def normalize_hla_allele(allele):
     return re.sub(r"^(HLA-[A-Z]{1,3})(\d)", r"\1*\2", allele)
 
 
-def load_lens(path):
+def load_lens(path, epitope_config=None):
     """
     Import a LENS report TSV and return a neoepitope report DataFrame
     plus a list of ``vaxrank.candidate_epitope.CandidateEpitope`` objects.
@@ -600,6 +732,10 @@ def load_lens(path):
     Parameters
     ----------
     path : str or Path
+    epitope_config : EpitopeConfig, optional
+        Effective DSL configuration to evaluate before returning candidates.
+        Supplying it here ensures vaccine ranking and template reports consume
+        the same scores as the neoepitope CSV/XLSX report.
 
     Returns
     -------
@@ -837,7 +973,7 @@ def load_lens(path):
     # CandidateEpitope.per_allele_scores. Loaders must populate it or
     # downstream ranking sees zero-scored epitopes and drops everything.
     from .epitope_dsl import attach_per_allele_scores
-    epitopes = attach_per_allele_scores(epitopes)
+    epitopes = attach_per_allele_scores(epitopes, epitope_config)
     logger.info(
         "Loaded %d epitope(s) (%d row(s) × %d predictor(s)) from %s",
         len(epitopes), len(report_df), len(chosen), path)

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -745,6 +745,26 @@ def normalize_hla_allele(allele):
     return re.sub(r"^(HLA-[A-Z]{1,3})(\d)", r"\1*\2", allele)
 
 
+def lens_epitope_position(peptide, peptide_context):
+    """Return the position identity shared by LENS import and ranking.
+
+    The identity is ``(peptide, source context, offset)``. Missing context is
+    represented by an empty source and offset zero; a peptide that does not
+    occur in a non-empty context has no valid position and returns ``None``.
+    """
+    peptide = _safe_str(peptide)
+    peptide_context = _safe_str(peptide_context)
+    if not peptide:
+        return None
+    if peptide_context:
+        offset = peptide_context.find(peptide)
+        if offset < 0:
+            return None
+    else:
+        offset = 0
+    return peptide, peptide_context, offset
+
+
 def load_lens(path, epitope_config=None):
     """
     Import a LENS report TSV and return a neoepitope report DataFrame
@@ -821,8 +841,8 @@ def load_lens(path, epitope_config=None):
     n_dropped_peptide_context_mismatch = 0
     mismatch_examples = []
     for _, row in df.iterrows():
-        peptide = row.get("peptide", "")
-        if not peptide or pd.isna(peptide):
+        peptide = _safe_str(row.get("peptide"))
+        if not peptide:
             continue
 
         allele_raw = row.get("allele", "")
@@ -848,12 +868,13 @@ def load_lens(path, epitope_config=None):
         # and pepsickle. An empty pep_context is a different case (no
         # SLP window at all): keep it, offset 0, bare-neoepitope fallback.
         pep_context = _safe_str(row.get("pep_context"))
-        if pep_context and str(peptide) not in pep_context:
+        position = lens_epitope_position(peptide, pep_context)
+        if position is None:
             n_dropped_peptide_context_mismatch += 1
             if len(mismatch_examples) < 1:
-                mismatch_examples.append((str(peptide), pep_context))
+                mismatch_examples.append((peptide, pep_context))
             continue
-        offset = pep_context.find(str(peptide)) if pep_context else 0
+        peptide, pep_context, offset = position
         row_added = False
         shared_epitope_fields = {
             'peptide': str(peptide),

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -21,7 +21,7 @@ from topiary import TopiaryPredictor
 from topiary.ranking import EvalContext, apply_filter
 
 from .epitope_config import EpitopeConfig
-from .epitope_dsl import build_filter_node, build_score_node, drop_empty_sample_name
+from .epitope_dsl import build_filter_node, build_score_node
 from .mutant_protein_fragment import MutantProteinFragment
 from .prediction_input import finite_prediction_value
 from .candidate_epitope import (
@@ -144,7 +144,6 @@ def predict_epitopes(
 
     if predictions_df.empty:
         return []
-    predictions_df = drop_empty_sample_name(predictions_df)
 
     # ``default_methods`` (per-kind ``prediction_method_name`` defaults
     # for unqualified DSL refs) is required when multi-predictor data
@@ -232,7 +231,6 @@ def predict_epitopes(
     if valid_wt_peptides:
         try:
             wt_df = topiary_predictor.predict_from_named_peptides(valid_wt_peptides)
-            wt_df = drop_empty_sample_name(wt_df)
             for _, row in wt_df.iterrows():
                 key = (row["source_sequence_name"], row["allele"])
                 wt_predictions_grouped[key] = row

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -21,7 +21,9 @@ from topiary import TopiaryPredictor
 from topiary.ranking import EvalContext, apply_filter
 
 from .epitope_config import EpitopeConfig
-from .epitope_dsl import build_filter_node, build_score_node
+from .epitope_dsl import (
+    build_filter_node, build_score_node, prediction_group_columns,
+)
 from .mutant_protein_fragment import MutantProteinFragment
 from .prediction_input import finite_prediction_value
 from .candidate_epitope import (
@@ -154,10 +156,19 @@ def predict_epitopes(
 
     # Apply the configured filter (default: affinity or percentile-rank cutoff)
     # so that rows dropped by the filter are never scored or WT-predicted.
+    # ``kind_support`` is per-(model, kind) MHC context — which kinds are
+    # allele-dependent, and for which class. topiary's DSL uses it to guard
+    # mhc_dependence, and without it those guards resolve by scanning rows,
+    # which is a guess. We are holding the predictor that knows the answer,
+    # so forward it rather than making topiary infer it (openvax/topiary#178).
+    kind_support = getattr(topiary_predictor, "kind_support", None)
     filter_node = build_filter_node(epitope_config)
     if filter_node is not None:
         predictions_df = apply_filter(
-            predictions_df, filter_node, default_methods=default_methods)
+            predictions_df, filter_node,
+            group_keys=prediction_group_columns(predictions_df),
+            default_methods=default_methods,
+            kind_support=kind_support)
         if predictions_df.empty:
             return []
 
@@ -189,7 +200,11 @@ def predict_epitopes(
     # Evaluate the score expression once; indexed by
     # (source_sequence_name, peptide, peptide_offset, allele) group tuple.
     score_node = build_score_node(epitope_config)
-    score_ctx = EvalContext(predictions_df, default_methods=default_methods)
+    score_ctx = EvalContext(
+        predictions_df,
+        group_keys=prediction_group_columns(predictions_df),
+        default_methods=default_methods,
+        kind_support=kind_support)
     score_series = (
         score_node.eval(score_ctx).reindex(score_ctx.group_index).fillna(0.0)
     )

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -43,14 +43,16 @@ import os
 
 import pandas as pd
 
+from . import cells
 from .amino_acids import has_only_standard_amino_acids
+from .epitope_logic import slice_epitopes
 from .external_prediction import (
-    ExternalPredictionKey,
     external_text,
     external_values,
     lens_variant_id,
     pvacseq_variant_id,
 )
+from .external_report import GENOMIC_VARIANT_COLUMN, ExternalRecord
 from .mutant_protein_fragment import MutantProteinFragment
 from .vaccine_library import truncate_at_stop_codon
 from .vaccine_peptide import VaccinePeptide
@@ -257,20 +259,11 @@ class ExternalRankingResult:
 
 
 @dataclasses.dataclass(frozen=True)
-class ExternalPredictionRecord:
-    """One raw external row joined to its exact scored candidate."""
-
-    row: dict
-    key: ExternalPredictionKey
-    epitope: object
-
-
-@dataclasses.dataclass(frozen=True)
 class ExternalConstructSelection:
     """DSL-selected source window and the candidates it contains."""
 
-    representative: ExternalPredictionRecord
-    records: tuple[ExternalPredictionRecord, ...]
+    representative: ExternalRecord
+    records: tuple[ExternalRecord, ...]
 
     @property
     def epitopes(self):
@@ -283,20 +276,6 @@ class ExternalConstructSelection:
                 seen.add(identity)
                 result.append(record.epitope)
         return tuple(result)
-
-
-def external_epitopes_by_id(epitopes):
-    """Index externally sourced candidates without sequence fallbacks."""
-    result = {}
-    for epitope in epitopes:
-        if not epitope.prediction_id:
-            raise ValueError(
-                "External construct ranking requires prediction provenance")
-        if epitope.prediction_id in result:
-            raise ValueError(
-                "Duplicate external prediction identity after loading")
-        result[epitope.prediction_id] = epitope
-    return result
 
 
 def select_external_construct(records):
@@ -324,28 +303,6 @@ def select_external_construct(records):
         representative=representative,
         records=selected,
     )
-
-
-def _missing_cell(value):
-    if value is None:
-        return True
-    try:
-        return bool(pd.isna(value))
-    except (TypeError, ValueError):
-        return False
-
-
-def _first_cell(row, *names):
-    for name in names:
-        value = row.get(name)
-        if not _missing_cell(value):
-            return value
-    return None
-
-
-def _first_str(row, *names):
-    value = _first_cell(row, *names)
-    return str(value) if value is not None else ""
 
 
 def parse_lens_variant_coordinates(coords):
@@ -601,28 +558,6 @@ def peptide_offsets_in_context(peptide, peptide_context):
     return idx, idx + len(peptide)
 
 
-def _coerce_int(value, default=0):
-    """Coerce a value (possibly NaN / None / str) to int.
-
-    Returns ``default`` when the value is genuinely missing — pandas
-    NaN, None, or a non-numeric string. Used to read RNA-read-count
-    columns from LENS / pVACseq cleanly: when LENS omits the column
-    or the row has no RNA support, we want 0 (honest "no signal"),
-    not a fabricated stand-in.
-    """
-    if value is None:
-        return default
-    try:
-        if pd.isna(value):
-            return default
-    except (TypeError, ValueError):
-        pass
-    try:
-        return int(round(float(value)))
-    except (TypeError, ValueError):
-        return default
-
-
 def _read_counts_from_lens_row(row):
     """Extract real RNA-read counts from a LENS row.
 
@@ -637,15 +572,74 @@ def _read_counts_from_lens_row(row):
     n_alt_reads_supporting_protein_sequence)``. Missing columns yield
     0 — honest "no read signal" rather than a fabricated 1.
     """
-    n_total = _coerce_int(
+    n_total = cells.integer(
         row.get('rna_reads_covering_genomic_origin'), default=0)
-    n_alt_cds = _coerce_int(
+    n_alt_cds = cells.integer(
         row.get('rna_reads_covering_genomic_origin_with_peptide_cds'),
         default=0)
     n_alt_reads = n_alt_cds
     n_ref_reads = max(0, n_total - n_alt_reads)
     n_alt_supporting_protein = n_alt_cds
     return n_total, n_alt_reads, n_ref_reads, n_alt_supporting_protein
+
+
+@dataclasses.dataclass
+class ExternalRankingAccumulator:
+    """Fold per-variant entries into a ranking result.
+
+    Both external formats walk their variant groups the same way: build the
+    filter-independent metadata, build the construct, then tally the same six
+    facts. Only *how* a group is turned into an entry differs per format, so
+    that is the only thing the callers still supply. Keeping the tally here
+    means the LENS and pVACseq ``PatientInfo`` counts cannot drift apart the
+    way two hand-maintained counter blocks did.
+    """
+
+    ranked: list = dataclasses.field(default_factory=list)
+    dna_vaf_by_variant: dict = dataclasses.field(default_factory=dict)
+    annotation_results: list = dataclasses.field(default_factory=list)
+    n_unparseable: int = 0
+    n_parseable: int = 0
+    n_with_rna: int = 0
+    n_with_transcript_ids: int = 0
+    n_resolved_transcripts: int = 0
+
+    def add(self, entry):
+        """Record one variant's metadata and construct outcome."""
+        if entry is None or entry.unparseable:
+            self.n_unparseable += 1
+            return
+        if entry.variant is None:
+            return
+        self.n_parseable += 1
+        if entry.annotation is not None:
+            self.annotation_results.append(entry.annotation)
+        if entry.had_transcript_ids:
+            self.n_with_transcript_ids += 1
+            if entry.resolved_transcript:
+                self.n_resolved_transcripts += 1
+        if entry.has_rna_support:
+            self.n_with_rna += 1
+        if entry.dna_vaf is not None:
+            self.dna_vaf_by_variant[entry.variant] = entry.dna_vaf
+        if entry.vaccine_peptide is not None:
+            self.ranked.append((entry.variant, [entry.vaccine_peptide]))
+
+    def result(self, source_name, transcript_id_label="transcript IDs"):
+        """Emit the summaries every external format owes its caller."""
+        log_transcript_resolution(
+            self.n_with_transcript_ids, self.n_resolved_transcripts,
+            source_name, id_label=transcript_id_label)
+        log_varcode_agreement(self.annotation_results, source_name)
+        return ExternalRankingResult(
+            ranked=ranked_sorted_by_target_score(self.ranked),
+            dna_vaf_by_variant=self.dna_vaf_by_variant,
+            input_summary=ExternalInputSummary(
+                num_somatic_variants=self.n_parseable,
+                num_coding_effect_variants=self.n_resolved_transcripts,
+                num_variants_with_rna_support=self.n_with_rna,
+            ),
+        )
 
 
 def lens_variant_metadata(variant_id, group_rows, genome=None):
@@ -702,7 +696,7 @@ def lens_variant_metadata(variant_id, group_rows, genome=None):
     )
     for row in group_rows:
         value = row.get("vaf")
-        if _missing_cell(value):
+        if cells.missing(value):
             continue
         try:
             entry.dna_vaf = float(value)
@@ -712,12 +706,140 @@ def lens_variant_metadata(variant_id, group_rows, genome=None):
     return entry
 
 
-def lens_vaccine_entry(metadata, selection, genome=None,
+@dataclasses.dataclass(frozen=True)
+class ExternalConstructOptions:
+    """Everything the vaccine-config layer contributes to one construct.
+
+    External inputs used to build ``VaccinePeptide`` objects with nothing but
+    a peptide length, so ``vaccine_peptides:`` config — combined-score
+    expression, ranking rules, manufacturability thresholds, how many target
+    epitopes to keep — applied to VCF runs and silently did nothing to LENS /
+    pVACseq runs. Passing one object keeps the two paths honest.
+    """
+
+    vaccine_peptide_length: int = 25
+    num_target_epitopes_to_keep: object = None
+    combined_score_expr: object = None
+    ranking_rules: object = None
+    manufacturability_thresholds: dict = dataclasses.field(
+        default_factory=dict)
+    manufacturability_rules: object = None
+
+    @classmethod
+    def from_configs(cls, vaccine_config=None, manufacturability_config=None,
+                     vaccine_peptide_length=None,
+                     num_target_epitopes_to_keep=None):
+        """Build options from the resolved config objects, if any."""
+        if vaccine_config is None:
+            length = vaccine_peptide_length or 25
+            keep = num_target_epitopes_to_keep
+            expr = None
+            rules = None
+        else:
+            length = (
+                vaccine_peptide_length
+                or vaccine_config.preferred_peptide_length)
+            keep = (
+                num_target_epitopes_to_keep
+                if num_target_epitopes_to_keep is not None
+                else vaccine_config.num_target_epitopes_to_keep)
+            expr = vaccine_config.combined_score_expr
+            rules = vaccine_config.ranking_rules
+        if manufacturability_config is None:
+            thresholds, mfg_rules = {}, None
+        else:
+            thresholds = manufacturability_config.thresholds_dict()
+            mfg_rules = manufacturability_config.rules
+        return cls(
+            vaccine_peptide_length=length,
+            num_target_epitopes_to_keep=keep,
+            combined_score_expr=expr,
+            ranking_rules=rules,
+            manufacturability_thresholds=thresholds,
+            manufacturability_rules=mfg_rules,
+        )
+
+
+def external_vaccine_peptide(variant, selection, context, mutant_start,
+                             mutant_end, gene_name, transcripts, counts,
+                             options):
+    """Assemble one ``VaccinePeptide`` from an external construct window.
+
+    Shared by every external format so a construct built from a LENS
+    ``pep_context`` and one built from a pVACseq peptide obey the same
+    invariant the VCF pipeline enforces in ``core_logic``: *every epitope
+    attached to a vaccine peptide lies inside that vaccine peptide*.
+
+    ``context`` may be longer than the configured peptide length (LENS
+    ``pep_context`` is sometimes a 100+ aa protein prefix). Trimming it to an
+    SLP window without also re-slicing the epitopes is what used to let a
+    neoepitope 60 residues away from the mutation count toward the
+    construct's ``target_epitope_score`` and render in its report table while
+    being absent from the peptide that would actually be synthesized.
+
+    ``counts`` is ``(n_overlapping, n_alt, n_ref, n_alt_supporting_protein)``.
+    Returns ``None`` when nothing survives the window.
+    """
+    windowed, new_start, new_end = (
+        MutantProteinFragment.slp_window_around_mutation(
+            context, mutant_start, mutant_end,
+            options.vaccine_peptide_length))
+    # ``slp_window_around_mutation`` reports the mutation span rebased into
+    # the window; recover the window's own start so the epitopes can be
+    # rebased with it, and verify rather than trust the arithmetic.
+    window_start = mutant_start - new_start
+    window_end = window_start + len(windowed)
+    if context[window_start:window_end] != windowed:
+        raise ValueError(
+            "Could not locate the SLP window inside its source context")
+
+    epitopes = slice_epitopes(selection.epitopes, window_start, window_end)
+    if not epitopes:
+        logger.debug(
+            "No candidate epitope from variant %r fits the %d-aa construct "
+            "window; skipping.", variant, options.vaccine_peptide_length)
+        return None
+    epitopes = [
+        epitope
+        if epitope.overlaps_mutation
+        else dataclasses.replace(epitope, overlaps_mutation=True)
+        for epitope in epitopes
+    ]
+    n_total, n_alt, n_ref, n_alt_protein = counts
+    fragment = MutantProteinFragment(
+        variant=variant,
+        gene_name=gene_name,
+        amino_acids=windowed,
+        mutant_amino_acid_start_offset=new_start,
+        mutant_amino_acid_end_offset=new_end,
+        supporting_reference_transcripts=transcripts,
+        n_overlapping_reads=n_total,
+        n_alt_reads=n_alt,
+        n_ref_reads=n_ref,
+        n_alt_reads_supporting_protein_sequence=n_alt_protein,
+        placeholder_alleles=False,
+    )
+    return VaccinePeptide(
+        mutant_protein_fragment=fragment,
+        epitopes=epitopes,
+        num_target_epitopes_to_keep=options.num_target_epitopes_to_keep,
+        manufacturability_thresholds=options.manufacturability_thresholds,
+        manufacturability_rules=options.manufacturability_rules,
+        combined_score_expr=options.combined_score_expr,
+        ranking_rules=options.ranking_rules,
+    )
+
+
+def lens_vaccine_entry(metadata, selection, genome=None, options=None,
                        vaccine_peptide_length=25,
                        num_target_epitopes_to_keep=None):
     """Build one LENS vaccine peptide from a DSL-selected source window."""
     if selection is None or metadata.variant is None:
         return metadata
+    if options is None:
+        options = ExternalConstructOptions(
+            vaccine_peptide_length=vaccine_peptide_length,
+            num_target_epitopes_to_keep=num_target_epitopes_to_keep)
     key = selection.representative.key
     peptide = truncate_at_stop_codon(key.peptide)
     pep_context = truncate_at_stop_codon(key.source_sequence or key.peptide)
@@ -739,62 +861,44 @@ def lens_vaccine_entry(metadata, selection, genome=None,
         pep_context,
         variant_is_frameshift(metadata.variant),
     )
-    pep_context, start_off, end_off = (
-        MutantProteinFragment.slp_window_around_mutation(
-            pep_context, start_off, end_off, vaccine_peptide_length))
-
     counts = [_read_counts_from_lens_row(record.row)
               for record in selection.records]
     n_total = max((value[0] for value in counts), default=0)
     n_alt_reads = max((value[1] for value in counts), default=0)
-    n_ref_reads = max(0, n_total - n_alt_reads)
-    n_alt_supporting_protein = max((value[3] for value in counts), default=0)
-    transcripts = resolve_external_transcripts(key.transcript_ids, genome)
-    gene_name = key.gene_names[0] if key.gene_names else ""
-    fragment = MutantProteinFragment(
+    metadata.vaccine_peptide = external_vaccine_peptide(
         variant=metadata.variant,
-        gene_name=gene_name,
-        amino_acids=pep_context,
-        mutant_amino_acid_start_offset=start_off,
-        mutant_amino_acid_end_offset=end_off,
-        supporting_reference_transcripts=transcripts,
-        n_overlapping_reads=n_total,
-        n_alt_reads=n_alt_reads,
-        n_ref_reads=n_ref_reads,
-        n_alt_reads_supporting_protein_sequence=n_alt_supporting_protein,
-        placeholder_alleles=False,
-    )
-    epitopes = [
-        epitope
-        if epitope.overlaps_mutation
-        else dataclasses.replace(epitope, overlaps_mutation=True)
-        for epitope in selection.epitopes
-    ]
-    metadata.vaccine_peptide = VaccinePeptide(
-        mutant_protein_fragment=fragment,
-        epitopes=epitopes,
-        num_target_epitopes_to_keep=num_target_epitopes_to_keep,
+        selection=selection,
+        context=pep_context,
+        mutant_start=start_off,
+        mutant_end=end_off,
+        gene_name=key.gene_names[0] if key.gene_names else "",
+        transcripts=resolve_external_transcripts(key.transcript_ids, genome),
+        counts=(
+            n_total,
+            n_alt_reads,
+            max(0, n_total - n_alt_reads),
+            max((value[3] for value in counts), default=0),
+        ),
+        options=options,
     )
     return metadata
 
 
-def lens_ranking_result(epitopes, lens_tsv_path, genome=None,
+def lens_ranking_result(report, epitopes, genome=None, options=None,
                         num_target_epitopes_to_keep=None,
                         vaccine_peptide_length=25):
-    """Parse LENS input into construct ranking and input-level metadata.
+    """Rank LENS constructs from an already-parsed report.
 
     Parameters
     ----------
+    report : ExternalReport
+        The single parse produced by ``read_lens_report``. Its ``records``
+        already pair every source row with the identity derived from it, so
+        no row is re-read and no identity is re-derived here.
     epitopes : list of CandidateEpitope
         Output of ``load_lens(path)``. Each CandidateEpitope groups all
         per-(allele, predictor) ``mhctools.Prediction`` records for
         one ``(peptide, source_sequence, offset)`` position.
-    lens_tsv_path : str
-        Path to the original LENS TSV. We re-read the raw rows here
-        because the per-(peptide, allele) ``report_df`` returned by
-        ``load_lens`` doesn't carry ``pep_context`` / ``variant_coords``
-        in their original lower-snake form — they get rendered into
-        display columns. The raw TSV preserves them.
     genome : varcode-compatible genome reference, optional
         Passed through to ``Variant`` construction. When None,
         Variants are constructed without genome resolution and
@@ -807,16 +911,20 @@ def lens_ranking_result(epitopes, lens_tsv_path, genome=None,
     -------
     ExternalRankingResult
     """
-    if not lens_tsv_path:
+    if report is None or not report.rows:
         return ExternalRankingResult()
-    df = pd.read_csv(lens_tsv_path, sep="\t", low_memory=False)
-    if df.empty:
-        return ExternalRankingResult()
+    if options is None:
+        options = ExternalConstructOptions(
+            vaccine_peptide_length=vaccine_peptide_length,
+            num_target_epitopes_to_keep=num_target_epitopes_to_keep)
+    rows = list(report.rows)
 
-    epitopes_by_id = external_epitopes_by_id(epitopes)
-
-    # Group rows by variant. LENS uses lowercase snake_case columns.
-    rows = df.to_dict('records')
+    # Every ranking-eligible candidate, already bound to the source row whose
+    # identity selected it. LENS uses lowercase snake_case columns.
+    records_by_variant = {}
+    for record in report.records_with_epitopes(epitopes):
+        records_by_variant.setdefault(
+            lens_variant_id(record.row), []).append(record)
 
     # Up-front antigen_source breakdown — logged BEFORE any filter
     # log lines so the operator sees the composition of the input
@@ -885,68 +993,16 @@ def lens_ranking_result(epitopes, lens_tsv_path, genome=None,
                 sum(unexpected.values()),
                 '/'.join(sorted(unexpected)))
 
-    ranked = []
-    n_unparseable = 0
-    n_parseable = 0
-    n_with_rna = 0
-    # Aggregate transcript-resolution stats so we summarize once at
-    # the end instead of spamming a log line per row. ``n_with_ids`` is
-    # variants that *had* at least one transcript_id in the LENS file;
-    # ``n_resolved`` is the subset where pyensembl actually returned a
-    # Transcript. The gap is almost always a release mismatch.
-    n_with_ids = 0
-    n_resolved = 0
-    # Sanity-check varcode against LENS's own annotation. Collected
-    # per variant, summarized once by log_varcode_agreement.
-    annotation_results = []
-    # ``vaf`` column carries DNA VAF in LENS v1.9 (sits between
-    # ``mhcflurry_agretopicity`` and ``totcopynum`` / ``multiplicity``
-    # / ``ccf`` — all DNA-clonal annotations; values track DNA VAF
-    # rather than reads-derived RNA VAF on real Pt02 data, e.g.
-    # 0.141 vs computed 0.138). Plumb to ``dna_vaf_by_variant`` so
-    # the report's "DNA VAF" field gets populated instead of "n/a".
-    dna_vaf_by_variant = {}
+    tally = ExternalRankingAccumulator()
     for variant_id, group_rows in groups.items():
-        records = []
-        for row in group_rows:
-            key = ExternalPredictionKey.from_lens_row(row)
-            epitope = (
-                epitopes_by_id.get(key.identifier)
-                if key is not None else None)
-            if epitope is not None:
-                records.append(ExternalPredictionRecord(
-                    row=row, key=key, epitope=epitope))
-        input_entry = lens_variant_metadata(
-            variant_id, group_rows, genome=genome)
-        ranking_entry = lens_vaccine_entry(
-            input_entry,
-            select_external_construct(records),
+        tally.add(lens_vaccine_entry(
+            lens_variant_metadata(variant_id, group_rows, genome=genome),
+            select_external_construct(records_by_variant.get(variant_id, [])),
             genome=genome,
-            vaccine_peptide_length=vaccine_peptide_length,
-            num_target_epitopes_to_keep=num_target_epitopes_to_keep,
-        )
-        if input_entry.unparseable:
-            n_unparseable += 1
-            continue
-        if input_entry.variant is None:
-            continue
-        n_parseable += 1
-        if input_entry.annotation is not None:
-            annotation_results.append(input_entry.annotation)
-        if input_entry.had_transcript_ids:
-            n_with_ids += 1
-            if input_entry.resolved_transcript:
-                n_resolved += 1
-        if input_entry.has_rna_support:
-            n_with_rna += 1
-        if input_entry.dna_vaf is not None:
-            dna_vaf_by_variant[input_entry.variant] = input_entry.dna_vaf
-        if (
-            ranking_entry is not None
-            and ranking_entry.vaccine_peptide is not None
-        ):
-            ranked.append((
-                ranking_entry.variant, [ranking_entry.vaccine_peptide]))
+            options=options,
+        ))
+    n_unparseable = tally.n_unparseable
+    ranked = tally.ranked
 
     if n_unparseable:
         logger.warning(
@@ -1014,16 +1070,6 @@ def lens_ranking_result(epitopes, lens_tsv_path, genome=None,
             "— those kinds are expected to carry RNA-read counts.",
             n_snv_indel_no_reads)
 
-    # Transcript-resolution summary. The "no genome configured" case
-    # is now caught pre-flight in ``arg_parser.check_args`` for any
-    # run that requests template reports; if we still hit it here
-    # we're in a "loaded but reports will be empty" path that's
-    # acceptable (e.g., a CSV-only run — no transcript effects
-    # rendered anywhere). Only the release-mismatch case is worth
-    # logging here.
-    log_transcript_resolution(n_with_ids, n_resolved, "LENS")
-    log_varcode_agreement(annotation_results, "LENS")
-
     # ── Load funnel summary ──────────────────────────────────────────
     # One consolidated view of where the LENS rows went, replacing the
     # per-stage count lines that double-counted (the non-coord rows
@@ -1051,7 +1097,7 @@ def lens_ranking_result(epitopes, lens_tsv_path, genome=None,
     else:
         note = "all carry gene_name / transcript_id / rna_reads"
     funnel = [
-        "LENS load funnel: %s" % os.path.basename(lens_tsv_path),
+        "LENS load funnel: %s" % os.path.basename(report.path),
         "  %d rows in: %s" % (len(rows), breakdown or '(none)'),
         "  → %d candidate epitopes eligible for construct ranking after "
         "epitope DSL filtering and the minimum-score gate" % len(epitopes),
@@ -1067,26 +1113,20 @@ def lens_ranking_result(epitopes, lens_tsv_path, genome=None,
     funnel.append("  note (SNV/INDEL anomalies): %s" % note)
     logger.info("\n".join(funnel))
 
-    # Top candidates first so they win greedy bin-packing in the
-    # construct assemblers (shared ordering helper).
-    return ExternalRankingResult(
-        ranked=ranked_sorted_by_target_score(ranked),
-        dna_vaf_by_variant=dna_vaf_by_variant,
-        input_summary=ExternalInputSummary(
-            num_somatic_variants=n_parseable,
-            num_coding_effect_variants=n_resolved,
-            num_variants_with_rna_support=n_with_rna,
-        ),
-    )
+    # Top candidates first so they win greedy bin-packing in the construct
+    # assemblers. The transcript-resolution and varcode-agreement summaries
+    # every external format owes its caller are emitted by the accumulator.
+    return tally.result("LENS")
 
 
 def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
                                  num_target_epitopes_to_keep=None,
                                  vaccine_peptide_length=25):
     """Return the legacy ``(ranked, DNA VAF)`` view of a LENS result."""
+    from .epitope_io import read_lens_report
     result = lens_ranking_result(
+        read_lens_report(lens_tsv_path) if lens_tsv_path else None,
         epitopes,
-        lens_tsv_path,
         genome=genome,
         num_target_epitopes_to_keep=num_target_epitopes_to_keep,
         vaccine_peptide_length=vaccine_peptide_length,
@@ -1143,32 +1183,67 @@ def parse_pvacseq_variant(variant_id, genome=None):
     return v
 
 
+# pVACseq spells the same fact differently per flavor, and topiary normalizes
+# both onto a third spelling. All three are listed in one place, in one
+# precedence order, so every reader agrees about what a row says.
+_PVACSEQ_RNA_DEPTH_COLUMNS = (
+    "rna_depth", "tumor_rna_depth", "RNA Depth", "Tumor RNA Depth")
+_PVACSEQ_RNA_VAF_COLUMNS = (
+    "rna_vaf", "tumor_rna_vaf", "RNA VAF", "Tumor RNA VAF")
+_PVACSEQ_DNA_VAF_COLUMNS = (
+    "dna_vaf", "tumor_dna_vaf", "DNA VAF", "Tumor DNA VAF")
+
+
 def pvacseq_rna_depth(row):
     """RNA coverage reported by either pVACseq TSV flavor."""
-    return _coerce_int(_first_cell(row, 'RNA Depth', 'Tumor RNA Depth'), default=0)
+    return cells.integer(
+        cells.first(row, *_PVACSEQ_RNA_DEPTH_COLUMNS), default=0)
 
 
 def pvacseq_rna_vaf(row):
     """RNA variant allele fraction reported by either pVACseq flavor."""
-    raw = _first_cell(row, 'RNA VAF', 'Tumor RNA VAF')
-    try:
-        return float(raw) if raw is not None else 0.0
-    except (TypeError, ValueError):
-        return 0.0
+    return cells.first_number(row, *_PVACSEQ_RNA_VAF_COLUMNS, default=0.0)
 
 
 def pvacseq_dna_vaf(row):
     """DNA variant allele fraction reported by either pVACseq flavor."""
-    raw = _first_cell(row, 'DNA VAF', 'Tumor DNA VAF')
-    try:
-        return float(raw) if raw is not None else None
-    except (TypeError, ValueError):
-        return None
+    return cells.first_number(row, *_PVACSEQ_DNA_VAF_COLUMNS)
+
+
+def pvacseq_genomic_variant(variant_id, group_rows, genome=None):
+    """Resolve a pVACseq row group to a genomic ``varcode.Variant``.
+
+    The join identity and the genomic variant are *different things* and must
+    be derived differently. pVACseq's ``Index`` — which topiary prefers for
+    the identity because it is the file's own stable row key — spells a
+    variant as ``GENE.ENST….missense.806E/V``, which carries no coordinates
+    at all. Deriving the variant from the identity therefore drops every
+    all_epitopes file that ships an ``Index`` column, while deriving the
+    identity from coordinates makes it disagree with topiary's. Both are
+    needed, from their own sources: coordinates when the flavor supplies
+    them, the ``ID`` / ``variant`` string (``chr1-100-A-T``) otherwise.
+    """
+    for row in group_rows:
+        genomic = cells.first_text(
+            row, GENOMIC_VARIANT_COLUMN, "Chromosome")
+        if not genomic:
+            continue
+        if genomic == cells.text(row.get("Chromosome")):
+            parts = [
+                cells.text(row.get(column))
+                for column in ("Chromosome", "Start", "Reference", "Variant")]
+            if not all(parts):
+                continue
+            genomic = "-".join(parts)
+        variant = parse_pvacseq_variant(genomic, genome=genome)
+        if variant is not None:
+            return variant
+    return parse_pvacseq_variant(variant_id, genome=genome)
 
 
 def pvacseq_variant_metadata(variant_id, group_rows, genome=None):
     """Aggregate filter-independent facts from every raw pVACseq row."""
-    variant = parse_pvacseq_variant(variant_id, genome=genome)
+    variant = pvacseq_genomic_variant(variant_id, group_rows, genome=genome)
     if variant is None:
         return ExternalVariantEntry(unparseable=True)
     transcript_ids = external_values(*(
@@ -1213,13 +1288,22 @@ def pvacseq_variant_metadata(variant_id, group_rows, genome=None):
     return entry
 
 
-def pvacseq_vaccine_entry(metadata, selection, genome=None,
+def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None,
                           num_target_epitopes_to_keep=None):
     """Build one pVACseq vaccine peptide from a DSL-selected candidate."""
     if selection is None or metadata.variant is None:
         return metadata
+    if options is None:
+        options = ExternalConstructOptions(
+            num_target_epitopes_to_keep=num_target_epitopes_to_keep)
     key = selection.representative.key
-    transcripts = resolve_external_transcripts(key.transcript_ids, genome)
+    context = truncate_at_stop_codon(key.source_sequence or key.peptide)
+    if not context or not has_only_standard_amino_acids(context):
+        logger.warning(
+            "Dropped pVACseq construct for variant %r: antigen sequence %r "
+            "is empty or contains non-standard residues.",
+            key.variant_id, key.source_sequence)
+        return metadata
     counts = []
     for record in selection.records:
         n_total = pvacseq_rna_depth(record.row)
@@ -1227,138 +1311,80 @@ def pvacseq_vaccine_entry(metadata, selection, genome=None,
         counts.append((n_total, n_alt))
     n_total = max((count[0] for count in counts), default=0)
     n_alt_reads = max((count[1] for count in counts), default=0)
-    fragment = MutantProteinFragment(
+    metadata.vaccine_peptide = external_vaccine_peptide(
         variant=metadata.variant,
+        selection=selection,
+        # pVACseq ships no SLP context column, so the antigen window is the
+        # peptide itself and every residue of it is treated as targetable.
+        context=context,
+        mutant_start=0,
+        mutant_end=len(context),
         gene_name=key.gene_names[0] if key.gene_names else "",
-        amino_acids=key.source_sequence,
-        mutant_amino_acid_start_offset=0,
-        mutant_amino_acid_end_offset=len(key.source_sequence),
-        supporting_reference_transcripts=transcripts,
-        n_overlapping_reads=n_total,
-        n_alt_reads=n_alt_reads,
-        n_ref_reads=max(0, n_total - n_alt_reads),
-        n_alt_reads_supporting_protein_sequence=n_alt_reads,
-    )
-    epitopes = [
-        epitope
-        if epitope.overlaps_mutation
-        else dataclasses.replace(epitope, overlaps_mutation=True)
-        for epitope in selection.epitopes
-    ]
-    metadata.vaccine_peptide = VaccinePeptide(
-        mutant_protein_fragment=fragment,
-        epitopes=epitopes,
-        num_target_epitopes_to_keep=num_target_epitopes_to_keep,
+        transcripts=resolve_external_transcripts(key.transcript_ids, genome),
+        counts=(
+            n_total, n_alt_reads, max(0, n_total - n_alt_reads), n_alt_reads),
+        options=options,
     )
     return metadata
 
 
-def pvacseq_ranking_result(epitopes, pvacseq_tsv_path, genome=None,
+def pvacseq_ranking_result(report, epitopes, genome=None, options=None,
                            num_target_epitopes_to_keep=None):
-    """Parse pVACseq input into construct ranking and input metadata.
+    """Rank pVACseq constructs from an already-parsed report.
 
-    Re-reads the raw pVACseq TSV (the per-(peptide, allele)
-    ``report_df`` returned by ``load_pvacseq`` carries display columns
-    rather than every original aggregate / all_epitopes column).
+    Consumes the topiary-normalized rows of ``report``: both pVACseq flavors
+    have already been mapped onto one column vocabulary there, so the raw TSV
+    is never re-read and the identities used for ranking are the identities
+    the loader produced.
 
-    Uses ``Best Peptide`` / ``MT Epitope Seq`` as the antigen sequence
-    and treats the peptide itself as the mutation span (no SLP-context column).
-    mRNA construct generation from pVACseq input therefore produces
-    shorter antigen windows than the LENS path.
+    Uses ``Best Peptide`` / ``MT Epitope Seq`` as the antigen sequence and
+    treats the peptide itself as the mutation span (no SLP-context column).
+    mRNA construct generation from pVACseq input therefore produces shorter
+    antigen windows than the LENS path.
     """
-    if not pvacseq_tsv_path:
+    if report is None or not report.rows:
         return ExternalRankingResult()
-    df = pd.read_csv(pvacseq_tsv_path, sep="\t", low_memory=False)
-    if df.empty:
-        return ExternalRankingResult()
+    if options is None:
+        options = ExternalConstructOptions(
+            num_target_epitopes_to_keep=num_target_epitopes_to_keep)
 
-    epitopes_by_id = external_epitopes_by_id(epitopes)
-
-    rows = df.to_dict('records')
+    rows = list(report.rows)
     groups = {}
     for r in rows:
         variant_id = pvacseq_variant_id(r)
-        if _missing_cell(variant_id):
+        if not variant_id:
             continue
         groups.setdefault(variant_id, []).append(r)
 
-    ranked = []
-    n_skipped = 0
-    n_parseable = 0
-    n_with_rna = 0
-    # Aggregate transcript-resolution stats (see LENS path for rationale).
-    n_with_ids = 0
-    n_resolved = 0
-    annotation_results = []
-    # pVACseq carries an explicit ``DNA VAF`` column (separate from
-    # the ``RNA VAF`` we already consume for read counts). Plumb it
-    # through to the report's DNA-VAF field.
-    dna_vaf_by_variant = {}
+    records_by_variant = {}
+    for record in report.records_with_epitopes(epitopes):
+        records_by_variant.setdefault(
+            pvacseq_variant_id(record.row), []).append(record)
+
+    tally = ExternalRankingAccumulator()
     for variant_id, group_rows in groups.items():
-        records = []
-        for row in group_rows:
-            key = ExternalPredictionKey.from_pvacseq_row(row)
-            epitope = (
-                epitopes_by_id.get(key.identifier)
-                if key is not None else None)
-            if epitope is not None:
-                records.append(ExternalPredictionRecord(
-                    row=row, key=key, epitope=epitope))
-        input_entry = pvacseq_variant_metadata(
-            variant_id, group_rows, genome=genome)
-        if input_entry.unparseable:
-            n_skipped += 1
-            logger.debug(
-                "Could not parse pVACseq ID %r as a Variant; skipping.",
-                variant_id)
-            continue
-        n_parseable += 1
-        if input_entry.has_rna_support:
-            n_with_rna += 1
-        if input_entry.had_transcript_ids:
-            n_with_ids += 1
-            if input_entry.resolved_transcript:
-                n_resolved += 1
-        if input_entry.annotation is not None:
-            annotation_results.append(input_entry.annotation)
-        if input_entry.dna_vaf is not None:
-            dna_vaf_by_variant[input_entry.variant] = input_entry.dna_vaf
-        ranking_entry = pvacseq_vaccine_entry(
-            input_entry,
-            select_external_construct(records),
+        tally.add(pvacseq_vaccine_entry(
+            pvacseq_variant_metadata(variant_id, group_rows, genome=genome),
+            select_external_construct(records_by_variant.get(variant_id, [])),
             genome=genome,
-            num_target_epitopes_to_keep=num_target_epitopes_to_keep,
-        )
-        if ranking_entry.vaccine_peptide is not None:
-            ranked.append((
-                ranking_entry.variant, [ranking_entry.vaccine_peptide]))
-
-    if n_skipped:
+            options=options,
+        ))
+    if tally.n_unparseable:
         logger.warning(
-            "Skipped %d pVACseq row group(s) with unparseable IDs; "
-            "see DEBUG log for details.", n_skipped)
-
-    log_transcript_resolution(
-        n_with_ids, n_resolved, "pVACseq", id_label="Best Transcript IDs")
-    log_varcode_agreement(annotation_results, "pVACseq")
-    return ExternalRankingResult(
-        ranked=ranked_sorted_by_target_score(ranked),
-        dna_vaf_by_variant=dna_vaf_by_variant,
-        input_summary=ExternalInputSummary(
-            num_somatic_variants=n_parseable,
-            num_coding_effect_variants=n_resolved,
-            num_variants_with_rna_support=n_with_rna,
-        ),
-    )
+            "Skipped %d pVACseq row group(s) whose rows carried no genomic "
+            "coordinates and whose identifier could not be parsed as one; "
+            "see DEBUG log for details.", tally.n_unparseable)
+    return tally.result("pVACseq", transcript_id_label="Best Transcript IDs")
 
 
 def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
                                     genome=None,
                                     num_target_epitopes_to_keep=None):
     """Return the legacy ``(ranked, DNA VAF)`` view of a pVACseq result."""
+    from .epitope_io import read_pvacseq_report
     result = pvacseq_ranking_result(
+        read_pvacseq_report(pvacseq_tsv_path) if pvacseq_tsv_path else None,
         epitopes,
-        pvacseq_tsv_path,
         genome=genome,
         num_target_epitopes_to_keep=num_target_epitopes_to_keep,
     )
@@ -1455,7 +1481,8 @@ def patient_info_from_external(ranked, source_path, patient_id,
     )
 
 
-def load_external_ranked(args, epitope_config=None):
+def load_external_ranked(args, epitope_config=None, vaccine_config=None,
+                         manufacturability_config=None):
     """Dispatch helper: load LENS / pVACseq based on args, return
     ``(ranked, report_df, predictions, patient_info)`` or ``None`` if
     neither flag is set.
@@ -1467,6 +1494,10 @@ def load_external_ranked(args, epitope_config=None):
     ``epitope_config`` is evaluated by the selected loader before vaccine
     peptides are constructed, so ranking and template reports consume the
     configured DSL scores rather than the default affinity score.
+    ``vaccine_config`` / ``manufacturability_config`` reach construct
+    assembly through :class:`ExternalConstructOptions`, so peptide length,
+    epitope retention, combined-score expression, ranking rules, and
+    manufacturability thresholds apply identically to external and VCF runs.
 
     The returned ``predictions`` collection retains every loaded input group
     for audit reports and patient-genotype inference. ``ranked`` is built from
@@ -1474,40 +1505,42 @@ def load_external_ranked(args, epitope_config=None):
     meeting the configured minimum epitope score.
     """
     from .epitope_dsl import epitopes_for_ranking
-    from .epitope_io import load_lens, load_pvacseq
+    from .epitope_io import read_lens_report, read_pvacseq_report
+
     patient_id = getattr(args, 'output_patient_id', '') or ''
-    vaccine_peptide_length = getattr(args, 'vaccine_peptide_length', None) or 25
-    if getattr(args, 'input_lens', None):
-        report_df, predictions = load_lens(
-            args.input_lens, epitope_config=epitope_config)
-        ranking_predictions = epitopes_for_ranking(
-            predictions, epitope_config)
-        ranking_result = lens_ranking_result(
-            ranking_predictions, args.input_lens,
-            genome=getattr(args, 'genome', None),
-            vaccine_peptide_length=vaccine_peptide_length)
-        ranked = ranking_result.ranked
+    options = ExternalConstructOptions.from_configs(
+        vaccine_config=vaccine_config,
+        manufacturability_config=manufacturability_config,
+        vaccine_peptide_length=getattr(args, 'vaccine_peptide_length', None),
+        num_target_epitopes_to_keep=getattr(
+            args, 'num_epitopes_per_vaccine_peptide', None),
+    )
+    genome = getattr(args, 'genome', None)
+
+    for arg_name, reader, ranker, label in (
+        ('input_lens', read_lens_report, lens_ranking_result, 'LENS report'),
+        ('input_pvacseq', read_pvacseq_report, pvacseq_ranking_result,
+         'pVACseq report'),
+    ):
+        path = getattr(args, arg_name, None)
+        if not path:
+            continue
+        # One read. ``report`` carries the rows, the per-row identities, the
+        # grouped candidates, and the user-facing table; every stage below
+        # consumes that single parse.
+        report = reader(path, epitope_config=epitope_config)
+        predictions = list(report.epitopes)
+        ranking_result = ranker(
+            report,
+            epitopes_for_ranking(predictions, epitope_config),
+            genome=genome,
+            options=options,
+        )
         patient_info = patient_info_from_external(
-            ranked, args.input_lens, patient_id,
-            input_label='LENS report',
+            ranking_result.ranked, path, patient_id,
+            input_label=label,
             predictions=predictions,
             input_summary=ranking_result.input_summary)
-        return (ranked, report_df, predictions, patient_info,
-                ranking_result.dna_vaf_by_variant)
-    if getattr(args, 'input_pvacseq', None):
-        report_df, predictions = load_pvacseq(
-            args.input_pvacseq, epitope_config=epitope_config)
-        ranking_predictions = epitopes_for_ranking(
-            predictions, epitope_config)
-        ranking_result = pvacseq_ranking_result(
-            ranking_predictions, args.input_pvacseq,
-            genome=getattr(args, 'genome', None))
-        ranked = ranking_result.ranked
-        patient_info = patient_info_from_external(
-            ranked, args.input_pvacseq, patient_id,
-            input_label='pVACseq report',
-            predictions=predictions,
-            input_summary=ranking_result.input_summary)
-        return (ranked, report_df, predictions, patient_info,
-                ranking_result.dna_vaf_by_variant)
+        return (ranking_result.ranked, report.report_df, predictions,
+                patient_info, ranking_result.dna_vaf_by_variant)
     return None

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -47,6 +47,9 @@ from . import cells
 from .amino_acids import has_only_standard_amino_acids
 from .epitope_logic import slice_epitopes
 from .external_prediction import (
+    _PVACSEQ_DNA_VAF_COLUMNS,
+    _PVACSEQ_RNA_DEPTH_COLUMNS,
+    _PVACSEQ_RNA_VAF_COLUMNS,
     external_text,
     external_values,
     lens_variant_id,
@@ -856,24 +859,27 @@ def lens_vaccine_entry(metadata, selection, genome=None, options=None):
         pep_context,
         variant_is_frameshift(metadata.variant),
     )
+    # One row's counts, not four independent maxima. Maximizing each field
+    # separately can assemble a tuple no row ever reported — total from a
+    # deep row, alt from a shallow one — and n_alt_reads feeds the
+    # combined-score DSL, so an incoherent count reorders the ranking.
+    # Best-supported row wins: most alt reads, then most coverage.
     counts = [_read_counts_from_lens_row(record.row)
               for record in selection.records]
-    n_total = max((value[0] for value in counts), default=0)
-    n_alt_reads = max((value[1] for value in counts), default=0)
+    n_total, n_alt_reads, _, n_alt_protein = max(
+        counts, key=lambda c: (c[1], c[0]), default=(0, 0, 0, 0))
     metadata.vaccine_peptide = external_vaccine_peptide(
         variant=metadata.variant,
         selection=selection,
         context=pep_context,
         mutant_start=start_off,
         mutant_end=end_off,
-        gene_name=key.gene_names[0] if key.gene_names else "",
-        transcripts=resolve_external_transcripts(key.transcript_ids, genome),
+        gene_name=key.primary_gene_name,
+        transcripts=resolve_external_transcripts(
+            key.ordered_transcript_ids, genome),
         counts=(
-            n_total,
-            n_alt_reads,
-            max(0, n_total - n_alt_reads),
-            max((value[3] for value in counts), default=0),
-        ),
+            n_total, n_alt_reads, max(0, n_total - n_alt_reads),
+            n_alt_protein),
         options=options,
     )
     return metadata
@@ -1009,17 +1015,12 @@ def lens_ranking_result(report, epitopes, genome=None, options=None):
         1 for r in rows
         if not (r.get('pep_context') and not (
             isinstance(r.get('pep_context'), float) and pd.isna(r.get('pep_context')))))
-    def _is_missing(v):
-        return v is None or v == '' or (
-            isinstance(v, float) and pd.isna(v)) or (
-            isinstance(v, str) and v.strip().lower() == 'nan')
-
     def _kind(r):
         k = r.get('antigen_source')
-        return ('(missing)' if _is_missing(k) else str(k).strip())
+        return ('(missing)' if cells.missing(k) else str(k).strip())
 
-    rows_no_gene_name = [r for r in rows if _is_missing(r.get('gene_name'))]
-    rows_no_transcript = [r for r in rows if _is_missing(r.get('transcript_id'))]
+    rows_no_gene_name = [r for r in rows if cells.missing(r.get('gene_name'))]
+    rows_no_transcript = [r for r in rows if cells.missing(r.get('transcript_id'))]
     if n_no_pep_context:
         logger.warning(
             "%d / %d LENS row(s) lack pep_context — antigens for those "
@@ -1036,7 +1037,7 @@ def lens_ranking_result(report, epitopes, genome=None, options=None):
     _SNV_OR_INDEL_KINDS = {'SNV', 'INDEL'}
     rows_no_reads = [
         r for r in rows
-        if _is_missing(r.get('rna_reads_covering_genomic_origin'))]
+        if cells.missing(r.get('rna_reads_covering_genomic_origin'))]
     n_snv_indel_no_gene = sum(
         1 for r in rows_no_gene_name if _kind(r).upper() in _SNV_OR_INDEL_KINDS)
     n_snv_indel_no_transcript = sum(
@@ -1159,15 +1160,6 @@ def parse_pvacseq_variant(variant_id, genome=None):
     return v
 
 
-# pVACseq's two flavors spell the same fact differently; topiary normalizes
-# both onto one of these names. Rows only ever reach this module already
-# normalized, so the raw pVACseq spellings are deliberately absent — listing
-# them would imply a second vocabulary is still in play here.
-_PVACSEQ_RNA_DEPTH_COLUMNS = ("rna_depth", "tumor_rna_depth")
-_PVACSEQ_RNA_VAF_COLUMNS = ("rna_vaf", "tumor_rna_vaf")
-_PVACSEQ_DNA_VAF_COLUMNS = ("dna_vaf", "tumor_dna_vaf")
-
-
 def pvacseq_rna_depth(row):
     """RNA coverage reported by either pVACseq TSV flavor."""
     return cells.integer(
@@ -1211,6 +1203,11 @@ def pvacseq_variant_metadata(variant_id, group_rows, genome=None):
     """Aggregate filter-independent facts from every raw pVACseq row."""
     variant = pvacseq_genomic_variant(variant_id, group_rows, genome=genome)
     if variant is None:
+        # The aggregate warning tells operators to check DEBUG for the
+        # offenders, so there has to be something here to find.
+        logger.debug(
+            "pVACseq group %r carried no genomic coordinates and its "
+            "identifier could not be parsed as one; skipping.", variant_id)
         return ExternalVariantEntry(unparseable=True)
     transcript_ids = external_values(*(
         value
@@ -1222,11 +1219,10 @@ def pvacseq_variant_metadata(variant_id, group_rows, genome=None):
         )
     ))
     transcripts = resolve_external_transcripts(transcript_ids, genome)
+    # depth * vaf can only exceed zero when depth already does (vaf is >= 0
+    # by construction), so the product added nothing but a second pass.
     has_rna_support = any(
-        pvacseq_rna_depth(row) > 0
-        or pvacseq_rna_depth(row) * pvacseq_rna_vaf(row) > 0
-        for row in group_rows
-    )
+        pvacseq_rna_depth(row) > 0 for row in group_rows)
     gene_names = external_values(*(
         value
         for row in group_rows
@@ -1267,13 +1263,13 @@ def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None):
             "is empty or contains non-standard residues.",
             key.variant_id, key.source_sequence)
         return metadata
+    # Same rule as the LENS path: both counts come from one row.
     counts = []
     for record in selection.records:
-        n_total = pvacseq_rna_depth(record.row)
-        n_alt = int(round(n_total * pvacseq_rna_vaf(record.row)))
-        counts.append((n_total, n_alt))
-    n_total = max((count[0] for count in counts), default=0)
-    n_alt_reads = max((count[1] for count in counts), default=0)
+        depth = pvacseq_rna_depth(record.row)
+        counts.append((depth, int(round(depth * pvacseq_rna_vaf(record.row)))))
+    n_total, n_alt_reads = max(
+        counts, key=lambda c: (c[1], c[0]), default=(0, 0))
     metadata.vaccine_peptide = external_vaccine_peptide(
         variant=metadata.variant,
         selection=selection,
@@ -1282,8 +1278,9 @@ def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None):
         context=context,
         mutant_start=0,
         mutant_end=len(context),
-        gene_name=key.gene_names[0] if key.gene_names else "",
-        transcripts=resolve_external_transcripts(key.transcript_ids, genome),
+        gene_name=key.primary_gene_name,
+        transcripts=resolve_external_transcripts(
+            key.ordered_transcript_ids, genome),
         counts=(
             n_total, n_alt_reads, max(0, n_total - n_alt_reads), n_alt_reads),
         options=options,

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -830,16 +830,11 @@ def external_vaccine_peptide(variant, selection, context, mutant_start,
     )
 
 
-def lens_vaccine_entry(metadata, selection, genome=None, options=None,
-                       vaccine_peptide_length=25,
-                       num_target_epitopes_to_keep=None):
+def lens_vaccine_entry(metadata, selection, genome=None, options=None):
     """Build one LENS vaccine peptide from a DSL-selected source window."""
     if selection is None or metadata.variant is None:
         return metadata
-    if options is None:
-        options = ExternalConstructOptions(
-            vaccine_peptide_length=vaccine_peptide_length,
-            num_target_epitopes_to_keep=num_target_epitopes_to_keep)
+    options = options or ExternalConstructOptions()
     key = selection.representative.key
     peptide = truncate_at_stop_codon(key.peptide)
     pep_context = truncate_at_stop_codon(key.source_sequence or key.peptide)
@@ -884,9 +879,7 @@ def lens_vaccine_entry(metadata, selection, genome=None, options=None,
     return metadata
 
 
-def lens_ranking_result(report, epitopes, genome=None, options=None,
-                        num_target_epitopes_to_keep=None,
-                        vaccine_peptide_length=25):
+def lens_ranking_result(report, epitopes, genome=None, options=None):
     """Rank LENS constructs from an already-parsed report.
 
     Parameters
@@ -913,10 +906,7 @@ def lens_ranking_result(report, epitopes, genome=None, options=None,
     """
     if report is None or not report.rows:
         return ExternalRankingResult()
-    if options is None:
-        options = ExternalConstructOptions(
-            vaccine_peptide_length=vaccine_peptide_length,
-            num_target_epitopes_to_keep=num_target_epitopes_to_keep)
+    options = options or ExternalConstructOptions()
     rows = list(report.rows)
 
     # Every ranking-eligible candidate, already bound to the source row whose
@@ -1119,20 +1109,6 @@ def lens_ranking_result(report, epitopes, genome=None, options=None,
     return tally.result("LENS")
 
 
-def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
-                                 num_target_epitopes_to_keep=None,
-                                 vaccine_peptide_length=25):
-    """Return the legacy ``(ranked, DNA VAF)`` view of a LENS result."""
-    from .epitope_io import read_lens_report
-    result = lens_ranking_result(
-        read_lens_report(lens_tsv_path) if lens_tsv_path else None,
-        epitopes,
-        genome=genome,
-        num_target_epitopes_to_keep=num_target_epitopes_to_keep,
-        vaccine_peptide_length=vaccine_peptide_length,
-    )
-    return result.ranked, result.dna_vaf_by_variant
-
 
 def parse_pvacseq_variant(variant_id, genome=None):
     """Parse a pVACseq aggregate ``ID`` field into a ``varcode.Variant``.
@@ -1183,15 +1159,13 @@ def parse_pvacseq_variant(variant_id, genome=None):
     return v
 
 
-# pVACseq spells the same fact differently per flavor, and topiary normalizes
-# both onto a third spelling. All three are listed in one place, in one
-# precedence order, so every reader agrees about what a row says.
-_PVACSEQ_RNA_DEPTH_COLUMNS = (
-    "rna_depth", "tumor_rna_depth", "RNA Depth", "Tumor RNA Depth")
-_PVACSEQ_RNA_VAF_COLUMNS = (
-    "rna_vaf", "tumor_rna_vaf", "RNA VAF", "Tumor RNA VAF")
-_PVACSEQ_DNA_VAF_COLUMNS = (
-    "dna_vaf", "tumor_dna_vaf", "DNA VAF", "Tumor DNA VAF")
+# pVACseq's two flavors spell the same fact differently; topiary normalizes
+# both onto one of these names. Rows only ever reach this module already
+# normalized, so the raw pVACseq spellings are deliberately absent — listing
+# them would imply a second vocabulary is still in play here.
+_PVACSEQ_RNA_DEPTH_COLUMNS = ("rna_depth", "tumor_rna_depth")
+_PVACSEQ_RNA_VAF_COLUMNS = ("rna_vaf", "tumor_rna_vaf")
+_PVACSEQ_DNA_VAF_COLUMNS = ("dna_vaf", "tumor_dna_vaf")
 
 
 def pvacseq_rna_depth(row):
@@ -1224,17 +1198,9 @@ def pvacseq_genomic_variant(variant_id, group_rows, genome=None):
     them, the ``ID`` / ``variant`` string (``chr1-100-A-T``) otherwise.
     """
     for row in group_rows:
-        genomic = cells.first_text(
-            row, GENOMIC_VARIANT_COLUMN, "Chromosome")
+        genomic = cells.text(row.get(GENOMIC_VARIANT_COLUMN))
         if not genomic:
             continue
-        if genomic == cells.text(row.get("Chromosome")):
-            parts = [
-                cells.text(row.get(column))
-                for column in ("Chromosome", "Start", "Reference", "Variant")]
-            if not all(parts):
-                continue
-            genomic = "-".join(parts)
         variant = parse_pvacseq_variant(genomic, genome=genome)
         if variant is not None:
             return variant
@@ -1288,14 +1254,11 @@ def pvacseq_variant_metadata(variant_id, group_rows, genome=None):
     return entry
 
 
-def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None,
-                          num_target_epitopes_to_keep=None):
+def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None):
     """Build one pVACseq vaccine peptide from a DSL-selected candidate."""
     if selection is None or metadata.variant is None:
         return metadata
-    if options is None:
-        options = ExternalConstructOptions(
-            num_target_epitopes_to_keep=num_target_epitopes_to_keep)
+    options = options or ExternalConstructOptions()
     key = selection.representative.key
     context = truncate_at_stop_codon(key.source_sequence or key.peptide)
     if not context or not has_only_standard_amino_acids(context):
@@ -1328,8 +1291,7 @@ def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None,
     return metadata
 
 
-def pvacseq_ranking_result(report, epitopes, genome=None, options=None,
-                           num_target_epitopes_to_keep=None):
+def pvacseq_ranking_result(report, epitopes, genome=None, options=None):
     """Rank pVACseq constructs from an already-parsed report.
 
     Consumes the topiary-normalized rows of ``report``: both pVACseq flavors
@@ -1344,9 +1306,7 @@ def pvacseq_ranking_result(report, epitopes, genome=None, options=None,
     """
     if report is None or not report.rows:
         return ExternalRankingResult()
-    if options is None:
-        options = ExternalConstructOptions(
-            num_target_epitopes_to_keep=num_target_epitopes_to_keep)
+    options = options or ExternalConstructOptions()
 
     rows = list(report.rows)
     groups = {}
@@ -1377,23 +1337,11 @@ def pvacseq_ranking_result(report, epitopes, genome=None, options=None,
     return tally.result("pVACseq", transcript_id_label="Best Transcript IDs")
 
 
-def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
-                                    genome=None,
-                                    num_target_epitopes_to_keep=None):
-    """Return the legacy ``(ranked, DNA VAF)`` view of a pVACseq result."""
-    from .epitope_io import read_pvacseq_report
-    result = pvacseq_ranking_result(
-        read_pvacseq_report(pvacseq_tsv_path) if pvacseq_tsv_path else None,
-        epitopes,
-        genome=genome,
-        num_target_epitopes_to_keep=num_target_epitopes_to_keep,
-    )
-    return result.ranked, result.dna_vaf_by_variant
-
 
 def patient_info_from_external(ranked, source_path, patient_id,
+                               input_summary,
                                input_label='External report',
-                               predictions=None, input_summary=None):
+                               predictions=None):
     """Build a :class:`PatientInfo` from external-input data.
 
     Input counts come from the filter-independent summary produced while
@@ -1414,33 +1362,12 @@ def patient_info_from_external(ranked, source_path, patient_id,
       - ``num_variants_with_vaccine_peptides`` = ``len(ranked)``,
         same definition as the pipeline path
 
-    ``input_summary`` defaults to the legacy ranked-derived counts for direct
-    callers that do not have an :class:`ExternalRankingResult`.
+    ``input_summary`` is required: deriving these counts from ``ranked``
+    instead would report post-filter design output as if it were input
+    composition, which is the opposite of what the header claims.
     """
     from .patient_info import PatientInfo
-    n_with_transcript = 0
-    n_with_rna = 0
-    n_with_peptides = 0
-    for _variant, vps in ranked:
-        if not vps:
-            continue
-        n_with_peptides += 1
-        # ``vps[0]`` is sufficient on the LENS / pVACseq paths because
-        # both loaders emit exactly one VaccinePeptide per variant
-        # (the ``MutantProteinFragment`` is built from the
-        # representative row's pep_context). If a future loader emits
-        # multiple VPs per variant, this should iterate ``vps``.
-        frag = vps[0].mutant_protein_fragment
-        if frag.supporting_reference_transcripts:
-            n_with_transcript += 1
-        if (frag.n_alt_reads or 0) > 0 or (frag.n_overlapping_reads or 0) > 0:
-            n_with_rna += 1
-    if input_summary is None:
-        input_summary = ExternalInputSummary(
-            num_somatic_variants=len(ranked),
-            num_coding_effect_variants=n_with_transcript,
-            num_variants_with_rna_support=n_with_rna,
-        )
+    n_with_peptides = sum(1 for _variant, vps in ranked if vps)
     # MHC alleles aren't carried as a separate header in LENS /
     # pVACseq files — they're implicit in the per-row predictions.
     # Infer the unique set from the predictions and mark "(inferred)"
@@ -1538,9 +1465,9 @@ def load_external_ranked(args, epitope_config=None, vaccine_config=None,
         )
         patient_info = patient_info_from_external(
             ranking_result.ranked, path, patient_id,
+            ranking_result.input_summary,
             input_label=label,
-            predictions=predictions,
-            input_summary=ranking_result.input_summary)
+            predictions=predictions)
         return (ranking_result.ranked, report.report_df, predictions,
                 patient_info, ranking_result.dna_vaf_by_variant)
     return None

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -238,7 +238,27 @@ class ExternalVariantEntry:
     resolved_transcript: bool = False
     annotation: object = None       # (gene_ok, effect_ok, label) or None
     dna_vaf: object = None          # float or None
+    has_rna_support: bool = False
     unparseable: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
+class ExternalInputSummary:
+    """Filter-independent counts recovered from a parseable input report."""
+
+    num_somatic_variants: int = 0
+    num_coding_effect_variants: int = 0
+    num_variants_with_rna_support: int = 0
+
+
+@dataclasses.dataclass
+class ExternalRankingResult:
+    """Construct ranking plus metadata from the same external-file parse."""
+
+    ranked: list = dataclasses.field(default_factory=list)
+    dna_vaf_by_variant: dict = dataclasses.field(default_factory=dict)
+    input_summary: ExternalInputSummary = dataclasses.field(
+        default_factory=ExternalInputSummary)
 
 
 def _missing_cell(value):
@@ -703,11 +723,22 @@ def _lens_ranked_entry(coords, group_rows, by_position, genome,
         variant=variant,
         had_transcript_ids=bool(transcript_ids),
         resolved_transcript=bool(transcripts),
+        has_rna_support=(n_total > 0 or n_alt_reads > 0),
         # Sanity-check LENS's annotation against varcode on LENS's own
         # transcript (validation only — LENS's values are kept).
         annotation=(check_varcode_annotation(
             variant, transcripts[0] if transcripts else None,
             gene_name, lens_is_frameshift) + (str(coords),)))
+
+    # DNA VAF is input provenance, independent of whether this variant has an
+    # eligible construct target.
+    vaf_raw = rep.get('vaf')
+    if vaf_raw is not None and not (
+            isinstance(vaf_raw, float) and pd.isna(vaf_raw)):
+        try:
+            entry.dna_vaf = float(vaf_raw)
+        except (TypeError, ValueError):
+            pass
 
     fragment = MutantProteinFragment(
         variant=variant, gene_name=gene_name, amino_acids=str(pep_context),
@@ -748,21 +779,13 @@ def _lens_ranked_entry(coords, group_rows, by_position, genome,
         epitopes=variant_epitopes,
         num_target_epitopes_to_keep=num_target_epitopes_to_keep)
 
-    # DNA VAF for the report (representative row; LENS dedupes by variant).
-    vaf_raw = rep.get('vaf')
-    if vaf_raw is not None and not (
-            isinstance(vaf_raw, float) and pd.isna(vaf_raw)):
-        try:
-            entry.dna_vaf = float(vaf_raw)
-        except (TypeError, ValueError):
-            pass
     return entry
 
 
-def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
-                                 num_target_epitopes_to_keep=None,
-                                 vaccine_peptide_length=25):
-    """Group LENS epitopes by variant; emit ranked vaccine peptides.
+def lens_ranking_result(epitopes, lens_tsv_path, genome=None,
+                        num_target_epitopes_to_keep=None,
+                        vaccine_peptide_length=25):
+    """Parse LENS input into construct ranking and input-level metadata.
 
     Parameters
     ----------
@@ -786,13 +809,13 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
 
     Returns
     -------
-    list[(varcode.Variant, list[VaccinePeptide])]
+    ExternalRankingResult
     """
     if not lens_tsv_path:
-        return [], {}
+        return ExternalRankingResult()
     df = pd.read_csv(lens_tsv_path, sep="\t", low_memory=False)
     if df.empty:
-        return [], {}
+        return ExternalRankingResult()
 
     # Auto-detect which LENS predictor columns are present so the
     # representative-row pick reads real values. Without this, every
@@ -898,6 +921,8 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
 
     ranked = []
     n_unparseable = 0
+    n_parseable = 0
+    n_with_rna = 0
     # Aggregate transcript-resolution stats so we summarize once at
     # the end instead of spamming a log line per row. ``n_with_ids`` is
     # variants that *had* at least one transcript_id in the LENS file;
@@ -921,24 +946,47 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
             if lens_epitope_position(
                 row.get('peptide'), row.get('pep_context')) in by_position
         ]
-        if not eligible_rows:
-            continue
-        entry = _lens_ranked_entry(
-            coords, eligible_rows, by_position, genome, vaccine_peptide_length,
-            affinity_cols, rank_cols, num_target_epitopes_to_keep)
-        if entry.unparseable:
+        if len(eligible_rows) == len(group_rows):
+            input_entry = _lens_ranked_entry(
+                coords, group_rows, by_position, genome,
+                vaccine_peptide_length, affinity_cols, rank_cols,
+                num_target_epitopes_to_keep)
+            ranking_entry = input_entry
+        else:
+            # Parse the complete input group for metadata without attaching
+            # target epitopes. Construct selection, when present, gets its own
+            # representative chosen only from eligible source positions.
+            input_entry = _lens_ranked_entry(
+                coords, group_rows, {}, genome, vaccine_peptide_length,
+                affinity_cols, rank_cols, num_target_epitopes_to_keep)
+            ranking_entry = (
+                _lens_ranked_entry(
+                    coords, eligible_rows, by_position, genome,
+                    vaccine_peptide_length, affinity_cols, rank_cols,
+                    num_target_epitopes_to_keep)
+                if eligible_rows else None)
+        if input_entry.unparseable:
             n_unparseable += 1
             continue
-        if entry.annotation is not None:
-            annotation_results.append(entry.annotation)
-        if entry.had_transcript_ids:
+        if input_entry.variant is None:
+            continue
+        n_parseable += 1
+        if input_entry.annotation is not None:
+            annotation_results.append(input_entry.annotation)
+        if input_entry.had_transcript_ids:
             n_with_ids += 1
-            if entry.resolved_transcript:
+            if input_entry.resolved_transcript:
                 n_resolved += 1
-        if entry.dna_vaf is not None:
-            dna_vaf_by_variant[entry.variant] = entry.dna_vaf
-        if entry.vaccine_peptide is not None:
-            ranked.append((entry.variant, [entry.vaccine_peptide]))
+        if input_entry.has_rna_support:
+            n_with_rna += 1
+        if input_entry.dna_vaf is not None:
+            dna_vaf_by_variant[input_entry.variant] = input_entry.dna_vaf
+        if (
+            ranking_entry is not None
+            and ranking_entry.vaccine_peptide is not None
+        ):
+            ranked.append((
+                ranking_entry.variant, [ranking_entry.vaccine_peptide]))
 
     if n_unparseable:
         logger.warning(
@@ -1061,7 +1109,29 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
 
     # Top candidates first so they win greedy bin-packing in the
     # construct assemblers (shared ordering helper).
-    return ranked_sorted_by_target_score(ranked), dna_vaf_by_variant
+    return ExternalRankingResult(
+        ranked=ranked_sorted_by_target_score(ranked),
+        dna_vaf_by_variant=dna_vaf_by_variant,
+        input_summary=ExternalInputSummary(
+            num_somatic_variants=n_parseable,
+            num_coding_effect_variants=n_resolved,
+            num_variants_with_rna_support=n_with_rna,
+        ),
+    )
+
+
+def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
+                                 num_target_epitopes_to_keep=None,
+                                 vaccine_peptide_length=25):
+    """Return the legacy ``(ranked, DNA VAF)`` view of a LENS result."""
+    result = lens_ranking_result(
+        epitopes,
+        lens_tsv_path,
+        genome=genome,
+        num_target_epitopes_to_keep=num_target_epitopes_to_keep,
+        vaccine_peptide_length=vaccine_peptide_length,
+    )
+    return result.ranked, result.dna_vaf_by_variant
 
 
 def parse_pvacseq_variant(variant_id, genome=None):
@@ -1181,10 +1251,9 @@ def _pvacseq_dna_vaf(row):
         return None
 
 
-def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
-                                    genome=None,
-                                    num_target_epitopes_to_keep=None):
-    """pVACseq variant of :func:`ranked_from_lens_predictions`.
+def pvacseq_ranking_result(epitopes, pvacseq_tsv_path, genome=None,
+                           num_target_epitopes_to_keep=None):
+    """Parse pVACseq input into construct ranking and input metadata.
 
     Re-reads the raw pVACseq TSV (the per-(peptide, allele)
     ``report_df`` returned by ``load_pvacseq`` carries display columns
@@ -1196,10 +1265,10 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
     shorter antigen windows than the LENS path.
     """
     if not pvacseq_tsv_path:
-        return [], {}
+        return ExternalRankingResult()
     df = pd.read_csv(pvacseq_tsv_path, sep="\t", low_memory=False)
     if df.empty:
-        return [], {}
+        return ExternalRankingResult()
 
     by_source_peptide: dict[tuple[str, str], list] = {}
     for e in epitopes:
@@ -1215,6 +1284,8 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
 
     ranked = []
     n_skipped = 0
+    n_parseable = 0
+    n_with_rna = 0
     # Aggregate transcript-resolution stats (see LENS path for rationale).
     n_with_ids = 0
     n_resolved = 0
@@ -1238,6 +1309,7 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
                 "Could not parse pVACseq ID %r as a Variant; skipping.",
                 vid)
             continue
+        n_parseable += 1
 
         # Real RNA-read counts from pVACseq columns.
         # ``RNA Depth`` / ``Tumor RNA Depth`` = total coverage at the
@@ -1249,6 +1321,8 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
         vaf = _pvacseq_rna_vaf(rep)
         n_alt_reads = int(round(n_total * vaf)) if n_total > 0 else 0
         n_ref_reads = max(0, n_total - n_alt_reads)
+        if n_total > 0 or n_alt_reads > 0:
+            n_with_rna += 1
 
         # pVACseq aggregate's "Best Peptide" is the minimal-epitope
         # neoantigen, not an SLP context. The whole peptide IS the
@@ -1279,6 +1353,9 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
             variant, transcripts[0] if transcripts else None,
             gene, variant_is_frameshift(variant))
         annotation_results.append((gene_ok, effect_ok, str(vid)))
+        dna_vaf = _pvacseq_dna_vaf(rep)
+        if dna_vaf is not None:
+            dna_vaf_by_variant[variant] = dna_vaf
         fragment = MutantProteinFragment(
             variant=variant, gene_name=gene,
             amino_acids=str(best_pep),
@@ -1313,10 +1390,6 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
             num_target_epitopes_to_keep=num_target_epitopes_to_keep,
         )]))
 
-        dna_vaf = _pvacseq_dna_vaf(rep)
-        if dna_vaf is not None:
-            dna_vaf_by_variant[variant] = dna_vaf
-
     if n_skipped:
         logger.warning(
             "Skipped %d pVACseq row group(s) with unparseable IDs; "
@@ -1325,15 +1398,38 @@ def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
     log_transcript_resolution(
         n_with_ids, n_resolved, "pVACseq", id_label="Best Transcript IDs")
     log_varcode_agreement(annotation_results, "pVACseq")
-    return ranked_sorted_by_target_score(ranked), dna_vaf_by_variant
+    return ExternalRankingResult(
+        ranked=ranked_sorted_by_target_score(ranked),
+        dna_vaf_by_variant=dna_vaf_by_variant,
+        input_summary=ExternalInputSummary(
+            num_somatic_variants=n_parseable,
+            num_coding_effect_variants=n_resolved,
+            num_variants_with_rna_support=n_with_rna,
+        ),
+    )
+
+
+def ranked_from_pvacseq_predictions(epitopes, pvacseq_tsv_path,
+                                    genome=None,
+                                    num_target_epitopes_to_keep=None):
+    """Return the legacy ``(ranked, DNA VAF)`` view of a pVACseq result."""
+    result = pvacseq_ranking_result(
+        epitopes,
+        pvacseq_tsv_path,
+        genome=genome,
+        num_target_epitopes_to_keep=num_target_epitopes_to_keep,
+    )
+    return result.ranked, result.dna_vaf_by_variant
 
 
 def patient_info_from_external(ranked, source_path, patient_id,
                                input_label='External report',
-                               predictions=None):
+                               predictions=None, input_summary=None):
     """Build a :class:`PatientInfo` from external-input data.
 
-    Counts are derived from the ranked output:
+    Input counts come from the filter-independent summary produced while
+    parsing the external report:
+
       - ``num_somatic_variants`` = unique variants the input file
         produced antigens for (LENS / pVACseq are antigen-only files,
         so this is "variants that survived their pipeline"; silent
@@ -1343,8 +1439,14 @@ def patient_info_from_external(ranked, source_path, patient_id,
         (the rest are ERV / non-genic / unresolvable IDs)
       - ``num_variants_with_rna_support`` = unique variants with at
         least one row carrying a non-zero RNA-read count
+
+    Only the design-output count is derived from ``ranked``:
+
       - ``num_variants_with_vaccine_peptides`` = ``len(ranked)``,
         same definition as the pipeline path
+
+    ``input_summary`` defaults to the legacy ranked-derived counts for direct
+    callers that do not have an :class:`ExternalRankingResult`.
     """
     from .patient_info import PatientInfo
     n_with_transcript = 0
@@ -1364,6 +1466,12 @@ def patient_info_from_external(ranked, source_path, patient_id,
             n_with_transcript += 1
         if (frag.n_alt_reads or 0) > 0 or (frag.n_overlapping_reads or 0) > 0:
             n_with_rna += 1
+    if input_summary is None:
+        input_summary = ExternalInputSummary(
+            num_somatic_variants=len(ranked),
+            num_coding_effect_variants=n_with_transcript,
+            num_variants_with_rna_support=n_with_rna,
+        )
     # MHC alleles aren't carried as a separate header in LENS /
     # pVACseq files — they're implicit in the per-row predictions.
     # Infer the unique set from the predictions and mark "(inferred)"
@@ -1395,9 +1503,10 @@ def patient_info_from_external(ranked, source_path, patient_id,
         vcf_paths=[],
         bam_path=None,
         mhc_alleles=mhc_alleles,
-        num_somatic_variants=len(ranked),
-        num_coding_effect_variants=n_with_transcript,
-        num_variants_with_rna_support=n_with_rna,
+        num_somatic_variants=input_summary.num_somatic_variants,
+        num_coding_effect_variants=input_summary.num_coding_effect_variants,
+        num_variants_with_rna_support=(
+            input_summary.num_variants_with_rna_support),
         num_variants_with_vaccine_peptides=n_with_peptides,
         inputs=([(input_label, source_path)] if source_path else []),
     )
@@ -1408,9 +1517,9 @@ def load_external_ranked(args, epitope_config=None):
     ``(ranked, report_df, predictions, patient_info)`` or ``None`` if
     neither flag is set.
 
-    ``patient_info`` carries the variant-count metadata template
-    reports (ASCII / HTML / PDF) need; counts are proxies derived
-    from the ranked output (see :func:`patient_info_from_external`).
+    ``patient_info`` carries the variant-count metadata template reports
+    (ASCII / HTML / PDF) need. Input counts are captured before filtering;
+    only the vaccine-peptide count follows the filtered design output.
 
     ``epitope_config`` is evaluated by the selected loader before vaccine
     peptides are constructed, so ranking and template reports consume the
@@ -1430,28 +1539,32 @@ def load_external_ranked(args, epitope_config=None):
             args.input_lens, epitope_config=epitope_config)
         ranking_predictions = epitopes_for_ranking(
             predictions, epitope_config)
-        ranked, dna_vaf_by_variant = ranked_from_lens_predictions(
+        ranking_result = lens_ranking_result(
             ranking_predictions, args.input_lens,
             genome=getattr(args, 'genome', None),
             vaccine_peptide_length=vaccine_peptide_length)
+        ranked = ranking_result.ranked
         patient_info = patient_info_from_external(
             ranked, args.input_lens, patient_id,
             input_label='LENS report',
-            predictions=predictions)
+            predictions=predictions,
+            input_summary=ranking_result.input_summary)
         return (ranked, report_df, predictions, patient_info,
-                dna_vaf_by_variant)
+                ranking_result.dna_vaf_by_variant)
     if getattr(args, 'input_pvacseq', None):
         report_df, predictions = load_pvacseq(
             args.input_pvacseq, epitope_config=epitope_config)
         ranking_predictions = epitopes_for_ranking(
             predictions, epitope_config)
-        ranked, dna_vaf_by_variant = ranked_from_pvacseq_predictions(
+        ranking_result = pvacseq_ranking_result(
             ranking_predictions, args.input_pvacseq,
             genome=getattr(args, 'genome', None))
+        ranked = ranking_result.ranked
         patient_info = patient_info_from_external(
             ranked, args.input_pvacseq, patient_id,
             input_label='pVACseq report',
-            predictions=predictions)
+            predictions=predictions,
+            input_summary=ranking_result.input_summary)
         return (ranked, report_df, predictions, patient_info,
-                dna_vaf_by_variant)
+                ranking_result.dna_vaf_by_variant)
     return None

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -44,21 +44,16 @@ import os
 import pandas as pd
 
 from .amino_acids import has_only_standard_amino_acids
-from .epitope_io import detect_lens_predictors, lens_epitope_position
+from .external_prediction import (
+    ExternalPredictionKey,
+    external_text,
+    external_values,
+    lens_variant_id,
+    pvacseq_variant_id,
+)
 from .mutant_protein_fragment import MutantProteinFragment
 from .vaccine_library import truncate_at_stop_codon
 from .vaccine_peptide import VaccinePeptide
-
-# pVACseq scoring column priority. Sniffed against the row dict; the first
-# column present + non-NaN wins. Covers both aggregate and all_epitopes TSVs.
-_PVACSEQ_IC50_COLS = (
-    'IC50 MT', 'Best IC50 Score MT',
-    'Median MT IC50 Score', 'Best MT IC50 Score',
-)
-_PVACSEQ_RANK_COLS = (
-    '%ile MT', 'Best Percentile MT',
-    'Median MT Percentile', 'Best MT Percentile',
-)
 
 logger = logging.getLogger(__name__)
 
@@ -259,6 +254,76 @@ class ExternalRankingResult:
     dna_vaf_by_variant: dict = dataclasses.field(default_factory=dict)
     input_summary: ExternalInputSummary = dataclasses.field(
         default_factory=ExternalInputSummary)
+
+
+@dataclasses.dataclass(frozen=True)
+class ExternalPredictionRecord:
+    """One raw external row joined to its exact scored candidate."""
+
+    row: dict
+    key: ExternalPredictionKey
+    epitope: object
+
+
+@dataclasses.dataclass(frozen=True)
+class ExternalConstructSelection:
+    """DSL-selected source window and the candidates it contains."""
+
+    representative: ExternalPredictionRecord
+    records: tuple[ExternalPredictionRecord, ...]
+
+    @property
+    def epitopes(self):
+        """Candidates in the selected source window, without duplicates."""
+        seen = set()
+        result = []
+        for record in self.records:
+            identity = record.epitope.prediction_id
+            if identity not in seen:
+                seen.add(identity)
+                result.append(record.epitope)
+        return tuple(result)
+
+
+def external_epitopes_by_id(epitopes):
+    """Index externally sourced candidates without sequence fallbacks."""
+    result = {}
+    for epitope in epitopes:
+        if not epitope.prediction_id:
+            raise ValueError(
+                "External construct ranking requires prediction provenance")
+        if epitope.prediction_id in result:
+            raise ValueError(
+                "Duplicate external prediction identity after loading")
+        result[epitope.prediction_id] = epitope
+    return result
+
+
+def select_external_construct(records):
+    """Select one source window by configured DSL score.
+
+    The highest ``CandidateEpitope.epitope_score`` chooses the construct
+    context. Other eligible epitopes from that exact context accompany it;
+    evidence from another context can never inflate the selected construct.
+    File order is the deterministic tie-breaker.
+    """
+    records = tuple(records)
+    if not records:
+        return None
+    representative = records[0]
+    for record in records[1:]:
+        if record.epitope.epitope_score > representative.epitope.epitope_score:
+            representative = record
+    construct_id = representative.key.construct_identifier
+    selected = tuple(
+        record
+        for record in records
+        if record.key.construct_identifier == construct_id
+    )
+    return ExternalConstructSelection(
+        representative=representative,
+        records=selected,
+    )
 
 
 def _missing_cell(value):
@@ -536,44 +601,6 @@ def peptide_offsets_in_context(peptide, peptide_context):
     return idx, idx + len(peptide)
 
 
-def _row_score(row, ic50_cols, rank_cols):
-    """Numeric score for a row: smallest IC50 (strongest binder) wins,
-    falling back to smallest percentile rank when IC50 is missing.
-
-    ``ic50_cols`` / ``rank_cols`` are tuples of column names tried in
-    priority order; the first non-NaN match is used. Returns a sortable
-    ``(tier, value)`` tuple where tier 0 = real IC50, tier 1 = rank,
-    tier 2 = no signal (rows tie at 0.0).
-    """
-    for col in ic50_cols:
-        v = row.get(col)
-        if v is not None and pd.notna(v):
-            try:
-                return (0, float(v))
-            except (TypeError, ValueError):
-                continue
-    for col in rank_cols:
-        v = row.get(col)
-        if v is not None and pd.notna(v):
-            try:
-                return (1, float(v))
-            except (TypeError, ValueError):
-                continue
-    return (2, 0.0)
-
-
-def _pick_representative(group_rows, ic50_cols, rank_cols):
-    """Pick the row whose peptide will represent this variant in the
-    construct pipeline.
-
-    Strategy: smallest IC50 (= strongest predicted binder). If no
-    IC50 column is present, fall back to smallest percentile rank.
-
-    Returns the strongest-binder row from ``group_rows``.
-    """
-    return min(group_rows, key=lambda r: _row_score(r, ic50_cols, rank_cols))
-
-
 def _coerce_int(value, default=0):
     """Coerce a value (possibly NaN / None / str) to int.
 
@@ -621,165 +648,134 @@ def _read_counts_from_lens_row(row):
     return n_total, n_alt_reads, n_ref_reads, n_alt_supporting_protein
 
 
-def _lens_ranked_entry(coords, group_rows, by_position, genome,
-                       vaccine_peptide_length, affinity_cols, rank_cols,
-                       num_target_epitopes_to_keep):
-    """Build one variant's :class:`ExternalVariantEntry` from a LENS
-    row group. Returns the entry (with ``unparseable`` / ``vaccine_peptide``
-    None for rows that can't be turned into an antigen); the caller
-    aggregates the stats and the ranked list."""
-    rep = _pick_representative(group_rows, affinity_cols, rank_cols)
-    # Build the Variant from REAL ref/alt columns (snv_*_allele /
-    # indel_*_allele depending on antigen_source). variant_coords gives
-    # only chr:pos in LENS v1.9; the alleles live in dedicated columns.
-    variant = variant_from_lens_row(rep, genome=genome)
-    if variant is None:
+def lens_variant_metadata(variant_id, group_rows, genome=None):
+    """Aggregate filter-independent facts from every raw LENS row."""
+    parsed = [
+        (row, variant_from_lens_row(row, genome=genome))
+        for row in group_rows
+    ]
+    parsed = [(row, variant) for row, variant in parsed if variant is not None]
+    if not parsed:
         logger.debug(
-            "Could not build Variant from LENS row at coords=%r "
-            "(antigen_source=%r); skipping.", coords,
-            rep.get('antigen_source'))
+            "Could not build Variant for LENS identity %r; skipping.",
+            variant_id)
         return ExternalVariantEntry(unparseable=True)
+    representative_row, variant = parsed[0]
 
-    peptide = rep.get('peptide') or ""
-    pep_context = rep.get('pep_context') or ""
-    if not pep_context:
-        # No SLP window available — fall back to the neoepitope itself
-        # as the antigen. The construct will be short but valid.
-        pep_context = peptide
-    # Translation halts at the first stop codon — anything after ``*``
-    # doesn't exist as protein. Truncate so manufacturability /
-    # hydropathy / codon-optimization see only real residues.
-    pep_context = truncate_at_stop_codon(str(pep_context))
-    peptide = truncate_at_stop_codon(str(peptide))
-    if not pep_context or not peptide:
-        logger.debug(
-            "Dropped LENS row for variant %r: peptide / pep_context "
-            "empty after stop-codon truncation.", coords)
-        return ExternalVariantEntry()
-    # Some LENS files emit non-standard residues (U / O / X / B / Z / J);
-    # vaxrank's manufacturability / hydropathy code is keyed off the 20
-    # canonical AAs, so drop the row rather than crash.
-    if not has_only_standard_amino_acids(pep_context):
-        logger.warning(
-            "Dropped LENS row for variant %r: pep_context %r contains "
-            "non-standard residues (allowed: 20 canonical AAs).",
-            coords, pep_context)
-        return ExternalVariantEntry()
-    # Preserve LENS's own gene name; fall back to empty string (the
-    # codebase convention for "not known").
-    gene_name_raw = rep.get('gene_name')
-    gene_name = (
-        str(gene_name_raw) if gene_name_raw and not (
-            isinstance(gene_name_raw, float) and pd.isna(gene_name_raw))
-        else "")
-
-    start_off, end_off = peptide_offsets_in_context(peptide, pep_context)
-    if start_off is None:
-        logger.debug(
-            "Could not locate peptide %r in pep_context %r for variant "
-            "%r; skipping (mutation span unknown).",
-            peptide, pep_context, coords)
-        return ExternalVariantEntry()
-
-    # Frameshift → the whole downstream tail is novel; combine the
-    # variant's neoepitope rows into the maximal mutant span. Frameshift
-    # is derived from the variant's own ref/alt (general); LENS's own
-    # frameshift annotation is kept separately only to sanity-check
-    # varcode.
-    start_off, end_off = maximal_mutant_span(
-        start_off, end_off, [r.get('peptide') for r in group_rows],
-        pep_context, variant_is_frameshift(variant))
-    lens_is_frameshift = (
-        str(rep.get('indel_type') or '').strip().lower() == 'frameshift'
-        or 'fs' in str(rep.get('variant_effect') or '').lower())
-
-    # Window pep_context to the canonical SLP fragment size; the same
-    # operation the pipeline path's Isovar fragments satisfy by
-    # construction (see MutantProteinFragment.slp_window_around_mutation).
-    pep_context, start_off, end_off = (
-        MutantProteinFragment.slp_window_around_mutation(
-            pep_context, start_off, end_off, vaccine_peptide_length))
-
-    # Real RNA-read counts from LENS columns. Missing → 0 (honest "no
-    # signal"); never fabricated from TPM.
-    (n_total, n_alt_reads, n_ref_reads,
-     n_alt_supporting_protein) = _read_counts_from_lens_row(rep)
-
-    # Real transcript IDs → pyensembl Transcript objects so template
-    # reports have varcode context; shrinks to [] when unresolvable.
-    tid = rep.get('transcript_id')
-    all_tids = rep.get('all_transcript_ids_encoding_peptide')
-    transcript_ids = []
-    if tid and not (isinstance(tid, float) and pd.isna(tid)):
-        transcript_ids.append(str(tid))
-    if all_tids and isinstance(all_tids, str) and all_tids.lower() != 'nan':
-        for t in all_tids.split(','):
-            t = t.strip()
-            if t and t not in transcript_ids:
-                transcript_ids.append(t)
+    transcript_ids = external_values(*(
+        value
+        for row in group_rows
+        for value in (
+            row.get("transcript_id"),
+            row.get("all_transcript_ids_encoding_peptide"),
+        )
+    ))
     transcripts = resolve_external_transcripts(transcript_ids, genome)
-
+    has_rna_support = any(
+        counts[0] > 0 or counts[1] > 0
+        for counts in map(_read_counts_from_lens_row, group_rows)
+    )
+    gene_names = external_values(*(
+        value
+        for row in group_rows
+        for value in (
+            row.get("gene_name"),
+            row.get("all_gene_names_encoding_peptide"),
+        )
+    ))
+    lens_is_frameshift = any(
+        external_text(row.get("indel_type")).lower() == "frameshift"
+        or "fs" in external_text(row.get("variant_effect")).lower()
+        for row in group_rows
+    )
     entry = ExternalVariantEntry(
         variant=variant,
         had_transcript_ids=bool(transcript_ids),
         resolved_transcript=bool(transcripts),
-        has_rna_support=(n_total > 0 or n_alt_reads > 0),
-        # Sanity-check LENS's annotation against varcode on LENS's own
-        # transcript (validation only — LENS's values are kept).
+        has_rna_support=has_rna_support,
         annotation=(check_varcode_annotation(
-            variant, transcripts[0] if transcripts else None,
-            gene_name, lens_is_frameshift) + (str(coords),)))
-
-    # DNA VAF is input provenance, independent of whether this variant has an
-    # eligible construct target.
-    vaf_raw = rep.get('vaf')
-    if vaf_raw is not None and not (
-            isinstance(vaf_raw, float) and pd.isna(vaf_raw)):
+            variant,
+            transcripts[0] if transcripts else None,
+            gene_names[0] if gene_names else "",
+            lens_is_frameshift,
+        ) + (str(variant_id),)),
+    )
+    for row in group_rows:
+        value = row.get("vaf")
+        if _missing_cell(value):
+            continue
         try:
-            entry.dna_vaf = float(vaf_raw)
+            entry.dna_vaf = float(value)
+            break
         except (TypeError, ValueError):
-            pass
+            continue
+    return entry
 
+
+def lens_vaccine_entry(metadata, selection, genome=None,
+                       vaccine_peptide_length=25,
+                       num_target_epitopes_to_keep=None):
+    """Build one LENS vaccine peptide from a DSL-selected source window."""
+    if selection is None or metadata.variant is None:
+        return metadata
+    key = selection.representative.key
+    peptide = truncate_at_stop_codon(key.peptide)
+    pep_context = truncate_at_stop_codon(key.source_sequence or key.peptide)
+    if not peptide or not pep_context:
+        return metadata
+    if not has_only_standard_amino_acids(pep_context):
+        logger.warning(
+            "Dropped LENS construct for variant %r: pep_context %r contains "
+            "non-standard residues (allowed: 20 canonical AAs).",
+            key.variant_id, pep_context)
+        return metadata
+    start_off, end_off = peptide_offsets_in_context(peptide, pep_context)
+    if start_off is None:
+        return metadata
+    start_off, end_off = maximal_mutant_span(
+        start_off,
+        end_off,
+        [record.key.peptide for record in selection.records],
+        pep_context,
+        variant_is_frameshift(metadata.variant),
+    )
+    pep_context, start_off, end_off = (
+        MutantProteinFragment.slp_window_around_mutation(
+            pep_context, start_off, end_off, vaccine_peptide_length))
+
+    counts = [_read_counts_from_lens_row(record.row)
+              for record in selection.records]
+    n_total = max((value[0] for value in counts), default=0)
+    n_alt_reads = max((value[1] for value in counts), default=0)
+    n_ref_reads = max(0, n_total - n_alt_reads)
+    n_alt_supporting_protein = max((value[3] for value in counts), default=0)
+    transcripts = resolve_external_transcripts(key.transcript_ids, genome)
+    gene_name = key.gene_names[0] if key.gene_names else ""
     fragment = MutantProteinFragment(
-        variant=variant, gene_name=gene_name, amino_acids=str(pep_context),
+        variant=metadata.variant,
+        gene_name=gene_name,
+        amino_acids=pep_context,
         mutant_amino_acid_start_offset=start_off,
         mutant_amino_acid_end_offset=end_off,
         supporting_reference_transcripts=transcripts,
-        n_overlapping_reads=n_total, n_alt_reads=n_alt_reads,
+        n_overlapping_reads=n_total,
+        n_alt_reads=n_alt_reads,
         n_ref_reads=n_ref_reads,
         n_alt_reads_supporting_protein_sequence=n_alt_supporting_protein,
-        # Real ref/alt columns → real genotype, not a placeholder.
-        placeholder_alleles=False)
-
-    # Collect the variant's CandidateEpitopes (deduped on identity); LENS
-    # rows are mutant-derived, so every one overlaps the mutation.
-    seen_positions = set()
-    seen_epitope_ids = set()
-    variant_epitopes = []
-    for r in group_rows:
-        position = lens_epitope_position(
-            r.get('peptide'), r.get('pep_context'))
-        if position is None or position in seen_positions:
-            continue
-        seen_positions.add(position)
-        for e in by_position.get(position, []):
-            if id(e) in seen_epitope_ids:
-                continue
-            seen_epitope_ids.add(id(e))
-            if not e.overlaps_mutation:
-                e = dataclasses.replace(e, overlaps_mutation=True)
-            variant_epitopes.append(e)
-    if not variant_epitopes:
-        # Transcript stats + annotation already recorded above; just no
-        # vaccine peptide for this variant.
-        return entry
-
-    entry.vaccine_peptide = VaccinePeptide(
+        placeholder_alleles=False,
+    )
+    epitopes = [
+        epitope
+        if epitope.overlaps_mutation
+        else dataclasses.replace(epitope, overlaps_mutation=True)
+        for epitope in selection.epitopes
+    ]
+    metadata.vaccine_peptide = VaccinePeptide(
         mutant_protein_fragment=fragment,
-        epitopes=variant_epitopes,
-        num_target_epitopes_to_keep=num_target_epitopes_to_keep)
-
-    return entry
+        epitopes=epitopes,
+        num_target_epitopes_to_keep=num_target_epitopes_to_keep,
+    )
+    return metadata
 
 
 def lens_ranking_result(epitopes, lens_tsv_path, genome=None,
@@ -817,37 +813,7 @@ def lens_ranking_result(epitopes, lens_tsv_path, genome=None,
     if df.empty:
         return ExternalRankingResult()
 
-    # Auto-detect which LENS predictor columns are present so the
-    # representative-row pick reads real values. Without this, every
-    # row scored 0.0 and stable-sort returned the file-order first
-    # row (typically the alphabetically-first allele) instead of the
-    # strongest binder.
-    detected = detect_lens_predictors(df.columns)
-    affinity_cols = tuple(
-        d.value_col for d in detected if d.kind == 'pMHC_affinity')
-    rank_cols = tuple(
-        d.percentile_col for d in detected
-        if d.percentile_col and d.kind == 'pMHC_affinity')
-    if not affinity_cols and not rank_cols:
-        # No pMHC_affinity predictor detected — typically a
-        # presentation-only LENS file. _row_score will tie every row
-        # at (2, 0.0) and the file-order first row "wins". Warn so
-        # the user knows the representative pick is arbitrary.
-        kinds = sorted({d.kind for d in detected}) or ['(none)']
-        logger.warning(
-            "LENS file has no pMHC_affinity scoring columns "
-            "(detected kinds: %s); per-variant representative-peptide "
-            "pick will fall back to file order. Consider running with "
-            "a predictor that emits pMHC affinity (e.g. mhcflurry, "
-            "netmhcpan-ba).", kinds)
-
-    # Index by the complete CandidateEpitope position identity. Peptide
-    # sequence alone is insufficient: the same sequence can occur in
-    # different source contexts whose DSL filter outcomes differ.
-    by_position: dict[tuple[str, str, int], list] = {}
-    for e in epitopes:
-        position = (e.sequence, e.source_sequence, e.offset)
-        by_position.setdefault(position, []).append(e)
+    epitopes_by_id = external_epitopes_by_id(epitopes)
 
     # Group rows by variant. LENS uses lowercase snake_case columns.
     rows = df.to_dict('records')
@@ -896,7 +862,7 @@ def lens_ranking_result(epitopes, lens_tsv_path, genome=None,
                 else '(missing)')
             skipped_kinds[kind_key] = skipped_kinds.get(kind_key, 0) + 1
             continue
-        groups.setdefault(coords, []).append(r)
+        groups.setdefault(lens_variant_id(r), []).append(r)
     skipped_breakdown = ', '.join(
         "%s=%d" % (k, v) for k, v in sorted(
             skipped_kinds.items(), key=lambda kv: -kv[1]))
@@ -940,31 +906,25 @@ def lens_ranking_result(epitopes, lens_tsv_path, genome=None,
     # 0.141 vs computed 0.138). Plumb to ``dna_vaf_by_variant`` so
     # the report's "DNA VAF" field gets populated instead of "n/a".
     dna_vaf_by_variant = {}
-    for coords, group_rows in groups.items():
-        eligible_rows = [
-            row for row in group_rows
-            if lens_epitope_position(
-                row.get('peptide'), row.get('pep_context')) in by_position
-        ]
-        if len(eligible_rows) == len(group_rows):
-            input_entry = _lens_ranked_entry(
-                coords, group_rows, by_position, genome,
-                vaccine_peptide_length, affinity_cols, rank_cols,
-                num_target_epitopes_to_keep)
-            ranking_entry = input_entry
-        else:
-            # Parse the complete input group for metadata without attaching
-            # target epitopes. Construct selection, when present, gets its own
-            # representative chosen only from eligible source positions.
-            input_entry = _lens_ranked_entry(
-                coords, group_rows, {}, genome, vaccine_peptide_length,
-                affinity_cols, rank_cols, num_target_epitopes_to_keep)
-            ranking_entry = (
-                _lens_ranked_entry(
-                    coords, eligible_rows, by_position, genome,
-                    vaccine_peptide_length, affinity_cols, rank_cols,
-                    num_target_epitopes_to_keep)
-                if eligible_rows else None)
+    for variant_id, group_rows in groups.items():
+        records = []
+        for row in group_rows:
+            key = ExternalPredictionKey.from_lens_row(row)
+            epitope = (
+                epitopes_by_id.get(key.identifier)
+                if key is not None else None)
+            if epitope is not None:
+                records.append(ExternalPredictionRecord(
+                    row=row, key=key, epitope=epitope))
+        input_entry = lens_variant_metadata(
+            variant_id, group_rows, genome=genome)
+        ranking_entry = lens_vaccine_entry(
+            input_entry,
+            select_external_construct(records),
+            genome=genome,
+            vaccine_peptide_length=vaccine_peptide_length,
+            num_target_epitopes_to_keep=num_target_epitopes_to_keep,
+        )
         if input_entry.unparseable:
             n_unparseable += 1
             continue
@@ -1183,59 +1143,13 @@ def parse_pvacseq_variant(variant_id, genome=None):
     return v
 
 
-def _pvacseq_variant_key(row):
-    """Variant key for aggregated or all_epitopes pVACseq rows."""
-    existing = _first_cell(row, 'ID')
-    if existing is not None:
-        return existing
-    chrom = _first_cell(row, 'Chromosome')
-    start = _first_cell(row, 'Start')
-    ref = _first_cell(row, 'Reference')
-    alt = _first_cell(row, 'Variant')
-    if None in (chrom, start, ref, alt):
-        index = _first_cell(row, 'Index')
-        return index
-    stop = _first_cell(row, 'Stop')
-    if stop is not None:
-        return f"{chrom}-{start}-{stop}-{ref}-{alt}"
-    return f"{chrom}-{start}-{ref}-{alt}"
-
-
-def _pvacseq_source_key(row):
-    """Source key matching load_pvacseq's CandidateEpitope source."""
-    existing = _first_cell(row, 'ID')
-    if existing is not None:
-        return str(existing)
-    index = _first_cell(row, 'Index')
-    if index is not None:
-        return str(index)
-    chrom = _first_cell(row, 'Chromosome')
-    start = _first_cell(row, 'Start')
-    ref = _first_cell(row, 'Reference')
-    alt = _first_cell(row, 'Variant')
-    if None in (chrom, start, ref, alt):
-        return ""
-    return f"{chrom}-{start}-{ref}-{alt}"
-
-
-def _pvacseq_peptide(row):
-    return _first_str(row, 'Best Peptide', 'MT Epitope Seq', 'peptide')
-
-
-def _pvacseq_gene(row):
-    return _first_str(row, 'Gene', 'Gene Name', 'gene')
-
-
-def _pvacseq_transcript_ids(row):
-    transcript = _first_str(row, 'Best Transcript', 'Transcript', 'transcript')
-    return [transcript] if transcript else []
-
-
-def _pvacseq_rna_depth(row):
+def pvacseq_rna_depth(row):
+    """RNA coverage reported by either pVACseq TSV flavor."""
     return _coerce_int(_first_cell(row, 'RNA Depth', 'Tumor RNA Depth'), default=0)
 
 
-def _pvacseq_rna_vaf(row):
+def pvacseq_rna_vaf(row):
+    """RNA variant allele fraction reported by either pVACseq flavor."""
     raw = _first_cell(row, 'RNA VAF', 'Tumor RNA VAF')
     try:
         return float(raw) if raw is not None else 0.0
@@ -1243,12 +1157,100 @@ def _pvacseq_rna_vaf(row):
         return 0.0
 
 
-def _pvacseq_dna_vaf(row):
+def pvacseq_dna_vaf(row):
+    """DNA variant allele fraction reported by either pVACseq flavor."""
     raw = _first_cell(row, 'DNA VAF', 'Tumor DNA VAF')
     try:
         return float(raw) if raw is not None else None
     except (TypeError, ValueError):
         return None
+
+
+def pvacseq_variant_metadata(variant_id, group_rows, genome=None):
+    """Aggregate filter-independent facts from every raw pVACseq row."""
+    variant = parse_pvacseq_variant(variant_id, genome=genome)
+    if variant is None:
+        return ExternalVariantEntry(unparseable=True)
+    transcript_ids = external_values(*(
+        value
+        for row in group_rows
+        for value in (
+            row.get("Best Transcript"),
+            row.get("Transcript"),
+            row.get("transcript"),
+        )
+    ))
+    transcripts = resolve_external_transcripts(transcript_ids, genome)
+    has_rna_support = any(
+        pvacseq_rna_depth(row) > 0
+        or pvacseq_rna_depth(row) * pvacseq_rna_vaf(row) > 0
+        for row in group_rows
+    )
+    gene_names = external_values(*(
+        value
+        for row in group_rows
+        for value in (
+            row.get("Gene"), row.get("Gene Name"), row.get("gene"))
+    ))
+    annotation = check_varcode_annotation(
+        variant,
+        transcripts[0] if transcripts else None,
+        gene_names[0] if gene_names else "",
+        variant_is_frameshift(variant),
+    ) + (str(variant_id),)
+    entry = ExternalVariantEntry(
+        variant=variant,
+        had_transcript_ids=bool(transcript_ids),
+        resolved_transcript=bool(transcripts),
+        annotation=annotation,
+        has_rna_support=has_rna_support,
+    )
+    for row in group_rows:
+        dna_vaf = pvacseq_dna_vaf(row)
+        if dna_vaf is not None:
+            entry.dna_vaf = dna_vaf
+            break
+    return entry
+
+
+def pvacseq_vaccine_entry(metadata, selection, genome=None,
+                          num_target_epitopes_to_keep=None):
+    """Build one pVACseq vaccine peptide from a DSL-selected candidate."""
+    if selection is None or metadata.variant is None:
+        return metadata
+    key = selection.representative.key
+    transcripts = resolve_external_transcripts(key.transcript_ids, genome)
+    counts = []
+    for record in selection.records:
+        n_total = pvacseq_rna_depth(record.row)
+        n_alt = int(round(n_total * pvacseq_rna_vaf(record.row)))
+        counts.append((n_total, n_alt))
+    n_total = max((count[0] for count in counts), default=0)
+    n_alt_reads = max((count[1] for count in counts), default=0)
+    fragment = MutantProteinFragment(
+        variant=metadata.variant,
+        gene_name=key.gene_names[0] if key.gene_names else "",
+        amino_acids=key.source_sequence,
+        mutant_amino_acid_start_offset=0,
+        mutant_amino_acid_end_offset=len(key.source_sequence),
+        supporting_reference_transcripts=transcripts,
+        n_overlapping_reads=n_total,
+        n_alt_reads=n_alt_reads,
+        n_ref_reads=max(0, n_total - n_alt_reads),
+        n_alt_reads_supporting_protein_sequence=n_alt_reads,
+    )
+    epitopes = [
+        epitope
+        if epitope.overlaps_mutation
+        else dataclasses.replace(epitope, overlaps_mutation=True)
+        for epitope in selection.epitopes
+    ]
+    metadata.vaccine_peptide = VaccinePeptide(
+        mutant_protein_fragment=fragment,
+        epitopes=epitopes,
+        num_target_epitopes_to_keep=num_target_epitopes_to_keep,
+    )
+    return metadata
 
 
 def pvacseq_ranking_result(epitopes, pvacseq_tsv_path, genome=None,
@@ -1270,17 +1272,15 @@ def pvacseq_ranking_result(epitopes, pvacseq_tsv_path, genome=None,
     if df.empty:
         return ExternalRankingResult()
 
-    by_source_peptide: dict[tuple[str, str], list] = {}
-    for e in epitopes:
-        by_source_peptide.setdefault((e.source_sequence, e.sequence), []).append(e)
+    epitopes_by_id = external_epitopes_by_id(epitopes)
 
     rows = df.to_dict('records')
     groups = {}
     for r in rows:
-        key = _pvacseq_variant_key(r)
-        if _missing_cell(key):
+        variant_id = pvacseq_variant_id(r)
+        if _missing_cell(variant_id):
             continue
-        groups.setdefault(key, []).append(r)
+        groups.setdefault(variant_id, []).append(r)
 
     ranked = []
     n_skipped = 0
@@ -1294,101 +1294,44 @@ def pvacseq_ranking_result(epitopes, pvacseq_tsv_path, genome=None,
     # the ``RNA VAF`` we already consume for read counts). Plumb it
     # through to the report's DNA-VAF field.
     dna_vaf_by_variant = {}
-    for vid, group_rows in groups.items():
-        rep = _pick_representative(
-            group_rows, _PVACSEQ_IC50_COLS, _PVACSEQ_RANK_COLS)
-        best_pep = _pvacseq_peptide(rep)
-        # Preserve pVACseq's own gene name; empty string when missing
-        # (codebase convention for "not known"). No 'unknown' invention.
-        gene = _pvacseq_gene(rep)
-
-        variant = parse_pvacseq_variant(vid, genome=genome)
-        if variant is None:
+    for variant_id, group_rows in groups.items():
+        records = []
+        for row in group_rows:
+            key = ExternalPredictionKey.from_pvacseq_row(row)
+            epitope = (
+                epitopes_by_id.get(key.identifier)
+                if key is not None else None)
+            if epitope is not None:
+                records.append(ExternalPredictionRecord(
+                    row=row, key=key, epitope=epitope))
+        input_entry = pvacseq_variant_metadata(
+            variant_id, group_rows, genome=genome)
+        if input_entry.unparseable:
             n_skipped += 1
             logger.debug(
                 "Could not parse pVACseq ID %r as a Variant; skipping.",
-                vid)
+                variant_id)
             continue
         n_parseable += 1
-
-        # Real RNA-read counts from pVACseq columns.
-        # ``RNA Depth`` / ``Tumor RNA Depth`` = total coverage at the
-        # variant position. ``RNA VAF`` / ``Tumor RNA VAF`` = variant
-        # allele frequency (alt / total).
-        # n_alt_reads = round(depth × vaf); ref = depth − alt. Missing
-        # values yield 0 — honest "no read signal," never fabricated.
-        n_total = _pvacseq_rna_depth(rep)
-        vaf = _pvacseq_rna_vaf(rep)
-        n_alt_reads = int(round(n_total * vaf)) if n_total > 0 else 0
-        n_ref_reads = max(0, n_total - n_alt_reads)
-        if n_total > 0 or n_alt_reads > 0:
+        if input_entry.has_rna_support:
             n_with_rna += 1
-
-        # pVACseq aggregate's "Best Peptide" is the minimal-epitope
-        # neoantigen, not an SLP context. The whole peptide IS the
-        # mutation span (the aggregate doesn't split mutant vs.
-        # flanking residues), so claiming offsets [0, len(best_pep))
-        # is structurally honest — a transcript-aware loader could
-        # narrow this further but the aggregate doesn't carry the
-        # data to do so.
-        # pVACseq's aggregate carries one ``Best Transcript`` column
-        # per row (the transcript backing the chosen Best Peptide).
-        # Resolve to a pyensembl ``Transcript`` so template reports
-        # have real effect context; falls back to [] when the genome
-        # isn't plumbed through or the ID can't be resolved.
-        transcript_ids = _pvacseq_transcript_ids(rep)
-        transcripts = resolve_external_transcripts(transcript_ids, genome)
-        if transcript_ids:
+        if input_entry.had_transcript_ids:
             n_with_ids += 1
-            if transcripts:
+            if input_entry.resolved_transcript:
                 n_resolved += 1
-        # Sanity-check varcode against the variant. pVACseq's aggregate
-        # carries no explicit effect annotation, so the "provided"
-        # frameshift comes from the variant's own ref/alt (provider
-        # data) — this still cross-checks that varcode's effect class
-        # is consistent with the genomic alleles, and that the gene
-        # agrees. Shared with the LENS path via check_varcode_annotation
-        # + log_varcode_agreement.
-        gene_ok, effect_ok = check_varcode_annotation(
-            variant, transcripts[0] if transcripts else None,
-            gene, variant_is_frameshift(variant))
-        annotation_results.append((gene_ok, effect_ok, str(vid)))
-        dna_vaf = _pvacseq_dna_vaf(rep)
-        if dna_vaf is not None:
-            dna_vaf_by_variant[variant] = dna_vaf
-        fragment = MutantProteinFragment(
-            variant=variant, gene_name=gene,
-            amino_acids=str(best_pep),
-            mutant_amino_acid_start_offset=0,
-            mutant_amino_acid_end_offset=len(best_pep),
-            supporting_reference_transcripts=transcripts,
-            n_overlapping_reads=n_total, n_alt_reads=n_alt_reads,
-            n_ref_reads=n_ref_reads,
-            n_alt_reads_supporting_protein_sequence=n_alt_reads,
-        )
-        seen_peptides = set()
-        seen_epitope_ids = set()
-        variant_epitopes = []
-        for r in group_rows:
-            pep = _pvacseq_peptide(r)
-            if not pep or pep in seen_peptides:
-                continue
-            seen_peptides.add(pep)
-            source_key = _pvacseq_source_key(r)
-            for e in by_source_peptide.get((source_key, pep), []):
-                if id(e) in seen_epitope_ids:
-                    continue
-                seen_epitope_ids.add(id(e))
-                if not e.overlaps_mutation:
-                    e = dataclasses.replace(e, overlaps_mutation=True)
-                variant_epitopes.append(e)
-        if not variant_epitopes:
-            continue
-        ranked.append((variant, [VaccinePeptide(
-            mutant_protein_fragment=fragment,
-            epitopes=variant_epitopes,
+        if input_entry.annotation is not None:
+            annotation_results.append(input_entry.annotation)
+        if input_entry.dna_vaf is not None:
+            dna_vaf_by_variant[input_entry.variant] = input_entry.dna_vaf
+        ranking_entry = pvacseq_vaccine_entry(
+            input_entry,
+            select_external_construct(records),
+            genome=genome,
             num_target_epitopes_to_keep=num_target_epitopes_to_keep,
-        )]))
+        )
+        if ranking_entry.vaccine_peptide is not None:
+            ranked.append((
+                ranking_entry.variant, [ranking_entry.vaccine_peptide]))
 
     if n_skipped:
         logger.warning(

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -1038,8 +1038,8 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
     funnel = [
         "LENS load funnel: %s" % os.path.basename(lens_tsv_path),
         "  %d rows in: %s" % (len(rows), breakdown or '(none)'),
-        "  → %d candidate epitopes scored for the neoepitope report "
-        "(all antigen sources)" % len(epitopes),
+        "  → %d candidate epitopes eligible for construct ranking after "
+        "epitope DSL filtering" % len(epitopes),
         "  → %d row(s) with genomic variant_coords (%s) → %d unique "
         "variant(s) → %d ranked with vaccine peptide(s) for constructs" % (
             n_coord_rows, coord_breakdown, len(groups), n_variants_ranked),
@@ -1366,16 +1366,13 @@ def patient_info_from_external(ranked, source_path, patient_id,
     if predictions:
         seen = set()
         for ep in predictions:
-            # ``predictions`` here is a list of CandidateEpitope, which
-            # has no ``.allele`` — its alleles are the keys of
-            # ``per_allele_scores`` (populated by the DSL at load).
-            # Fall back to the raw Prediction.allele list for any loader
-            # that doesn't populate per_allele_scores.
-            alleles = list((getattr(ep, 'per_allele_scores', None) or {}))
+            # Patient genotype is input provenance, not a side effect of
+            # which peptide-allele groups survived the target filter.
+            alleles = list(getattr(ep, 'patient_alleles', ()) or ())
             if not alleles:
                 alleles = [
-                    getattr(p, 'allele', '')
-                    for p in (getattr(ep, 'predictions', None) or [])]
+                    prediction.allele
+                    for prediction in ep.predictions_flat()]
             for allele in alleles:
                 if allele and allele not in seen:
                     seen.add(allele)
@@ -1411,15 +1408,21 @@ def load_external_ranked(args, epitope_config=None):
     ``epitope_config`` is evaluated by the selected loader before vaccine
     peptides are constructed, so ranking and template reports consume the
     configured DSL scores rather than the default affinity score.
+
+    The returned ``predictions`` collection retains every loaded input group
+    for audit reports and patient-genotype inference. ``ranked`` is built from
+    separate copies narrowed to the groups retained by the Topiary filter.
     """
+    from .epitope_dsl import epitopes_after_dsl_filter
     from .epitope_io import load_lens, load_pvacseq
     patient_id = getattr(args, 'output_patient_id', '') or ''
     vaccine_peptide_length = getattr(args, 'vaccine_peptide_length', None) or 25
     if getattr(args, 'input_lens', None):
         report_df, predictions = load_lens(
             args.input_lens, epitope_config=epitope_config)
+        ranking_predictions = epitopes_after_dsl_filter(predictions)
         ranked, dna_vaf_by_variant = ranked_from_lens_predictions(
-            predictions, args.input_lens,
+            ranking_predictions, args.input_lens,
             genome=getattr(args, 'genome', None),
             vaccine_peptide_length=vaccine_peptide_length)
         patient_info = patient_info_from_external(
@@ -1431,8 +1434,9 @@ def load_external_ranked(args, epitope_config=None):
     if getattr(args, 'input_pvacseq', None):
         report_df, predictions = load_pvacseq(
             args.input_pvacseq, epitope_config=epitope_config)
+        ranking_predictions = epitopes_after_dsl_filter(predictions)
         ranked, dna_vaf_by_variant = ranked_from_pvacseq_predictions(
-            predictions, args.input_pvacseq,
+            ranking_predictions, args.input_pvacseq,
             genome=getattr(args, 'genome', None))
         patient_info = patient_info_from_external(
             ranked, args.input_pvacseq, patient_id,

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -1399,7 +1399,7 @@ def patient_info_from_external(ranked, source_path, patient_id,
     )
 
 
-def load_external_ranked(args):
+def load_external_ranked(args, epitope_config=None):
     """Dispatch helper: load LENS / pVACseq based on args, return
     ``(ranked, report_df, predictions, patient_info)`` or ``None`` if
     neither flag is set.
@@ -1407,12 +1407,17 @@ def load_external_ranked(args):
     ``patient_info`` carries the variant-count metadata template
     reports (ASCII / HTML / PDF) need; counts are proxies derived
     from the ranked output (see :func:`patient_info_from_external`).
+
+    ``epitope_config`` is evaluated by the selected loader before vaccine
+    peptides are constructed, so ranking and template reports consume the
+    configured DSL scores rather than the default affinity score.
     """
     from .epitope_io import load_lens, load_pvacseq
     patient_id = getattr(args, 'output_patient_id', '') or ''
     vaccine_peptide_length = getattr(args, 'vaccine_peptide_length', None) or 25
     if getattr(args, 'input_lens', None):
-        report_df, predictions = load_lens(args.input_lens)
+        report_df, predictions = load_lens(
+            args.input_lens, epitope_config=epitope_config)
         ranked, dna_vaf_by_variant = ranked_from_lens_predictions(
             predictions, args.input_lens,
             genome=getattr(args, 'genome', None),
@@ -1424,7 +1429,8 @@ def load_external_ranked(args):
         return (ranked, report_df, predictions, patient_info,
                 dna_vaf_by_variant)
     if getattr(args, 'input_pvacseq', None):
-        report_df, predictions = load_pvacseq(args.input_pvacseq)
+        report_df, predictions = load_pvacseq(
+            args.input_pvacseq, epitope_config=epitope_config)
         ranked, dna_vaf_by_variant = ranked_from_pvacseq_predictions(
             predictions, args.input_pvacseq,
             genome=getattr(args, 'genome', None))

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -44,7 +44,7 @@ import os
 import pandas as pd
 
 from .amino_acids import has_only_standard_amino_acids
-from .epitope_io import detect_lens_predictors
+from .epitope_io import detect_lens_predictors, lens_epitope_position
 from .mutant_protein_fragment import MutantProteinFragment
 from .vaccine_library import truncate_at_stop_codon
 from .vaccine_peptide import VaccinePeptide
@@ -601,7 +601,7 @@ def _read_counts_from_lens_row(row):
     return n_total, n_alt_reads, n_ref_reads, n_alt_supporting_protein
 
 
-def _lens_ranked_entry(coords, group_rows, by_peptide, genome,
+def _lens_ranked_entry(coords, group_rows, by_position, genome,
                        vaccine_peptide_length, affinity_cols, rank_cols,
                        num_target_epitopes_to_keep):
     """Build one variant's :class:`ExternalVariantEntry` from a LENS
@@ -722,15 +722,16 @@ def _lens_ranked_entry(coords, group_rows, by_peptide, genome,
 
     # Collect the variant's CandidateEpitopes (deduped on identity); LENS
     # rows are mutant-derived, so every one overlaps the mutation.
-    seen_peptides = set()
+    seen_positions = set()
     seen_epitope_ids = set()
     variant_epitopes = []
     for r in group_rows:
-        pep = r.get('peptide') or ""
-        if not pep or pep in seen_peptides:
+        position = lens_epitope_position(
+            r.get('peptide'), r.get('pep_context'))
+        if position is None or position in seen_positions:
             continue
-        seen_peptides.add(pep)
-        for e in by_peptide.get(pep, []):
+        seen_positions.add(position)
+        for e in by_position.get(position, []):
             if id(e) in seen_epitope_ids:
                 continue
             seen_epitope_ids.add(id(e))
@@ -817,14 +818,13 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
             "a predictor that emits pMHC affinity (e.g. mhcflurry, "
             "netmhcpan-ba).", kinds)
 
-    # Index epitopes by their mutant peptide sequence so we can attach
-    # the right CandidateEpitope(s) to each candidate vaccine peptide. One
-    # peptide can map to multiple Epitopes when the same sequence
-    # appears with different source contexts / offsets across
-    # variants — we'll filter by (peptide, allele) presence below.
-    by_peptide: dict[str, list] = {}
+    # Index by the complete CandidateEpitope position identity. Peptide
+    # sequence alone is insufficient: the same sequence can occur in
+    # different source contexts whose DSL filter outcomes differ.
+    by_position: dict[tuple[str, str, int], list] = {}
     for e in epitopes:
-        by_peptide.setdefault(e.sequence, []).append(e)
+        position = (e.sequence, e.source_sequence, e.offset)
+        by_position.setdefault(position, []).append(e)
 
     # Group rows by variant. LENS uses lowercase snake_case columns.
     rows = df.to_dict('records')
@@ -916,8 +916,15 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
     # the report's "DNA VAF" field gets populated instead of "n/a".
     dna_vaf_by_variant = {}
     for coords, group_rows in groups.items():
+        eligible_rows = [
+            row for row in group_rows
+            if lens_epitope_position(
+                row.get('peptide'), row.get('pep_context')) in by_position
+        ]
+        if not eligible_rows:
+            continue
         entry = _lens_ranked_entry(
-            coords, group_rows, by_peptide, genome, vaccine_peptide_length,
+            coords, eligible_rows, by_position, genome, vaccine_peptide_length,
             affinity_cols, rank_cols, num_target_epitopes_to_keep)
         if entry.unparseable:
             n_unparseable += 1
@@ -1039,7 +1046,7 @@ def ranked_from_lens_predictions(epitopes, lens_tsv_path, genome=None,
         "LENS load funnel: %s" % os.path.basename(lens_tsv_path),
         "  %d rows in: %s" % (len(rows), breakdown or '(none)'),
         "  → %d candidate epitopes eligible for construct ranking after "
-        "epitope DSL filtering" % len(epitopes),
+        "epitope DSL filtering and the minimum-score gate" % len(epitopes),
         "  → %d row(s) with genomic variant_coords (%s) → %d unique "
         "variant(s) → %d ranked with vaccine peptide(s) for constructs" % (
             n_coord_rows, coord_breakdown, len(groups), n_variants_ranked),
@@ -1411,16 +1418,18 @@ def load_external_ranked(args, epitope_config=None):
 
     The returned ``predictions`` collection retains every loaded input group
     for audit reports and patient-genotype inference. ``ranked`` is built from
-    separate copies narrowed to the groups retained by the Topiary filter.
+    separate copies narrowed to groups retained by the Topiary filter and
+    meeting the configured minimum epitope score.
     """
-    from .epitope_dsl import epitopes_after_dsl_filter
+    from .epitope_dsl import epitopes_for_ranking
     from .epitope_io import load_lens, load_pvacseq
     patient_id = getattr(args, 'output_patient_id', '') or ''
     vaccine_peptide_length = getattr(args, 'vaccine_peptide_length', None) or 25
     if getattr(args, 'input_lens', None):
         report_df, predictions = load_lens(
             args.input_lens, epitope_config=epitope_config)
-        ranking_predictions = epitopes_after_dsl_filter(predictions)
+        ranking_predictions = epitopes_for_ranking(
+            predictions, epitope_config)
         ranked, dna_vaf_by_variant = ranked_from_lens_predictions(
             ranking_predictions, args.input_lens,
             genome=getattr(args, 'genome', None),
@@ -1434,7 +1443,8 @@ def load_external_ranked(args, epitope_config=None):
     if getattr(args, 'input_pvacseq', None):
         report_df, predictions = load_pvacseq(
             args.input_pvacseq, epitope_config=epitope_config)
-        ranking_predictions = epitopes_after_dsl_filter(predictions)
+        ranking_predictions = epitopes_for_ranking(
+            predictions, epitope_config)
         ranked, dna_vaf_by_variant = ranked_from_pvacseq_predictions(
             ranking_predictions, args.input_pvacseq,
             genome=getattr(args, 'genome', None))

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -889,7 +889,7 @@ def lens_ranking_result(report, epitopes, genome=None, options=None):
         already pair every source row with the identity derived from it, so
         no row is re-read and no identity is re-derived here.
     epitopes : list of CandidateEpitope
-        Output of ``load_lens(path)``. Each CandidateEpitope groups all
+        Output of ``read_lens_report(path)``. Each CandidateEpitope groups all
         per-(allele, predictor) ``mhctools.Prediction`` records for
         one ``(peptide, source_sequence, offset)`` position.
     genome : varcode-compatible genome reference, optional
@@ -1003,7 +1003,7 @@ def lens_ranking_result(report, epitopes, genome=None, options=None):
 
     # Per-load summary of missing essential / important per-row data.
     # Essential = blocked the row (already counted as "skipped" above
-    # or in load_lens itself). Important-but-recoverable = warns so
+    # or in the reader itself). Important-but-recoverable = warns so
     # users know what's degraded.
     n_no_pep_context = sum(
         1 for r in rows

--- a/vaxrank/external_prediction.py
+++ b/vaxrank/external_prediction.py
@@ -1,0 +1,231 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stable identities for prediction records imported from external tools.
+
+External reports routinely contain the same peptide and flanking sequence for
+different variants, genes, or transcripts. Sequence position is therefore not
+an identity. :class:`ExternalPredictionKey` is the public join key shared by
+loading, Topiary evaluation, audit reports, native exports, and construct
+selection. Its JSON representation is deterministic, human-readable, and
+round-trippable without access to the original report.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+
+import pandas as pd
+
+
+def external_text(value) -> str:
+    """Return a normalized external-report cell as text or ``""``."""
+    if value is None:
+        return ""
+    try:
+        if pd.isna(value):
+            return ""
+    except (TypeError, ValueError):
+        pass
+    text = str(value).strip()
+    if text.lower() in {"", "na", "nan", "none"}:
+        return ""
+    return text
+
+
+def external_values(*values) -> tuple[str, ...]:
+    """Return the sorted unique comma/semicolon-delimited cell values."""
+    result = set()
+    for value in values:
+        text = external_text(value)
+        if not text:
+            continue
+        for comma_part in text.split(","):
+            for part in comma_part.split(";"):
+                normalized = part.strip()
+                if normalized:
+                    result.add(normalized)
+    return tuple(sorted(result))
+
+
+def pvacseq_variant_id(row) -> str:
+    """Return one stable variant identifier from either pVACseq flavor."""
+    existing = external_text(row.get("variant")) or external_text(row.get("ID"))
+    if existing:
+        return existing
+    chrom = external_text(row.get("Chromosome"))
+    start = external_text(row.get("Start"))
+    ref = external_text(row.get("Reference"))
+    alt = external_text(row.get("Variant"))
+    if all((chrom, start, ref, alt)):
+        return f"{chrom}-{start}-{ref}-{alt}"
+    return external_text(row.get("Index"))
+
+
+def lens_variant_id(row) -> str:
+    """Return a LENS variant identity including alleles when available."""
+    coords = external_text(row.get("variant_coords"))
+    ref = (
+        external_text(row.get("snv_ref_allele"))
+        or external_text(row.get("indel_ref_allele"))
+    )
+    alt = (
+        external_text(row.get("snv_alt_allele"))
+        or external_text(row.get("indel_alt_allele"))
+    )
+    if ref or alt:
+        return f"{coords}:{ref}>{alt}"
+    return coords
+
+
+@dataclass(frozen=True)
+class ExternalPredictionKey:
+    """Complete provenance and peptide position for one score group.
+
+    Allele and predictor are deliberately absent: they are leaves within one
+    candidate score group. Variant, gene, transcript, source context, peptide,
+    and offset are present because none of those fields is individually unique.
+    """
+
+    source_format: str
+    schema_version: int = 1
+    variant_id: str = ""
+    antigen_source: str = ""
+    gene_ids: tuple[str, ...] = ()
+    gene_names: tuple[str, ...] = ()
+    transcript_ids: tuple[str, ...] = ()
+    species: str = ""
+    peptide: str = ""
+    source_sequence: str = ""
+    offset: int = 0
+
+    def __post_init__(self):
+        if not self.source_format:
+            raise ValueError("External prediction source format is required")
+        if self.schema_version != 1:
+            raise ValueError(
+                f"Unsupported external prediction schema {self.schema_version}")
+        if not self.peptide:
+            raise ValueError("External prediction peptide is required")
+        if self.offset < 0:
+            raise ValueError("External prediction offset cannot be negative")
+        for name in ("gene_ids", "gene_names", "transcript_ids"):
+            values = tuple(sorted(set(getattr(self, name))))
+            object.__setattr__(self, name, values)
+
+    def payload(self, include_position=True) -> dict:
+        """Return the canonical JSON-compatible identity fields."""
+        result = asdict(self)
+        if not include_position:
+            result.pop("peptide")
+            result.pop("offset")
+        return result
+
+    @property
+    def identifier(self) -> str:
+        """Canonical, externally legible prediction-group identifier."""
+        return json.dumps(
+            self.payload(), sort_keys=True, separators=(",", ":"))
+
+    @property
+    def construct_identifier(self) -> str:
+        """Identity of the source context used to build one construct.
+
+        Multiple candidate epitopes from the same source window share this
+        value. The peptide and offset are omitted while all biological source
+        provenance remains.
+        """
+        return json.dumps(
+            self.payload(include_position=False),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @classmethod
+    def from_identifier(cls, identifier: str) -> "ExternalPredictionKey":
+        """Reconstruct a key from :attr:`identifier`."""
+        payload = json.loads(identifier)
+        for name in ("gene_ids", "gene_names", "transcript_ids"):
+            payload[name] = tuple(payload.get(name) or ())
+        return cls(**payload)
+
+    @classmethod
+    def from_lens_row(cls, row) -> "ExternalPredictionKey | None":
+        """Build the exact score-group key for one raw LENS row."""
+        peptide = external_text(row.get("peptide"))
+        source_sequence = external_text(row.get("pep_context"))
+        if not peptide:
+            return None
+        if source_sequence:
+            offset = source_sequence.find(peptide)
+            if offset < 0:
+                return None
+        else:
+            source_sequence = peptide
+            offset = 0
+        return cls(
+            source_format="lens",
+            variant_id=lens_variant_id(row),
+            antigen_source=external_text(row.get("antigen_source")),
+            gene_ids=external_values(
+                row.get("gene_id"),
+                row.get("all_gene_ids_encoding_peptide"),
+            ),
+            gene_names=external_values(
+                row.get("gene_name"),
+                row.get("all_gene_names_encoding_peptide"),
+            ),
+            transcript_ids=external_values(
+                row.get("transcript_id"),
+                row.get("all_transcript_ids_encoding_peptide"),
+            ),
+            species=external_text(row.get("species")),
+            peptide=peptide,
+            source_sequence=source_sequence,
+            offset=offset,
+        )
+
+    @classmethod
+    def from_pvacseq_row(cls, row) -> "ExternalPredictionKey | None":
+        """Build the exact score-group key for either pVACseq flavor."""
+        peptide = (
+            external_text(row.get("peptide"))
+            or external_text(row.get("Best Peptide"))
+            or external_text(row.get("MT Epitope Seq"))
+        )
+        if not peptide:
+            return None
+        offset_text = external_text(row.get("peptide_offset"))
+        try:
+            offset = int(float(offset_text)) if offset_text else 0
+        except ValueError:
+            offset = 0
+        return cls(
+            source_format="pvacseq",
+            variant_id=pvacseq_variant_id(row),
+            # The aggregated and all-epitopes readers do not expose effect
+            # type consistently. Variant/gene/transcript carry the stable
+            # provenance; effect remains a report annotation, not identity.
+            antigen_source="",
+            gene_names=external_values(
+                row.get("gene"), row.get("Gene"), row.get("Gene Name")),
+            transcript_ids=external_values(
+                row.get("transcript"),
+                row.get("Best Transcript"),
+                row.get("Transcript"),
+            ),
+            species=external_text(row.get("species")),
+            peptide=peptide,
+            source_sequence=peptide,
+            offset=offset,
+        )

--- a/vaxrank/external_prediction.py
+++ b/vaxrank/external_prediction.py
@@ -34,6 +34,15 @@ external_text = cells.text
 external_values = cells.values
 
 
+# pVACseq's two flavors spell the same fact differently; topiary normalizes
+# both onto one of these names. Rows only ever reach this module already
+# normalized, so the raw pVACseq spellings are deliberately absent — listing
+# them would imply a second vocabulary is still in play here.
+_PVACSEQ_RNA_DEPTH_COLUMNS = ("rna_depth", "tumor_rna_depth")
+_PVACSEQ_RNA_VAF_COLUMNS = ("rna_vaf", "tumor_rna_vaf")
+_PVACSEQ_DNA_VAF_COLUMNS = ("dna_vaf", "tumor_dna_vaf")
+
+
 def pvacseq_variant_id(row) -> str:
     """Return one stable variant identifier from either pVACseq flavor.
 
@@ -91,6 +100,13 @@ class ExternalPredictionKey:
     gene_ids: tuple[str, ...] = ()
     gene_names: tuple[str, ...] = ()
     transcript_ids: tuple[str, ...] = ()
+    # The row's own gene / transcript, before the multi-value columns are
+    # folded in. The sets above are sorted so that two rows listing the same
+    # genes in different orders resolve to one identity — which makes
+    # ``gene_names[0]`` alphabetical, not primary. Anything labelling a
+    # construct must use these instead.
+    primary_gene_name: str = ""
+    primary_transcript_id: str = ""
     species: str = ""
     peptide: str = ""
     source_sequence: str = ""
@@ -120,13 +136,36 @@ class ExternalPredictionKey:
             values = tuple(sorted(set(getattr(self, name))))
             object.__setattr__(self, name, values)
 
+    # Annotation carried alongside the key but deliberately outside its
+    # identity. Which gene a report *named first* for a row is presentation,
+    # not biology: two rows listing the same genes in different orders
+    # describe the same candidate, and folding order into the identity would
+    # split them — the exact fragility the sorted sets above prevent.
+    NON_IDENTITY_FIELDS = ("primary_gene_name", "primary_transcript_id")
+
     def payload(self, include_position=True) -> dict:
         """Return the canonical JSON-compatible identity fields."""
         result = asdict(self)
+        for name in self.NON_IDENTITY_FIELDS:
+            result.pop(name, None)
         if not include_position:
             result.pop("peptide")
             result.pop("offset")
         return result
+
+    @property
+    def ordered_transcript_ids(self) -> tuple[str, ...]:
+        """Transcript IDs with the row's own first.
+
+        ``transcript_ids`` is sorted for identity stability, so its first
+        element is alphabetical. Anything that treats one transcript as
+        representative — construct annotation, varcode cross-checks — wants
+        the one the report actually named for this row.
+        """
+        if not self.primary_transcript_id:
+            return self.transcript_ids
+        return (self.primary_transcript_id,) + tuple(
+            t for t in self.transcript_ids if t != self.primary_transcript_id)
 
     @property
     def identifier(self) -> str:
@@ -150,7 +189,12 @@ class ExternalPredictionKey:
 
     @classmethod
     def from_identifier(cls, identifier: str) -> "ExternalPredictionKey":
-        """Reconstruct a key from :attr:`identifier`."""
+        """Reconstruct a key from :attr:`identifier`.
+
+        The annotation fields in :data:`NON_IDENTITY_FIELDS` are absent from
+        the identifier by design, so a reconstructed key carries the identity
+        but not the report's own naming order.
+        """
         payload = json.loads(identifier)
         for name in ("gene_ids", "gene_names", "transcript_ids"):
             payload[name] = tuple(payload.get(name) or ())
@@ -186,6 +230,8 @@ class ExternalPredictionKey:
                 row.get("transcript_id"),
                 row.get("all_transcript_ids_encoding_peptide"),
             ),
+            primary_gene_name=cells.text(row.get("gene_name")),
+            primary_transcript_id=cells.text(row.get("transcript_id")),
             species=external_text(row.get("species")),
             peptide=peptide,
             source_sequence=source_sequence,
@@ -202,7 +248,6 @@ class ExternalPredictionKey:
         )
         if not peptide:
             return None
-        offset = cells.integer(row.get("peptide_offset"), default=0)
         return cls(
             source_format="pvacseq",
             variant_id=pvacseq_variant_id(row),
@@ -217,8 +262,19 @@ class ExternalPredictionKey:
                 row.get("Best Transcript"),
                 row.get("Transcript"),
             ),
+            primary_gene_name=cells.first_text(
+                row, "gene", "Gene", "Gene Name"),
+            primary_transcript_id=cells.first_text(
+                row, "transcript", "Best Transcript", "Transcript"),
             species=external_text(row.get("species")),
             peptide=peptide,
+            # pVACseq ships no source-protein context, so the peptide is its
+            # own window and its offset within that window is 0 by
+            # definition. Carrying a source-protein offset here instead would
+            # describe the peptide as sitting partway inside itself, which
+            # the position invariant rejects — and rejecting it mid-load
+            # would take down the whole run, where every other malformed-row
+            # case skips the row.
             source_sequence=peptide,
-            offset=offset,
+            offset=0,
         )

--- a/vaxrank/external_prediction.py
+++ b/vaxrank/external_prediction.py
@@ -25,51 +25,38 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 import json
 
-import pandas as pd
+from . import cells
 
-
-def external_text(value) -> str:
-    """Return a normalized external-report cell as text or ``""``."""
-    if value is None:
-        return ""
-    try:
-        if pd.isna(value):
-            return ""
-    except (TypeError, ValueError):
-        pass
-    text = str(value).strip()
-    if text.lower() in {"", "na", "nan", "none"}:
-        return ""
-    return text
-
-
-def external_values(*values) -> tuple[str, ...]:
-    """Return the sorted unique comma/semicolon-delimited cell values."""
-    result = set()
-    for value in values:
-        text = external_text(value)
-        if not text:
-            continue
-        for comma_part in text.split(","):
-            for part in comma_part.split(";"):
-                normalized = part.strip()
-                if normalized:
-                    result.add(normalized)
-    return tuple(sorted(result))
+# Re-exported under their historical names. :mod:`vaxrank.cells` is the one
+# normalization vocabulary; these aliases exist so the many external-report
+# call sites keep reading in the domain's language.
+external_text = cells.text
+external_values = cells.values
 
 
 def pvacseq_variant_id(row) -> str:
-    """Return one stable variant identifier from either pVACseq flavor."""
-    existing = external_text(row.get("variant")) or external_text(row.get("ID"))
-    if existing:
-        return existing
-    chrom = external_text(row.get("Chromosome"))
-    start = external_text(row.get("Start"))
-    ref = external_text(row.get("Reference"))
-    alt = external_text(row.get("Variant"))
+    """Return one stable variant identifier from either pVACseq flavor.
+
+    Precedence is **not** arbitrary: it mirrors ``topiary.read_pvacseq``,
+    which prefers pVACseq's own ``Index`` when the column exists and only
+    falls back to composing ``chrom-start-ref-alt`` when it does not. A reader
+    that chose coordinates first would build identities that never join
+    against topiary-normalized ones for any file carrying both.
+
+    ``variant`` / ``ID`` come first because those are the already-normalized
+    spellings (topiary's output column and pVACseq's aggregated-flavor column
+    respectively); they carry the same value ``Index`` would have produced.
+    """
+    normalized = cells.first_text(row, "variant", "ID", "Index")
+    if normalized:
+        return normalized
+    chrom = cells.text(row.get("Chromosome"))
+    start = cells.text(row.get("Start"))
+    ref = cells.text(row.get("Reference"))
+    alt = cells.text(row.get("Variant"))
     if all((chrom, start, ref, alt)):
         return f"{chrom}-{start}-{ref}-{alt}"
-    return external_text(row.get("Index"))
+    return ""
 
 
 def lens_variant_id(row) -> str:
@@ -119,6 +106,16 @@ class ExternalPredictionKey:
             raise ValueError("External prediction peptide is required")
         if self.offset < 0:
             raise ValueError("External prediction offset cannot be negative")
+        # The key is only a usable join target if its position fields describe
+        # a real position. Enforcing it here means every producer is held to
+        # the same invariant instead of each one re-checking (or forgetting).
+        if self.source_sequence:
+            window = self.source_sequence[
+                self.offset:self.offset + len(self.peptide)]
+            if window != self.peptide:
+                raise ValueError(
+                    "External prediction peptide %r is not at offset %d of "
+                    "its source sequence" % (self.peptide, self.offset))
         for name in ("gene_ids", "gene_names", "transcript_ids"):
             values = tuple(sorted(set(getattr(self, name))))
             object.__setattr__(self, name, values)
@@ -205,11 +202,7 @@ class ExternalPredictionKey:
         )
         if not peptide:
             return None
-        offset_text = external_text(row.get("peptide_offset"))
-        try:
-            offset = int(float(offset_text)) if offset_text else 0
-        except ValueError:
-            offset = 0
+        offset = cells.integer(row.get("peptide_offset"), default=0)
         return cls(
             source_format="pvacseq",
             variant_id=pvacseq_variant_id(row),

--- a/vaxrank/external_report.py
+++ b/vaxrank/external_report.py
@@ -79,11 +79,6 @@ class ExternalReport:
     records: tuple = ()
     rows: tuple = ()
 
-    @property
-    def loaded(self):
-        """Back-compat view matching the historical loader return shape."""
-        return self.report_df, list(self.epitopes)
-
     def records_with_epitopes(self, epitopes):
         """Bind *epitopes* to the records whose identity selected them.
 

--- a/vaxrank/external_report.py
+++ b/vaxrank/external_report.py
@@ -1,0 +1,107 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One parse of an external report, shared by every downstream consumer.
+
+An external report is read exactly once. That read produces four things that
+must agree with each other:
+
+``report_df``  the user-facing per-(peptide, allele) neoepitope table
+``epitopes``   grouped, DSL-scored :class:`CandidateEpitope` objects
+``records``    every source row paired with the identity derived from it
+``rows``       the source rows themselves, for format-specific evidence
+
+The ``records`` list is what makes the rest safe. Construct ranking used to
+re-read the report from disk and re-derive each row's
+:class:`ExternalPredictionKey` from a *different* column vocabulary than the
+loader had used; whenever the two derivations disagreed — a pVACseq file
+carrying both ``Index`` and genomic coordinates, a LENS ``pep_context`` with a
+stray trailing space — the join silently produced zero rows and the run
+emitted no vaccine peptides. Deriving the identity once and carrying it
+forward removes that entire class of failure by construction: there is no
+second derivation left to disagree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from .external_prediction import ExternalPredictionKey
+
+# Column added to a normalized row when the source file carried real genomic
+# coordinates that the normalization step did not preserve. It is deliberately
+# separate from the row's *identity*: the two answer different questions and
+# conflating them is what makes a report load but rank nothing.
+GENOMIC_VARIANT_COLUMN = "vaxrank_genomic_variant"
+
+
+@dataclass(frozen=True)
+class ExternalRecord:
+    """One source row of an external report and the identity it produced.
+
+    ``row`` is the row the identity was derived from, kept so format-specific
+    evidence (read counts, VAFs, alleles, expression) stays reachable without
+    a second pass over the file. ``epitope`` is attached later, once the DSL
+    has decided which candidates are eligible for ranking.
+    """
+
+    key: ExternalPredictionKey
+    row: dict
+    epitope: object = None
+
+    def with_epitope(self, epitope) -> "ExternalRecord":
+        """Return a copy bound to a scored candidate epitope."""
+        return ExternalRecord(key=self.key, row=self.row, epitope=epitope)
+
+
+@dataclass(frozen=True)
+class ExternalReport:
+    """Everything one read of an external report produced."""
+
+    source_format: str
+    path: str
+    report_df: pd.DataFrame = field(default_factory=pd.DataFrame)
+    epitopes: tuple = ()
+    records: tuple = ()
+    rows: tuple = ()
+
+    @property
+    def loaded(self):
+        """Back-compat view matching the historical loader return shape."""
+        return self.report_df, list(self.epitopes)
+
+    def records_with_epitopes(self, epitopes):
+        """Bind *epitopes* to the records whose identity selected them.
+
+        *epitopes* is the ranking-eligible subset (post-DSL-filter,
+        post-``min_epitope_score``). Records whose identity is absent from it
+        are dropped: their candidate did not survive scoring, so they carry no
+        evidence a construct may be built from.
+        """
+        by_id = {}
+        for epitope in epitopes:
+            if not epitope.prediction_id:
+                raise ValueError(
+                    "External construct ranking requires prediction "
+                    "provenance")
+            if epitope.prediction_id in by_id:
+                raise ValueError(
+                    "Duplicate external prediction identity after loading")
+            by_id[epitope.prediction_id] = epitope
+        bound = []
+        for record in self.records:
+            epitope = by_id.get(record.key.identifier)
+            if epitope is not None:
+                bound.append(record.with_epitope(epitope))
+        return tuple(bound)

--- a/vaxrank/external_report.py
+++ b/vaxrank/external_report.py
@@ -33,6 +33,7 @@ second derivation left to disagree.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 
 import pandas as pd
@@ -44,6 +45,8 @@ from .external_prediction import ExternalPredictionKey
 # separate from the row's *identity*: the two answer different questions and
 # conflating them is what makes a report load but rank nothing.
 GENOMIC_VARIANT_COLUMN = "vaxrank_genomic_variant"
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -94,14 +97,39 @@ class ExternalReport:
             if not epitope.prediction_id:
                 raise ValueError(
                     "External construct ranking requires prediction "
-                    "provenance")
+                    "provenance, but the candidate for peptide %r in %s "
+                    "carries none. Candidates must come from a %s reader, "
+                    "not be constructed directly."
+                    % (epitope.sequence, self.path, self.source_format))
             if epitope.prediction_id in by_id:
+                # Reachable only if two candidates normalized to one identity
+                # while grouping kept them apart — i.e. a reader is using a
+                # different vocabulary for the identity than for the group
+                # key. Name both so the offending field is findable.
+                other = by_id[epitope.prediction_id]
                 raise ValueError(
-                    "Duplicate external prediction identity after loading")
+                    "Two %s candidates share prediction identity %s but were "
+                    "grouped separately: %r at offset %d of %r, and %r at "
+                    "offset %d of %r. The reader is normalizing the identity "
+                    "and the grouping key differently."
+                    % (self.source_format, epitope.prediction_id,
+                       other.sequence, other.offset, other.source_sequence,
+                       epitope.sequence, epitope.offset,
+                       epitope.source_sequence))
             by_id[epitope.prediction_id] = epitope
         bound = []
         for record in self.records:
             epitope = by_id.get(record.key.identifier)
             if epitope is not None:
                 bound.append(record.with_epitope(epitope))
+        if epitopes and not bound:
+            # Every candidate was eligible and none joined: the identities the
+            # reader produced do not match the identities on the candidates.
+            # Silence here is what F1 looked like in production.
+            logger.warning(
+                "None of the %d ranking-eligible %s candidate(s) matched a "
+                "row of %s, so this input will produce no vaccine peptides. "
+                "This means prediction identities were derived inconsistently "
+                "— it is a bug, not a property of the data.",
+                len(epitopes), self.source_format, self.path)
         return tuple(bound)

--- a/vaxrank/processing.py
+++ b/vaxrank/processing.py
@@ -308,7 +308,7 @@ def annotate_processing(epitopes, predictor=None,
             n_annotated, len(epitopes_list), len(by_source))
     if n_skipped_peptide_not_in_context:
         # LENS-import mismatches are already dropped at load
-        # (epitope_io.load_lens); reaching here means a pipeline-path
+        # (epitope_io.read_lens_report); reaching here means a pipeline-path
         # peptide wasn't locatable in its source, which is unexpected.
         ex_peptide, ex_source = skipped_examples[0]
         logger.warning(

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -57,34 +57,50 @@ class EpitopeReportRowInput:
 def epitope_report_row_inputs(epitope):
     """Return explicit row inputs for a candidate's template table.
 
-    Affinity predictions remain the preferred row anchors. When affinity is
-    absent, presentation predictions anchor rows instead. A candidate with
-    only allele-independent processing evidence emits one row per explicitly
-    retained patient allele without duplicating its canonical Prediction.
+    Select one anchor per ``(patient allele, predictor, version)``. Affinity
+    is preferred, followed by presentation, followed by allele-independent
+    processing for combinations not covered by either allele-specific kind.
+    This preserves every scored allele and predictor in mixed-evidence inputs
+    without duplicating the canonical processing Prediction.
     """
     predictions = epitope.predictions_flat()
+    row_inputs_by_key = {}
     for kind in ('pMHC_affinity', 'pMHC_presentation'):
-        kind_predictions = tuple(
-            prediction for prediction in predictions
-            if prediction.kind == kind)
-        if kind_predictions:
-            return tuple(
-                EpitopeReportRowInput(prediction, prediction.allele)
-                for prediction in kind_predictions)
+        for prediction in predictions:
+            if prediction.kind != kind:
+                continue
+            if not prediction.allele:
+                raise ValueError(
+                    f"{kind} report evidence requires a patient allele")
+            key = (
+                prediction.allele,
+                prediction.predictor_name,
+                prediction.predictor_version,
+            )
+            row_inputs_by_key.setdefault(
+                key,
+                EpitopeReportRowInput(prediction, prediction.allele),
+            )
 
     processing_predictions = tuple(
         prediction for prediction in predictions
         if prediction.kind == 'antigen_processing')
-    if not processing_predictions:
-        return ()
-    if not epitope.patient_alleles:
+    if processing_predictions and not epitope.patient_alleles:
         raise ValueError(
             "Cannot render allele-independent antigen-processing evidence "
             "without explicit patient alleles")
-    return tuple(
-        EpitopeReportRowInput(prediction, allele)
-        for prediction in processing_predictions
-        for allele in epitope.patient_alleles)
+    for prediction in processing_predictions:
+        for allele in epitope.patient_alleles:
+            key = (
+                allele,
+                prediction.predictor_name,
+                prediction.predictor_version,
+            )
+            row_inputs_by_key.setdefault(
+                key,
+                EpitopeReportRowInput(prediction, allele),
+            )
+    return tuple(row_inputs_by_key.values())
 
 
 class TemplateDataCreator(object):

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 from collections import OrderedDict
+from dataclasses import dataclass
 from importlib import import_module
 import logging
 import os
@@ -21,6 +22,7 @@ from astropy.io import ascii as asc
 import jinja2
 import pandas as pd
 import roman
+from mhctools.pred import Prediction
 from varcode import load_vcf_fast
 
 from .cancer_hotspots import get_hotspot_url
@@ -42,6 +44,47 @@ JINJA_ENVIRONMENT = jinja2.Environment(
     trim_blocks=True,
     lstrip_blocks=True,
 )
+
+
+@dataclass(frozen=True)
+class EpitopeReportRowInput:
+    """Prediction evidence and patient allele used for one report row."""
+
+    prediction: Prediction
+    allele: str
+
+
+def epitope_report_row_inputs(epitope):
+    """Return explicit row inputs for a candidate's template table.
+
+    Affinity predictions remain the preferred row anchors. When affinity is
+    absent, presentation predictions anchor rows instead. A candidate with
+    only allele-independent processing evidence emits one row per explicitly
+    retained patient allele without duplicating its canonical Prediction.
+    """
+    predictions = epitope.predictions_flat()
+    for kind in ('pMHC_affinity', 'pMHC_presentation'):
+        kind_predictions = tuple(
+            prediction for prediction in predictions
+            if prediction.kind == kind)
+        if kind_predictions:
+            return tuple(
+                EpitopeReportRowInput(prediction, prediction.allele)
+                for prediction in kind_predictions)
+
+    processing_predictions = tuple(
+        prediction for prediction in predictions
+        if prediction.kind == 'antigen_processing')
+    if not processing_predictions:
+        return ()
+    if not epitope.patient_alleles:
+        raise ValueError(
+            "Cannot render allele-independent antigen-processing evidence "
+            "without explicit patient alleles")
+    return tuple(
+        EpitopeReportRowInput(prediction, allele)
+        for prediction in processing_predictions
+        for allele in epitope.patient_alleles)
 
 
 class TemplateDataCreator(object):
@@ -363,15 +406,19 @@ class TemplateDataCreator(object):
         return None
 
     def epitope_data(self, epitope, prediction, include_processing=False,
-                     include_additional_prediction_axes=False):
+                     include_additional_prediction_axes=False, allele=None):
         """Returns an OrderedDict with epitope data for one
         (CandidateEpitope, mutant Prediction) row.
 
         One mutant ``CandidateEpitope`` carries N per-allele × per-predictor
-        ``mhctools.Prediction`` records. The report keeps the legacy
-        one-row-per-(peptide, allele, predictor) shape, so the caller
-        iterates over ``epitope.predictions_for('pMHC_affinity')``
-        and passes each leaf record here alongside its parent CandidateEpitope.
+        ``mhctools.Prediction`` records. The report keeps one row per explicit
+        :func:`epitope_report_row_inputs` result, using affinity as the
+        preferred anchor and presentation or processing when affinity is
+        absent.
+
+        ``allele`` defaults to ``prediction.allele``. Report rows anchored by
+        canonical allele-independent processing evidence pass an explicitly
+        retained patient allele here.
 
         ``include_processing``: when True, always emit the three
         proteasomal-cleavage credibility columns
@@ -399,8 +446,12 @@ class TemplateDataCreator(object):
         from the same predictor/version. Missing axes render as ``'—'``
         so mixed-predictor tables retain consistent columns.
         """
+        row_allele = prediction.allele if allele is None else allele
+        if not row_allele:
+            raise ValueError(
+                "Template epitope rows require an explicit patient allele")
         wt_ic50 = self._wt_ic50_for_allele(
-            epitope, prediction.allele, predictor=prediction.predictor_name)
+            epitope, row_allele, predictor=prediction.predictor_name)
         wt_ic50_str = _format_ic50(wt_ic50)
         ic50_str = _format_ic50(prediction.value)
         wt_peptide_sequence = (
@@ -423,9 +474,9 @@ class TemplateDataCreator(object):
             # from ``epitope.per_allele_scores`` — the single source
             # of truth — rather than recomputing from the raw IC50.
             ('Score',
-                _sanitize(epitope.per_allele_scores.get(
-                    prediction.allele, 0.0))),
-            ('Allele', prediction.allele.replace('HLA-', '')),
+                _sanitize(epitope.per_allele_scores[row_allele])
+                if row_allele in epitope.per_allele_scores else '—'),
+            ('Allele', row_allele.replace('HLA-', '')),
             ('WT sequence', wt_peptide_sequence),
             ('WT IC50', wt_ic50_str),
         ])
@@ -440,7 +491,7 @@ class TemplateDataCreator(object):
                     continue
                 if (
                     related.kind == 'pMHC_presentation'
-                    and related.allele == prediction.allele
+                    and related.allele == row_allele
                 ):
                     presentation = related
                 elif (
@@ -598,27 +649,22 @@ class TemplateDataCreator(object):
 
                 epitopes = []
                 wt_epitopes = []
-                # One report row per (CandidateEpitope, allele × predictor)
-                # leaf record. Keeps today's table shape: one row per
-                # (peptide, allele) in single-predictor runs; multiple
-                # rows per (peptide, allele) when multi-predictor data
-                # is in play (mhcflurry + netmhcpan), with the
-                # Predictor column distinguishing them.
-                def _affinity_leaves(e):
-                    return [
-                        p for p in e.predictions_flat()
-                        if p.kind == 'pMHC_affinity']
-
+                # One row per explicit report input. Affinity remains the
+                # preferred anchor; presentation-only and processing-only
+                # candidates still render rather than disappearing.
                 for e in vaccine_peptide.target_epitopes:
-                    for p in _affinity_leaves(e):
+                    for row_input in epitope_report_row_inputs(e):
                         epitopes.append(self.epitope_data(
-                            e, p,
+                            e, row_input.prediction,
                             include_processing=any_processing,
                             include_additional_prediction_axes=(
-                                any_additional_prediction_axes)))
+                                any_additional_prediction_axes),
+                            allele=row_input.allele))
 
                 for e in vaccine_peptide.self_epitopes:
-                    for p in _affinity_leaves(e):
+                    for p in e.predictions_flat():
+                        if p.kind != 'pMHC_affinity':
+                            continue
                         epitope_data = self.epitope_data(e, p)
                         key_list = ['Allele', 'IC50', 'Sequence']
                         wt_epitopes.append(

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -362,7 +362,8 @@ class TemplateDataCreator(object):
                 return p.value
         return None
 
-    def epitope_data(self, epitope, prediction, include_processing=False):
+    def epitope_data(self, epitope, prediction, include_processing=False,
+                     include_additional_prediction_axes=False):
         """Returns an OrderedDict with epitope data for one
         (CandidateEpitope, mutant Prediction) row.
 
@@ -392,6 +393,11 @@ class TemplateDataCreator(object):
         by ``(peptide, source, predictor_name)``. Pre-2.23 these
         lived as ``pepsickle_*`` attributes on the flat record
         itself; the join is the new contract (#272).
+
+        ``include_additional_prediction_axes`` appends presentation
+        score/percentile and integrated antigen-processing score leaves
+        from the same predictor/version. Missing axes render as ``'—'``
+        so mixed-predictor tables retain consistent columns.
         """
         wt_ic50 = self._wt_ic50_for_allele(
             epitope, prediction.allele, predictor=prediction.predictor_name)
@@ -423,6 +429,37 @@ class TemplateDataCreator(object):
             ('WT sequence', wt_peptide_sequence),
             ('WT IC50', wt_ic50_str),
         ])
+        if include_additional_prediction_axes:
+            presentation = None
+            antigen_processing = None
+            for related in epitope.predictions_flat():
+                if (
+                    related.predictor_name != prediction.predictor_name
+                    or related.predictor_version != prediction.predictor_version
+                ):
+                    continue
+                if (
+                    related.kind == 'pMHC_presentation'
+                    and related.allele == prediction.allele
+                ):
+                    presentation = related
+                elif (
+                    related.kind == 'antigen_processing'
+                    and not related.allele
+                ):
+                    antigen_processing = related
+            epitope_data['Presentation score'] = (
+                '%.3f' % presentation.score
+                if presentation is not None else '—')
+            epitope_data['Presentation %ile'] = (
+                '%.3f' % presentation.percentile_rank
+                if (
+                    presentation is not None
+                    and presentation.percentile_rank is not None
+                ) else '—')
+            epitope_data['Integrated processing score'] = (
+                '%.3f' % antigen_processing.score
+                if antigen_processing is not None else '—')
         if include_processing:
             # Column headers are predictor-agnostic ("Processing: …")
             # so a future per-position predictor (NetChop, PAProC)
@@ -553,6 +590,11 @@ class TemplateDataCreator(object):
                 any_processing = any(
                     _has_processing(e)
                     for e in vaccine_peptide.target_epitopes)
+                any_additional_prediction_axes = any(
+                    prediction.kind in {
+                        'pMHC_presentation', 'antigen_processing'}
+                    for epitope in vaccine_peptide.target_epitopes
+                    for prediction in epitope.predictions_flat())
 
                 epitopes = []
                 wt_epitopes = []
@@ -570,7 +612,10 @@ class TemplateDataCreator(object):
                 for e in vaccine_peptide.target_epitopes:
                     for p in _affinity_leaves(e):
                         epitopes.append(self.epitope_data(
-                            e, p, include_processing=any_processing))
+                            e, p,
+                            include_processing=any_processing,
+                            include_additional_prediction_axes=(
+                                any_additional_prediction_axes)))
 
                 for e in vaccine_peptide.self_epitopes:
                     for p in _affinity_leaves(e):

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.35"
+__version__ = "3.1.36"
 
 
 def print_version():

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.36"
+__version__ = "3.2.0"
 
 
 def print_version():


### PR DESCRIPTION
Started as "preserve LENS presentation/processing predictions" and grew well past it. What follows is what is actually in the branch.

## The thesis

Six of the defects below share one shape: **a single fact was derived in two places, and the two places were allowed to disagree.** A prediction's *identity* (what joins a row to a candidate), its *evidence* (what the tool measured), and its *position* (where the peptide sits in a sequence) are three different facts. The loader and the construct ranker each derived all three, from different column vocabularies, and nothing checked that they agreed. When they didn't, the join returned nothing and the run wrote zero vaccine peptides without an error.

## Defects fixed

Each reproduces on a small fixture and is pinned by a regression test.

**1. A pVACseq `all_epitopes` file with an `Index` column produced zero ranked vaccine peptides.** `topiary.read_pvacseq` normalizes `variant` from `Index` when that column exists, so the loader embedded it in every `prediction_id`; the raw re-read in `pvacseq_ranking_result` preferred genomic coordinates, so its identifiers never matched and every loaded epitope was discarded.

Making the precedence consistent is *not* sufficient — it fixes the join and the run still produces nothing, because `Index` (`GENE.ENST….missense.806E/V`) carries no coordinates and every group then drops as unparseable. Identity and genomic position are separate facts and now come from separate sources; `pvacseq_genomic_coordinates` recovers the coordinate columns topiary discards once `Index` wins.

**2. One trailing space in a LENS `pep_context` aborted the entire run.** `epitope_io._safe_str` did not strip whitespace; `external_prediction.external_text` did. One row became two identities and hit `ValueError: Duplicate external prediction identity after loading` — an internal invariant error naming no row, column, or file.

**3. Epitopes outside the construct window still scored it.** LENS `pep_context` is sometimes a 100+ aa protein prefix. `lens_vaccine_entry` trimmed it to an SLP window but never re-sliced its epitopes, so a neoepitope 60 residues from the mutation counted toward `target_epitope_score` (1.978 vs 0.991 in the fixture), rendered in the construct's report table, and competed for `num_target_epitopes_to_keep` — while being absent from the peptide that would be synthesized. Since construct ranking sorts on that score, external runs were ranked partly on evidence their constructs do not contain. `core_logic` already asserts this invariant on the VCF path.

**4. pVACseq epitopes stored a variant string in `source_sequence`.** Surfaced by (3): `CandidateEpitope.source_sequence` is an amino-acid window everywhere else, but held `chr1-154590262-T-A`. Nothing sliced it, so nothing noticed; the moment construct assembly did, it returned `'chr1-1545'` — a fragment of the variant's *name*.

**5. `vaccine_peptides:` config was silently ignored on every LENS and pVACseq run.** It was resolved only inside `run_vaxrank_from_parsed_args`, the pipeline-only entry point. Peptide length fell back to a hard-coded 25, `num_target_epitopes_to_keep` was never forwarded, and every external `VaccinePeptide` used the default combined-score expression and empty manufacturability thresholds. `external_input_arg_parser()` did not accept the flags either — they were rejected as unknown, not merely ineffective.

**6. A save/load cycle re-admitted held-out epitopes as vaccine targets.** `VAXRANK_COLUMNS` is hand-maintained against a dataclass that keeps gaining fields and had fallen four behind. Two are safety decisions that *fail open*: `overlaps_targetable` falls back to "targetable" when absent, `self_reference_match` to the raw reference boolean. Flanks (which drive processing predictors) and `source_name` were dropped too. `overlaps_targetable` is now tri-state so a blank cell reloads as "undecided", not `False`.

**7. A rounding difference in LENS processing scores aborted the load.** MHCflurry's processing score depends on peptide and flanks, not MHC, so LENS repeats it per allele row and the repeats should agree. Exact equality was required, making `0.80` vs `0.8001` fatal with nothing the operator could act on. Now: values within tolerance pass silently; a real difference keeps the first-seen value and is reported once with the peptide, predictor, and both values.

## The compatibility layer is gone

Nobody consumes these paths yet, so every back-compat branch was cost without a beneficiary — and two were actively wrong:

- `write_neoepitope_report` fell back to a `(peptide, allele)` join when a frame lacked identity columns, **broadcasting one source's score onto every row sharing a sequence** — exactly the merge `prediction_id` exists to prevent. A test pinned that broadcast; it now asserts two sources get two scores.
- `patient_info_from_external` derived input counts from post-filter `ranked` output, reporting design results under a header that claims input composition.

Also deleted: `ranked_from_lens_predictions` / `ranked_from_pvacseq_predictions` (the last place that re-read the file, so "one parse" is now literally true), `load_lens` / `load_pvacseq` / `ExternalReport.loaded`, `prediction_group_columns` returning `None`, the raw pVACseq column spellings, duplicate construct-config kwargs, and `predictions_to_dataframe`'s pre-3.0 dict input. topiary 5.17.1 retired two more: `filter_prediction_groups` and `drop_empty_sample_name`.

`parse_pvacseq_variant`'s dotted-ID form stays — that is compatibility with an old pVACtools output shape, not one of ours.

## Surface area

Line count went up (two new modules, and the shared abstractions carry their rationale). The number that matters is how many places must agree for the code to be correct:

| Concern | Before | After |
|---|---|---|
| Cell normalization | 4 vocabularies | 1 (`vaxrank.cells`) |
| Identity derivation per source | 2, from different columns | 1 |
| Reads of the source file | 2–3 per run | 1 + one documented coordinate recovery |
| Ways to load a report | 2 | 1 |
| Ways to rank constructs | 2 | 1 |
| Score-join strategies | 2 (identity, or sequence broadcast) | 1 |
| VaccinePeptide assembly | 3, one of which sliced its epitopes | 2, both slicing |
| `PatientInfo` tallies | 2 hand-maintained blocks + a fallback | 1, required |
| Topiary grouping wrappers | 2 | 0 |

## Topiary synchronization

Audited what topiary 5.18.1 accepts against what vaxrank passes:

- **`kind_support` was never forwarded.** `mhc_dependence` guards resolve from it when supplied and by scanning rows otherwise. The pipeline path holds the `TopiaryPredictor` that knows the answer and was making topiary guess — the same defect topiary fixed on its own `--filter-by` path (openvax/topiary#178).
- **The pipeline path left its group keys to inference** while the external path named them. What topiary infers has changed twice. `prediction_group_columns` now recognizes both shapes explicitly and refuses a frame carrying neither identity.

`requirements.txt` moves to `topiary>=5.17.1` — deleting `filter_prediction_groups` moved vaxrank onto `apply_filter(group_keys=…)`, which 5.16.x would `TypeError` on. Verified green on 5.17.1 and 5.18.1.

**`peptide_view()` is deliberately not adopted.** It broadcasts correctly when a peptide also has affinity rows, but two gaps remain, both silent: openvax/topiary#182 (a peptide whose only evidence is allele-free has one empty-allele group, so per-allele scores can't be produced and it scores 0 — reproducing #295's failure mode on LENS processing-only rows) and openvax/topiary#183 (an allele-free row is its own group, so any filter on an allele-scoped kind removes it and a later `peptide_view` reads NaN). A test pins the projection so it cannot be removed silently.

## Also

Closes #347 — `test_cta_admission` asserted an exact oncoref release, so a routine bump failed an unrelated test. `_patch_oncoref` already stubbed oncoref's data; it now stubs `__version__` too.

## Not in this branch

`--input-epitopes` (#346) is a feature and needs a design decision on whether it re-evaluates the DSL with the run's `--config` or trusts stored `per_allele_scores`. The `--output-epitopes` help text promised the flag; it now states what is true and names the issue.

Note for #295: its stated root cause is fixed, but the identical symptom had a **second, independent cause** — defect (1) above. A reproducer that still ranks nothing is not necessarily a regression.

## Verification

1040 passed, 1 skipped, ruff clean, on topiary 5.18.1. Version 3.1.36 → 3.2.0: external runs now honor config that previously did nothing, the native format gained four columns, scores no longer broadcast across sources, and the dependency floor moved.

History is deliberately split by concern — please don't squash.
