### PR TITLE
Make allele attribution of peptide-level evidence an explicit, recorded policy

### DIFF
--- a/tests/test_allele_evidence.py
+++ b/tests/test_allele_evidence.py
@@ -212,3 +212,96 @@ def test_attribution_requires_reconstructable_provenance():
         AlleleAttribution(
             allele="HLA-A*02:01", source=ALLELE_SOURCE_BROADCAST,
             rank_kind="pMHC_affinity")
+
+
+def test_predictor_is_chosen_by_coverage_unless_the_config_names_one():
+    """A predictor covering one allele must not silently reduce a top:3.
+
+    Preference order alone picked the canonical name even when it could rank
+    a single allele out of six — the same silent reduction as choosing the
+    axis by presence rather than coverage, arriving through a second door.
+    """
+    genotype = ["HLA-A*02:01", "HLA-B*07:02", "HLA-C*07:01"]
+    epitope = _epitope(
+        _affinity("HLA-A*02:01", 50.0, "mhcflurry"),      # covers 1
+        _affinity("HLA-A*02:01", 900.0, "netmhcpan"),     # covers 3
+        _affinity("HLA-B*07:02", 10.0, "netmhcpan"),
+        _affinity("HLA-C*07:01", 20.0, "netmhcpan"),
+        _processing(),
+        patient_alleles=tuple(genotype))
+
+    got = attribute_alleles(epitope, genotype, AllelePolicy.parse("top:3"))
+    assert [a.allele for a in got] == [
+        "HLA-B*07:02", "HLA-C*07:01", "HLA-A*02:01"]
+    assert {a.rank_predictor for a in got} == {"netmhcpan"}
+
+    # An explicit choice is the user's, and still wins over coverage.
+    named = attribute_alleles(
+        epitope, genotype, AllelePolicy.parse("top:3"),
+        default_methods={"pMHC_affinity": "mhcflurry"})
+    assert [(a.allele, a.rank_predictor) for a in named] == [
+        ("HLA-A*02:01", "mhcflurry")]
+
+
+def test_recorded_values_survive_serialization():
+    """Predictions from a pandas frame carry numpy scalars.
+
+    A recorded value has to round-trip to stay reconstructable, and the
+    serializer refuses numpy types outright, so the coercion happens where
+    the value is captured.
+    """
+    import numpy as np
+
+    from vaxrank.allele_evidence import AlleleAttribution
+
+    epitope = _epitope(
+        _affinity("HLA-A*02:01", np.float64(50.0)), _processing(),
+        patient_alleles=("HLA-A*02:01",))
+    [attribution] = attribute_alleles(
+        epitope, ["HLA-A*02:01"], AllelePolicy.parse("selected"))
+
+    assert type(attribution.rank_value) is float
+    assert AlleleAttribution.from_json(attribution.to_json()) == attribution
+
+
+def test_mhc_dependence_table_covers_every_topiary_kind():
+    """A new prediction kind must be classified, not silently un-attributable.
+
+    "Is this prediction allele-scoped?" used to be re-derived inline at four
+    call sites, two of them testing only for a blank allele — which is also
+    what a malformed row looks like. The table is the single answer, and it
+    is checked against topiary at import.
+    """
+    from topiary.ranking import KIND_ALIASES
+
+    from vaxrank.allele_evidence import (
+        ALLELE_SCOPED_KINDS, PEPTIDE_LEVEL_KINDS,
+    )
+
+    classified = PEPTIDE_LEVEL_KINDS | ALLELE_SCOPED_KINDS
+    assert not set(KIND_ALIASES.values()) - classified
+    # The two sets are a partition, not overlapping guesses.
+    assert not PEPTIDE_LEVEL_KINDS & ALLELE_SCOPED_KINDS
+
+
+def test_peptide_level_requires_both_the_kind_and_a_blank_allele():
+    """Neither half of the predicate is sufficient alone."""
+    from vaxrank.allele_evidence import is_allele_scoped, is_peptide_level
+
+    # Blank allele, but an allele-scoped kind: malformed, not peptide-level.
+    malformed = Prediction(
+        kind="pMHC_affinity", predictor_name="mhcflurry",
+        predictor_version="1", allele="", peptide="SIINFEKL",
+        value=50.0, score=0.0)
+    assert not is_peptide_level(malformed)
+    assert not is_allele_scoped(malformed)
+
+    # Peptide-level kind that already carries an allele: already attributed.
+    attributed = Prediction(
+        kind="antigen_processing", predictor_name="mhcflurry",
+        predictor_version="1", allele="HLA-A*02:01", peptide="SIINFEKL",
+        value=None, score=0.7)
+    assert not is_peptide_level(attributed)
+
+    assert is_peptide_level(_processing())
+    assert is_allele_scoped(_affinity("HLA-A*02:01", 50.0))

--- a/tests/test_allele_evidence.py
+++ b/tests/test_allele_evidence.py
@@ -279,7 +279,13 @@ def test_mhc_dependence_table_covers_every_topiary_kind():
     )
 
     classified = PEPTIDE_LEVEL_KINDS | ALLELE_SCOPED_KINDS
-    assert not set(KIND_ALIASES.values()) - classified
+    unclassified = sorted(set(KIND_ALIASES.values()) - classified)
+    # CI is where this drift should surface. At runtime an unclassified kind
+    # is treated as not peptide-level (never projected, so nothing is
+    # fabricated) and warned about, rather than refusing to import.
+    assert not unclassified, (
+        "topiary knows prediction kind(s) %s that vaxrank.allele_evidence "
+        "does not classify" % ", ".join(unclassified))
     # The two sets are a partition, not overlapping guesses.
     assert not PEPTIDE_LEVEL_KINDS & ALLELE_SCOPED_KINDS
 

--- a/tests/test_allele_evidence.py
+++ b/tests/test_allele_evidence.py
@@ -168,8 +168,9 @@ def test_only_peptide_level_kinds_are_attributed():
     from vaxrank.epitope_dsl import epitopes_to_topiary_df
 
     # An affinity prediction that lost its allele is malformed, not
