### PR TITLE
Defer default-method resolution to topiary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.17.1,<6.0.0
+topiary>=5.26.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_epitope_dsl.py
+++ b/tests/test_epitope_dsl.py
@@ -588,3 +588,80 @@ def test_external_readers_leave_kind_support_unset():
     # for a frame no predictor produced.
     [epitope] = report.epitopes
     assert epitope.per_allele_scores
+
+
+def test_canonical_method_preference_is_topiary_s_not_a_local_copy():
+    """vaxrank must not carry its own idea of which model is canonical.
+
+    It used to, and the two had already drifted: vaxrank ordered
+    ``netmhcstabpan`` ahead of ``netmhcpan_el`` / ``netmhcpan_ba`` where
+    topiary orders it last. The same frame could therefore resolve to
+    different models depending on which table was consulted — exactly the
+    disagreement topiary's own docstring warns consumers about.
+    """
+    import vaxrank.epitope_dsl as dsl
+
+    assert not hasattr(dsl, "_CANONICAL_METHOD_PREFERENCE")
+    assert not hasattr(dsl, "_auto_pick_canonical_method")
+
+
+def test_default_methods_resolution_delegates_but_keeps_the_user_s_choice():
+    """topiary picks the canonical model; an explicit config entry overrides.
+
+    The auto-pick is topiary's to define. Which entry the *user* wrote is
+    vaxrank's config, and has to win — that is the half topiary has no
+    opinion about.
+    """
+    import pandas as pd
+    from topiary.ranking import resolve_default_methods as topiary_resolve
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import resolve_default_methods
+
+    def row(method, kind="pMHC_affinity", value=50.0):
+        return {
+            "prediction_id": "p", "source_sequence_name": "ctx",
+            "peptide": "SIINFEKL", "peptide_offset": 0, "peptide_length": 8,
+            "allele": "HLA-A*02:01", "n_flank": "", "c_flank": "",
+            "prediction_method_name": method, "predictor_version": "1",
+            "kind": kind, "value": value, "affinity": value,
+            "percentile_rank": None, "score": 0.0,
+        }
+
+    frame = pd.DataFrame([row("mhcflurry"), row("netmhcpan", value=60.0)])
+
+    # With nothing configured, the answer is topiary's, verbatim.
+    assert resolve_default_methods(EpitopeConfig(), frame) == dict(
+        topiary_resolve(frame))
+
+    # An explicit entry overrides the canonical pick.
+    configured = resolve_default_methods(
+        EpitopeConfig(default_methods={"pMHC_affinity": "netmhcpan"}), frame)
+    assert configured["pMHC_affinity"] == "netmhcpan"
+
+
+def test_invalid_default_methods_names_the_config_key():
+    """The error must say which setting to edit, not only what is missing.
+
+    topiary reports what the data lacks — the half it can know. Which config
+    key produced it is the half it cannot, and is what the user needs.
+    """
+    import pandas as pd
+    import pytest
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import validate_default_methods
+
+    frame = pd.DataFrame([{
+        "prediction_id": "p", "source_sequence_name": "ctx",
+        "peptide": "SIINFEKL", "peptide_offset": 0, "peptide_length": 8,
+        "allele": "HLA-A*02:01", "n_flank": "", "c_flank": "",
+        "prediction_method_name": "mhcflurry", "predictor_version": "1",
+        "kind": "pMHC_affinity", "value": 50.0, "affinity": 50.0,
+        "percentile_rank": None, "score": 0.0,
+    }])
+    cfg = EpitopeConfig(default_methods={"pMHC_affinity": "mhcnuggets"})
+    with pytest.raises(
+            ValueError,
+            match=r"default_methods\['pMHC_affinity'\]='mhcnuggets'"):
+        validate_default_methods(cfg, frame)

--- a/tests/test_epitope_dsl.py
+++ b/tests/test_epitope_dsl.py
@@ -665,3 +665,77 @@ def test_invalid_default_methods_names_the_config_key():
             ValueError,
             match=r"default_methods\['pMHC_affinity'\]='mhcnuggets'"):
         validate_default_methods(cfg, frame)
+
+
+def test_canonical_pick_is_announced_only_when_the_user_did_not_choose():
+    """Don't tell someone to set an entry they have already set.
+
+    The log exists to make an implicit choice explicit. For a kind the user
+    configured there is no implicit choice, and saying "no default_methods
+    entry names one" is simply false.
+    """
+    import logging
+
+    import pandas as pd
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import resolve_default_methods
+
+    def row(method, value):
+        return {
+            "prediction_id": "p", "source_sequence_name": "ctx",
+            "peptide": "SIINFEKL", "peptide_offset": 0, "peptide_length": 8,
+            "allele": "HLA-A*02:01", "n_flank": "", "c_flank": "",
+            "prediction_method_name": method, "predictor_version": "1",
+            "kind": "pMHC_affinity", "value": value, "affinity": value,
+            "percentile_rank": None, "score": 0.0,
+        }
+
+    frame = pd.DataFrame([row("mhcflurry", 50.0), row("netmhcpan", 60.0)])
+    messages = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            messages.append(record.getMessage())
+
+    logger = logging.getLogger("vaxrank.epitope_dsl")
+    handler = _Capture()
+    logger.addHandler(handler)
+    previous = logger.level
+    logger.setLevel(logging.INFO)
+    try:
+        configured = resolve_default_methods(
+            EpitopeConfig(default_methods={"pMHC_affinity": "netmhcpan"}),
+            frame)
+        assert configured == {"pMHC_affinity": "netmhcpan"}
+        assert not messages
+
+        messages.clear()
+        auto = resolve_default_methods(EpitopeConfig(), frame)
+        assert auto == {"pMHC_affinity": "mhcflurry"}
+        assert any("canonical pick" in message for message in messages)
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous)
+
+
+def test_typo_in_a_default_methods_kind_is_rejected():
+    """A kind the data does not have is a config error, not a no-op."""
+    import pandas as pd
+    import pytest
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import validate_default_methods
+
+    frame = pd.DataFrame([{
+        "prediction_id": "p", "source_sequence_name": "ctx",
+        "peptide": "SIINFEKL", "peptide_offset": 0, "peptide_length": 8,
+        "allele": "HLA-A*02:01", "n_flank": "", "c_flank": "",
+        "prediction_method_name": "mhcflurry", "predictor_version": "1",
+        "kind": "pMHC_affinity", "value": 50.0, "affinity": 50.0,
+        "percentile_rank": None, "score": 0.0,
+    }])
+    with pytest.raises(ValueError, match=r"pMHC_affinty"):
+        validate_default_methods(
+            EpitopeConfig(default_methods={"pMHC_affinty": "mhcflurry"}),
+            frame)

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -1605,7 +1605,7 @@ def test_default_methods_auto_picked_when_unset(tmp_path, caplog):
             csv_report_path=str(tmp_path / "out.csv"), epitope_config=cfg)
 
     assert any(
-        "auto-picking 'mhcflurry'" in rec.getMessage()
+        "canonical pick is 'mhcflurry'" in rec.getMessage()
         for rec in caplog.records), (
         f"Expected auto-pick info log; got: "
         f"{[r.getMessage() for r in caplog.records]}")

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -216,84 +216,70 @@ def prediction_group_columns(topiary_df):
 
 
 
-# Priority order for auto-picking a canonical method when the user hasn't
-# set ``default_methods[kind]`` and the data exposes multiple models for
-# that Kind. Listed by decreasing preference; any method not listed falls
-# back to alphabetical.
-_CANONICAL_METHOD_PREFERENCE = (
-    "mhcflurry",
-    "netmhcpan",
-    "netmhcstabpan",
-    "netmhcpan_el",
-    "netmhcpan_ba",
-)
-
-
-def _auto_pick_canonical_method(methods):
-    """Pick one method name from a non-empty set by priority order."""
-    for pref in _CANONICAL_METHOD_PREFERENCE:
-        if pref in methods:
-            return pref
-    return sorted(methods)[0]
-
-
 def resolve_default_methods(cfg, topiary_df):
     """Return the ``default_methods`` dict to pass to topiary's
     :class:`~topiary.ranking.EvalContext` / :func:`apply_filter`.
 
-    For every Kind with multiple models in ``topiary_df``:
+    The auto-pick — which model is "canonical" for a kind produced by
+    several — is topiary's :func:`~topiary.ranking.resolve_default_methods`
+    and its ``CANONICAL_METHOD_PREFERENCE``. vaxrank used to carry its own
+    copy of that preference tuple, and the two had already drifted: ours
+    ordered ``netmhcstabpan`` ahead of ``netmhcpan_el`` / ``netmhcpan_ba``
+    where topiary orders it last, so the same frame could resolve to
+    different models depending on which table was consulted.
 
-    - if ``cfg.default_methods[kind]`` is set, use it;
-    - otherwise auto-pick the canonical method (``mhcflurry`` >
-      ``netmhcpan`` > ``netmhcstabpan`` > alphabetical) and log
-      INFO so the user can make it explicit.
-
-    Kinds with a single model are omitted (topiary doesn't need a
-    default for them). Assumes ``validate_default_methods`` has
-    already caught any typos in ``cfg.default_methods``.
+    What stays here is the part topiary has no opinion about: an explicit
+    ``cfg.default_methods`` entry is the user's stated choice and overrides
+    the canonical pick. Kinds with a single model are omitted by topiary —
+    the result only speaks where there is a real choice.
     """