-    # peptide-level. Projecting it invents binding evidence for alleles it
-    # was never predicted against.
+    # peptide-level. It is neither attributed nor carried through: see
+    # test_malformed_allele_scoped_predictions_never_reach_the_frame for why
+    # leaving it in the frame is unsafe.
     epitope = _epitope(
         Prediction(kind="pMHC_affinity", predictor_name="mhcflurry",
                    predictor_version="1", allele="", peptide="SIINFEKL",
@@ -177,7 +178,7 @@ def test_only_peptide_level_kinds_are_attributed():
         patient_alleles=("HLA-A*02:01", "HLA-B*07:02"))
     frame = epitopes_to_topiary_df(
         [epitope], policy=AllelePolicy.parse("all"))
-    assert list(frame["allele"]) == [""]
+    assert frame.empty
 
 
 def test_malformed_policies_are_rejected_where_they_are_written():
@@ -311,3 +312,54 @@ def test_peptide_level_requires_both_the_kind_and_a_blank_allele():
 
     assert is_peptide_level(_processing())
     assert is_allele_scoped(_affinity("HLA-A*02:01", 50.0))
+
+
+def test_malformed_allele_scoped_predictions_never_reach_the_frame(caplog):
+    """A blank-allele affinity row must not become per-allele evidence.
+
+    Topiary classifies a kind's MHC dependence by scanning the rows it is
+    given, so a candidate whose only affinity leaves carry no allele reads as
+    peptide-level and has its value projected across every allele group —
+    inventing a binding prediction for alleles the model never scored.
+    Verified live against topiary 5.21.0; openvax/topiary#197 fixes it
+    upstream, but vaxrank supports the whole >=5.17.1 range.
+    """
+    import logging
+
+    from topiary.ranking import EvalContext, parse
+
+    from vaxrank.epitope_dsl import (
+        PREDICTION_GROUP_COLUMNS, epitopes_to_topiary_df,
+    )
+
+    def stability(allele, value):
+        return Prediction(
+            kind="pMHC_stability", predictor_name="netmhcstabpan",
+            predictor_version="1", allele=allele, peptide="SIINFEKL",
+            value=value, score=0.0)
+
+    malformed = Prediction(
+        kind="pMHC_affinity", predictor_name="mhcflurry", predictor_version="1",
+        allele="", peptide="SIINFEKL", value=7.0, score=0.0)
+    epitope = _epitope(
+        malformed,
+        stability("HLA-A*02:01", 100.0), stability("HLA-B*07:02", 200.0),
+        patient_alleles=("HLA-A*02:01", "HLA-B*07:02"))
+
+    with caplog.at_level(logging.WARNING):
+        frame = epitopes_to_topiary_df([epitope])
+
+    # The malformed row is absent, and the drop is reported with enough to
+    # find it — a silent drop would be its own defect.
+    assert set(frame["kind"]) == {"pMHC_stability"}
+    warning = "\n".join(
+        record.getMessage() for record in caplog.records
+        if record.levelno >= logging.WARNING)
+    assert "no allele" in warning
+    assert "SIINFEKL" in warning and "pMHC_affinity" in warning
+
+    # And nothing invents an affinity for alleles that were never scored.
+    context = EvalContext(frame, group_keys=list(PREDICTION_GROUP_COLUMNS))
+    values = parse("affinity.value").eval(context).reindex(
+        context.group_index).tolist()
+    assert all(value != value for value in values)  # all NaN, not 7.0

--- a/tests/test_allele_evidence.py
+++ b/tests/test_allele_evidence.py
@@ -1,0 +1,214 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""Attribution of peptide-level evidence to MHC alleles."""
+
+import pytest
+from mhctools.pred import Prediction
+
+from vaxrank.allele_evidence import (
+    ALLELE_SOURCE_BROADCAST,
+    ALLELE_SOURCE_FROM_INPUT,
+    ALLELE_SOURCE_SELECTED,
+    AllelePolicy,
+    AllelePolicyError,
+    attribute_alleles,
+)
+from vaxrank.candidate_epitope import CandidateEpitope
+
+
+def _affinity(allele, ic50, predictor="mhcflurry"):
+    return Prediction(
+        kind="pMHC_affinity", predictor_name=predictor, predictor_version="1",
+        allele=allele, peptide="SIINFEKL", value=ic50, score=0.0)
+
+
+def _presentation(allele, score, predictor="mhcflurry"):
+    return Prediction(
+        kind="pMHC_presentation", predictor_name=predictor,
+        predictor_version="1", allele=allele, peptide="SIINFEKL",
+        value=None, score=score)
+
+
+def _processing(score=0.7):
+    return Prediction(
+        kind="antigen_processing", predictor_name="mhcflurry",
+        predictor_version="1", allele="", peptide="SIINFEKL",
+        value=None, score=score)
+
+
+def _epitope(*predictions, patient_alleles=()):
+    return CandidateEpitope(
+        sequence="SIINFEKL", source_sequence="SIINFEKL", offset=0,
+        prediction_id="p", patient_alleles=tuple(patient_alleles),
+        predictions=tuple(predictions))
+
+
+def test_selection_ranks_within_one_predictor():
+    """A recorded (predictor, value) pair must be one the predictor emitted.
+
+    Taking a per-allele best across predictors compares two independent
+    scales *and* records a value the named predictor never produced — which
+    makes the attribution unreconstructable, the one thing it exists for.
+    """
+    epitope = _epitope(
+        _affinity("HLA-A*02:01", 9000.0, "mhcflurry"),
+        _affinity("HLA-A*02:01", 5.0, "netmhcpan"),
+        _affinity("HLA-B*07:02", 100.0, "mhcflurry"),
+        _affinity("HLA-B*07:02", 8000.0, "netmhcpan"),
+        _processing(),
+        patient_alleles=("HLA-A*02:01", "HLA-B*07:02"))
+    genotype = ["HLA-A*02:01", "HLA-B*07:02"]
+
+    [chosen] = attribute_alleles(
+        epitope, genotype, AllelePolicy.parse("selected"))
+    # mhcflurry is the canonical default, so its numbers rank: B (100) beats
+    # A (9000). The cross-predictor minimum would have picked A on 5.0 and
+    # attributed that value to mhcflurry, which never predicted it.
+    assert chosen.allele == "HLA-B*07:02"
+    assert chosen.rank_predictor == "mhcflurry"
+    assert chosen.rank_value == pytest.approx(100.0)
+
+    # The value recorded is one the named predictor actually emitted.
+    emitted = {
+        (p.predictor_name, p.allele): p.value
+        for p in epitope.predictions_flat() if p.kind == "pMHC_affinity"}
+    assert emitted[(chosen.rank_predictor, chosen.allele)] == pytest.approx(
+        chosen.rank_value)
+
+
+def test_selection_honors_default_methods():
+    """The config's chosen model decides, not the most optimistic one."""
+    epitope = _epitope(
+        _affinity("HLA-A*02:01", 9000.0, "mhcflurry"),
+        _affinity("HLA-A*02:01", 5.0, "netmhcpan"),
+        _affinity("HLA-B*07:02", 100.0, "mhcflurry"),
+        _affinity("HLA-B*07:02", 8000.0, "netmhcpan"),
+        _processing(),
+        patient_alleles=("HLA-A*02:01", "HLA-B*07:02"))
+
+    [chosen] = attribute_alleles(
+        epitope, ["HLA-A*02:01", "HLA-B*07:02"],
+        AllelePolicy.parse("selected"),
+        default_methods={"pMHC_affinity": "netmhcpan"})
+    assert (chosen.allele, chosen.rank_predictor) == (
+        "HLA-A*02:01", "netmhcpan")
+    assert chosen.rank_value == pytest.approx(5.0)
+
+
+def test_auto_axis_picks_the_axis_that_covers_the_alleles():
+    """Partial presentation columns must not drop the unranked alleles.
+
+    A file carrying presentation for one allele and affinity for all of them
+    should rank on affinity. Short-circuiting on the first non-empty axis
+    silently reduced a ``top:3`` to a single allele.
+    """
+    epitope = _epitope(
+        _presentation("HLA-A*02:01", 0.4),
+        _affinity("HLA-A*02:01", 900.0, "netmhcpan"),
+        _affinity("HLA-B*07:02", 10.0, "netmhcpan"),
+        _affinity("HLA-C*07:01", 20.0, "netmhcpan"),
+        _processing(),
+        patient_alleles=("HLA-A*02:01", "HLA-B*07:02", "HLA-C*07:01"))
+
+    got = attribute_alleles(
+        epitope, ["HLA-A*02:01", "HLA-B*07:02", "HLA-C*07:01"],
+        AllelePolicy.parse("top:3"))
+    assert [a.allele for a in got] == [
+        "HLA-B*07:02", "HLA-C*07:01", "HLA-A*02:01"]
+    assert {a.rank_kind for a in got} == {"pMHC_affinity"}
+
+
+def test_from_input_reflects_the_input_not_the_growing_allele_set():
+    """Attribution must be idempotent across repeated scoring passes.
+
+    ``CandidateEpitope.__post_init__`` folds every scored allele back into
+    ``patient_alleles``, so deriving "the input paired these" from that field
+    made a broadcast allele claim, on a second pass, that the source file had
+    named it.
+    """
+    epitope = _epitope(
+        _affinity("HLA-A*02:01", 50.0), _processing(),
+        patient_alleles=("HLA-A*02:01",))
+    genotype = ["HLA-A*02:01", "HLA-C*07:01"]
+
+    first = attribute_alleles(epitope, genotype, AllelePolicy.parse("all"))
+    by_allele = {a.allele: a.source for a in first}
+    assert by_allele == {
+        "HLA-A*02:01": ALLELE_SOURCE_FROM_INPUT,
+        "HLA-C*07:01": ALLELE_SOURCE_BROADCAST,
+    }
+
+    # Simulate the widened patient_alleles a scoring pass produces.
+    widened = _epitope(
+        _affinity("HLA-A*02:01", 50.0), _processing(),
+        patient_alleles=("HLA-A*02:01", "HLA-C*07:01"))
+    again = attribute_alleles(widened, genotype, AllelePolicy.parse("all"))
+    assert {a.allele: a.source for a in again} == by_allele
+
+
+def test_explicit_genotype_can_narrow_not_only_widen():
+    """A patient's real typing must be able to correct a wider input panel."""
+    epitope = _epitope(
+        _affinity("HLA-A*02:01", 50.0),
+        _affinity("HLA-B*07:02", 60.0),
+        _processing(),
+        patient_alleles=("HLA-A*02:01", "HLA-B*07:02"))
+
+    got = attribute_alleles(
+        epitope, ["HLA-A*02:01"], AllelePolicy.parse("all"))
+    assert [a.allele for a in got] == ["HLA-A*02:01"]
+
+
+def test_only_peptide_level_kinds_are_attributed():
+    """A malformed blank-allele row must not become per-allele evidence."""
+    from vaxrank.epitope_dsl import epitopes_to_topiary_df
+
+    # An affinity prediction that lost its allele is malformed, not
+    # peptide-level. Projecting it invents binding evidence for alleles it
+    # was never predicted against.
+    epitope = _epitope(
+        Prediction(kind="pMHC_affinity", predictor_name="mhcflurry",
+                   predictor_version="1", allele="", peptide="SIINFEKL",
+                   value=50.0, score=0.0),
+        patient_alleles=("HLA-A*02:01", "HLA-B*07:02"))
+    frame = epitopes_to_topiary_df(
+        [epitope], policy=AllelePolicy.parse("all"))
+    assert list(frame["allele"]) == [""]
+
+
+def test_malformed_policies_are_rejected_where_they_are_written():
+    """Typos fail at config time, not silently mid-run."""
+    with pytest.raises(AllelePolicyError, match="Unknown allele policy"):
+        AllelePolicy.parse("typo")
+    with pytest.raises(AllelePolicyError, match="at least one allele"):
+        AllelePolicy.parse("top:0")
+    with pytest.raises(AllelePolicyError, match="integer N"):
+        AllelePolicy.parse("top:many")
+    # The axis is validated too — it used to escape until a selection ran,
+    # and for "all" / "from_input" it never ran at all.
+    with pytest.raises(AllelePolicyError, match="selection axis"):
+        AllelePolicy.parse("selected", axis="affinity")
+    with pytest.raises(AllelePolicyError, match="selection axis"):
+        AllelePolicy.parse("all", axis="nonsense")
+
+    # A hand-built policy that never went through parse is refused rather
+    # than silently treated as top-N.
+    epitope = _epitope(_processing(), patient_alleles=("HLA-A*02:01",))
+    with pytest.raises(AllelePolicyError, match="Unknown allele policy name"):
+        attribute_alleles(epitope, ["HLA-A*02:01"], AllelePolicy(name="typo"))
+
+
+def test_attribution_requires_reconstructable_provenance():
+    """A selection without its ranking axis could not be reproduced."""
+    from vaxrank.allele_evidence import AlleleAttribution
+
+    with pytest.raises(ValueError, match="must record the axis"):
+        AlleleAttribution(allele="HLA-A*02:01", source=ALLELE_SOURCE_SELECTED)
+    with pytest.raises(ValueError, match="Only a selected allele"):
+        AlleleAttribution(
+            allele="HLA-A*02:01", source=ALLELE_SOURCE_BROADCAST,
+            rank_kind="pMHC_affinity")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1626,3 +1626,58 @@ peptide:
     linker2 = coalesce_config_value(
         args2, 'peptide_linker', yaml_kwargs2, 'linker')
     assert linker2 == 'EAAAK'
+
+
+def test_allele_evidence_policy_is_reachable_from_yaml_and_cli(tmp_path):
+    """The policy must be settable through a supported path.
+
+    3.3.0 changes the default attribution of peptide-level evidence. A knob
+    that exists only on the dataclass leaves every user with no way to
+    restore the previous behavior short of editing Python.
+    """
+    from vaxrank.cli.epitope_config_args import epitope_config_from_args
+    from vaxrank.config.loader import load_vaxrank_config
+
+    path = tmp_path / "epitopes.yaml"
+    path.write_text(
+        "epitopes:\n"
+        "  allele_free_evidence: all\n"
+        "  allele_selection_axis: pMHC_affinity\n")
+
+    class _Args:
+        config = [str(path)]
+        config_set_overrides = None
+        config_expr_overrides = None
+
+        def __getattr__(self, name):
+            return None
+
+    from_yaml = epitope_config_from_args(
+        _Args(), merged_config=load_vaxrank_config(_Args()))
+    assert from_yaml.allele_free_evidence == "all"
+    assert from_yaml.allele_policy.name == "all"
+    assert from_yaml.allele_policy.axis == "pMHC_affinity"
+
+    class _FlagArgs(_Args):
+        config = None
+        allele_free_evidence = "top:2"
+        allele_selection_axis = "pMHC_presentation"
+
+    from_cli = epitope_config_from_args(_FlagArgs(), merged_config={})
+    assert from_cli.allele_policy.name == "top"
+    assert from_cli.allele_policy.limit == 2
+
+
+def test_allele_evidence_flags_exist_on_the_parsers():
+    """Both entry points accept the flags, not just the pipeline one."""
+    from vaxrank.cli.arg_parser import (
+        external_input_arg_parser, make_vaxrank_arg_parser,
+    )
+
+    for parser in (make_vaxrank_arg_parser(), external_input_arg_parser()):
+        options = {
+            option
+            for action in parser._actions
+            for option in action.option_strings}
+        assert "--allele-free-evidence" in options
+        assert "--allele-selection-axis" in options

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -741,7 +741,7 @@ def test_lens_processing_evidence_is_attributed_by_the_configured_policy(
 
     Antigen processing depends on the peptide and its flanks, not on MHC, so
     crediting it to an allele is a choice. The default selects the allele
-    the model ranks best; ``all`` broadcasts to the genotype; ``observed``
+    the model ranks best; ``all`` broadcasts to the genotype; ``from_input``
     reproduces the pre-3.3 behavior of using whichever alleles the input
     happened to score, which is row incidence rather than a claim about
     presentation.

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -777,7 +777,7 @@ def test_lens_processing_evidence_is_attributed_by_the_configured_policy(
 
     assert credited("selected") == {"HLA-A*02:01"}
     assert credited("all") == {"HLA-A*02:01", "HLA-B*07:02"}
-    assert credited("reported") == {"HLA-A*02:01", "HLA-B*07:02"}
+    assert credited("from_input") == {"HLA-A*02:01", "HLA-B*07:02"}
     assert credited("top:2") == {"HLA-A*02:01", "HLA-B*07:02"}
 
     # And the scores follow the policy. Note B*07:02 is still a scored group
@@ -809,7 +809,7 @@ def test_allele_attribution_records_how_the_allele_was_chosen(tmp_path):
     patient, or picked by us — nor, if picked, on what axis and at what value.
     """
     from vaxrank.allele_evidence import (
-        BASIS_GENOTYPE, BASIS_SELECTED, BASIS_REPORTED,
+        ALLELE_SOURCE_BROADCAST, ALLELE_SOURCE_SELECTED, ALLELE_SOURCE_FROM_INPUT,
     )
     from vaxrank.epitope_config import EpitopeConfig
     from vaxrank.epitope_dsl import attach_per_allele_scores
@@ -825,28 +825,28 @@ def test_allele_attribution_records_how_the_allele_was_chosen(tmp_path):
     [selected] = attach_per_allele_scores(epitopes, EpitopeConfig())
     [attribution] = selected.allele_attributions
     assert attribution.allele == "HLA-A*02:01"
-    assert attribution.basis == BASIS_SELECTED
+    assert attribution.source == ALLELE_SOURCE_SELECTED
     # Everything needed to redo the ranking by hand.
     assert attribution.rank_kind == "pMHC_affinity"
     assert attribution.rank_predictor == "mhcflurry"
     assert attribution.rank_value == pytest.approx(50.0)
     assert attribution.rank_position == 1
-    assert "ranked #1" in attribution.describe()
+    assert "selected: ranked #1" in attribution.describe()
 
     # Broadcasting distinguishes alleles the input scored from ones supplied
     # only by the genotype.
     [broadcast] = attach_per_allele_scores(
         epitopes, EpitopeConfig(allele_free_evidence="all"),
         genotype=["HLA-A*02:01", "HLA-B*07:02", "HLA-C*07:01"])
-    bases = {a.allele: a.basis for a in broadcast.allele_attributions}
+    bases = {a.allele: a.source for a in broadcast.allele_attributions}
     assert bases == {
-        "HLA-A*02:01": BASIS_REPORTED,
-        "HLA-B*07:02": BASIS_REPORTED,
-        "HLA-C*07:01": BASIS_GENOTYPE,
+        "HLA-A*02:01": ALLELE_SOURCE_FROM_INPUT,
+        "HLA-B*07:02": ALLELE_SOURCE_FROM_INPUT,
+        "HLA-C*07:01": ALLELE_SOURCE_BROADCAST,
     }
     # A candidate with no allele-free evidence records no attribution at all,
     # rather than implying a decision was made.
-    assert not any(a.basis == BASIS_SELECTED
+    assert not any(a.source == ALLELE_SOURCE_SELECTED
                    for a in broadcast.allele_attributions)
 
 

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -735,8 +735,17 @@ def test_load_lens_preserves_allele_independent_processing_once():
     assert all(epitope.per_allele_scores)
 
 
-def test_lens_processing_dsl_scores_every_patient_allele(tmp_path):
-    """Canonical processing evidence participates in allele-scoped DSL groups."""
+def test_lens_processing_evidence_is_attributed_by_the_configured_policy(
+        tmp_path):
+    """Which alleles get peptide-level evidence is a stated policy.
+
+    Antigen processing depends on the peptide and its flanks, not on MHC, so
+    crediting it to an allele is a choice. The default nominates the allele
+    the model ranks best; ``all`` broadcasts to the genotype; ``observed``
+    reproduces the pre-3.3 behavior of using whichever alleles the input
+    happened to score, which is row incidence rather than a claim about
+    presentation.
+    """
     from vaxrank.epitope_config import EpitopeConfig
     from vaxrank.epitope_dsl import (
         attach_per_allele_scores,
@@ -747,31 +756,98 @@ def test_lens_processing_dsl_scores_every_patient_allele(tmp_path):
     path.write_text(
         "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
         "mhcflurry_2.1.1.proc_score\n"
+        # A*02:01 is the far stronger binder, so it is the model's nominee.
         "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\n"
-        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t60\t0.8\n")
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t5000\t0.8\n")
 
-    _loaded = read_lens_report(path)
-    epitopes = list(_loaded.epitopes)
+    epitopes = list(read_lens_report(path).epitopes)
     assert len(epitopes) == 1
-    epitope = epitopes[0]
-    processing = epitope.predictions_for(
+    # The candidate keeps ONE canonical allele-free leaf regardless of policy;
+    # only the evaluation view repeats it.
+    processing = epitopes[0].predictions_for(
         "antigen_processing", predictor="mhcflurry")
     assert len(processing) == 1
     assert processing[0].allele == ""
 
-    topiary_df = epitopes_to_topiary_df(epitopes)
-    processing_rows = topiary_df[
-        topiary_df["kind"] == "antigen_processing"]
-    assert set(processing_rows["allele"]) == {
-        "HLA-A*02:01", "HLA-B*07:02"}
+    def credited(policy):
+        frame = epitopes_to_topiary_df(
+            epitopes, policy=EpitopeConfig(
+                allele_free_evidence=policy).allele_policy)
+        return set(frame[frame["kind"] == "antigen_processing"]["allele"])
 
-    scored = attach_per_allele_scores(
-        epitopes,
-        EpitopeConfig(score_expr="processing[mhcflurry].score"))
-    assert scored[0].per_allele_scores == {
+    assert credited("nominated") == {"HLA-A*02:01"}
+    assert credited("all") == {"HLA-A*02:01", "HLA-B*07:02"}
+    assert credited("observed") == {"HLA-A*02:01", "HLA-B*07:02"}
+    assert credited("top:2") == {"HLA-A*02:01", "HLA-B*07:02"}
+
+    # And the scores follow the policy. Note B*07:02 is still a scored group
+    # — it has its own affinity evidence — it simply was not credited with
+    # the peptide-level processing score, so a processing-only expression
+    # gives it nothing. Narrowing attribution does not delete allele groups.
+    nominated = attach_per_allele_scores(
+        epitopes, EpitopeConfig(score_expr="processing[mhcflurry].score"))
+    assert nominated[0].per_allele_scores == {
+        "HLA-A*02:01": pytest.approx(0.8),
+        "HLA-B*07:02": pytest.approx(0.0),
+    }
+
+    broadcast = attach_per_allele_scores(
+        epitopes, EpitopeConfig(
+            score_expr="processing[mhcflurry].score",
+            allele_free_evidence="all"))
+    assert broadcast[0].per_allele_scores == {
         "HLA-A*02:01": pytest.approx(0.8),
         "HLA-B*07:02": pytest.approx(0.8),
     }
+
+
+def test_allele_attribution_records_how_the_allele_was_chosen(tmp_path):
+    """A finished run must say why an allele was credited, not just that.
+
+    Without the provenance the attribution cannot be reconstructed: a reader
+    cannot tell whether an allele was scored by the input, carried by the
+    patient, or picked by us — nor, if picked, on what axis and at what value.
+    """
+    from vaxrank.allele_evidence import (
+        BASIS_GENOTYPE, BASIS_NOMINATED, BASIS_OBSERVED,
+    )
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import attach_per_allele_scores
+
+    path = tmp_path / "attribution.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\n"
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t5000\t0.8\n")
+    epitopes = list(read_lens_report(path).epitopes)
+
+    [nominated] = attach_per_allele_scores(epitopes, EpitopeConfig())
+    [attribution] = nominated.allele_attributions
+    assert attribution.allele == "HLA-A*02:01"
+    assert attribution.basis == BASIS_NOMINATED
+    # Everything needed to redo the ranking by hand.
+    assert attribution.rank_kind == "pMHC_affinity"
+    assert attribution.rank_predictor == "mhcflurry"
+    assert attribution.rank_value == pytest.approx(50.0)
+    assert attribution.rank_position == 1
+    assert "ranked #1" in attribution.describe()
+
+    # Broadcasting distinguishes alleles the input scored from ones supplied
+    # only by the genotype.
+    [broadcast] = attach_per_allele_scores(
+        epitopes, EpitopeConfig(allele_free_evidence="all"),
+        genotype=["HLA-A*02:01", "HLA-B*07:02", "HLA-C*07:01"])
+    bases = {a.allele: a.basis for a in broadcast.allele_attributions}
+    assert bases == {
+        "HLA-A*02:01": BASIS_OBSERVED,
+        "HLA-B*07:02": BASIS_OBSERVED,
+        "HLA-C*07:01": BASIS_GENOTYPE,
+    }
+    # A candidate with no allele-free evidence records no attribution at all,
+    # rather than implying a decision was made.
+    assert not any(a.basis == BASIS_NOMINATED
+                   for a in broadcast.allele_attributions)
 
 
 def test_lens_processing_only_rows_preserve_alleles_scores_and_report_rows(
@@ -894,7 +970,12 @@ def test_lens_report_anchors_mixed_evidence_per_allele_and_predictor(tmp_path):
     epitopes = list(_loaded.epitopes)
     epitope = attach_per_allele_scores(
         epitopes,
-        EpitopeConfig(score_expr="processing[mhcflurry].score"),
+        # This test is about which report anchor each allele/predictor gets,
+        # not about how peptide-level evidence is attributed — so pin the
+        # broadcast policy rather than inheriting the default nomination and
+        # letting an unrelated change move these rows.
+        EpitopeConfig(score_expr="processing[mhcflurry].score",
+                      allele_free_evidence="all"),
     )[0]
     row_inputs = epitope_report_row_inputs(epitope)
     assert [
@@ -2303,3 +2384,67 @@ def test_native_roundtrip_keeps_undecided_targetability_undecided(tmp_path):
 
     assert reloaded.overlaps_targetable is None
     assert reloaded.is_targetable is True
+
+
+def _write_pvacseq_sparse_fixture(tmp_path):
+    """all_epitopes rows exercising the two paths fixtures never took.
+
+    Row 1 is complete. Row 2 has no WT columns filled — topiary leaves
+    ``wt_value`` NA — which is the shape an aggregate written without WT
+    prediction produces. Row 3 has no IC50 at all and must be dropped.
+    """
+    path = tmp_path / "pvacseq_sparse.tsv"
+    columns = [
+        "Chromosome", "Start", "Stop", "Reference", "Variant",
+        "Transcript", "Variant Type", "Mutation", "Gene Name", "HLA Allele",
+        "Mutation Position", "MT Epitope Seq", "WT Epitope Seq",
+        "Median MT IC50 Score", "Median WT IC50 Score",
+        "Median MT Percentile", "Median WT Percentile",
+    ]
+    rows = [
+        ["chr1", "100", "101", "T", "A", "ENST1", "missense", "E1V", "GENEA",
+         "HLA-A*02:01", "5", "AERMGFTVV", "AERMGFTEV",
+         "76.11", "61.80", "0.10", "0.12"],
+        # no WT IC50 -> the wt-absent branch
+        ["chr1", "100", "101", "T", "A", "ENST1", "missense", "E1V", "GENEA",
+         "HLA-B*07:02", "5", "AERMGFTVV", "NA",
+         "80.00", "NA", "0.20", "NA"],
+        # no MT IC50 -> the skip branch
+        ["chr1", "100", "101", "T", "A", "ENST1", "missense", "E1V", "GENEA",
+         "HLA-C*07:01", "5", "AERMGFTVV", "AERMGFTEV",
+         "NA", "NA", "NA", "NA"],
+    ]
+    path.write_text(
+        "\t".join(columns) + "\n"
+        + "\n".join("\t".join(r) for r in rows) + "\n")
+    return path
+
+
+def test_pvacseq_rows_without_wt_or_without_affinity(tmp_path):
+    """The two branches every existing pVACseq fixture happened to skip.
+
+    Both are real input shapes: an aggregate written without WT prediction,
+    and a row whose algorithm produced no IC50. Neither had ever executed,
+    so nothing said what they should do.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import read_pvacseq_report
+
+    report = read_pvacseq_report(
+        _write_pvacseq_sparse_fixture(tmp_path),
+        epitope_config=EpitopeConfig())
+
+    # The unscored row is dropped rather than carried as a zero.
+    alleles = {
+        prediction.allele
+        for epitope in report.epitopes
+        for prediction in epitope.predictions_flat()}
+    assert "HLA-C*07:01" not in alleles
+    assert alleles == {"HLA-A*02:01", "HLA-B*07:02"}
+
+    [epitope] = report.epitopes
+    # A WT comparator exists because one row supplied one; the row that did
+    # not simply contributes no WT leaf, rather than a fabricated zero.
+    wt_alleles = {p.allele for p in epitope.wt.predictions_flat()}
+    assert wt_alleles == {"HLA-A*02:01"}
+    assert epitope.wt.sequence == "AERMGFTEV"

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -740,7 +740,7 @@ def test_lens_processing_evidence_is_attributed_by_the_configured_policy(
     """Which alleles get peptide-level evidence is a stated policy.
 
     Antigen processing depends on the peptide and its flanks, not on MHC, so
-    crediting it to an allele is a choice. The default nominates the allele
+    crediting it to an allele is a choice. The default selects the allele
     the model ranks best; ``all`` broadcasts to the genotype; ``observed``
     reproduces the pre-3.3 behavior of using whichever alleles the input
     happened to score, which is row incidence rather than a claim about
@@ -775,18 +775,18 @@ def test_lens_processing_evidence_is_attributed_by_the_configured_policy(
                 allele_free_evidence=policy).allele_policy)
         return set(frame[frame["kind"] == "antigen_processing"]["allele"])
 
-    assert credited("nominated") == {"HLA-A*02:01"}
+    assert credited("selected") == {"HLA-A*02:01"}
     assert credited("all") == {"HLA-A*02:01", "HLA-B*07:02"}
-    assert credited("observed") == {"HLA-A*02:01", "HLA-B*07:02"}
+    assert credited("reported") == {"HLA-A*02:01", "HLA-B*07:02"}
     assert credited("top:2") == {"HLA-A*02:01", "HLA-B*07:02"}
 
     # And the scores follow the policy. Note B*07:02 is still a scored group
     # — it has its own affinity evidence — it simply was not credited with
     # the peptide-level processing score, so a processing-only expression
     # gives it nothing. Narrowing attribution does not delete allele groups.
-    nominated = attach_per_allele_scores(
+    selected = attach_per_allele_scores(
         epitopes, EpitopeConfig(score_expr="processing[mhcflurry].score"))
-    assert nominated[0].per_allele_scores == {
+    assert selected[0].per_allele_scores == {
         "HLA-A*02:01": pytest.approx(0.8),
         "HLA-B*07:02": pytest.approx(0.0),
     }
@@ -809,7 +809,7 @@ def test_allele_attribution_records_how_the_allele_was_chosen(tmp_path):
     patient, or picked by us — nor, if picked, on what axis and at what value.
     """
     from vaxrank.allele_evidence import (
-        BASIS_GENOTYPE, BASIS_NOMINATED, BASIS_OBSERVED,
+        BASIS_GENOTYPE, BASIS_SELECTED, BASIS_REPORTED,
     )
     from vaxrank.epitope_config import EpitopeConfig
     from vaxrank.epitope_dsl import attach_per_allele_scores
@@ -822,10 +822,10 @@ def test_allele_attribution_records_how_the_allele_was_chosen(tmp_path):
         "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t5000\t0.8\n")
     epitopes = list(read_lens_report(path).epitopes)
 
-    [nominated] = attach_per_allele_scores(epitopes, EpitopeConfig())
-    [attribution] = nominated.allele_attributions
+    [selected] = attach_per_allele_scores(epitopes, EpitopeConfig())
+    [attribution] = selected.allele_attributions
     assert attribution.allele == "HLA-A*02:01"
-    assert attribution.basis == BASIS_NOMINATED
+    assert attribution.basis == BASIS_SELECTED
     # Everything needed to redo the ranking by hand.
     assert attribution.rank_kind == "pMHC_affinity"
     assert attribution.rank_predictor == "mhcflurry"
@@ -840,13 +840,13 @@ def test_allele_attribution_records_how_the_allele_was_chosen(tmp_path):
         genotype=["HLA-A*02:01", "HLA-B*07:02", "HLA-C*07:01"])
     bases = {a.allele: a.basis for a in broadcast.allele_attributions}
     assert bases == {
-        "HLA-A*02:01": BASIS_OBSERVED,
-        "HLA-B*07:02": BASIS_OBSERVED,
+        "HLA-A*02:01": BASIS_REPORTED,
+        "HLA-B*07:02": BASIS_REPORTED,
         "HLA-C*07:01": BASIS_GENOTYPE,
     }
     # A candidate with no allele-free evidence records no attribution at all,
     # rather than implying a decision was made.
-    assert not any(a.basis == BASIS_NOMINATED
+    assert not any(a.basis == BASIS_SELECTED
                    for a in broadcast.allele_attributions)
 
 
@@ -972,7 +972,7 @@ def test_lens_report_anchors_mixed_evidence_per_allele_and_predictor(tmp_path):
         epitopes,
         # This test is about which report anchor each allele/predictor gets,
         # not about how peptide-level evidence is attributed — so pin the
-        # broadcast policy rather than inheriting the default nomination and
+        # broadcast policy rather than inheriting the default selection and
         # letting an unrelated change move these rows.
         EpitopeConfig(score_expr="processing[mhcflurry].score",
                       allele_free_evidence="all"),

--- a/tests/test_epitope_prediction.py
+++ b/tests/test_epitope_prediction.py
@@ -343,3 +343,33 @@ def test_allele_free_leaf_does_not_become_a_per_allele_score():
     # The evidence itself is still on the candidate, just not as an allele.
     assert len(epitope.predictions_for(
         "antigen_processing", predictor="mhcflurry")) == 1
+
+
+def test_pipeline_warns_that_peptide_level_evidence_is_unattributed():
+    """A configured policy must not look like it took effect where it doesn't.
+
+    The native pipeline scores topiary's own frame and never runs allele
+    attribution, so peptide-level evidence forms an empty-allele group and
+    contributes to no per-allele score. Shipping a config knob that silently
+    does nothing on the path most runs take is the failure this codebase has
+    already removed once for vaccine_peptides config.
+    """
+    import pandas as pd
+
+    from vaxrank.allele_evidence import PEPTIDE_LEVEL_KINDS
+
+    # The warning is driven purely by which kinds appear in the frame.
+    assert "antigen_processing" in PEPTIDE_LEVEL_KINDS
+    frame = pd.DataFrame({"kind": ["pMHC_affinity", "antigen_processing"]})
+    unattributed = sorted({
+        kind for kind in frame["kind"].dropna().unique()
+        if kind in PEPTIDE_LEVEL_KINDS})
+    assert unattributed == ["antigen_processing"]
+
+    # And the config records the limitation next to the field.
+    import inspect
+
+    from vaxrank import epitope_config
+
+    source = inspect.getsource(epitope_config)
+    assert "vaxrank#349" in source

--- a/vaxrank/allele_evidence.py
+++ b/vaxrank/allele_evidence.py
@@ -41,9 +41,12 @@ that declares one allele set for a whole frame, while every policy except
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from serializable import DataclassSerializable
+
+logger = logging.getLogger(__name__)
 
 
 # How the evidence reached this allele.
@@ -102,23 +105,36 @@ ALLELE_SCOPED_KINDS = frozenset({
 })
 
 
-def _assert_dependence_table_is_complete():
-    """Fail loudly if topiary knows a kind this module has not classified."""
+def unclassified_kinds() -> tuple:
+    """Canonical topiary kinds this module has not classified."""
     try:
         from topiary.ranking import KIND_ALIASES
     except Exception:  # pragma: no cover - topiary always present in practice
-        return
+        return ()
     known = PEPTIDE_LEVEL_KINDS | ALLELE_SCOPED_KINDS
-    unclassified = sorted(set(KIND_ALIASES.values()) - known)
-    if unclassified:
-        raise RuntimeError(
-            "vaxrank.allele_evidence does not classify prediction kind(s) %s "
-            "as allele-scoped or peptide-level. Add them to one of the two "
-            "sets above; leaving a kind unclassified would make it silently "
-            "un-attributable." % ", ".join(unclassified))
+    return tuple(sorted(set(KIND_ALIASES.values()) - known))
 
 
-_assert_dependence_table_is_complete()
+def _warn_about_unclassified_kinds():
+    """Report kinds we cannot classify, without refusing to run.
+
+    Raising here would mean a topiary release that adds a prediction kind
+    breaks ``import vaxrank`` outright — a worse failure than the one being
+    guarded against. Unclassified kinds are instead treated as *not*
+    peptide-level, which is the safe direction: they are never projected
+    across alleles, so nothing is fabricated. A test pins the table against
+    the pinned topiary, so drift surfaces in CI rather than in a run.
+    """
+    missing = unclassified_kinds()
+    if missing:
+        logger.warning(
+            "Prediction kind(s) %s are not classified as allele-scoped or "
+            "peptide-level by vaxrank.allele_evidence. They will not be "
+            "attributed to alleles. Add them to one of the two sets there.",
+            ", ".join(missing))
+
+
+_warn_about_unclassified_kinds()
 
 
 def is_peptide_level(prediction) -> bool:

--- a/vaxrank/allele_evidence.py
+++ b/vaxrank/allele_evidence.py
@@ -70,17 +70,96 @@ SELECTION_AXES = (
 )
 SELECTION_AUTO = "auto"
 
-# Kinds that describe a peptide rather than a peptide-MHC pair, and are
-# therefore the only ones this module may attribute to alleles. A prediction
-# of any other kind that arrives with a blank allele is malformed, not
-# peptide-level: projecting it would manufacture per-allele binding evidence
-# for alleles it was never predicted against.
-PEPTIDE_LEVEL_KINDS = frozenset({"antigen_processing", "proteasome_cleavage"})
+
+# ── MHC dependence: the one table ───────────────────────────────────────────
+#
+# Every prediction kind is either *allele-scoped* (it describes a peptide-MHC
+# pair) or *peptide-level* (it describes the peptide and its flanks alone).
+# That distinction was previously re-expressed inline at four call sites, each
+# slightly differently — ``p.kind == "antigen_processing" and not p.allele``
+# in one, a bare ``not p.allele`` in another, ``if allele:`` in a third. The
+# bare forms are wrong in the same way: a blank allele also means a
+# *malformed* row, and projecting one of those manufactures per-allele
+# binding evidence for alleles the model never scored.
+#
+# So the question is answered here, once, from the kind. Every topiary
+# canonical kind is listed; _assert_dependence_table_is_complete below fails
+# at import if topiary adds one we have not classified, so a new kind is a
+# visible decision rather than a silent default.
+PEPTIDE_LEVEL_KINDS = frozenset({
+    "antigen_processing",       # mhcflurry integrated processing
+    "proteasome_cleavage",      # NetChop / PAProC / pepsickle
+    "endolysosomal_cleavage",   # class-II processing
+    "erap_trimming",            # ERAP1/2 N-terminal trimming
+    "tap_transport",            # TAP peptide transport
+})
+ALLELE_SCOPED_KINDS = frozenset({
+    "pMHC_affinity",
+    "pMHC_presentation",
+    "pMHC_stability",
+    "pMHC_TCR_binding",
+    "immunogenicity",           # scored for a peptide-MHC pair
+})
+
+
+def _assert_dependence_table_is_complete():
+    """Fail loudly if topiary knows a kind this module has not classified."""
+    try:
+        from topiary.ranking import KIND_ALIASES
+    except Exception:  # pragma: no cover - topiary always present in practice
+        return
+    known = PEPTIDE_LEVEL_KINDS | ALLELE_SCOPED_KINDS
+    unclassified = sorted(set(KIND_ALIASES.values()) - known)
+    if unclassified:
+        raise RuntimeError(
+            "vaxrank.allele_evidence does not classify prediction kind(s) %s "
+            "as allele-scoped or peptide-level. Add them to one of the two "
+            "sets above; leaving a kind unclassified would make it silently "
+            "un-attributable." % ", ".join(unclassified))
+
+
+_assert_dependence_table_is_complete()
 
 
 def is_peptide_level(prediction) -> bool:
-    """True when a prediction describes the peptide, not a peptide-MHC pair."""
-    return not prediction.allele and prediction.kind in PEPTIDE_LEVEL_KINDS
+    """True when a prediction describes the peptide, not a peptide-MHC pair.
+
+    Both halves are required. The kind must be one that carries no MHC
+    context, *and* the record must actually be allele-free — a peptide-level
+    kind that arrived stamped with an allele is already attributed, and an
+    allele-scoped kind that arrived blank is malformed, not peptide-level.
+    """
+    return prediction.kind in PEPTIDE_LEVEL_KINDS and not prediction.allele
+
+
+def is_allele_scoped(prediction) -> bool:
+    """True when a prediction names the allele it applies to."""
+    return bool(prediction.allele) and prediction.kind in ALLELE_SCOPED_KINDS
+
+
+def alleles_named_by(predictions) -> tuple:
+    """The alleles a set of predictions was actually scored against."""
+    return tuple(sorted({
+        prediction.allele for prediction in predictions
+        if is_allele_scoped(prediction)}))
+
+
+def _plain_number(value):
+    """Coerce a prediction value to a plain Python float, or None.
+
+    Predictions built from a pandas frame carry numpy scalars, which the
+    serializer refuses ("Cannot convert 1 : <class 'numpy.int64'>"). Since a
+    recorded value has to survive a round-trip to stay reconstructable, the
+    conversion belongs here, at the point the value is captured, rather than
+    at each place one is written out.
+    """
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return None if result != result else result  # drop NaN
 
 
 class AllelePolicyError(ValueError):
@@ -181,36 +260,72 @@ class AllelePolicy:
 _PREDICTOR_PREFERENCE = ("mhcflurry", "netmhcpan", "netmhcstabpan")
 
 
-def _pick_predictor(available, default_methods, kind):
-    """Choose the one predictor whose values will rank the alleles."""
+@dataclass(frozen=True)
+class RankedEvidence:
+    """One predictor's values for one kind, and the ranking they produce.
+
+    The kind, the predictor, and the values travel together in one object on
+    purpose. The first version of this code accumulated them in separate
+    locals inside one loop — ``predictor`` latched to the first predictor
+    seen, ``values`` kept the best across *all* predictors — so an
+    attribution could record a ``(predictor, value)`` pair that predictor
+    never emitted. Making them one value makes that class of mistake
+    unrepresentable rather than merely fixed.
+    """
+
+    kind: str
+    predictor: str
+    values: dict
+    higher_is_better: bool
+
+    @property
+    def coverage(self) -> int:
+        """How many of the requested alleles this evidence can rank."""
+        return len(self.values)
+
+    @property
+    def ordered(self) -> tuple:
+        """Alleles best-first, ties broken by name for determinism."""
+        return tuple(sorted(
+            self.values,
+            key=lambda a: (
+                -self.values[a] if self.higher_is_better else self.values[a],
+                a)))
+
+
+def _pick_predictor(by_predictor, default_methods, kind):
+    """Choose the one predictor whose values will rank the alleles.
+
+    An explicit ``default_methods`` entry is the user's stated choice of
+    model and always wins, so a selection resolves to the same model the
+    score does. Absent one, prefer the predictor that can rank the most
+    alleles, and only then fall back to the canonical name order: a
+    predictor covering one allele out of six would otherwise silently reduce
+    a ``top:3`` to a single attribution.
+    """
     named = (default_methods or {}).get(kind)
-    if named and named in available:
+    if named and named in by_predictor:
         return named
-    for preferred in _PREDICTOR_PREFERENCE:
-        if preferred in available:
-            return preferred
-    return sorted(available)[0]
+    return max(
+        by_predictor,
+        key=lambda name: (
+            len(by_predictor[name]),
+            -_PREDICTOR_PREFERENCE.index(name)
+            if name in _PREDICTOR_PREFERENCE else -len(_PREDICTOR_PREFERENCE),
+            name,
+        ))
 
 
 def _ranked_alleles(epitope, alleles, axis, default_methods=None):
-    """Rank *alleles* by the peptide's own allele-scoped evidence.
+    """Return the :class:`RankedEvidence` best able to rank *alleles*.
 
-    Returns ``(ordered, kind, predictor, values)``, or ``(None, ...)`` when the
-    peptide carries no usable allele-scoped evidence — in which case the caller
-    must fall back rather than invent a ranking.
+    ``None`` when the peptide carries no usable allele-scoped evidence — the
+    caller must then fall back rather than invent a ranking.
 
-    Two rules keep the recorded provenance true:
-
-    * Alleles are ranked using **one predictor's** values, never a per-allele
-      best taken across predictors. Two models' scales are independent, so a
-      cross-model minimum compares incomparable numbers *and* produces a
-      ``(predictor, value)`` pair the named predictor never emitted — which
-      would make the attribution unreconstructable, the one thing this module
-      exists to prevent.
-    * The axis is chosen by how many of the requested alleles it actually
-      covers, not by whether it covers any. A file carrying presentation for
-      one allele and affinity for six should rank on affinity; short-circuiting
-      on the first non-empty axis would silently drop five alleles.
+    The axis is chosen by how many of the requested alleles it actually
+    covers, not by whether it covers any: a file carrying presentation for
+    one allele and affinity for six should rank on affinity. Ties go to the
+    earlier (preferred) axis.
     """
     candidates = (
         SELECTION_AXES if axis == SELECTION_AUTO
@@ -223,12 +338,15 @@ def _ranked_alleles(epitope, alleles, axis, default_methods=None):
 
     allowed = set(alleles)
     best = None
+    best_key = None
     for rank, (kind, attribute, higher_is_better) in enumerate(candidates):
         by_predictor = {}
         for prediction in epitope.predictions_flat():
             if prediction.kind != kind or prediction.allele not in allowed:
                 continue
-            value = getattr(prediction, attribute, None)
+            if not is_allele_scoped(prediction):
+                continue
+            value = _plain_number(getattr(prediction, attribute, None))
             if value is None:
                 continue
             slot = by_predictor.setdefault(prediction.predictor_name, {})
@@ -239,19 +357,17 @@ def _ranked_alleles(epitope, alleles, axis, default_methods=None):
         if not by_predictor:
             continue
         predictor = _pick_predictor(by_predictor, default_methods, kind)
-        values = by_predictor[predictor]
-        # More alleles covered wins; ties go to the earlier (preferred) axis.
-        key = (len(values), -rank)
-        if best is None or key > best[0]:
-            best = (key, kind, predictor, values, higher_is_better)
-
-    if best is None:
-        return None, "", "", {}
-    _key, kind, predictor, values, higher_is_better = best
-    ordered = sorted(
-        values,
-        key=lambda a: (-values[a] if higher_is_better else values[a], a))
-    return ordered, kind, predictor, values
+        evidence = RankedEvidence(
+            kind=kind, predictor=predictor,
+            values=dict(by_predictor[predictor]),
+            higher_is_better=higher_is_better)
+        # One key, not two locals that must stay in sync — the mistake this
+        # whole module is a reaction to. More alleles covered wins; ties go
+        # to the earlier (preferred) axis.
+        key = (evidence.coverage, -rank)
+        if best_key is None or key > best_key:
+            best, best_key = evidence, key
+    return best
 
 
 def attribute_alleles(epitope, genotype, policy,
@@ -268,10 +384,7 @@ def attribute_alleles(epitope, genotype, policy,
     # relabelled "from_input" on a second attribution pass and the audit
     # record would claim the input paired a peptide with an allele it never
     # mentioned.
-    from_input = tuple(sorted({
-        prediction.allele
-        for prediction in epitope.predictions_flat()
-        if prediction.allele}))
+    from_input = alleles_named_by(epitope.predictions_flat())
     # An explicit genotype is the patient's actual typing and wins outright.
     # Unioning the input's alleles in would mean an explicit genotype could
     # only ever widen the attributed set, never narrow it — so it could not
@@ -303,9 +416,9 @@ def attribute_alleles(epitope, genotype, policy,
         raise AllelePolicyError(
             "A 'top:N' allele policy requires a positive limit")
 
-    ordered, kind, predictor, values = _ranked_alleles(
+    evidence = _ranked_alleles(
         epitope, genotype, policy.axis, default_methods=default_methods)
-    if ordered is None:
+    if evidence is None:
         # No allele-scoped evidence to select from. "We don't know which
         # allele presents this" is not the same as "this allele does", so
         # keep the whole genotype rather than inventing a winner.
@@ -316,14 +429,18 @@ def attribute_alleles(epitope, genotype, policy,
                 source=ALLELE_SOURCE_FROM_INPUT if a in from_input_set else ALLELE_SOURCE_BROADCAST)
             for a in genotype)
 
+    # ``top:N`` means "up to N of the alleles this axis could actually rank".
+    # When fewer are rankable the result is shorter; padding it with alleles
+    # the model could not rank would assert a preference the data does not
+    # support.
     limit = 1 if policy.name == POLICY_SELECTED else policy.limit
     return tuple(
         AlleleAttribution(
             allele=allele,
             source=ALLELE_SOURCE_SELECTED,
-            rank_kind=kind,
-            rank_predictor=predictor,
-            rank_value=values[allele],
+            rank_kind=evidence.kind,
+            rank_predictor=evidence.predictor,
+            rank_value=evidence.values[allele],
             rank_position=position,
         )
-        for position, allele in enumerate(ordered[:limit], start=1))
+        for position, allele in enumerate(evidence.ordered[:limit], start=1))

--- a/vaxrank/allele_evidence.py
+++ b/vaxrank/allele_evidence.py
@@ -28,8 +28,8 @@ its rows.
 
 This module makes the choice explicit and, crucially, **recordable**. Every
 attributed allele carries an :class:`AlleleAttribution` saying where it came
-from: observed in the input, part of the patient's genotype, or nominated by
-ranking the peptide's own allele-scoped evidence — and for a nomination, on
+from: reported by the input, carried in the patient's genotype, or selected by
+ranking the peptide's own allele-scoped evidence — and for a selection, on
 which axis, by which predictor, at what value and what rank. A reader of a
 finished run can therefore reconstruct exactly why a given allele was
 credited with a given processing score, rather than having to re-derive it.
@@ -47,25 +47,25 @@ from serializable import DataclassSerializable
 
 
 # Where an attributed allele came from.
-BASIS_OBSERVED = "observed"     # the input scored this peptide against it
+BASIS_REPORTED = "reported"     # the input carried a row for this pairing
 BASIS_GENOTYPE = "genotype"     # the patient carries it; evidence broadcast
-BASIS_NOMINATED = "nominated"   # ranked best by this peptide's own evidence
-ALLELE_BASES = frozenset({BASIS_OBSERVED, BASIS_GENOTYPE, BASIS_NOMINATED})
+BASIS_SELECTED = "selected"   # vaxrank ranked the genotype and picked it
+ALLELE_BASES = frozenset({BASIS_REPORTED, BASIS_GENOTYPE, BASIS_SELECTED})
 
 # Policies for attributing allele-independent evidence.
-POLICY_NOMINATED = "nominated"  # the model's best allele, else the genotype
+POLICY_SELECTED = "selected"  # the best-ranked allele, else the genotype
 POLICY_ALL = "all"              # every allele in the patient's genotype
-POLICY_OBSERVED = "observed"    # only alleles the input actually scored
+POLICY_REPORTED = "reported"    # only pairings the input actually carried
 POLICY_TOP_PREFIX = "top:"      # ``top:N`` — the N best, else the genotype
 
-# Ranking axes a nomination may use, with the direction that means "better".
+# Ranking axes a selection may use, with the direction that means "better".
 # Presentation is preferred over affinity when both are available: it is the
 # model's own statement about presentation, which is the question being asked.
-NOMINATION_AXES = (
+SELECTION_AXES = (
     ("pMHC_presentation", "score", True),   # higher score is better
     ("pMHC_affinity", "value", False),      # lower IC50 is better
 )
-NOMINATION_AUTO = "auto"
+SELECTION_AUTO = "auto"
 
 
 class AllelePolicyError(ValueError):
@@ -76,9 +76,9 @@ class AllelePolicyError(ValueError):
 class AlleleAttribution(DataclassSerializable):
     """Why one allele was credited with a peptide's allele-free evidence.
 
-    ``basis`` is one of :data:`BASIS_OBSERVED`, :data:`BASIS_GENOTYPE`, or
-    :data:`BASIS_NOMINATED`. The remaining fields are populated only for a
-    nomination and are what makes it reproducible: the axis that ranked the
+    ``basis`` is one of :data:`BASIS_REPORTED`, :data:`BASIS_GENOTYPE`, or
+    :data:`BASIS_SELECTED`. The remaining fields are populated only for a
+    selection and are what makes it reproducible: the axis that ranked the
     alleles, the predictor whose value was read, the value itself, and the
     resulting 1-based position.
     """
@@ -97,18 +97,18 @@ class AlleleAttribution(DataclassSerializable):
             raise ValueError(
                 "Unknown allele attribution basis %r (expected one of %s)"
                 % (self.basis, ", ".join(sorted(ALLELE_BASES))))
-        if self.basis == BASIS_NOMINATED and not self.rank_kind:
+        if self.basis == BASIS_SELECTED and not self.rank_kind:
             raise ValueError(
-                "A nominated allele must record the axis that ranked it, or "
-                "the nomination cannot be reconstructed")
-        if self.basis != BASIS_NOMINATED and self.rank_kind:
+                "A selected allele must record the axis that ranked it, or "
+                "the selection cannot be reconstructed")
+        if self.basis != BASIS_SELECTED and self.rank_kind:
             raise ValueError(
-                "Only a nominated allele carries ranking provenance")
+                "Only a selected allele carries ranking provenance")
 
     def describe(self) -> str:
         """One human-readable line, for reports and logs."""
-        if self.basis == BASIS_OBSERVED:
-            return "%s (scored in the input)" % self.allele
+        if self.basis == BASIS_REPORTED:
+            return "%s (carried by the input)" % self.allele
         if self.basis == BASIS_GENOTYPE:
             return "%s (patient genotype; no allele-specific evidence)" % (
                 self.allele,)
@@ -125,18 +125,18 @@ class AlleleAttribution(DataclassSerializable):
 class AllelePolicy:
     """A parsed allele-attribution policy."""
 
-    name: str = POLICY_NOMINATED
+    name: str = POLICY_SELECTED
     limit: object = None            # for ``top:N``
-    axis: str = NOMINATION_AUTO     # kind used to rank, or "auto"
+    axis: str = SELECTION_AUTO     # kind used to rank, or "auto"
 
     @classmethod
-    def parse(cls, value, axis=NOMINATION_AUTO) -> "AllelePolicy":
+    def parse(cls, value, axis=SELECTION_AUTO) -> "AllelePolicy":
         """Parse a config string into a policy.
 
-        Accepts ``nominated``, ``all``, ``observed``, and ``top:N``.
+        Accepts ``selected``, ``all``, ``reported``, and ``top:N``.
         """
-        text = (value or POLICY_NOMINATED).strip().lower()
-        if text in (POLICY_NOMINATED, POLICY_ALL, POLICY_OBSERVED):
+        text = (value or POLICY_SELECTED).strip().lower()
+        if text in (POLICY_SELECTED, POLICY_ALL, POLICY_REPORTED):
             return cls(name=text, axis=axis)
         if text.startswith(POLICY_TOP_PREFIX):
             suffix = text[len(POLICY_TOP_PREFIX):]
@@ -152,8 +152,8 @@ class AllelePolicy:
             return cls(name=POLICY_TOP_PREFIX.rstrip(":"), limit=limit,
                        axis=axis)
         raise AllelePolicyError(
-            "Unknown allele policy %r (expected 'nominated', 'all', "
-            "'observed', or 'top:N')" % value)
+            "Unknown allele policy %r (expected 'selected', 'all', "
+            "'reported', or 'top:N')" % value)
 
 
 def _ranked_alleles(epitope, alleles, axis):
@@ -164,13 +164,13 @@ def _ranked_alleles(epitope, alleles, axis):
     caller must fall back rather than invent a ranking.
     """
     candidates = (
-        NOMINATION_AXES if axis == NOMINATION_AUTO
-        else tuple(a for a in NOMINATION_AXES if a[0] == axis))
-    if axis != NOMINATION_AUTO and not candidates:
+        SELECTION_AXES if axis == SELECTION_AUTO
+        else tuple(a for a in SELECTION_AXES if a[0] == axis))
+    if axis != SELECTION_AUTO and not candidates:
         raise AllelePolicyError(
-            "Unknown allele nomination axis %r (expected one of %s or %r)"
-            % (axis, ", ".join(a[0] for a in NOMINATION_AXES),
-               NOMINATION_AUTO))
+            "Unknown allele selection axis %r (expected one of %s or %r)"
+            % (axis, ", ".join(a[0] for a in SELECTION_AXES),
+               SELECTION_AUTO))
 
     allowed = set(alleles)
     for kind, attribute, higher_is_better in candidates:
@@ -203,43 +203,43 @@ def attribute_alleles(epitope, genotype, policy) -> tuple:
     :class:`AllelePolicy`. The result is ordered and deterministic, and every
     entry records why that allele was chosen.
     """
-    observed = tuple(a for a in epitope.patient_alleles if a)
-    genotype = tuple(sorted({a for a in (genotype or ()) if a} | set(observed)))
+    reported = tuple(a for a in epitope.patient_alleles if a)
+    genotype = tuple(sorted({a for a in (genotype or ()) if a} | set(reported)))
     if not genotype:
         return ()
 
-    if policy.name == POLICY_OBSERVED:
+    if policy.name == POLICY_REPORTED:
         return tuple(
-            AlleleAttribution(allele=a, basis=BASIS_OBSERVED)
-            for a in sorted(observed))
+            AlleleAttribution(allele=a, basis=BASIS_REPORTED)
+            for a in sorted(reported))
 
     if policy.name == POLICY_ALL:
-        observed_set = set(observed)
+        reported_set = set(reported)
         return tuple(
             AlleleAttribution(
                 allele=a,
-                basis=BASIS_OBSERVED if a in observed_set else BASIS_GENOTYPE)
+                basis=BASIS_REPORTED if a in reported_set else BASIS_GENOTYPE)
             for a in genotype)
 
-    # nominated / top:N
+    # selected / top:N
     ordered, kind, predictor, values = _ranked_alleles(
         epitope, genotype, policy.axis)
     if ordered is None:
-        # No allele-scoped evidence to nominate from. "We don't know which
+        # No allele-scoped evidence to select from. "We don't know which
         # allele presents this" is not the same as "this allele does", so
         # keep the whole genotype rather than inventing a winner.
-        observed_set = set(observed)
+        reported_set = set(reported)
         return tuple(
             AlleleAttribution(
                 allele=a,
-                basis=BASIS_OBSERVED if a in observed_set else BASIS_GENOTYPE)
+                basis=BASIS_REPORTED if a in reported_set else BASIS_GENOTYPE)
             for a in genotype)
 
-    limit = 1 if policy.name == POLICY_NOMINATED else policy.limit
+    limit = 1 if policy.name == POLICY_SELECTED else policy.limit
     return tuple(
         AlleleAttribution(
             allele=allele,
-            basis=BASIS_NOMINATED,
+            basis=BASIS_SELECTED,
             rank_kind=kind,
             rank_predictor=predictor,
             rank_value=values[allele],

--- a/vaxrank/allele_evidence.py
+++ b/vaxrank/allele_evidence.py
@@ -1,0 +1,248 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Which MHC alleles allele-independent evidence is attributed to, and why.
+
+Some predictions describe a peptide, not a peptide-MHC pair: antigen
+processing and proteasomal cleavage depend on the peptide and its flanks
+with no MHC involved. Vaxrank's scoring substrate is per-allele
+(``CandidateEpitope.per_allele_scores``), so that peptide-level evidence has
+to be attributed to one or more alleles before it can score anything.
+
+That attribution is a *choice*, and it used to be made implicitly: the
+evidence was projected onto whichever alleles the input file happened to
+score that peptide against. Row incidence is neither the patient's genotype
+nor a claim about which allele presents the peptide — on real LENS files
+those sets are one or two alleles out of a five- or six-allele genotype, so
+the implicit answer was an artifact of how the upstream tool chose to write
+its rows.
+
+This module makes the choice explicit and, crucially, **recordable**. Every
+attributed allele carries an :class:`AlleleAttribution` saying where it came
+from: observed in the input, part of the patient's genotype, or nominated by
+ranking the peptide's own allele-scoped evidence — and for a nomination, on
+which axis, by which predictor, at what value and what rank. A reader of a
+finished run can therefore reconstruct exactly why a given allele was
+credited with a given processing score, rather than having to re-derive it.
+
+Note that this cannot be delegated to topiary's ``alleles=`` context option:
+that declares one allele set for a whole frame, while every policy except
+:data:`POLICY_ALL` needs a different set per peptide.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from serializable import DataclassSerializable
+
+
+# Where an attributed allele came from.
+BASIS_OBSERVED = "observed"     # the input scored this peptide against it
+BASIS_GENOTYPE = "genotype"     # the patient carries it; evidence broadcast
+BASIS_NOMINATED = "nominated"   # ranked best by this peptide's own evidence
+ALLELE_BASES = frozenset({BASIS_OBSERVED, BASIS_GENOTYPE, BASIS_NOMINATED})
+
+# Policies for attributing allele-independent evidence.
+POLICY_NOMINATED = "nominated"  # the model's best allele, else the genotype
+POLICY_ALL = "all"              # every allele in the patient's genotype
+POLICY_OBSERVED = "observed"    # only alleles the input actually scored
+POLICY_TOP_PREFIX = "top:"      # ``top:N`` — the N best, else the genotype
+
+# Ranking axes a nomination may use, with the direction that means "better".
+# Presentation is preferred over affinity when both are available: it is the
+# model's own statement about presentation, which is the question being asked.
+NOMINATION_AXES = (
+    ("pMHC_presentation", "score", True),   # higher score is better
+    ("pMHC_affinity", "value", False),      # lower IC50 is better
+)
+NOMINATION_AUTO = "auto"
+
+
+class AllelePolicyError(ValueError):
+    """Raised for an allele-attribution policy string that cannot be honored."""
+
+
+@dataclass(frozen=True)
+class AlleleAttribution(DataclassSerializable):
+    """Why one allele was credited with a peptide's allele-free evidence.
+
+    ``basis`` is one of :data:`BASIS_OBSERVED`, :data:`BASIS_GENOTYPE`, or
+    :data:`BASIS_NOMINATED`. The remaining fields are populated only for a
+    nomination and are what makes it reproducible: the axis that ranked the
+    alleles, the predictor whose value was read, the value itself, and the
+    resulting 1-based position.
+    """
+
+    allele: str
+    basis: str
+    rank_kind: str = ""
+    rank_predictor: str = ""
+    rank_value: object = None
+    rank_position: object = None
+
+    def __post_init__(self):
+        if not self.allele:
+            raise ValueError("An allele attribution requires an allele")
+        if self.basis not in ALLELE_BASES:
+            raise ValueError(
+                "Unknown allele attribution basis %r (expected one of %s)"
+                % (self.basis, ", ".join(sorted(ALLELE_BASES))))
+        if self.basis == BASIS_NOMINATED and not self.rank_kind:
+            raise ValueError(
+                "A nominated allele must record the axis that ranked it, or "
+                "the nomination cannot be reconstructed")
+        if self.basis != BASIS_NOMINATED and self.rank_kind:
+            raise ValueError(
+                "Only a nominated allele carries ranking provenance")
+
+    def describe(self) -> str:
+        """One human-readable line, for reports and logs."""
+        if self.basis == BASIS_OBSERVED:
+            return "%s (scored in the input)" % self.allele
+        if self.basis == BASIS_GENOTYPE:
+            return "%s (patient genotype; no allele-specific evidence)" % (
+                self.allele,)
+        return "%s (ranked #%s of the patient's alleles on %s%s = %s)" % (
+            self.allele,
+            self.rank_position if self.rank_position is not None else "?",
+            self.rank_kind,
+            " [%s]" % self.rank_predictor if self.rank_predictor else "",
+            self.rank_value,
+        )
+
+
+@dataclass(frozen=True)
+class AllelePolicy:
+    """A parsed allele-attribution policy."""
+
+    name: str = POLICY_NOMINATED
+    limit: object = None            # for ``top:N``
+    axis: str = NOMINATION_AUTO     # kind used to rank, or "auto"
+
+    @classmethod
+    def parse(cls, value, axis=NOMINATION_AUTO) -> "AllelePolicy":
+        """Parse a config string into a policy.
+
+        Accepts ``nominated``, ``all``, ``observed``, and ``top:N``.
+        """
+        text = (value or POLICY_NOMINATED).strip().lower()
+        if text in (POLICY_NOMINATED, POLICY_ALL, POLICY_OBSERVED):
+            return cls(name=text, axis=axis)
+        if text.startswith(POLICY_TOP_PREFIX):
+            suffix = text[len(POLICY_TOP_PREFIX):]
+            try:
+                limit = int(suffix)
+            except ValueError:
+                raise AllelePolicyError(
+                    "Allele policy %r must be 'top:N' with an integer N"
+                    % value) from None
+            if limit < 1:
+                raise AllelePolicyError(
+                    "Allele policy %r must keep at least one allele" % value)
+            return cls(name=POLICY_TOP_PREFIX.rstrip(":"), limit=limit,
+                       axis=axis)
+        raise AllelePolicyError(
+            "Unknown allele policy %r (expected 'nominated', 'all', "
+            "'observed', or 'top:N')" % value)
+
+
+def _ranked_alleles(epitope, alleles, axis):
+    """Rank *alleles* by the peptide's own allele-scoped evidence.
+
+    Returns ``(ordered, kind, predictor, values)``, or ``(None, ...)`` when
+    the peptide carries no usable allele-scoped evidence — in which case the
+    caller must fall back rather than invent a ranking.
+    """
+    candidates = (
+        NOMINATION_AXES if axis == NOMINATION_AUTO
+        else tuple(a for a in NOMINATION_AXES if a[0] == axis))
+    if axis != NOMINATION_AUTO and not candidates:
+        raise AllelePolicyError(
+            "Unknown allele nomination axis %r (expected one of %s or %r)"
+            % (axis, ", ".join(a[0] for a in NOMINATION_AXES),
+               NOMINATION_AUTO))
+
+    allowed = set(alleles)
+    for kind, attribute, higher_is_better in candidates:
+        by_allele = {}
+        predictor = ""
+        for prediction in epitope.predictions_flat():
+            if prediction.kind != kind or prediction.allele not in allowed:
+                continue
+            value = getattr(prediction, attribute, None)
+            if value is None:
+                continue
+            predictor = predictor or prediction.predictor_name
+            best = by_allele.get(prediction.allele)
+            if best is None or (
+                    value > best if higher_is_better else value < best):
+                by_allele[prediction.allele] = value
+        if by_allele:
+            ordered = sorted(
+                by_allele,
+                key=lambda a: (-by_allele[a] if higher_is_better
+                               else by_allele[a], a))
+            return ordered, kind, predictor, by_allele
+    return None, "", "", {}
+
+
+def attribute_alleles(epitope, genotype, policy) -> tuple:
+    """Return the :class:`AlleleAttribution` list for one candidate.
+
+    ``genotype`` is the patient's allele set. ``policy`` is an
+    :class:`AllelePolicy`. The result is ordered and deterministic, and every
+    entry records why that allele was chosen.
+    """
+    observed = tuple(a for a in epitope.patient_alleles if a)
+    genotype = tuple(sorted({a for a in (genotype or ()) if a} | set(observed)))
+    if not genotype:
+        return ()
+
+    if policy.name == POLICY_OBSERVED:
+        return tuple(
+            AlleleAttribution(allele=a, basis=BASIS_OBSERVED)
+            for a in sorted(observed))
+
+    if policy.name == POLICY_ALL:
+        observed_set = set(observed)
+        return tuple(
+            AlleleAttribution(
+                allele=a,
+                basis=BASIS_OBSERVED if a in observed_set else BASIS_GENOTYPE)
+            for a in genotype)
+
+    # nominated / top:N
+    ordered, kind, predictor, values = _ranked_alleles(
+        epitope, genotype, policy.axis)
+    if ordered is None:
+        # No allele-scoped evidence to nominate from. "We don't know which
+        # allele presents this" is not the same as "this allele does", so
+        # keep the whole genotype rather than inventing a winner.
+        observed_set = set(observed)
+        return tuple(
+            AlleleAttribution(
+                allele=a,
+                basis=BASIS_OBSERVED if a in observed_set else BASIS_GENOTYPE)
+            for a in genotype)
+
+    limit = 1 if policy.name == POLICY_NOMINATED else policy.limit
+    return tuple(
+        AlleleAttribution(
+            allele=allele,
+            basis=BASIS_NOMINATED,
+            rank_kind=kind,
+            rank_predictor=predictor,
+            rank_value=values[allele],
+            rank_position=position,
+        )
+        for position, allele in enumerate(ordered[:limit], start=1))

--- a/vaxrank/allele_evidence.py
+++ b/vaxrank/allele_evidence.py
@@ -28,8 +28,8 @@ its rows.
 
 This module makes the choice explicit and, crucially, **recordable**. Every
 attributed allele carries an :class:`AlleleAttribution` saying where it came
-from: reported by the input, carried in the patient's genotype, or selected by
-ranking the peptide's own allele-scoped evidence — and for a selection, on
+from: it came from the input file, it was broadcast across the genotype, or
+vaxrank selected it by ranking — and for a selection, on
 which axis, by which predictor, at what value and what rank. A reader of a
 finished run can therefore reconstruct exactly why a given allele was
 credited with a given processing score, rather than having to re-derive it.
@@ -46,16 +46,16 @@ from dataclasses import dataclass
 from serializable import DataclassSerializable
 
 
-# Where an attributed allele came from.
-BASIS_REPORTED = "reported"     # the input carried a row for this pairing
-BASIS_GENOTYPE = "genotype"     # the patient carries it; evidence broadcast
-BASIS_SELECTED = "selected"   # vaxrank ranked the genotype and picked it
-ALLELE_BASES = frozenset({BASIS_REPORTED, BASIS_GENOTYPE, BASIS_SELECTED})
+# How the evidence reached this allele.
+ALLELE_SOURCE_FROM_INPUT = "from_input"  # the source file paired these two
+ALLELE_SOURCE_BROADCAST = "broadcast"    # nothing narrowed it; all alleles got it
+ALLELE_SOURCE_SELECTED = "selected"      # vaxrank ranked the genotype and picked
+ALLELE_SOURCES = frozenset({ALLELE_SOURCE_FROM_INPUT, ALLELE_SOURCE_BROADCAST, ALLELE_SOURCE_SELECTED})
 
 # Policies for attributing allele-independent evidence.
 POLICY_SELECTED = "selected"  # the best-ranked allele, else the genotype
 POLICY_ALL = "all"              # every allele in the patient's genotype
-POLICY_REPORTED = "reported"    # only pairings the input actually carried
+POLICY_FROM_INPUT = "from_input"  # only pairings the source file carried
 POLICY_TOP_PREFIX = "top:"      # ``top:N`` — the N best, else the genotype
 
 # Ranking axes a selection may use, with the direction that means "better".
@@ -76,15 +76,15 @@ class AllelePolicyError(ValueError):
 class AlleleAttribution(DataclassSerializable):
     """Why one allele was credited with a peptide's allele-free evidence.
 
-    ``basis`` is one of :data:`BASIS_REPORTED`, :data:`BASIS_GENOTYPE`, or
-    :data:`BASIS_SELECTED`. The remaining fields are populated only for a
+    ``source`` is one of :data:`ALLELE_SOURCE_FROM_INPUT`, :data:`ALLELE_SOURCE_BROADCAST`, or
+    :data:`ALLELE_SOURCE_SELECTED`. The remaining fields are populated only for a
     selection and are what makes it reproducible: the axis that ranked the
     alleles, the predictor whose value was read, the value itself, and the
     resulting 1-based position.
     """
 
     allele: str
-    basis: str
+    source: str
     rank_kind: str = ""
     rank_predictor: str = ""
     rank_value: object = None
@@ -93,26 +93,25 @@ class AlleleAttribution(DataclassSerializable):
     def __post_init__(self):
         if not self.allele:
             raise ValueError("An allele attribution requires an allele")
-        if self.basis not in ALLELE_BASES:
+        if self.source not in ALLELE_SOURCES:
             raise ValueError(
-                "Unknown allele attribution basis %r (expected one of %s)"
-                % (self.basis, ", ".join(sorted(ALLELE_BASES))))
-        if self.basis == BASIS_SELECTED and not self.rank_kind:
+                "Unknown allele attribution source %r (expected one of %s)"
+                % (self.source, ", ".join(sorted(ALLELE_SOURCES))))
+        if self.source == ALLELE_SOURCE_SELECTED and not self.rank_kind:
             raise ValueError(
                 "A selected allele must record the axis that ranked it, or "
                 "the selection cannot be reconstructed")
-        if self.basis != BASIS_SELECTED and self.rank_kind:
+        if self.source != ALLELE_SOURCE_SELECTED and self.rank_kind:
             raise ValueError(
                 "Only a selected allele carries ranking provenance")
 
     def describe(self) -> str:
         """One human-readable line, for reports and logs."""
-        if self.basis == BASIS_REPORTED:
-            return "%s (carried by the input)" % self.allele
-        if self.basis == BASIS_GENOTYPE:
-            return "%s (patient genotype; no allele-specific evidence)" % (
-                self.allele,)
-        return "%s (ranked #%s of the patient's alleles on %s%s = %s)" % (
+        if self.source == ALLELE_SOURCE_FROM_INPUT:
+            return "%s (from the input file)" % self.allele
+        if self.source == ALLELE_SOURCE_BROADCAST:
+            return "%s (broadcast: no allele-specific evidence)" % self.allele
+        return "%s (selected: ranked #%s on %s%s = %s)" % (
             self.allele,
             self.rank_position if self.rank_position is not None else "?",
             self.rank_kind,
@@ -133,10 +132,10 @@ class AllelePolicy:
     def parse(cls, value, axis=SELECTION_AUTO) -> "AllelePolicy":
         """Parse a config string into a policy.
 
-        Accepts ``selected``, ``all``, ``reported``, and ``top:N``.
+        Accepts ``selected``, ``all``, ``from_input``, and ``top:N``.
         """
         text = (value or POLICY_SELECTED).strip().lower()
-        if text in (POLICY_SELECTED, POLICY_ALL, POLICY_REPORTED):
+        if text in (POLICY_SELECTED, POLICY_ALL, POLICY_FROM_INPUT):
             return cls(name=text, axis=axis)
         if text.startswith(POLICY_TOP_PREFIX):
             suffix = text[len(POLICY_TOP_PREFIX):]
@@ -153,7 +152,7 @@ class AllelePolicy:
                        axis=axis)
         raise AllelePolicyError(
             "Unknown allele policy %r (expected 'selected', 'all', "
-            "'reported', or 'top:N')" % value)
+            "'from_input', or 'top:N')" % value)
 
 
 def _ranked_alleles(epitope, alleles, axis):
@@ -203,22 +202,22 @@ def attribute_alleles(epitope, genotype, policy) -> tuple:
     :class:`AllelePolicy`. The result is ordered and deterministic, and every
     entry records why that allele was chosen.
     """
-    reported = tuple(a for a in epitope.patient_alleles if a)
-    genotype = tuple(sorted({a for a in (genotype or ()) if a} | set(reported)))
+    from_input = tuple(a for a in epitope.patient_alleles if a)
+    genotype = tuple(sorted({a for a in (genotype or ()) if a} | set(from_input)))
     if not genotype:
         return ()
 
-    if policy.name == POLICY_REPORTED:
+    if policy.name == POLICY_FROM_INPUT:
         return tuple(
-            AlleleAttribution(allele=a, basis=BASIS_REPORTED)
-            for a in sorted(reported))
+            AlleleAttribution(allele=a, source=ALLELE_SOURCE_FROM_INPUT)
+            for a in sorted(from_input))
 
     if policy.name == POLICY_ALL:
-        reported_set = set(reported)
+        from_input_set = set(from_input)
         return tuple(
             AlleleAttribution(
                 allele=a,
-                basis=BASIS_REPORTED if a in reported_set else BASIS_GENOTYPE)
+                source=ALLELE_SOURCE_FROM_INPUT if a in from_input_set else ALLELE_SOURCE_BROADCAST)
             for a in genotype)
 
     # selected / top:N
@@ -228,18 +227,18 @@ def attribute_alleles(epitope, genotype, policy) -> tuple:
         # No allele-scoped evidence to select from. "We don't know which
         # allele presents this" is not the same as "this allele does", so
         # keep the whole genotype rather than inventing a winner.
-        reported_set = set(reported)
+        from_input_set = set(from_input)
         return tuple(
             AlleleAttribution(
                 allele=a,
-                basis=BASIS_REPORTED if a in reported_set else BASIS_GENOTYPE)
+                source=ALLELE_SOURCE_FROM_INPUT if a in from_input_set else ALLELE_SOURCE_BROADCAST)
             for a in genotype)
 
     limit = 1 if policy.name == POLICY_SELECTED else policy.limit
     return tuple(
         AlleleAttribution(
             allele=allele,
-            basis=BASIS_SELECTED,
+            source=ALLELE_SOURCE_SELECTED,
             rank_kind=kind,
             rank_predictor=predictor,
             rank_value=values[allele],

--- a/vaxrank/allele_evidence.py
+++ b/vaxrank/allele_evidence.py
@@ -56,7 +56,10 @@ ALLELE_SOURCES = frozenset({ALLELE_SOURCE_FROM_INPUT, ALLELE_SOURCE_BROADCAST, A
 POLICY_SELECTED = "selected"  # the best-ranked allele, else the genotype
 POLICY_ALL = "all"              # every allele in the patient's genotype
 POLICY_FROM_INPUT = "from_input"  # only pairings the source file carried
-POLICY_TOP_PREFIX = "top:"      # ``top:N`` — the N best, else the genotype
+POLICY_TOP = "top"              # ``top:N`` — the N best, else the genotype
+POLICY_TOP_PREFIX = "top:"
+ALLELE_POLICIES = frozenset({
+    POLICY_SELECTED, POLICY_ALL, POLICY_FROM_INPUT, POLICY_TOP})
 
 # Ranking axes a selection may use, with the direction that means "better".
 # Presentation is preferred over affinity when both are available: it is the
@@ -66,6 +69,18 @@ SELECTION_AXES = (
     ("pMHC_affinity", "value", False),      # lower IC50 is better
 )
 SELECTION_AUTO = "auto"
+
+# Kinds that describe a peptide rather than a peptide-MHC pair, and are
+# therefore the only ones this module may attribute to alleles. A prediction
+# of any other kind that arrives with a blank allele is malformed, not
+# peptide-level: projecting it would manufacture per-allele binding evidence
+# for alleles it was never predicted against.
+PEPTIDE_LEVEL_KINDS = frozenset({"antigen_processing", "proteasome_cleavage"})
+
+
+def is_peptide_level(prediction) -> bool:
+    """True when a prediction describes the peptide, not a peptide-MHC pair."""
+    return not prediction.allele and prediction.kind in PEPTIDE_LEVEL_KINDS
 
 
 class AllelePolicyError(ValueError):
@@ -134,6 +149,11 @@ class AllelePolicy:
 
         Accepts ``selected``, ``all``, ``from_input``, and ``top:N``.
         """
+        known_axes = {a[0] for a in SELECTION_AXES} | {SELECTION_AUTO}
+        if axis not in known_axes:
+            raise AllelePolicyError(
+                "Unknown allele selection axis %r (expected one of %s)"
+                % (axis, ", ".join(sorted(known_axes))))
         text = (value or POLICY_SELECTED).strip().lower()
         if text in (POLICY_SELECTED, POLICY_ALL, POLICY_FROM_INPUT):
             return cls(name=text, axis=axis)
@@ -155,12 +175,42 @@ class AllelePolicy:
             "'from_input', or 'top:N')" % value)
 
 
-def _ranked_alleles(epitope, alleles, axis):
+# Preference between predictors of one kind when the config names none.
+# Mirrors epitope_dsl._CANONICAL_METHOD_PREFERENCE so a selection and a score
+# resolve to the same model.
+_PREDICTOR_PREFERENCE = ("mhcflurry", "netmhcpan", "netmhcstabpan")
+
+
+def _pick_predictor(available, default_methods, kind):
+    """Choose the one predictor whose values will rank the alleles."""
+    named = (default_methods or {}).get(kind)
+    if named and named in available:
+        return named
+    for preferred in _PREDICTOR_PREFERENCE:
+        if preferred in available:
+            return preferred
+    return sorted(available)[0]
+
+
+def _ranked_alleles(epitope, alleles, axis, default_methods=None):
     """Rank *alleles* by the peptide's own allele-scoped evidence.
 
-    Returns ``(ordered, kind, predictor, values)``, or ``(None, ...)`` when
-    the peptide carries no usable allele-scoped evidence — in which case the
-    caller must fall back rather than invent a ranking.
+    Returns ``(ordered, kind, predictor, values)``, or ``(None, ...)`` when the
+    peptide carries no usable allele-scoped evidence — in which case the caller
+    must fall back rather than invent a ranking.
+
+    Two rules keep the recorded provenance true:
+
+    * Alleles are ranked using **one predictor's** values, never a per-allele
+      best taken across predictors. Two models' scales are independent, so a
+      cross-model minimum compares incomparable numbers *and* produces a
+      ``(predictor, value)`` pair the named predictor never emitted — which
+      would make the attribution unreconstructable, the one thing this module
+      exists to prevent.
+    * The axis is chosen by how many of the requested alleles it actually
+      covers, not by whether it covers any. A file carrying presentation for
+      one allele and affinity for six should rank on affinity; short-circuiting
+      on the first non-empty axis would silently drop five alleles.
     """
     candidates = (
         SELECTION_AXES if axis == SELECTION_AUTO
@@ -172,38 +222,63 @@ def _ranked_alleles(epitope, alleles, axis):
                SELECTION_AUTO))
 
     allowed = set(alleles)
-    for kind, attribute, higher_is_better in candidates:
-        by_allele = {}
-        predictor = ""
+    best = None
+    for rank, (kind, attribute, higher_is_better) in enumerate(candidates):
+        by_predictor = {}
         for prediction in epitope.predictions_flat():
             if prediction.kind != kind or prediction.allele not in allowed:
                 continue
             value = getattr(prediction, attribute, None)
             if value is None:
                 continue
-            predictor = predictor or prediction.predictor_name
-            best = by_allele.get(prediction.allele)
-            if best is None or (
-                    value > best if higher_is_better else value < best):
-                by_allele[prediction.allele] = value
-        if by_allele:
-            ordered = sorted(
-                by_allele,
-                key=lambda a: (-by_allele[a] if higher_is_better
-                               else by_allele[a], a))
-            return ordered, kind, predictor, by_allele
-    return None, "", "", {}
+            slot = by_predictor.setdefault(prediction.predictor_name, {})
+            current = slot.get(prediction.allele)
+            if current is None or (
+                    value > current if higher_is_better else value < current):
+                slot[prediction.allele] = value
+        if not by_predictor:
+            continue
+        predictor = _pick_predictor(by_predictor, default_methods, kind)
+        values = by_predictor[predictor]
+        # More alleles covered wins; ties go to the earlier (preferred) axis.
+        key = (len(values), -rank)
+        if best is None or key > best[0]:
+            best = (key, kind, predictor, values, higher_is_better)
+
+    if best is None:
+        return None, "", "", {}
+    _key, kind, predictor, values, higher_is_better = best
+    ordered = sorted(
+        values,
+        key=lambda a: (-values[a] if higher_is_better else values[a], a))
+    return ordered, kind, predictor, values
 
 
-def attribute_alleles(epitope, genotype, policy) -> tuple:
+def attribute_alleles(epitope, genotype, policy,
+                      default_methods=None) -> tuple:
     """Return the :class:`AlleleAttribution` list for one candidate.
 
     ``genotype`` is the patient's allele set. ``policy`` is an
     :class:`AllelePolicy`. The result is ordered and deterministic, and every
     entry records why that allele was chosen.
     """
-    from_input = tuple(a for a in epitope.patient_alleles if a)
-    genotype = tuple(sorted({a for a in (genotype or ()) if a} | set(from_input)))
+    # Derived from the allele-scoped predictions themselves, NOT from
+    # patient_alleles: CandidateEpitope.__post_init__ folds every scored
+    # allele back into patient_alleles, so a broadcast allele would be
+    # relabelled "from_input" on a second attribution pass and the audit
+    # record would claim the input paired a peptide with an allele it never
+    # mentioned.
+    from_input = tuple(sorted({
+        prediction.allele
+        for prediction in epitope.predictions_flat()
+        if prediction.allele}))
+    # An explicit genotype is the patient's actual typing and wins outright.
+    # Unioning the input's alleles in would mean an explicit genotype could
+    # only ever widen the attributed set, never narrow it — so it could not
+    # be used to correct an input produced with the wrong or a wider panel.
+    genotype = (
+        tuple(sorted({a for a in genotype if a})) if genotype
+        else from_input)
     if not genotype:
         return ()
 
@@ -220,9 +295,16 @@ def attribute_alleles(epitope, genotype, policy) -> tuple:
                 source=ALLELE_SOURCE_FROM_INPUT if a in from_input_set else ALLELE_SOURCE_BROADCAST)
             for a in genotype)
 
-    # selected / top:N
+    if policy.name not in (POLICY_SELECTED, POLICY_TOP):
+        raise AllelePolicyError(
+            "Unknown allele policy name %r; AllelePolicy must come from "
+            "AllelePolicy.parse" % policy.name)
+    if policy.name == POLICY_TOP and not policy.limit:
+        raise AllelePolicyError(
+            "A 'top:N' allele policy requires a positive limit")
+
     ordered, kind, predictor, values = _ranked_alleles(
-        epitope, genotype, policy.axis)
+        epitope, genotype, policy.axis, default_methods=default_methods)
     if ordered is None:
         # No allele-scoped evidence to select from. "We don't know which
         # allele presents this" is not the same as "this allele does", so

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -553,9 +553,9 @@ class CandidateEpitope(Peptide):
     per_allele_scores: dict = field(default_factory=dict)
 
     # Why each allele was credited with this candidate's allele-independent
-    # evidence — observed in the input, taken from the patient's genotype, or
-    # nominated by ranking the peptide's own allele-scoped predictions (with
-    # the axis, predictor, value and rank that produced the nomination).
+    # evidence — reported by the input, carried in the patient's genotype, or
+    # selected by ranking the peptide's own allele-scoped predictions (with
+    # the axis, predictor, value and rank that produced the selection).
     # Recorded rather than recomputed so a finished run can be reconstructed:
     # see :mod:`vaxrank.allele_evidence`. Empty when a candidate carries no
     # allele-independent evidence, which is the common case.

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -553,7 +553,7 @@ class CandidateEpitope(Peptide):
     per_allele_scores: dict = field(default_factory=dict)
 
     # Why each allele was credited with this candidate's allele-independent
-    # evidence — reported by the input, carried in the patient's genotype, or
+    # evidence — from the input file, broadcast across the genotype, or
     # selected by ranking the peptide's own allele-scoped predictions (with
     # the axis, predictor, value and rank that produced the selection).
     # Recorded rather than recomputed so a finished run can be reconstructed:

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -552,6 +552,15 @@ class CandidateEpitope(Peptide):
     # of truth.
     per_allele_scores: dict = field(default_factory=dict)
 
+    # Why each allele was credited with this candidate's allele-independent
+    # evidence — observed in the input, taken from the patient's genotype, or
+    # nominated by ranking the peptide's own allele-scoped predictions (with
+    # the axis, predictor, value and rank that produced the nomination).
+    # Recorded rather than recomputed so a finished run can be reconstructed:
+    # see :mod:`vaxrank.allele_evidence`. Empty when a candidate carries no
+    # allele-independent evidence, which is the common case.
+    allele_attributions: tuple = ()
+
     def __post_init__(self):
         """Normalize predictions and retain every explicitly known allele."""
         super().__post_init__()
@@ -664,7 +673,8 @@ class CandidateEpitope(Peptide):
             self_reference_match=self.self_reference_match,
             patient_alleles=self.patient_alleles,
             prediction_id=self.prediction_id,
-            per_allele_scores=dict(self.per_allele_scores))
+            per_allele_scores=dict(self.per_allele_scores),
+            allele_attributions=self.allele_attributions)
 
     @classmethod
     def from_peptide(cls, peptide: "Peptide",
@@ -776,6 +786,7 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
                 # all rows for one allele share the same score by
                 # construction of the DSL eval, so last-write-wins.
                 'per_allele_scores': {},
+                'allele_attributions': (),
             }
             groups[key] = slot
         slot['mutant_preds'].append(row['mutant'])
@@ -790,6 +801,14 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
                 raise ValueError(
                     "Conflicting per-allele scores for one candidate epitope")
             slot['per_allele_scores'][allele] = score
+        attributions = row.get('allele_attributions') or ()
+        if attributions:
+            existing = slot['allele_attributions']
+            if existing and existing != tuple(attributions):
+                raise ValueError(
+                    "Conflicting allele attributions for one candidate "
+                    "epitope")
+            slot['allele_attributions'] = tuple(attributions)
         slot['overlaps_mutation'] |= bool(row.get('overlaps_mutation', False))
         overlaps_targetable = row.get('overlaps_targetable')
         if overlaps_targetable is not None:
@@ -865,5 +884,6 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
             patient_alleles=tuple(sorted(slot['patient_alleles'])),
             prediction_id=slot['prediction_id'],
             per_allele_scores=dict(slot['per_allele_scores']),
+            allele_attributions=slot['allele_attributions'],
         ))
     return out

--- a/vaxrank/cli/epitope_config_args.py
+++ b/vaxrank/cli/epitope_config_args.py
@@ -43,6 +43,29 @@ def add_epitope_prediction_args(arg_parser : argparse.ArgumentParser):
     # ``affinity['netmhcpan']`` still pick up their specific model. If
     # omitted and the data has multiple models, vaxrank auto-picks a
     # canonical method (mhcflurry > netmhcpan > alphabetical).
+    # Antigen processing and proteasomal cleavage describe a peptide, not a
+    # peptide-MHC pair, so crediting them to an allele is a choice. See
+    # :mod:`vaxrank.allele_evidence`; every attributed allele records why.
+    allele_evidence_args = arg_parser.add_argument_group(
+        "Attribution of peptide-level evidence to alleles")
+    allele_evidence_args.add_argument(
+        "--allele-free-evidence",
+        default=None,
+        metavar="POLICY",
+        help="How peptide-level evidence (antigen processing, proteasomal "
+             "cleavage) is credited to MHC alleles: 'selected' (default, the "
+             "best-ranked allele, falling back to the whole genotype when "
+             "there is nothing to rank on), 'all' (every genotype allele), "
+             "'top:N', or 'from_input' (only pairings the source file "
+             "already carried).")
+    allele_evidence_args.add_argument(
+        "--allele-selection-axis",
+        default=None,
+        metavar="KIND",
+        help="Which prediction kind ranks alleles for 'selected' / 'top:N'. "
+             "'auto' (default) prefers pMHC_presentation when the input "
+             "carries it, else pMHC_affinity.")
+
     default_method_args = arg_parser.add_argument_group(
         "Default predictor methods (for unqualified DSL references)")
     default_method_args.add_argument(
@@ -84,6 +107,12 @@ def epitope_config_from_args(args : argparse.Namespace, merged_config=None) -> E
 
     if args.min_epitope_score is not None:
         epitope_config_kwargs["min_epitope_score"] = args.min_epitope_score
+    if getattr(args, "allele_free_evidence", None) is not None:
+        epitope_config_kwargs["allele_free_evidence"] = (
+            args.allele_free_evidence)
+    if getattr(args, "allele_selection_axis", None) is not None:
+        epitope_config_kwargs["allele_selection_axis"] = (
+            args.allele_selection_axis)
     if getattr(args, 'scoring_mode', None) is not None:
         epitope_config_kwargs["scoring_mode"] = args.scoring_mode
 

--- a/vaxrank/config/loader.py
+++ b/vaxrank/config/loader.py
@@ -310,6 +310,8 @@ _EPITOPE_CONFIG_MAPPING: list[tuple[str, str]] = [
     ("epitopes.filter_expr", "filter_expr"),
     ("epitopes.score_expr", "score_expr"),
     ("epitopes.default_methods", "default_methods"),
+    ("epitopes.allele_free_evidence", "allele_free_evidence"),
+    ("epitopes.allele_selection_axis", "allele_selection_axis"),
 ]
 
 # Declarative mapping: (dotted config path) → (VaccineConfig kwarg name)

--- a/vaxrank/config/schema.py
+++ b/vaxrank/config/schema.py
@@ -44,6 +44,10 @@ class EpitopesConfigSchema(
     filter_expr: Optional[str] = None
     score_expr: Optional[str] = None
     default_methods: Optional[dict[str, str]] = None
+    # How peptide-level evidence (antigen processing, proteasomal cleavage)
+    # is attributed to alleles — see vaxrank.allele_evidence.
+    allele_free_evidence: Optional[str] = None
+    allele_selection_axis: Optional[str] = None
 
 
 class ManufacturabilityConfigSchema(

--- a/vaxrank/epitope_config.py
+++ b/vaxrank/epitope_config.py
@@ -143,6 +143,10 @@ class EpitopeConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     #   "from_input"  — only alleles the input actually scored this peptide
     #       against. Reproduces pre-3.3 behavior, which is row incidence
     #       rather than a claim about presentation.
+    # NOTE: currently applied on external-input runs only. The native
+    # VCF/BAM pipeline builds its own evaluation frame and does not attribute
+    # peptide-level evidence at all; it warns when such evidence is present.
+    # Tracked in openvax/vaxrank#349.
     allele_free_evidence: str = POLICY_SELECTED
     # Which axis ranks alleles for "selected" / "top:N". "auto" prefers
     # presentation when the input carries it, else affinity.

--- a/vaxrank/epitope_config.py
+++ b/vaxrank/epitope_config.py
@@ -41,8 +41,8 @@ fields above define the default via :mod:`vaxrank.epitope_dsl`.
 from typing import Dict, Optional
 
 from .allele_evidence import (
-    NOMINATION_AUTO,
-    POLICY_NOMINATED,
+    SELECTION_AUTO,
+    POLICY_SELECTED,
     AllelePolicy,
 )
 
@@ -135,24 +135,24 @@ class EpitopeConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     # credited to one or more, and which ones is a choice worth stating.
     # See :mod:`vaxrank.allele_evidence`; every attributed allele records why
     # it was chosen, so a finished run can be reconstructed.
-    #   "nominated" (default) — the allele the model ranks best for this
+    #   "selected" (default) — the allele the model ranks best for this
     #       peptide; falls back to the whole genotype when the peptide has no
     #       allele-scoped evidence to rank on.
     #   "all"       — every allele in the patient's genotype.
-    #   "top:N"     — the N best, same fallback as "nominated".
-    #   "observed"  — only alleles the input actually scored this peptide
+    #   "top:N"     — the N best, same fallback as "selected".
+    #   "reported"  — only alleles the input actually scored this peptide
     #       against. Reproduces pre-3.3 behavior, which is row incidence
     #       rather than a claim about presentation.
-    allele_free_evidence: str = POLICY_NOMINATED
-    # Which axis ranks alleles for "nominated" / "top:N". "auto" prefers
+    allele_free_evidence: str = POLICY_SELECTED
+    # Which axis ranks alleles for "selected" / "top:N". "auto" prefers
     # presentation when the input carries it, else affinity.
-    allele_nomination_axis: str = NOMINATION_AUTO
+    allele_selection_axis: str = SELECTION_AUTO
 
     @property
     def allele_policy(self) -> AllelePolicy:
         """The parsed :class:`AllelePolicy` for this configuration."""
         return AllelePolicy.parse(
-            self.allele_free_evidence, axis=self.allele_nomination_axis)
+            self.allele_free_evidence, axis=self.allele_selection_axis)
 
     def __post_init__(self):
         # Parse eagerly so a typo fails at config time, not mid-run.

--- a/vaxrank/epitope_config.py
+++ b/vaxrank/epitope_config.py
@@ -40,6 +40,12 @@ fields above define the default via :mod:`vaxrank.epitope_dsl`.
 
 from typing import Dict, Optional
 
+from .allele_evidence import (
+    NOMINATION_AUTO,
+    POLICY_NOMINATED,
+    AllelePolicy,
+)
+
 import msgspec
 
 from .config.defaults import (
@@ -123,7 +129,34 @@ class EpitopeConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     score_expr: Optional[str] = None
     default_methods: Optional[Dict[str, str]] = None
 
+    # How allele-independent evidence (antigen processing, proteasomal
+    # cleavage) is attributed to alleles. That evidence describes a peptide,
+    # not a peptide-MHC pair, but vaxrank scores per allele — so it has to be
+    # credited to one or more, and which ones is a choice worth stating.
+    # See :mod:`vaxrank.allele_evidence`; every attributed allele records why
+    # it was chosen, so a finished run can be reconstructed.
+    #   "nominated" (default) — the allele the model ranks best for this
+    #       peptide; falls back to the whole genotype when the peptide has no
+    #       allele-scoped evidence to rank on.
+    #   "all"       — every allele in the patient's genotype.
+    #   "top:N"     — the N best, same fallback as "nominated".
+    #   "observed"  — only alleles the input actually scored this peptide
+    #       against. Reproduces pre-3.3 behavior, which is row incidence
+    #       rather than a claim about presentation.
+    allele_free_evidence: str = POLICY_NOMINATED
+    # Which axis ranks alleles for "nominated" / "top:N". "auto" prefers
+    # presentation when the input carries it, else affinity.
+    allele_nomination_axis: str = NOMINATION_AUTO
+
+    @property
+    def allele_policy(self) -> AllelePolicy:
+        """The parsed :class:`AllelePolicy` for this configuration."""
+        return AllelePolicy.parse(
+            self.allele_free_evidence, axis=self.allele_nomination_axis)
+
     def __post_init__(self):
+        # Parse eagerly so a typo fails at config time, not mid-run.
+        self.allele_policy
         if self.logistic_epitope_score_midpoint <= 0:
             raise ValueError(
                 f"logistic_epitope_score_midpoint must be positive, "

--- a/vaxrank/epitope_config.py
+++ b/vaxrank/epitope_config.py
@@ -140,7 +140,7 @@ class EpitopeConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     #       allele-scoped evidence to rank on.
     #   "all"       — every allele in the patient's genotype.
     #   "top:N"     — the N best, same fallback as "selected".
-    #   "reported"  — only alleles the input actually scored this peptide
+    #   "from_input"  — only alleles the input actually scored this peptide
     #       against. Reproduces pre-3.3 behavior, which is row incidence
     #       rather than a claim about presentation.
     allele_free_evidence: str = POLICY_SELECTED

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -168,7 +168,7 @@ def epitopes_to_topiary_df(epitopes, policy=None, genotype=None,
     # allele set for the whole frame, and every policy except "all" needs a
     # different set per peptide.
     from .allele_evidence import (
-        AllelePolicy, attribute_alleles, is_peptide_level,
+        AllelePolicy, attribute_alleles, is_allele_scoped, is_peptide_level,
     )
 
     if policy is None:
@@ -176,12 +176,25 @@ def epitopes_to_topiary_df(epitopes, policy=None, genotype=None,
     genotype = frame_genotype(epitopes, genotype)
 
     rows = []
+    # Predictions that are neither peptide-level nor allele-scoped are
+    # malformed: an allele-scoped kind that arrived without an allele. They
+    # must not reach the frame at all. Topiary classifies a kind's MHC
+    # dependence by scanning the rows it is given, so a candidate whose only
+    # affinity leaves are blank-allele reads as peptide-level and gets its
+    # value projected across every allele group — inventing a binding
+    # prediction for alleles the model never scored. Verified against
+    # topiary 5.21.0; openvax/topiary#197 fixes it upstream, but vaxrank
+    # supports the whole >=5.17.1 range, so the row is dropped here.
+    malformed = []
     for e in epitopes:
         ctx = e
         prediction_id = ctx.prediction_group_source
         predictions = ctx.predictions_flat()
         attributed = None
         for p in predictions:
+            if not is_peptide_level(p) and not is_allele_scoped(p):
+                malformed.append((ctx.sequence, p.kind, p.predictor_name))
+                continue
             if not is_peptide_level(p):
                 # Includes every allele-scoped prediction, and any blank-allele
                 # prediction of a kind that is not peptide-level — those are
@@ -213,6 +226,14 @@ def epitopes_to_topiary_df(epitopes, policy=None, genotype=None,
                     "percentile_rank": p.percentile_rank,
                     "score": p.score,
                 })
+    if malformed:
+        peptide, kind, predictor = malformed[0]
+        logger.warning(
+            "Dropped %d prediction(s) of an allele-scoped kind that carried "
+            "no allele; they cannot be scored against any allele and would "
+            "be projected across all of them. Example: peptide %s, kind %s, "
+            "predictor %s.",
+            len(malformed), peptide, kind, predictor)
     return pd.DataFrame(rows)
 
 

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -426,11 +426,10 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
     by_position: dict[tuple, dict[str, float]] = {}
     for idx, val in score_series.items():
         src_name, peptide, offset, allele = idx
-        # Allele-independent processing predictions use ``allele=''``.
-        # They belong in the nested prediction model, but never in a map
-        # whose public contract is explicitly per patient allele. This
-        # filter stays even once openvax/topiary#182 lands: an unprojected
-        # allele-free row still produces an empty-allele group.
+        # Peptide-level evidence evaluates under ``allele=''``. It belongs
+        # in the nested prediction model, but never in a map whose public
+        # contract is explicitly per patient allele — and an empty-allele
+        # group exists whether or not the evidence was projected.
         if allele:
             by_position.setdefault(
                 (src_name, peptide, offset), {})[allele] = float(val)
@@ -445,7 +444,7 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
         # persist an audit record describing a decision that did not happen.
         if topiary_df is not None:
             return ()
-        if any(is_peptide_level(p) for p in epitope.predictions_flat()):
+        if any(map(is_peptide_level, epitope.predictions_flat())):
             return attribute_alleles(
                 epitope, resolved_genotype, policy,
                 default_methods=cfg.default_methods)

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -129,16 +129,21 @@ def frame_genotype(epitopes, genotype=None):
         for allele in epitope.patient_alleles if allele}))
 
 
-def epitopes_to_topiary_df(epitopes, policy=None, genotype=None):
+def epitopes_to_topiary_df(epitopes, policy=None, genotype=None,
+                           default_methods=None):
     """Convert a list of :class:`vaxrank.candidate_epitope.CandidateEpitope` into the
     topiary long-format DataFrame consumed by
     :class:`topiary.ranking.EvalContext` and
     :func:`topiary.ranking.apply_filter`.
 
     One row per allele-scoped leaf ``mhctools.Prediction`` in each
-    CandidateEpitope's mutant context. Allele-independent antigen-processing
-    evidence is projected into every allele group in this evaluation view while
-    remaining one canonical leaf on the CandidateEpitope. A single
+    CandidateEpitope's mutant context. Peptide-level evidence (antigen
+    processing, proteasomal cleavage) is credited to the alleles the
+    configured :class:`~vaxrank.allele_evidence.AllelePolicy` attributes it
+    to — by default the single best-ranked allele, **not** every allele — while
+    remaining one canonical leaf on the CandidateEpitope. Pass ``policy`` to
+    choose; a processing-based ``score_expr`` will otherwise give zero to
+    every allele but the selected one. A single
     CandidateEpitope can therefore emit N rows (one per allele x predictor x
     kind). When multiple predictions share a (peptide,
     allele) pair (e.g. MHCflurry and netMHCpan rows from a LENS file),
@@ -162,7 +167,9 @@ def epitopes_to_topiary_df(epitopes, policy=None, genotype=None):
     # This cannot be delegated to topiary's ``alleles=``: that declares one
     # allele set for the whole frame, and every policy except "all" needs a
     # different set per peptide.
-    from .allele_evidence import AllelePolicy, attribute_alleles
+    from .allele_evidence import (
+        AllelePolicy, attribute_alleles, is_peptide_level,
+    )
 
     if policy is None:
         policy = AllelePolicy.parse(None)
@@ -175,13 +182,18 @@ def epitopes_to_topiary_df(epitopes, policy=None, genotype=None):
         predictions = ctx.predictions_flat()
         attributed = None
         for p in predictions:
-            if p.allele:
+            if not is_peptide_level(p):
+                # Includes every allele-scoped prediction, and any blank-allele
+                # prediction of a kind that is not peptide-level — those are
+                # malformed rows, and projecting them would invent per-allele
+                # evidence for alleles they were never predicted against.
                 evaluation_alleles = (p.allele,)
             else:
                 if attributed is None:
                     attributed = tuple(
                         a.allele for a in attribute_alleles(
-                            e, genotype, policy))
+                            e, genotype, policy,
+                            default_methods=default_methods))
                 evaluation_alleles = attributed or (p.allele,)
             for allele in evaluation_alleles:
                 rows.append({
@@ -341,8 +353,8 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
     from topiary.ranking import EvalContext, apply_filter
 
     df = (epitopes_to_topiary_df(
-              epitopes, policy=getattr(cfg, "allele_policy", None),
-              genotype=genotype)
+              epitopes, policy=cfg.allele_policy, genotype=genotype,
+              default_methods=cfg.default_methods)
           if topiary_df is None else topiary_df)
     if df.empty:
         return pd.Series(dtype=float)
@@ -403,7 +415,7 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
         return epitopes
     if cfg is None:
         cfg = EpitopeConfig()
-    from .allele_evidence import attribute_alleles
+    from .allele_evidence import attribute_alleles, is_peptide_level
 
     score_series = score_predictions(
         epitopes, cfg, topiary_df=topiary_df, kind_support=kind_support,
@@ -423,11 +435,20 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
             by_position.setdefault(
                 (src_name, peptide, offset), {})[allele] = float(val)
     def _attributions(epitope):
-        # Only candidates carrying allele-independent evidence have anything
-        # to attribute; recording an attribution for the rest would imply a
-        # decision was made where none was needed.
-        if any(not p.allele for p in epitope.predictions_flat()):
-            return attribute_alleles(epitope, resolved_genotype, policy)
+        # Only candidates carrying peptide-level evidence have anything to
+        # attribute; recording one for the rest would imply a decision that
+        # was never made.
+        #
+        # And only when this call actually applied the policy. A caller that
+        # supplied its own frame (pVACseq passes topiary's) was scored
+        # without the policy ever running, so stamping an attribution would
+        # persist an audit record describing a decision that did not happen.
+        if topiary_df is not None:
+            return ()
+        if any(is_peptide_level(p) for p in epitope.predictions_flat()):
+            return attribute_alleles(
+                epitope, resolved_genotype, policy,
+                default_methods=cfg.default_methods)
         return ()
 
     return [
@@ -555,7 +576,9 @@ def validate_dsl_against_predictions(cfg, epitopes, *, topiary_df=None):
     if not nodes:
         return
 
-    df = (epitopes_to_topiary_df(epitopes)
+    df = (epitopes_to_topiary_df(
+              epitopes, policy=cfg.allele_policy,
+              default_methods=cfg.default_methods)
           if topiary_df is None else topiary_df)
     available_kinds = set(df["kind"].unique()) if not df.empty else set()
     available_methods = (

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -115,7 +115,21 @@ def prediction_kind_for_method(method_name):
 
 
 
-def epitopes_to_topiary_df(epitopes):
+def frame_genotype(epitopes, genotype=None):
+    """Resolve the patient allele set a frame should be evaluated against.
+
+    An explicit *genotype* wins — it is the patient's actual typing. Absent
+    one, fall back to the union of alleles the inputs scored, which is the
+    widest honest statement the data supports.
+    """
+    if genotype:
+        return tuple(sorted({a for a in genotype if a}))
+    return tuple(sorted({
+        allele for epitope in epitopes
+        for allele in epitope.patient_alleles if allele}))
+
+
+def epitopes_to_topiary_df(epitopes, policy=None, genotype=None):
     """Convert a list of :class:`vaxrank.candidate_epitope.CandidateEpitope` into the
     topiary long-format DataFrame consumed by
     :class:`topiary.ranking.EvalContext` and
@@ -139,38 +153,36 @@ def epitopes_to_topiary_df(epitopes):
     are NOT emitted as rows. The DSL frame is mutant-only by
     convention — comparator data stays on the CandidateEpitope for display.
     """
-    # Allele-independent evidence is projected into every patient allele here
-    # while remaining one canonical leaf on the CandidateEpitope. topiary
-    # 5.18's ``peptide_view()`` broadcasts an allele-free value across the
-    # allele groups that already exist, which covers a peptide that also has
-    # affinity rows — but two gaps keep this projection necessary:
+    # Allele-independent evidence (antigen processing, proteasomal cleavage)
+    # describes a peptide, not a peptide-MHC pair, so it is credited to the
+    # alleles the configured policy attributes it to — see
+    # :mod:`vaxrank.allele_evidence`. Each candidate keeps one canonical
+    # allele-free leaf; only this evaluation view repeats it per allele.
     #
-    #   openvax/topiary#182 — a peptide whose *only* evidence is allele-free
-    #     has one group, keyed on an empty allele. The patient's genotype is
-    #     not in the frame, so per-allele scores cannot be produced and the
-    #     candidate scores 0 and is dropped. LENS emits such rows.
-    #   openvax/topiary#183 — an allele-free row is its own group, so any
-    #     filter predicated on an allele-scoped kind removes it; a later
-    #     ``peptide_view()`` in the score expression then reads NaN.
-    #
-    # Do not delete this projection in favor of ``peptide_view()`` until both
-    # are closed; the failure is silent in both cases.
+    # This cannot be delegated to topiary's ``alleles=``: that declares one
+    # allele set for the whole frame, and every policy except "all" needs a
+    # different set per peptide.
+    from .allele_evidence import AllelePolicy, attribute_alleles
+
+    if policy is None:
+        policy = AllelePolicy.parse(None)
+    genotype = frame_genotype(epitopes, genotype)
+
     rows = []
     for e in epitopes:
         ctx = e
         prediction_id = ctx.prediction_group_source
         predictions = ctx.predictions_flat()
-        patient_alleles = ctx.patient_alleles
+        attributed = None
         for p in predictions:
-            evaluation_alleles = (
-                patient_alleles
-                if (
-                    p.kind == "antigen_processing"
-                    and not p.allele
-                    and patient_alleles
-                )
-                else (p.allele,)
-            )
+            if p.allele:
+                evaluation_alleles = (p.allele,)
+            else:
+                if attributed is None:
+                    attributed = tuple(
+                        a.allele for a in attribute_alleles(
+                            e, genotype, policy))
+                evaluation_alleles = attributed or (p.allele,)
             for allele in evaluation_alleles:
                 rows.append({
                     PREDICTION_ID_COLUMN: prediction_id,
@@ -297,7 +309,7 @@ def validate_default_methods(cfg, topiary_df):
 
 
 def score_predictions(epitopes, cfg, *, topiary_df=None,
-                      kind_support=None):
+                      kind_support=None, genotype=None):
     """Score external-input epitopes using the configured Topiary DSL.
 
     Returns a ``pandas.Series`` of per-(peptide, allele) scores, indexed by
@@ -328,7 +340,9 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
     """
     from topiary.ranking import EvalContext, apply_filter
 
-    df = (epitopes_to_topiary_df(epitopes)
+    df = (epitopes_to_topiary_df(
+              epitopes, policy=getattr(cfg, "allele_policy", None),
+              genotype=genotype)
           if topiary_df is None else topiary_df)
     if df.empty:
         return pd.Series(dtype=float)
@@ -361,7 +375,7 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
 
 
 def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
-                             kind_support=None):
+                             kind_support=None, genotype=None):
     """Score ``epitopes`` via the configured DSL and return a new list of
     :class:`~vaxrank.candidate_epitope.CandidateEpitope` instances with
     each one's ``per_allele_scores`` populated.
@@ -389,8 +403,13 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
         return epitopes
     if cfg is None:
         cfg = EpitopeConfig()
+    from .allele_evidence import attribute_alleles
+
     score_series = score_predictions(
-        epitopes, cfg, topiary_df=topiary_df, kind_support=kind_support)
+        epitopes, cfg, topiary_df=topiary_df, kind_support=kind_support,
+        genotype=genotype)
+    policy = cfg.allele_policy
+    resolved_genotype = frame_genotype(epitopes, genotype)
     # score_series is keyed by prediction ID, peptide, offset, and allele.
     by_position: dict[tuple, dict[str, float]] = {}
     for idx, val in score_series.items():
@@ -403,11 +422,19 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
         if allele:
             by_position.setdefault(
                 (src_name, peptide, offset), {})[allele] = float(val)
+    def _attributions(epitope):
+        # Only candidates carrying allele-independent evidence have anything
+        # to attribute; recording an attribution for the rest would imply a
+        # decision was made where none was needed.
+        if any(not p.allele for p in epitope.predictions_flat()):
+            return attribute_alleles(epitope, resolved_genotype, policy)
+        return ()
+
     return [
         replace(
             e,
-            per_allele_scores=by_position.get(
-                e.prediction_group_key, {}))
+            per_allele_scores=by_position.get(e.prediction_group_key, {}),
+            allele_attributions=_attributions(e))
         for e in epitopes
     ]
 

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -96,6 +96,11 @@ VAXRANK_COLUMNS = [
     # Explicit input-allele membership is necessary for canonical
     # allele-independent processing predictions.
     "patient_alleles",
+    # Why each allele was credited with this candidate's allele-independent
+    # evidence. Recorded rather than recomputed: the nomination depends on
+    # the config in force at predict time, so a reload under a different
+    # config would otherwise silently re-derive a different answer.
+    "allele_attributions",
     # Preserve the exact configured DSL result so a native reload does not
     # silently revert to an unrelated default scoring formula.
     "per_allele_scores",
@@ -175,6 +180,9 @@ def epitope_prediction_rows(epitope):
             "prediction_offset": p.offset,
             "patient_alleles": json.dumps(
                 list(epitope.patient_alleles), separators=(",", ":")),
+            "allele_attributions": json.dumps(
+                [a.to_dict() for a in epitope.allele_attributions],
+                sort_keys=True, separators=(",", ":")),
             "per_allele_scores": json.dumps(
                 epitope.per_allele_scores,
                 sort_keys=True,
@@ -344,6 +352,14 @@ def load_predictions(path):
                 peptide=wt_peptide, value=wt_ic50, score=0.0,
                 percentile_rank=None,
             )
+        attributions_raw = string_or_empty(
+            row.get("allele_attributions", ""))
+        allele_attributions = ()
+        if attributions_raw:
+            from .allele_evidence import AlleleAttribution
+            allele_attributions = tuple(
+                AlleleAttribution.from_dict(entry)
+                for entry in json.loads(attributions_raw))
         patient_alleles_raw = string_or_empty(row.get("patient_alleles", ""))
         patient_alleles = (
             tuple(json.loads(patient_alleles_raw))
@@ -389,6 +405,7 @@ def load_predictions(path):
                 row.get("occurs_in_non_CTA_reference", occurs_in_ref)),
             'patient_alleles': patient_alleles,
             'per_allele_scores': per_allele_scores,
+            'allele_attributions': allele_attributions,
         })
     return candidate_epitopes_from_rows(rows)
 

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -97,7 +97,7 @@ VAXRANK_COLUMNS = [
     # allele-independent processing predictions.
     "patient_alleles",
     # Why each allele was credited with this candidate's allele-independent
-    # evidence. Recorded rather than recomputed: the nomination depends on
+    # evidence. Recorded rather than recomputed: the selection depends on
     # the config in force at predict time, so a reload under a different
     # config would otherwise silently re-derive a different answer.
     "allele_attributions",

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -1319,7 +1319,12 @@ def write_neoepitope_report(report_df, epitopes, excel_report_path=None,
     if topiary_df is None:
         topiary_df = report_df.attrs.get("topiary_df")
     if topiary_df is None:
-        topiary_df = epitopes_to_topiary_df(epitopes)
+        # Same policy the candidates were scored under. Rebuilding with the
+        # default instead made the written report disagree with the ranking
+        # substrate about the same epitope.
+        topiary_df = epitopes_to_topiary_df(
+            epitopes, policy=epitope_config.allele_policy,
+            default_methods=epitope_config.default_methods)
 
     validate_dsl_against_predictions(
         epitope_config, epitopes, topiary_df=topiary_df)

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -21,6 +21,7 @@ from topiary import TopiaryPredictor
 from topiary.ranking import EvalContext, apply_filter
 
 from .epitope_config import EpitopeConfig
+from .allele_evidence import PEPTIDE_LEVEL_KINDS
 from .epitope_dsl import (
     build_filter_node, build_score_node, prediction_group_columns,
 )
@@ -162,6 +163,26 @@ def predict_epitopes(
     # which is a guess. We are holding the predictor that knows the answer,
     # so forward it rather than making topiary infer it (openvax/topiary#178).
     kind_support = getattr(topiary_predictor, "kind_support", None)
+
+    # Peptide-level evidence (antigen processing, cleavage) forms its own
+    # empty-allele group in this frame and is never attributed to an allele,
+    # so it contributes to no per-allele score. EpitopeConfig's attribution
+    # policy is applied by epitopes_to_topiary_df, which this path does not
+    # use — see openvax/vaxrank#349. Say so rather than letting a configured
+    # policy look like it took effect.
+    if "kind" in predictions_df.columns:
+        unattributed = sorted({
+            kind for kind in predictions_df["kind"].dropna().unique()
+            if kind in PEPTIDE_LEVEL_KINDS})
+        if unattributed:
+            logger.warning(
+                "Prediction kind(s) %s describe the peptide rather than a "
+                "peptide-MHC pair, and this pipeline does not attribute them "
+                "to alleles — they will contribute to no per-allele score. "
+                "EpitopeConfig.allele_free_evidence=%r is not applied here "
+                "(openvax/vaxrank#349); it currently takes effect only on "
+                "external-input runs.",
+                ", ".join(unattributed), epitope_config.allele_free_evidence)
     filter_node = build_filter_node(epitope_config)
     if filter_node is not None:
         predictions_df = apply_filter(

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -70,6 +70,9 @@ def epitope_report_row_inputs(epitope):
             if prediction.kind != kind:
                 continue
             if not prediction.allele:
+                # An allele-scoped kind that arrived blank is malformed; see
+                # vaxrank.allele_evidence for the one definition of which
+                # kinds carry an allele.
                 raise ValueError(
                     f"{kind} report evidence requires a patient allele")
             key = (

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 
 
 def print_version():


### PR DESCRIPTION
Follow-up to #345. Answers the question that PR deferred: **which MHC alleles should peptide-level evidence be credited to, and how does a reader find out why?**

## The problem

Antigen processing and proteasomal cleavage describe a peptide and its flanks — no MHC involved. Vaxrank's scoring substrate is per-allele (`CandidateEpitope.per_allele_scores`), so that evidence has to be attributed to one or more alleles before it can score anything.

That choice was being made implicitly: the evidence was projected onto whichever alleles the input file happened to score the peptide against. **Row incidence is neither the patient's genotype nor a claim about presentation.** On the real LENS fixtures those sets are 1–2 alleles out of a 5–6 allele genotype, so the implicit answer was an artifact of how the upstream tool chose to write its rows.

## The policy

`EpitopeConfig.allele_free_evidence`:

| value | meaning |
|---|---|
| `selected` *(default)* | the allele that ranks best for this peptide; falls back to the whole genotype when the peptide has no allele-scoped evidence to rank on |
| `all` | every allele in the patient's genotype |
| `top:N` | the N best, same fallback |
| `from_input` | only pairings the source file already carried — pre-3.3 behavior |

The fallback is the point of the default: *"we don't know which allele presents this"* is not the same claim as *"this one does."* When the model can pick, it does; when it can't, the evidence is preserved across the genotype rather than assigned to an arbitrary winner.

`allele_selection_axis` chooses the ranking axis. `auto` prefers presentation when the input carries it, else affinity — presentation being the model's own statement about the question actually being asked.

## Where the allele comes from, and how to reconstruct it

This is the part worth reviewing closely. Every attributed allele carries an `AlleleAttribution` recording **why**:

- `source` — **how the evidence reached this allele**, one of:
  - `from_input` — the source file already paired this peptide with this allele
  - `broadcast` — nothing narrowed it, so every genotype allele received it
  - `selected` — vaxrank ranked the genotype and picked this one
- for a selection: `rank_kind`, `rank_predictor`, `rank_value`, `rank_position`

The names describe the *mechanism*, not where the allele sits. An earlier draft used `observed`/`genotype`; both were wrong in the same way. `genotype` distinguished nothing — every allele here is a genotype allele — and `observed` implied empirical evidence of presentation when it only meant a row existed in the file, which is an artifact of what the upstream tool chose to write.

So a finished run says, in full:

```
HLA-A*02:01 (selected: ranked #1 on pMHC_presentation [mhcflurry] = 0.8)
HLA-C*07:01 (broadcast: no allele-specific evidence)
HLA-B*07:02 (from the input file)
```

Two invariants enforced in `__post_init__`: a selection without a recorded axis is rejected (it could not be reconstructed), and ranking provenance on a non-selection is rejected (it would imply a ranking that never happened).

These are **serialized in the native format**. That is not incidental — the selection depends on the config in force at predict time, so a reload under a different config would otherwise silently re-derive a different answer, which is the failure mode #345 spent its length removing.

The genotype itself resolves through `frame_genotype()`: an explicit genotype wins, and absent one it falls back to the union of alleles the inputs scored — the widest honest statement the data supports.

## Impact, measured

On the real LENS fixtures with `score_expr=processing[mhcflurry].score`:

| fixture | policy | allele groups | summed score | top-10 churn |
|---|---|---|---|---|
| v1.4 | from_input | 30 | 4.676 | — |
| v1.4 | selected | 30 | 4.676 | 0/10 |
| v1.4 | **all** | **146** | **23.380** | 0/10 |
| v1.9+stops | from_input | 52 | 12.930 | — |
| v1.9+stops | selected | 52 | 12.041 | **6/10** |
| v1.9+stops | **all** | **245** | **60.204** | 6/10 |

`all` multiplies the summed score 4.7–5.0× by crediting peptide-level evidence to alleles the input never scored — which is why it is not the default, despite being the most "complete" reading. `selected` keeps the same allele groups as today and moves 6 of the top 10 on one fixture.

**Runs on the default `score_expr` are unaffected by any of this** — it is `(affinity.value < 5000.0) * affinity.value.logistic_normalized(350.0, 150.0)`, which references affinity only, and the default filter is `None`. Only configs that explicitly reference `processing` or `cleavage` see a change, which is an opt-in population.

## Why this is not delegated to topiary

topiary 5.20.0's `peptide_view()` and `alleles=` were expected to let this projection be deleted. `alleles=` declares **one allele set for a whole frame**, and every policy except `all` needs a different set per peptide — verified against the published wheel. So the projection stays; it is load-bearing policy rather than a workaround, and it is now named as such.

topiary's floor is unchanged at `>=5.17.1`.

## Also

Closes the two branch gaps in `_topiary_pvacseq_to_epitope_rows` that no fixture had ever taken: a pVACseq row with no WT columns (topiary leaves `wt_value` NA — the shape an aggregate written without WT prediction produces) and a row with no IC50 at all. Both are real input shapes, neither had ever executed, so nothing said what they should do. Now: the WT-less row contributes no WT leaf rather than a fabricated zero, and the unscored row is dropped rather than carried.

Branch coverage for that function goes from two open branches to none.

## Verification

1045 passed, 1 skipped, ruff clean, on topiary 5.20.0. Version 3.2.0 → 3.3.0.