+    from topiary.ranking import resolve_default_methods as topiary_resolve
+
     if topiary_df.empty:
         return {}
-    user_defaults = dict(cfg.default_methods or {})
-    resolved = {}
-    for kind, group in topiary_df.groupby("kind", sort=False):
-        methods = set(group["prediction_method_name"].dropna().unique())
-        if len(methods) <= 1:
-            continue
-        if kind in user_defaults:
-            resolved[kind] = user_defaults[kind]
-        else:
-            picked = _auto_pick_canonical_method(methods)
-            logger.info(
-                "Kind %s has multiple methods %s and no default_methods "
-                "entry; auto-picking %r. Set default_methods[%r] in the "
-                "epitope config to override.",
-                kind, sorted(methods), picked, kind)
-            resolved[kind] = picked
+    resolved = dict(topiary_resolve(topiary_df))
+    for kind, picked in sorted(resolved.items()):
+        logger.info(
+            "Kind %s was produced by more than one model and no "
+            "default_methods entry names one; topiary's canonical pick is "
+            "%r. Set default_methods[%r] in the epitope config to override.",
+            kind, picked, kind)
+    # The user's explicit choice wins, and may name a kind topiary did not
+    # consider ambiguous — harmless, and validated separately.
+    resolved.update({
+        kind: method
+        for kind, method in (cfg.default_methods or {}).items()
+        if kind in resolved
+    })
     return resolved
 
 
 def validate_default_methods(cfg, topiary_df):
-    """Error if ``cfg.default_methods`` names a method that isn't in the data.
+    """Error if ``cfg.default_methods`` names a kind or model absent from the
+    data.
 
-    Runs even for Kinds with a single model (where the default isn't
-    actually consulted by topiary) so typos are caught eagerly.
+    Delegates to topiary's
+    :func:`~topiary.ranking.validate_default_methods`, which checks the same
+    thing for the same reason: an entry naming a model that never ran is
+    silently inert, and stays inert until the day two models do produce that
+    kind — at which point it starts deciding.
     """
-    if not cfg.default_methods:
+    from topiary.ranking import validate_default_methods as topiary_validate
+
+    if not cfg.default_methods or topiary_df.empty:
         return
-    if topiary_df.empty:
-        return
-    methods_by_kind = (
-        topiary_df.groupby("kind")["prediction_method_name"]
-        .apply(lambda s: set(s.dropna().unique()))
-        .to_dict())
-    for kind, method in cfg.default_methods.items():
-        available = methods_by_kind.get(kind, set())
-        if method not in available:
+    # Checked one entry at a time so the failure can name the exact config
+    # key and value. topiary reports what is missing from the *data*, which
+    # is the half it can know; which setting to edit is the half it cannot,
+    # and is what the user actually needs in order to fix it.
+    for kind, method in dict(cfg.default_methods).items():
+        try:
+            topiary_validate(topiary_df, {kind: method})
+        except ValueError as error:
             raise ValueError(
-                f"default_methods[{kind!r}]={method!r} but that method "
-                f"is not present in the loaded predictions "
-                f"(available for {kind}: {sorted(available)})")
+                "default_methods[%r]=%r is not usable: %s Name a method "
+                "present in the loaded predictions, or remove the entry."
+                % (kind, method, error)) from error
 
 
 def score_predictions(epitopes, cfg, *, topiary_df=None,

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -238,17 +238,24 @@ def resolve_default_methods(cfg, topiary_df):
     if topiary_df.empty:
         return {}
     resolved = dict(topiary_resolve(topiary_df))
+    configured = dict(cfg.default_methods or {})
+    # Only announce a pick the user did not make. Logging it for a kind they
+    # configured would tell them to set an entry they have already set.
     for kind, picked in sorted(resolved.items()):
+        if kind in configured:
+            continue
         logger.info(
             "Kind %s was produced by more than one model and no "
             "default_methods entry names one; topiary's canonical pick is "
             "%r. Set default_methods[%r] in the epitope config to override.",
             kind, picked, kind)
-    # The user's explicit choice wins, and may name a kind topiary did not
-    # consider ambiguous — harmless, and validated separately.
+    # The user's explicit choice wins. An entry for a kind topiary did not
+    # consider ambiguous is dropped: topiary only consults a default where
+    # there is a real choice, so carrying it would change nothing, and
+    # validate_default_methods has already rejected a name the data lacks.
     resolved.update({
         kind: method
-        for kind, method in (cfg.default_methods or {}).items()
+        for kind, method in configured.items()
         if kind in resolved
     })
     return resolved

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 
 
 def print_version():


### PR DESCRIPTION
topiary 5.26.0 makes public the two functions vaxrank had reimplemented, plus the preference table behind them. Adopting them removes a copy that had **already diverged**.

## The divergence

```
topiary  mhcflurry, netmhcpan, netmhcpan_ba, netmhcpan_el, netmhcstabpan
vaxrank  mhcflurry, netmhcpan, netmhcstabpan, netmhcpan_el, netmhcpan_ba
```

Same five names, different order. The order only decides when two of `{netmhcstabpan, netmhcpan_el, netmhcpan_ba}` produce the *same* kind, and the two tables disagree about which wins.

**Reachability, checked rather than asserted.** On the LENS path it is unreachable: across every fixture the only method names that appear are `mhcflurry`, `netmhcpan`, `netmhcstabpan`, and `netmhcstabpan` produces `pMHC_stability` only — so no kind has two divergent-order candidates. On the pipeline path it is reachable in principle: mhctools ships `NetMHCpan41_BA` and `NetMHCpan41_EL` as separate predictors that both emit `pMHC_affinity`, and `--mhc-predictor` accepts several. Whether it bites depends on the emitted `prediction_method_name` matching the preference strings exactly, which I could not verify here — those predictors need external binaries.

So: not demonstrated on any data we have, plausible on a multi-predictor pipeline run. Adopting topiary's table changes that resolution where it does apply, and topiary's order is the better one — `netmhcpan_ba` predicts affinity directly, while NetMHCstabPan's affinity is a by-product of stability.

The divergence is real, silent, and exactly what topiary's docstring predicts:

> consumers stop writing their own preference table and disagreeing with each other about what canonical means

We were the consumer it predicted.

## What changed

**`resolve_default_methods`** returns topiary's answer, with the one part topiary has no opinion about layered on top: an explicit `epitopes.default_methods` entry is the user's stated choice and overrides the canonical pick.

**`validate_default_methods`** delegates too, but checks **one entry at a time** so the failure can name the exact config key and value:

```
default_methods['pMHC_affinity']='mhcnuggets' is not usable: No pMHC_affinity
predictions from method matching 'mhcnuggets'. Available: ['mhcflurry', 'netmhcpan'].
Name a method present in the loaded predictions, or remove the entry.
```

topiary reports what the *data* lacks — the half it can know. Which config key produced it is the half it cannot, and is the half the user needs in order to fix it.

Deleted: `_CANONICAL_METHOD_PREFERENCE` and `_auto_pick_canonical_method`. A test asserts they stay gone.

Floor moves to `topiary>=5.26.0`.

## Deliberately not adopted

**`from_predictions()`** — the right idea, and its docstring names our situation exactly ("a hand-written builder is a copy of topiary's long form that topiary can't see and can't migrate: a column added here (`allele_set`, say) silently never reaches it"). `epitopes_to_topiary_df` *is* that copy, and our frame is indeed missing `allele_set`. But it cannot carry a consumer's own columns — vaxrank groups by an explicit `prediction_id`, and its `peptide_offset` is a property of the candidate rather than of the `mhctools.Prediction` — nor per-peptide allele sets, which the attribution policy in #348 needs. Adopting it would still mean hand-writing the schema. Filed as [openvax/topiary#203](https://github.com/openvax/topiary/issues/203).

**`KIND_MHC_DEPENDENCE`** — #357. Depends on `allele_evidence.py`, which only exists on the #348 branch. Verified separately that the two tables agree on all ten canonical kinds, so that adoption is de-duplication with no behavior change.

**`apply_sort` ordering fix and scoped fields in filters** — re-verified these do not reach vaxrank: no `apply_sort` import anywhere, no `best_*` DSL references, `sort_epitopes_by` is plain Python, and nothing expresses a differential criterion inside a DSL expression (`wt_ic50` exists only as a serialization column and a comparator).

## Note on new warnings

The floor bump surfaces topiary's advisory migration warnings for bare allele-free references (`processing[mhcflurry].score` → `peptide_view(...)`), raised by test configs. Behavior is unchanged — topiary auto-projects and says so. Left alone here because the expressions in question are the ones #348 changes the semantics of; migrating them belongs with that work, not with a dependency dedup.

## Verification

1046 passed, 1 skipped, ruff clean, on topiary 5.26.0. Version 3.2.0 → 3.2.1.

Independent of #348 — different regions of `epitope_dsl.py`, so the two should merge in either order.
