### PR TITLE
Read LENS through topiary instead of sniffing columns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.28.0,<6.0.0
+topiary>=5.28.2,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.26.0,<6.0.0
+topiary>=5.28.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -2389,3 +2389,29 @@ def test_unrecognized_predictor_version_still_yields_its_predictor(tmp_path):
         p for p in epitope.predictions_flat()
         if p.predictor_name == "netmhcpan"]
     assert netmhcpan.value == pytest.approx(75.0)
+
+
+def test_two_versions_of_one_tool_are_kept_apart(tmp_path):
+    """A LENS file may carry two versions of the same predictor.
+
+    vaxrank's DSL addresses them individually — ``affinity['netmhcpan',
+    '4.2']`` — so collapsing them is a loss of capability, not just of a
+    column. topiary's normalized column name strips the version, which makes
+    two versions collide into one name (openvax/topiary#208); this pins the
+    behaviour vaxrank has to preserve regardless of how that is resolved.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+
+    path = tmp_path / "two_versions.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tnetmhcpan_4.1b.aff_nm\t"
+        "netmhcpan_4.2.aff_nm\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t75\t120\n")
+
+    [epitope] = read_lens_report(path, epitope_config=EpitopeConfig()).epitopes
+    by_version = {
+        p.predictor_version: p.value
+        for p in epitope.predictions_flat()
+        if p.predictor_name == "netmhcpan"}
+    assert by_version == {"4.1b": pytest.approx(75.0),
+                          "4.2": pytest.approx(120.0)}

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -2394,11 +2394,10 @@ def test_unrecognized_predictor_version_still_yields_its_predictor(tmp_path):
 def test_two_versions_of_one_tool_are_kept_apart(tmp_path):
     """A LENS file may carry two versions of the same predictor.
 
-    vaxrank's DSL addresses them individually — ``affinity['netmhcpan',
-    '4.2']`` — so collapsing them is a loss of capability, not just of a
-    column. topiary's normalized column name strips the version, which makes
-    two versions collide into one name (openvax/topiary#208); this pins the
-    behaviour vaxrank has to preserve regardless of how that is resolved.
+    topiary qualifies the column names when two versions would otherwise
+    collide (openvax/topiary#208), so both survive the read. vaxrank's DSL
+    addresses them individually — ``affinity['netmhcpan', '4.2']`` — so
+    collapsing them would be a loss of capability, not just of a column.
     """
     from vaxrank.epitope_config import EpitopeConfig
 
@@ -2408,10 +2407,58 @@ def test_two_versions_of_one_tool_are_kept_apart(tmp_path):
         "netmhcpan_4.2.aff_nm\n"
         "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t75\t120\n")
 
-    [epitope] = read_lens_report(path, epitope_config=EpitopeConfig()).epitopes
+    [epitope] = read_lens_report(
+        path, epitope_config=EpitopeConfig()).epitopes
     by_version = {
         p.predictor_version: p.value
         for p in epitope.predictions_flat()
         if p.predictor_name == "netmhcpan"}
+    # Both leaves stay on the candidate. Only the evaluation frame is
+    # narrowed, so nothing is lost from the data itself.
     assert by_version == {"4.1b": pytest.approx(75.0),
                           "4.2": pytest.approx(120.0)}
+
+
+def test_unqualified_scoring_resolves_to_the_newest_version(tmp_path, caplog):
+    """An ambiguous version must not make the file unscoreable.
+
+    topiary raises on an unqualified reference when a model appears at two
+    versions and offers no ``default_versions`` to resolve it
+    (openvax/topiary#214) — so with the default ``score_expr``, which is
+    unqualified, the whole run would fail. vaxrank resolves to the newest by
+    PEP 440, which is what ``CandidateEpitope`` already does for unqualified
+    access, and says so.
+    """
+    import logging
+
+    from vaxrank.epitope_config import EpitopeConfig
+
+    path = tmp_path / "two_versions.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tnetmhcpan_4.1b.aff_nm\t"
+        "netmhcpan_4.2.aff_nm\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t75\t120\n")
+
+    with caplog.at_level(logging.WARNING):
+        [default_scored] = read_lens_report(
+            path, epitope_config=EpitopeConfig()).epitopes
+    assert default_scored.per_allele_scores  # scored at all, rather than raising
+
+    warning = "\n".join(
+        record.getMessage() for record in caplog.records
+        if record.levelno >= logging.WARNING)
+    assert "4.1b" in warning and "4.2" in warning
+    assert "newest" in warning
+
+    # An expression that pins a version is left alone — dropping rows would
+    # break the reference the caller wrote.
+    [pinned] = read_lens_report(
+        path,
+        epitope_config=EpitopeConfig(
+            score_expr=(
+                "affinity['netmhcpan', '4.1b']"
+                ".value.logistic_normalized(350,150)"))).epitopes
+    # 4.1b is the stronger binder (75 nM vs 120), so pinning it scores higher
+    # than the newest-version default — proving the pin was honored.
+    assert (list(pinned.per_allele_scores.values())[0]
+            > list(default_scored.per_allele_scores.values())[0])

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -707,9 +707,16 @@ def test_load_lens_preserves_mhcflurry_axes_for_coverage_and_dsl():
     epitope = next(e for e in epitopes if e.sequence == "SVVGSSSSS")
 
     coverage = compute_coverage([epitope], ["HLA-A*02:01"])["HLA-A*02:01"]
-    # Coverage aggregates the best affinity evidence across models;
-    # netMHCpan's 0.30 beats MHCflurry's independently preserved 0.45.
-    assert coverage.best_affinity_pct == pytest.approx(0.30)
+    # netMHCpan emits two percentiles that mean different things:
+    # ``perc_rank_el`` is eluted-ligand (presentation) and ``perc_rank_ba``
+    # is binding affinity. vaxrank's own column registry listed
+    # ``perc_rank_el`` first among the *affinity* percentiles, so netMHCpan's
+    # 0.30 EL percentile was reported as an affinity percentile and beat
+    # MHCflurry's real 0.45. Reading topiary's normalized frame files each
+    # under its own kind, so the best affinity percentile is now MHCflurry's
+    # 0.45 (netMHCpan's real affinity rank is 0.50) and the EL value joins
+    # the presentation axis where it belongs.
+    assert coverage.best_affinity_pct == pytest.approx(0.45)
     assert coverage.best_presentation_pct == pytest.approx(0.28)
 
     scores = score_predictions(
@@ -1056,8 +1063,14 @@ def test_epitope_report_surfaces_integrated_mhcflurry_axes():
     assert mhcflurry_row["Presentation score"] != "—"
     assert mhcflurry_row["Presentation %ile"] != "—"
     assert mhcflurry_row["Integrated processing score"] != "—"
-    assert netmhcpan_row["Presentation score"] == "—"
-    assert netmhcpan_row["Presentation %ile"] == "—"
+    # netMHCpan's eluted-ligand score IS a presentation signal; vaxrank's
+    # own column registry never read it, so this used to be blank. topiary
+    # files score_el / perc_rank_el under presentation, so the axis is
+    # populated for netMHCpan too.
+    assert netmhcpan_row["Presentation score"] != "—"
+    assert netmhcpan_row["Presentation %ile"] != "—"
+    # Integrated antigen processing stays MHCflurry-only — netMHCpan emits
+    # no such axis, so this one is still blank and the columns stay aligned.
     assert netmhcpan_row["Integrated processing score"] == "—"
     assert tuple(mhcflurry_row) == tuple(netmhcpan_row)
 
@@ -1230,8 +1243,10 @@ def test_resolve_default_methods_auto_picks_canonical():
     _loaded = read_lens_report(path)
     preds = list(_loaded.epitopes)
     df = epitopes_to_topiary_df(preds)
+    # netMHCpan's eluted-ligand columns now land on the presentation axis,
+    # so presentation is multi-model here too and gets a canonical default.
     assert resolve_default_methods(EpitopeConfig(), df) == {
-        "pMHC_affinity": "mhcflurry"}
+        "pMHC_affinity": "mhcflurry", "pMHC_presentation": "mhcflurry"}
 
 
 def test_resolve_default_methods_user_override_wins():
@@ -1245,7 +1260,10 @@ def test_resolve_default_methods_user_override_wins():
     preds = list(_loaded.epitopes)
     df = epitopes_to_topiary_df(preds)
     cfg = EpitopeConfig(default_methods={"pMHC_affinity": "netmhcpan"})
-    assert resolve_default_methods(cfg, df) == {"pMHC_affinity": "netmhcpan"}
+    # Presentation is multi-model here too now that netMHCpan's eluted-ligand
+    # columns land on that axis, so it also gets a canonical default.
+    assert resolve_default_methods(cfg, df) == {
+        "pMHC_affinity": "netmhcpan", "pMHC_presentation": "mhcflurry"}
 
 
 def test_default_methods_works_on_synthetic_main_pipeline_frame(tmp_path):
@@ -1848,7 +1866,8 @@ def test_real_lens_v15_emits_both_affinity_predictors():
     assert methods == {"mhcflurry", "netmhcpan"}
     # MHCflurry contributes affinity + presentation + processing while
     # netMHCpan contributes affinity. NA cells produce fewer leaves.
-    assert len(leaves) <= 4 * len(report_df)
+    # affinity + presentation per tool, plus one processing leaf.
+    assert len(leaves) <= 6 * len(report_df)
     predictors_used = report_df["Predictors used"].iloc[0]
     assert predictors_used.startswith("mhcflurry")
 
@@ -2303,3 +2322,75 @@ def test_native_roundtrip_keeps_undecided_targetability_undecided(tmp_path):
 
     assert reloaded.overlaps_targetable is None
     assert reloaded.is_targetable is True
+
+
+def test_netmhcpan_eluted_ligand_percentile_is_presentation_not_affinity(
+        tmp_path):
+    """netMHCpan's two percentiles mean different things.
+
+    ``perc_rank_el`` is the eluted-ligand percentile — a presentation
+    signal — and ``perc_rank_ba`` is the binding-affinity percentile.
+    vaxrank's own column registry listed ``perc_rank_el`` first among the
+    *affinity* percentiles, so an EL percentile was reported as an affinity
+    percentile and could win "best affinity" over a real one. Reading
+    topiary's normalized frame files each under its own kind.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+
+    path = tmp_path / "netmhcpan_axes.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tnetmhcpan_4.1b.aff_nm\t"
+        "netmhcpan_4.1b.perc_rank_ba\tnetmhcpan_4.1b.perc_rank_el\t"
+        "netmhcpan_4.1b.score_el\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t76.11\t0.5\t0.3\t0.92\n")
+
+    [epitope] = read_lens_report(path, epitope_config=EpitopeConfig()).epitopes
+    by_kind = {
+        p.kind: p for p in epitope.predictions_flat()
+        if p.predictor_name == "netmhcpan"}
+
+    # The affinity leaf carries the BA percentile, not the EL one.
+    assert by_kind["pMHC_affinity"].value == pytest.approx(76.11)
+    assert by_kind["pMHC_affinity"].percentile_rank == pytest.approx(0.5)
+    # The EL signal is a presentation leaf of its own.
+    assert by_kind["pMHC_presentation"].percentile_rank == pytest.approx(0.3)
+    assert by_kind["pMHC_presentation"].score == pytest.approx(0.92)
+
+
+def test_unrecognized_predictor_version_is_bridged_not_dropped(
+        tmp_path, caplog):
+    """A version topiary does not recognize must not lose the predictor.
+
+    ``read_lens`` normalizes a binding column only when it recognizes the
+    version string, passing an unrecognized one through verbatim — so
+    ``netmhcpan_4.1.aff_nm`` (no ``b``) would drop netMHCpan's whole
+    affinity axis with nothing in the logs. Tracked as
+    openvax/topiary#206; bridged here by mapping on the metric, which is
+    what determines meaning, and saying so.
+    """
+    import logging
+
+    from vaxrank.epitope_config import EpitopeConfig
+
+    path = tmp_path / "unknown_version.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "netmhcpan_4.1.aff_nm\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t75\n")
+
+    with caplog.at_level(logging.WARNING):
+        [epitope] = read_lens_report(
+            path, epitope_config=EpitopeConfig()).epitopes
+
+    predictors = {
+        (p.predictor_name, p.kind) for p in epitope.predictions_flat()}
+    assert ("netmhcpan", "pMHC_affinity") in predictors
+    assert ("mhcflurry", "pMHC_affinity") in predictors
+
+    warning = "\n".join(
+        record.getMessage() for record in caplog.records
+        if record.levelno >= logging.WARNING)
+    # Recovering it silently would be its own defect — the file is unusual
+    # and the operator should know why we had to guess.
+    assert "netmhcpan_4.1.aff_nm" in warning
+    assert "topiary#206" in warning

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -2357,19 +2357,20 @@ def test_netmhcpan_eluted_ligand_percentile_is_presentation_not_affinity(
     assert by_kind["pMHC_presentation"].score == pytest.approx(0.92)
 
 
-def test_unrecognized_predictor_version_is_bridged_not_dropped(
-        tmp_path, caplog):
-    """A version topiary does not recognize must not lose the predictor.
+def test_unrecognized_predictor_version_still_yields_its_predictor(tmp_path):
+    """A version string topiary has not seen must not lose the predictor.
 
-    ``read_lens`` normalizes a binding column only when it recognizes the
-    version string, passing an unrecognized one through verbatim — so
-    ``netmhcpan_4.1.aff_nm`` (no ``b``) would drop netMHCpan's whole
-    affinity axis with nothing in the logs. Tracked as
-    openvax/topiary#206; bridged here by mapping on the metric, which is
-    what determines meaning, and saying so.
+    ``read_lens`` used to normalize a binding column only when it recognized
+    the version, passing an unrecognized one through verbatim — so
+    ``netmhcpan_4.1.aff_nm`` (no ``b``) dropped netMHCpan's entire affinity
+    axis with nothing in the logs. vaxrank carried a bridge that remapped
+    such columns by metric; topiary 5.28.0 matches structurally
+    (openvax/topiary#206) and the bridge is gone.
+
+    This pins the capability rather than the bridge: if a future topiary
+    reverts to version-keyed matching, a whole predictor disappears from
+    scoring and the report, and nothing else in the suite would notice.
     """
-    import logging
-
     from vaxrank.epitope_config import EpitopeConfig
 
     path = tmp_path / "unknown_version.tsv"
@@ -2378,19 +2379,13 @@ def test_unrecognized_predictor_version_is_bridged_not_dropped(
         "netmhcpan_4.1.aff_nm\n"
         "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t75\n")
 
-    with caplog.at_level(logging.WARNING):
-        [epitope] = read_lens_report(
-            path, epitope_config=EpitopeConfig()).epitopes
-
+    [epitope] = read_lens_report(
+        path, epitope_config=EpitopeConfig()).epitopes
     predictors = {
         (p.predictor_name, p.kind) for p in epitope.predictions_flat()}
     assert ("netmhcpan", "pMHC_affinity") in predictors
     assert ("mhcflurry", "pMHC_affinity") in predictors
-
-    warning = "\n".join(
-        record.getMessage() for record in caplog.records
-        if record.levelno >= logging.WARNING)
-    # Recovering it silently would be its own defect — the file is unusual
-    # and the operator should know why we had to guess.
-    assert "netmhcpan_4.1.aff_nm" in warning
-    assert "topiary#206" in warning
+    [netmhcpan] = [
+        p for p in epitope.predictions_flat()
+        if p.predictor_name == "netmhcpan"]
+    assert netmhcpan.value == pytest.approx(75.0)

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -214,7 +214,7 @@ def test_variant_from_lens_row_uses_real_snv_alleles():
     biology so it can be fed to varcode-effect annotation safely."""
     from vaxrank.external_input import variant_from_lens_row
     row = {
-        'variant_coords': 'chr1:1624824',
+        'variant': 'chr1:1624824',
         'antigen_source': 'SNV',
         'snv_ref_allele': 'C',
         'snv_alt_allele': '[T]',  # LENS's bracketed format
@@ -236,7 +236,7 @@ def test_variant_from_lens_row_uses_real_indel_alleles():
     representation a downstream caller would expect."""
     from vaxrank.external_input import variant_from_lens_row
     row = {
-        'variant_coords': 'chr3:150742445',
+        'variant': 'chr3:150742445',
         'antigen_source': 'INDEL',
         'indel_ref_allele': 'CA',
         'indel_alt_allele': '[C]',
@@ -259,7 +259,7 @@ def test_variant_from_lens_row_skips_non_snv_indel():
     from vaxrank.external_input import variant_from_lens_row
     for src in ('SPLICE', 'FUSION', 'CTA/SELF', 'ERV'):
         row = {
-            'variant_coords': None,
+            'variant': None,
             'antigen_source': src,
         }
         assert variant_from_lens_row(row) is None
@@ -270,7 +270,7 @@ def test_variant_from_lens_row_skips_when_alleles_missing():
     rather than fabricate a placeholder."""
     from vaxrank.external_input import variant_from_lens_row
     row = {
-        'variant_coords': 'chr1:1000',
+        'variant': 'chr1:1000',
         'antigen_source': 'SNV',
         'snv_ref_allele': None,
         'snv_alt_allele': None,

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -120,8 +120,17 @@ def _nan_safe(x) -> tuple[bool, float]:
     return (is_nan, 0.0 if is_nan else x)
 
 
-def _sort_versions(versions) -> list:
-    """Sort ``predictor_version`` strings: legacy / unparseable
+def sort_versions(versions) -> list:
+    """Canonical ordering for ``predictor_version`` strings.
+
+    Public because two layers now depend on it agreeing: the leaf accessors
+    below, and :func:`vaxrank.epitope_dsl.resolve_default_versions`, which
+    resolves an unqualified DSL reference. If those two ordered versions
+    differently the object API and the DSL would disagree about the same
+    candidate — which is openvax/vaxrank#362, and is what resolving through
+    one function prevents.
+
+    Sorts ``predictor_version`` strings: legacy / unparseable
     strings come first (lex-sorted), valid PEP 440 versions follow
     oldest → newest. The last element is therefore the *most recent*
     valid version when any are valid, else the last legacy string
@@ -265,7 +274,7 @@ class Peptide:
         """
         canonical = _resolve_kind(kind)
         by_version = self.predictions.get(canonical, {}).get(predictor, {})
-        return tuple(_sort_versions(by_version))
+        return tuple(sort_versions(by_version))
 
     def alleles_for(self, kind: str, *,
                     predictor: Optional[str] = None,
@@ -354,7 +363,7 @@ class Peptide:
         if not by_version:
             return ()
         if version is None:
-            version = _sort_versions(by_version)[-1]
+            version = sort_versions(by_version)[-1]
         return by_version.get(version, ())
 
     def best(self, kind: str, *,

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -289,6 +289,71 @@ def validate_default_methods(cfg, topiary_df):
                 % (kind, method, error)) from error
 
 
+def dsl_pins_a_version(cfg):
+    """True when a configured expression names an explicit predictor version."""
+    for expr in (cfg.filter_expr, cfg.score_expr):
+        if expr is None:
+            continue
+        refs = collect_dsl_references(parse_epitope_expression(expr))
+        if any(version for _kind, _method, version in refs["kinds"]):
+            return True
+    return False
+
+
+def resolve_default_versions(cfg, topiary_df):
+    """Narrow a frame to one predictor version per ``(kind, model)``.
+
+    topiary raises on an unqualified reference when a model appears at more
+    than one version, and offers no ``default_versions`` to resolve it the
+    way ``default_methods`` resolves an ambiguous model
+    (openvax/topiary#214). Without this a multi-version LENS table cannot be
+    scored with a default configuration at all — the default ``score_expr``
+    references ``affinity.value``, which is exactly the unqualified form.
+
+    Newest wins, by PEP 440 ordering. That is not an arbitrary pick: it is
+    what ``CandidateEpitope`` already does for unqualified access, so
+    resolving the same way makes the DSL and the object API agree where they
+    currently disagree (openvax/vaxrank#362).
+
+    Left alone when a configured expression pins a version — that caller has
+    said which one they want, and dropping rows would break the reference
+    they wrote.
+    """
+    if topiary_df.empty or "predictor_version" not in topiary_df.columns:
+        return topiary_df
+    versions_by_model = {}
+    for (kind, method), group in topiary_df.groupby(
+            ["kind", "prediction_method_name"], sort=False):
+        found = {v for v in group["predictor_version"].dropna().unique() if v}
+        if len(found) > 1:
+            versions_by_model[(kind, method)] = found
+    if not versions_by_model:
+        return topiary_df
+    if dsl_pins_a_version(cfg):
+        return topiary_df
+
+    from .candidate_epitope import _sort_versions
+
+    keep = {}
+    for (kind, method), found in versions_by_model.items():
+        newest = _sort_versions(found)[-1]
+        keep[(kind, method)] = newest
+        logger.warning(
+            "%s appears at versions %s for kind %s. No configured expression "
+            "names one, so the newest (%r) is used and the others are "
+            "excluded from scoring — matching how CandidateEpitope resolves "
+            "unqualified access. Write affinity[%r, %r] to choose "
+            "explicitly.",
+            method, sorted(found), kind, newest, method, sorted(found)[0])
+
+    def _row_kept(row):
+        chosen = keep.get((row["kind"], row["prediction_method_name"]))
+        return chosen is None or row["predictor_version"] == chosen
+
+    return topiary_df[topiary_df.apply(_row_kept, axis=1)].reset_index(
+        drop=True)
+
+
 def score_predictions(epitopes, cfg, *, topiary_df=None,
                       kind_support=None):
     """Score external-input epitopes using the configured Topiary DSL.
@@ -326,6 +391,7 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
     if df.empty:
         return pd.Series(dtype=float)
 
+    df = resolve_default_versions(cfg, df)
     validate_default_methods(cfg, df)
     resolved = resolve_default_methods(cfg, df)
 

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -332,11 +332,11 @@ def resolve_default_versions(cfg, topiary_df):
     if dsl_pins_a_version(cfg):
         return topiary_df
 
-    from .candidate_epitope import _sort_versions
+    from .candidate_epitope import sort_versions
 
     keep = {}
     for (kind, method), found in versions_by_model.items():
-        newest = _sort_versions(found)[-1]
+        newest = sort_versions(found)[-1]
         keep[(kind, method)] = newest
         logger.warning(
             "%s appears at versions %s for kind %s. No configured expression "
@@ -346,12 +346,14 @@ def resolve_default_versions(cfg, topiary_df):
             "explicitly.",
             method, sorted(found), kind, newest, method, sorted(found)[0])
 
-    def _row_kept(row):
-        chosen = keep.get((row["kind"], row["prediction_method_name"]))
-        return chosen is None or row["predictor_version"] == chosen
-
-    return topiary_df[topiary_df.apply(_row_kept, axis=1)].reset_index(
-        drop=True)
+    # Vectorized rather than a row-wise apply: this runs on every scoring
+    # pass, and the frames are one row per prediction leaf.
+    chosen = pd.Series(
+        list(zip(topiary_df["kind"], topiary_df["prediction_method_name"]))
+    ).map(keep)
+    keep_mask = chosen.isna().to_numpy() | (
+        chosen.to_numpy() == topiary_df["predictor_version"].to_numpy())
+    return topiary_df[keep_mask].reset_index(drop=True)
 
 
 def score_predictions(epitopes, cfg, *, topiary_df=None,

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -726,47 +726,76 @@ class DetectedPredictor:
     version: str = ""
 
 
+def _parse_lens_binding_column(column):
+    """Split a topiary-normalized LENS binding column into its parts.
+
+    Returns ``(tool, version, kind, field)`` or ``None``. Two shapes exist:
+
+        mhcflurry_affinity_value             tool, kind, metric
+        netmhcpan_4.1b_affinity_value        tool, VERSION, kind, metric
+
+    topiary qualifies with the version only when two versions of one tool
+    would otherwise claim the same column name (openvax/topiary#208), so
+    both forms appear — sometimes in the same frame. Parsing from the right
+    handles that without guessing: the metric and kind are a known suffix,
+    and whatever precedes them is the tool, optionally followed by a
+    version. Splitting from the left cannot work, because a version segment
+    is indistinguishable from part of a tool name until you know where the
+    kind starts.
+    """
+    text = str(column)
+    for metric, kind in _LENS_KIND_METRICS:
+        for field in ("value", "score", "rank"):
+            suffix = "_%s_%s" % (metric, field)
+            if not text.endswith(suffix):
+                continue
+            prefix = text[:-len(suffix)]
+            if not prefix:
+                return None
+            head, _, tail = prefix.rpartition("_")
+            # A trailing segment starting with a digit is a version, not
+            # part of the tool name — the convention LENS itself uses.
+            if head and tail[:1].isdigit():
+                return head, tail, kind, field
+            return prefix, "", kind, field
+    return None
+
+
 def detect_lens_predictors(columns, versions=None):
-    """Return a :class:`DetectedPredictor` per ``(tool, kind)`` present.
+    """Return a :class:`DetectedPredictor` per ``(tool, version, kind)``.
 
     ``columns`` are the columns of a ``topiary.read_lens`` frame; ``versions``
-    is topiary's ``{method: version}`` map when available. Tools are whatever
-    topiary emitted — vaxrank no longer keeps its own list, so a predictor
-    topiary learns to read needs no change here.
+    is topiary's ``{method: version}`` map. A version parsed out of a column
+    name wins over that map, which cannot represent two versions of one tool
+    — it is a plain ``{tool: version}`` dict, so on a multi-version table it
+    reports only one of them and every leaf would be stamped with it.
+
+    Tools are whatever topiary emitted; vaxrank keeps no list of its own, so
+    a predictor topiary learns to read needs no change here.
     """
-    columns = set(columns)
     versions = versions or {}
+    parsed = {}
+    for column in columns:
+        fields = _parse_lens_binding_column(column)
+        if fields is None:
+            continue
+        tool, version, kind, field = fields
+        parsed.setdefault((tool, version, kind), {})[field] = str(column)
+
     detected = []
-    tools = sorted({
-        column.split("_", 1)[0]
-        for column in columns
-        for metric, _kind in _LENS_KIND_METRICS
-        if column.startswith(("%s_" % metric,)) is False
-        and ("_%s_" % metric) in column
-    })
-    for tool in tools:
-        for metric, kind in _LENS_KIND_METRICS:
-            names = {
-                field: "%s_%s_%s" % (tool, metric, field)
-                for field in ("value", "score", "rank")
-            }
-            present = {
-                field: name for field, name in names.items()
-                if name in columns}
-            if not present:
-                continue
-            agretopicity = "%s_agretopicity" % tool
-            detected.append(DetectedPredictor(
-                tool=tool,
-                kind=kind,
-                value_col=present.get("value"),
-                score_col=present.get("score"),
-                rank_col=present.get("rank"),
-                agretopicity_col=(
-                    agretopicity if agretopicity in columns else None),
-                version=str(versions.get(tool, "") or ""),
-            ))
-    detected.sort(key=lambda d: (d.tool, d.kind))
+    for (tool, version, kind), present in parsed.items():
+        agretopicity = "%s_agretopicity" % tool
+        detected.append(DetectedPredictor(
+            tool=tool,
+            kind=kind,
+            value_col=present.get("value"),
+            score_col=present.get("score"),
+            rank_col=present.get("rank"),
+            agretopicity_col=(
+                agretopicity if agretopicity in set(columns) else None),
+            version=version or str(versions.get(tool, "") or ""),
+        ))
+    detected.sort(key=lambda d: (d.tool, d.version, d.kind))
     return detected
 
 

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -726,65 +726,6 @@ class DetectedPredictor:
     version: str = ""
 
 
-# Bridge for openvax/topiary#206: read_lens normalizes a binding column only
-# when it recognizes the version string, and passes an unrecognized one
-# through verbatim — so a LENS file written by netMHCpan "4.1" rather than
-# "4.1b" would lose its entire affinity axis with nothing in the logs. Map
-# any residual predictor-shaped column by its metric, which is what actually
-# determines meaning, and say so. Delete once topiary matches structurally.
-_RESIDUAL_LENS_COLUMN_RE = re.compile(
-    r"^([A-Za-z][A-Za-z0-9]*)_(\d[\w.]*)\.(.+)$")
-
-# LENS metric suffix -> (topiary kind segment, metric field).
-_RESIDUAL_METRIC_MAP = {
-    "aff": ("affinity", "value"),
-    "aff_nm": ("affinity", "value"),
-    "aff_perc": ("affinity", "rank"),
-    "perc_rank_ba": ("affinity", "rank"),
-    "score_ba": ("affinity", "score"),
-    "perc_rank_el": ("presentation", "rank"),
-    "score_el": ("presentation", "score"),
-    "pres_score": ("presentation", "score"),
-    "pres_perc": ("presentation", "rank"),
-    "proc_score": ("antigen_processing", "score"),
-    "halflife_hours": ("stability", "value"),
-    "perc_rank_stab": ("stability", "rank"),
-}
-
-
-def _map_residual_lens_columns(df):
-    """Normalize predictor columns topiary left unmapped, and report them."""
-    renames = {}
-    unmapped = []
-    for column in df.columns:
-        match = _RESIDUAL_LENS_COLUMN_RE.match(str(column))
-        if not match:
-            continue
-        tool, version, metric = match.groups()
-        mapped = _RESIDUAL_METRIC_MAP.get(metric)
-        if mapped is None:
-            unmapped.append(str(column))
-            continue
-        kind, field = mapped
-        target = "%s_%s_%s" % (tool, kind, field)
-        if target not in df.columns:
-            renames[column] = target
-    if renames:
-        logger.warning(
-            "topiary did not normalize %d LENS binding column(s), most "
-            "likely an unrecognized predictor version (openvax/topiary#206). "
-            "Mapping them by metric so the signal is not lost: %s",
-            len(renames),
-            ", ".join("%s -> %s" % kv for kv in sorted(renames.items())))
-        df = df.rename(columns=renames)
-    if unmapped:
-        logger.warning(
-            "LENS column(s) %s look like predictor output but their metric "
-            "is unknown to vaxrank and to topiary; they are ignored.",
-            ", ".join(sorted(unmapped)))
-    return df
-
-
 def detect_lens_predictors(columns, versions=None):
     """Return a :class:`DetectedPredictor` per ``(tool, kind)`` present.
 
@@ -923,7 +864,7 @@ def read_lens_report(path, epitope_config=None):
     # names too — ``gene``, ``variant``, ``effect``, ``gene_tpm`` — which is
     # the vocabulary the rest of this module now reads.
     result = read_lens(path)
-    df = _map_residual_lens_columns(result.df)
+    df = result.df
     # topiary detects each binding model's version while parsing and records
     # it on the metadata. vaxrank's version-qualified DSL references
     # (``affinity['mhcflurry', '2.1.1']``) depend on those reaching the

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -678,144 +678,177 @@ def read_pvacseq_report(path, epitope_config=None):
 
 # ── LENS import ──────────────────────────────────────────────────────────────
 
-# LENS columns follow the convention "<tool>_<version>.<metric>", e.g.
-# "mhcflurry_2.1.1.aff", "netmhcpan_4.1b.perc_rank_el",
-# "netmhcstabpan_1.0.halflife_hours". We sniff which tools are present by
-# regex, bucket columns by (tool, version), and consult the registry below
-# to know which metric is the "value" and which are percentile ranks.
-_LENS_COLUMN_RE = re.compile(r"^([A-Za-z][A-Za-z0-9]*)_(\d[\w.]*)\.(.+)$")
+# ── LENS import ──────────────────────────────────────────────────────────────
+#
+# LENS column names vary across versions — v1.4 writes ``mhcflurry_2.1.1.aff``,
+# v1.9 writes something else, and each tool spells its metrics differently.
+# vaxrank used to absorb that itself with a ``<tool>_<version>.<metric>`` regex
+# and a per-tool registry of metric-name preferences.
+#
+# ``topiary.read_lens`` already does it, for every LENS version topiary knows,
+# and normalizes onto a regular ``<tool>_<kind>_<metric>`` scheme. Reading that
+# instead of re-deriving it means new LENS versions arrive with a topiary
+# upgrade rather than a vaxrank patch — and it surfaces signals the local
+# registry never listed, notably netmhcpan presentation and netmhcstabpan
+# score.
 
 # Two printings of one processing score are "the same value" below this.
 # Wide enough to absorb a file that writes 0.8 on one row and 0.8000 on the
 # next, tight enough that a genuinely different score still gets reported.
 PROCESSING_SCORE_TOLERANCE = 1e-9
 
-# Registry describing how each LENS-emitted predictor maps into the Topiary
-# DSL. ``kind`` is the topiary prediction Kind (pMHC_affinity etc.).
-# ``value_cols`` and ``percentile_cols`` are LENS metric suffixes in
-# preference order — the first present metric wins. MHCflurry's integrated
-# model contributes two additional kinds: allele-specific presentation and
-# allele-independent antigen processing. Their columns stay attached to the
-# same detected tool/version so the loader can emit all three canonical
-# mhctools prediction kinds.
-_LENS_PREDICTOR_REGISTRY = {
-    "mhcflurry": {
-        "kind": "pMHC_affinity",
-        "value_cols": ("aff",),
-        "percentile_cols": ("aff_perc",),
-        "presentation_score_cols": ("pres_score",),
-        "presentation_percentile_cols": ("pres_perc",),
-        "processing_score_cols": ("proc_score",),
-    },
-    "netmhcpan": {
-        "kind": "pMHC_affinity",
-        "value_cols": ("aff_nm",),
-        "percentile_cols": ("perc_rank_el", "perc_rank_ba"),
-    },
-    "netmhcstabpan": {
-        "kind": "pMHC_stability",
-        "value_cols": ("halflife_hours",),
-        "percentile_cols": ("perc_rank_stab",),
-    },
-}
+# (topiary metric suffix, mhctools Kind, which Prediction field it fills).
+# ``value`` is the predicted quantity (IC50 nM, stability half-life);
+# ``score`` is a normalized 0-1 signal; ``rank`` is a percentile.
+_LENS_KIND_METRICS = (
+    ("affinity", "pMHC_affinity"),
+    ("presentation", "pMHC_presentation"),
+    ("stability", "pMHC_stability"),
+    ("antigen_processing", "antigen_processing"),
+)
+
 
 @dataclass(slots=True)
 class DetectedPredictor:
-    """A predictor whose columns were found in a LENS TSV.
+    """One ``(tool, kind)`` signal found in a topiary-normalized LENS frame.
 
-    ``value_col`` is the LENS column carrying the predicted value
-    (IC50 for affinity, half-life hours for stability). The other
-    ``*_col`` attributes are ``None`` when that signal isn't emitted
-    for the detected ``(tool, version)``. MHCflurry presentation and
-    processing columns are modeled separately rather than overloading
-    its affinity percentile.
+    Built from the columns ``topiary.read_lens`` produced rather than from
+    raw LENS spellings. ``value_col`` / ``score_col`` / ``rank_col`` are
+    ``None`` where that metric is absent for this tool and kind.
     """
     tool: str
-    version: str
     kind: str
-    value_col: str
-    percentile_col: str | None = None
+    value_col: str | None = None
+    score_col: str | None = None
+    rank_col: str | None = None
     agretopicity_col: str | None = None
-    presentation_score_col: str | None = None
-    presentation_percentile_col: str | None = None
-    processing_score_col: str | None = None
+    # Retained so report columns and log lines keep naming a version.
+    version: str = ""
 
 
-def detect_lens_predictors(columns):
-    """Return a list of :class:`DetectedPredictor` for every known tool present.
+# Bridge for openvax/topiary#206: read_lens normalizes a binding column only
+# when it recognizes the version string, and passes an unrecognized one
+# through verbatim — so a LENS file written by netMHCpan "4.1" rather than
+# "4.1b" would lose its entire affinity axis with nothing in the logs. Map
+# any residual predictor-shaped column by its metric, which is what actually
+# determines meaning, and say so. Delete once topiary matches structurally.
+_RESIDUAL_LENS_COLUMN_RE = re.compile(
+    r"^([A-Za-z][A-Za-z0-9]*)_(\d[\w.]*)\.(.+)$")
 
-    Unknown tools (not in ``_LENS_PREDICTOR_REGISTRY``) are ignored; we'd have
-    no way to know which of their columns is the affinity / percentile / kind.
-    """
-    # Group columns by (tool, version)
-    buckets = {}
-    for col in columns:
-        match = _LENS_COLUMN_RE.match(col)
+# LENS metric suffix -> (topiary kind segment, metric field).
+_RESIDUAL_METRIC_MAP = {
+    "aff": ("affinity", "value"),
+    "aff_nm": ("affinity", "value"),
+    "aff_perc": ("affinity", "rank"),
+    "perc_rank_ba": ("affinity", "rank"),
+    "score_ba": ("affinity", "score"),
+    "perc_rank_el": ("presentation", "rank"),
+    "score_el": ("presentation", "score"),
+    "pres_score": ("presentation", "score"),
+    "pres_perc": ("presentation", "rank"),
+    "proc_score": ("antigen_processing", "score"),
+    "halflife_hours": ("stability", "value"),
+    "perc_rank_stab": ("stability", "rank"),
+}
+
+
+def _map_residual_lens_columns(df):
+    """Normalize predictor columns topiary left unmapped, and report them."""
+    renames = {}
+    unmapped = []
+    for column in df.columns:
+        match = _RESIDUAL_LENS_COLUMN_RE.match(str(column))
         if not match:
             continue
-        tool, version, metric = match.group(1), match.group(2), match.group(3)
-        buckets.setdefault((tool, version), {})[metric] = col
+        tool, version, metric = match.groups()
+        mapped = _RESIDUAL_METRIC_MAP.get(metric)
+        if mapped is None:
+            unmapped.append(str(column))
+            continue
+        kind, field = mapped
+        target = "%s_%s_%s" % (tool, kind, field)
+        if target not in df.columns:
+            renames[column] = target
+    if renames:
+        logger.warning(
+            "topiary did not normalize %d LENS binding column(s), most "
+            "likely an unrecognized predictor version (openvax/topiary#206). "
+            "Mapping them by metric so the signal is not lost: %s",
+            len(renames),
+            ", ".join("%s -> %s" % kv for kv in sorted(renames.items())))
+        df = df.rename(columns=renames)
+    if unmapped:
+        logger.warning(
+            "LENS column(s) %s look like predictor output but their metric "
+            "is unknown to vaxrank and to topiary; they are ignored.",
+            ", ".join(sorted(unmapped)))
+    return df
 
+
+def detect_lens_predictors(columns, versions=None):
+    """Return a :class:`DetectedPredictor` per ``(tool, kind)`` present.
+
+    ``columns`` are the columns of a ``topiary.read_lens`` frame; ``versions``
+    is topiary's ``{method: version}`` map when available. Tools are whatever
+    topiary emitted — vaxrank no longer keeps its own list, so a predictor
+    topiary learns to read needs no change here.
+    """
+    columns = set(columns)
+    versions = versions or {}
     detected = []
-    for (tool, version), metrics in buckets.items():
-        spec = _LENS_PREDICTOR_REGISTRY.get(tool)
-        if spec is None:
-            logger.debug(
-                "Skipping unknown LENS predictor %r (version %s)", tool, version)
-            continue
-        value_col = next(
-            (metrics[m] for m in spec["value_cols"] if m in metrics), None)
-        if value_col is None:
-            # A tool prefix was present but without its canonical value metric
-            # — treat as not emitted rather than raising.
-            continue
-        percentile_col = next(
-            (metrics[m] for m in spec["percentile_cols"] if m in metrics), None)
-        presentation_score_col = next(
-            (metrics[m] for m in spec.get("presentation_score_cols", ())
-             if m in metrics), None)
-        presentation_percentile_col = next(
-            (metrics[m] for m in spec.get(
-                "presentation_percentile_cols", ()) if m in metrics), None)
-        processing_score_col = next(
-            (metrics[m] for m in spec.get("processing_score_cols", ())
-             if m in metrics), None)
-        # Agretopicity columns aren't versioned (just "<tool>_agretopicity"),
-        # so we look them up directly on the full column set.
-        agretopicity_col = f"{tool}_agretopicity"
-        if agretopicity_col not in columns:
-            agretopicity_col = None
-        detected.append(DetectedPredictor(
-            tool=tool,
-            version=version,
-            kind=spec["kind"],
-            value_col=value_col,
-            percentile_col=percentile_col,
-            agretopicity_col=agretopicity_col,
-            presentation_score_col=presentation_score_col,
-            presentation_percentile_col=presentation_percentile_col,
-            processing_score_col=processing_score_col,
-        ))
-    # Deterministic order: tool name alphabetical
-    detected.sort(key=lambda d: (d.tool, d.version))
+    tools = sorted({
+        column.split("_", 1)[0]
+        for column in columns
+        for metric, _kind in _LENS_KIND_METRICS
+        if column.startswith(("%s_" % metric,)) is False
+        and ("_%s_" % metric) in column
+    })
+    for tool in tools:
+        for metric, kind in _LENS_KIND_METRICS:
+            names = {
+                field: "%s_%s_%s" % (tool, metric, field)
+                for field in ("value", "score", "rank")
+            }
+            present = {
+                field: name for field, name in names.items()
+                if name in columns}
+            if not present:
+                continue
+            agretopicity = "%s_agretopicity" % tool
+            detected.append(DetectedPredictor(
+                tool=tool,
+                kind=kind,
+                value_col=present.get("value"),
+                score_col=present.get("score"),
+                rank_col=present.get("rank"),
+                agretopicity_col=(
+                    agretopicity if agretopicity in columns else None),
+                version=str(versions.get(tool, "") or ""),
+            ))
+    detected.sort(key=lambda d: (d.tool, d.kind))
     return detected
 
 
 def _pick_canonical_predictor(affinity_preds):
-    """Pick the canonical pMHC_affinity :class:`DetectedPredictor` from a list.
+    """Pick the :class:`DetectedPredictor` whose value drives display columns.
 
-    Used to populate the report's display columns when multiple affinity
-    predictors are present. Preference order: ``mhcflurry`` (present
-    across all LENS versions), then ``netmhcpan``, then alphabetical on
-    tool name for any remainder.
+    Uses topiary's ``CANONICAL_METHOD_PREFERENCE`` so the report's headline
+    affinity names the same model the DSL resolves an unqualified reference
+    to. vaxrank used to keep its own preference order here, and it had
+    drifted from topiary's.
     """
     if not affinity_preds:
         return None
-    for preferred in ("mhcflurry", "netmhcpan"):
-        for d in affinity_preds:
-            if d.tool == preferred:
-                return d
-    return sorted(affinity_preds, key=lambda d: d.tool)[0]
+    from topiary.ranking import CANONICAL_METHOD_PREFERENCE
+
+    def rank(detected):
+        try:
+            return (CANONICAL_METHOD_PREFERENCE.index(detected.tool),
+                    detected.tool)
+        except ValueError:
+            return (len(CANONICAL_METHOD_PREFERENCE), detected.tool)
+
+    return sorted(affinity_preds, key=rank)[0]
 
 
 def normalize_hla_allele(allele):
@@ -882,7 +915,20 @@ def read_lens_report(path, epitope_config=None):
     """
     # low_memory=False avoids mixed-dtype warnings — LENS reports have many
     # optional columns that are mostly NA for a given antigen type.
-    df = pd.read_csv(path, sep="\t", low_memory=False)
+    from topiary import read_lens
+
+    # topiary owns LENS parsing: it detects the version, absorbs the
+    # per-version column spellings, and normalizes every predictor onto
+    # ``<tool>_<kind>_<metric>``. Metadata columns arrive under topiary's
+    # names too — ``gene``, ``variant``, ``effect``, ``gene_tpm`` — which is
+    # the vocabulary the rest of this module now reads.
+    result = read_lens(path)
+    df = _map_residual_lens_columns(result.df)
+    # topiary detects each binding model's version while parsing and records
+    # it on the metadata. vaxrank's version-qualified DSL references
+    # (``affinity['mhcflurry', '2.1.1']``) depend on those reaching the
+    # Prediction leaves, so read them from there rather than re-deriving.
+    lens_versions = dict(getattr(result.metadata, "models", None) or {})
 
     required = {"peptide", "allele"}
     missing = required - set(df.columns)
@@ -890,16 +936,18 @@ def read_lens_report(path, epitope_config=None):
         raise ValueError(
             f"LENS file {path} missing required columns: {missing}")
 
-    detected = detect_lens_predictors(df.columns)
+    detected = detect_lens_predictors(df.columns, lens_versions)
     if not detected:
         raise ValueError(
-            f"LENS file {path} has no recognized predictor columns "
-            f"(expected columns like 'mhcflurry_<version>.aff' or "
-            f"'netmhcpan_<version>.aff_nm')")
+            f"LENS file {path} has no recognized predictor columns. "
+            f"topiary normalizes LENS binding columns to "
+            f"'<tool>_<kind>_<metric>' (e.g. 'mhcflurry_affinity_value'); "
+            f"none were present after reading.")
 
     logger.info(
-        "LENS file %s: detected predictors=%s",
-        path, [(d.tool, d.version) for d in detected])
+        "LENS file %s (version %s): detected %s",
+        path, (result.extra or {}).get("lens_version", "unknown"),
+        sorted({(d.tool, d.kind) for d in detected}))
 
     # Report columns like 'Predicted mutant pMHC affinity' and '%ile rank'
     # render a single predictor's value. Pick the canonical pMHC_affinity
@@ -944,7 +992,9 @@ def read_lens_report(path, epitope_config=None):
         # way to recover wildtype affinity from a LENS row, since
         # LENS doesn't emit a WT IC50 column directly. Computed
         # once per row (shared across detected predictors).
-        agretopicity = cells.number(row.get("mhcflurry_agretopicity"))
+        agretopicities = {
+            d.tool: cells.number(row.get(d.agretopicity_col))
+            for d in detected if d.agretopicity_col}
         # Locate the neoepitope inside its surrounding context once per
         # row (pep_context is a row-level column, not per-predictor).
         # LENS centers the peptide within pep_context but doesn't emit
@@ -983,120 +1033,79 @@ def read_lens_report(path, epitope_config=None):
             'occurs_in_reference': False,
             'occurs_in_non_CTA_reference': False,
         }
+        # One detected entry per (tool, kind); each fills whichever of
+        # value / score / rank topiary's normalized frame carries for it.
         for d in chosen:
-            value = cells.number(row.get(d.value_col))
-            percentile_rank = (
-                cells.number(row.get(d.percentile_col))
-                if d.percentile_col else None)
-            # Derive WT IC50 from agretopicity, only for the
-            # mhcflurry-affinity predictor (the value matches that
-            # tool's IC50 scale). Other predictors leave wt_ic50=None.
-            if value is not None:
-                wt_ic50 = None
-                if (d.tool == "mhcflurry" and d.kind == "pMHC_affinity"
-                        and agretopicity is not None and agretopicity > 0):
-                    wt_ic50 = value / agretopicity
-                mutant = Prediction(
-                    kind=d.kind, predictor_name=d.tool,
-                    predictor_version=d.version, allele=allele,
-                    peptide=str(peptide), value=value, score=0.0,
-                    percentile_rank=percentile_rank,
-                )
-                wt = None
-                if wt_ic50 is not None:
-                    # LENS doesn't emit a WT peptide column — pass an
-                    # empty string. ``candidate_epitopes_from_rows`` keeps
-                    # the WT context (anonymous-WT signal) because wt_ic50
-                    # is non-None even though the sequence is unknown.
-                    wt = Prediction(
-                        kind=d.kind, predictor_name=d.tool,
-                        predictor_version=d.version, allele=allele,
-                        peptide="", value=wt_ic50, score=0.0,
-                        percentile_rank=None,
-                    )
-                epitope_rows.append({
-                    **shared_epitope_fields,
-                    'mutant': mutant,
-                    'wt': wt,
-                })
-                row_added = True
+            value = cells.number(row.get(d.value_col)) if d.value_col else None
+            score = cells.number(row.get(d.score_col)) if d.score_col else None
+            rank = cells.number(row.get(d.rank_col)) if d.rank_col else None
+            if value is None and score is None and rank is None:
+                continue
 
-            presentation_score = (
-                cells.number(row.get(d.presentation_score_col))
-                if d.presentation_score_col else None)
-            presentation_percentile = (
-                cells.number(row.get(d.presentation_percentile_col))
-                if d.presentation_percentile_col else None)
-            if (presentation_score is not None
-                    or presentation_percentile is not None):
-                # mhctools represents MHCflurry presentation as its own
-                # allele-specific kind. ``Prediction.score`` is required;
-                # retain a percentile-only legacy row with a neutral 0.0
-                # score rather than discarding the percentile evidence.
-                epitope_rows.append({
-                    **shared_epitope_fields,
-                    'mutant': Prediction(
-                        kind="pMHC_presentation",
-                        predictor_name=d.tool,
-                        predictor_version=d.version,
-                        allele=allele,
-                        peptide=str(peptide),
-                        value=None,
-                        score=(
-                            presentation_score
-                            if presentation_score is not None else 0.0),
-                        percentile_rank=presentation_percentile,
-                    ),
-                    'wt': None,
-                })
-                row_added = True
-
-            processing_score = (
-                cells.number(row.get(d.processing_score_col))
-                if d.processing_score_col else None)
-            if processing_score is not None:
-                # MHCflurry processing depends on peptide + flanks, not MHC.
-                # LENS repeats it on every allele row, while mhctools emits
-                # one allele-less prediction per peptide position. Preserve
-                # that canonical shape and reject inconsistent repeats.
-                processing_key = (
-                    prediction_id, d.tool, d.version)
-                if processing_key in processing_rows_by_position:
-                    processing_row = processing_rows_by_position[
-                        processing_key]
-                    kept = processing_row['mutant'].score
-                    if abs(kept - processing_score) > PROCESSING_SCORE_TOLERANCE:
-                        # The repeats *should* be identical — same peptide,
-                        # same flanks, no MHC involved — so a real difference
-                        # is worth surfacing. It is not worth aborting the
-                        # run over: the usual cause is a file printing the
-                        # same value at two precisions, and there is no way
-                        # for an operator to act on a hard failure here.
-                        # Keep the first-seen value (deterministic in file
-                        # order) and report the disagreement once at the end.
+            if d.kind == "antigen_processing":
+                if score is None:
+                    continue
+                # Processing depends on peptide + flanks, not MHC. LENS
+                # repeats it on every allele row, while mhctools emits one
+                # allele-less prediction per peptide position; preserve that
+                # canonical shape.
+                processing_key = (prediction_id, d.tool, d.version)
+                existing = processing_rows_by_position.get(processing_key)
+                if existing is not None:
+                    kept = existing['mutant'].score
+                    if abs(kept - score) > PROCESSING_SCORE_TOLERANCE:
                         processing_conflicts.append(
-                            (peptide, d.tool, kept, processing_score))
-                    processing_row['patient_alleles'].add(allele)
+                            (peptide, d.tool, kept, score))
+                    existing['patient_alleles'].add(allele)
                 else:
                     processing_row = {
                         **shared_epitope_fields,
                         'mutant': Prediction(
-                            kind="antigen_processing",
-                            predictor_name=d.tool,
-                            predictor_version=d.version,
-                            allele="",
-                            peptide=str(peptide),
-                            value=None,
-                            score=processing_score,
+                            kind=d.kind, predictor_name=d.tool,
+                            predictor_version=d.version, allele="",
+                            peptide=str(peptide), value=None, score=score,
                             percentile_rank=None,
                         ),
                         'wt': None,
                         'patient_alleles': {allele},
                     }
-                    processing_rows_by_position[
-                        processing_key] = processing_row
+                    processing_rows_by_position[processing_key] = (
+                        processing_row)
                     epitope_rows.append(processing_row)
                 row_added = True
+                continue
+
+            # Allele-scoped kinds. ``Prediction.score`` is required, so a
+            # signal that only carries a percentile keeps a neutral 0.0
+            # rather than discarding the percentile evidence.
+            mutant = Prediction(
+                kind=d.kind, predictor_name=d.tool,
+                predictor_version=d.version, allele=allele,
+                peptide=str(peptide), value=value,
+                score=score if score is not None else 0.0,
+                percentile_rank=rank,
+            )
+
+            # Agretopicity is MT/WT on this tool's own value scale, so it
+            # recovers a WT comparator only for that tool's affinity — LENS
+            # emits no WT column of its own.
+            wt = None
+            agretopicity = agretopicities.get(d.tool)
+            if (d.kind == "pMHC_affinity" and value is not None
+                    and agretopicity is not None and agretopicity > 0):
+                # No WT peptide sequence exists upstream; an empty sequence
+                # is the anonymous-WT signal candidate_epitopes_from_rows
+                # keeps because the value is non-None.
+                wt = Prediction(
+                    kind=d.kind, predictor_name=d.tool,
+                    predictor_version=d.version, allele=allele,
+                    peptide="", value=value / agretopicity, score=0.0,
+                    percentile_rank=None,
+                )
+
+            epitope_rows.append({
+                **shared_epitope_fields, 'mutant': mutant, 'wt': wt})
+            row_added = True
 
         if not row_added:
             continue
@@ -1110,7 +1119,7 @@ def read_lens_report(path, epitope_config=None):
             peptide_offset=offset,
             detected=detected,
             display_pred=display_pred,
-            chosen_tools=[d.tool for d in chosen],
+            chosen_tools=sorted({d.tool for d in chosen}),
         ))
 
     if processing_conflicts:
@@ -1166,18 +1175,19 @@ def _build_lens_report_row(row, allele, peptide, prediction_id,
     '<Tool> value (nM/hours)' so downstream DSL / scripts can see both.
     """
     antigen_source = cells.text(row.get("antigen_source"))
-    gene = cells.text(row.get("gene_name"))
-    variant_pos = cells.text(row.get("variant_coords"))
+    gene = cells.text(row.get("gene"))
+    variant_pos = cells.text(row.get("variant"))
     if not variant_pos:
         variant_pos = cells.text(row.get("mut_aa_pos"))
     if not variant_pos:
         variant_pos = cells.text(row.get("origin_descriptor"))
 
     display_value = (
-        cells.number(row.get(display_pred.value_col)) if display_pred else None)
+        cells.number(row.get(display_pred.value_col))
+        if display_pred and display_pred.value_col else None)
     display_percentile = (
-        cells.number(row.get(display_pred.percentile_col))
-        if display_pred and display_pred.percentile_col else None)
+        cells.number(row.get(display_pred.rank_col))
+        if display_pred and display_pred.rank_col else None)
     display_agretopicity = (
         cells.number(row.get(display_pred.agretopicity_col))
         if display_pred and display_pred.agretopicity_col else None)
@@ -1194,7 +1204,7 @@ def _build_lens_report_row(row, allele, peptide, prediction_id,
         'Predictors used': ','.join(chosen_tools),
         '%ile rank': display_percentile,
         'Agretopicity': display_agretopicity,
-        'TPM': cells.number(row.get("tpm")),
+        'TPM': cells.number(row.get("gene_tpm")),
         'Source sequence name': source_sequence_name,
         'Peptide offset': peptide_offset,
     })
@@ -1204,20 +1214,22 @@ def _build_lens_report_row(row, allele, peptide, prediction_id,
     unit_by_kind = {"pMHC_affinity": "nM", "pMHC_stability": "hours"}
     for d in detected:
         unit = unit_by_kind.get(d.kind, "")
-        label = f"{d.tool} value ({unit})" if unit else f"{d.tool} value"
-        out[label] = cells.number(row.get(d.value_col))
-        if d.kind == "pMHC_affinity" and d.percentile_col:
+        if d.value_col:
+            label = f"{d.tool} value ({unit})" if unit else f"{d.tool} value"
+            out[label] = cells.number(row.get(d.value_col))
+        if d.kind == "pMHC_affinity" and d.rank_col:
             out[f"{d.tool} affinity percentile rank"] = cells.number(
-                row.get(d.percentile_col))
-        if d.presentation_score_col:
-            out[f"{d.tool} presentation score"] = cells.number(
-                row.get(d.presentation_score_col))
-        if d.presentation_percentile_col:
-            out[f"{d.tool} presentation percentile rank"] = cells.number(
-                row.get(d.presentation_percentile_col))
-        if d.processing_score_col:
+                row.get(d.rank_col))
+        if d.kind == "pMHC_presentation":
+            if d.score_col:
+                out[f"{d.tool} presentation score"] = cells.number(
+                    row.get(d.score_col))
+            if d.rank_col:
+                out[f"{d.tool} presentation percentile rank"] = cells.number(
+                    row.get(d.rank_col))
+        if d.kind == "antigen_processing" and d.score_col:
             out[f"{d.tool} processing score"] = cells.number(
-                row.get(d.processing_score_col))
+                row.get(d.score_col))
     return out
 
 

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -510,7 +510,7 @@ def variant_from_lens_row(row, genome=None):
     NaN ``variant_coords`` and are skipped upstream.
     """
     from varcode import Variant
-    coords_parsed = parse_lens_variant_coordinates(row.get('variant_coords'))
+    coords_parsed = parse_lens_variant_coordinates(row.get('variant'))
     if coords_parsed is None:
         return None
     contig, pos = coords_parsed
@@ -676,13 +676,13 @@ def lens_variant_metadata(variant_id, group_rows, genome=None):
         value
         for row in group_rows
         for value in (
-            row.get("gene_name"),
+            row.get("gene"),
             row.get("all_gene_names_encoding_peptide"),
         )
     ))
     lens_is_frameshift = any(
         external_text(row.get("indel_type")).lower() == "frameshift"
-        or "fs" in external_text(row.get("variant_effect")).lower()
+        or "fs" in external_text(row.get("effect")).lower()
         for row in group_rows
     )
     entry = ExternalVariantEntry(
@@ -953,7 +953,7 @@ def lens_ranking_result(report, epitopes, genome=None, options=None):
     # an upstream bug worth surfacing distinctly.
     skipped_kinds = {}  # antigen_source value → count
     for r in rows:
-        coords = r.get('variant_coords')
+        coords = r.get('variant')
         if coords is None or (
                 isinstance(coords, float) and pd.isna(coords)) or (
                 isinstance(coords, str) and (
@@ -1019,7 +1019,7 @@ def lens_ranking_result(report, epitopes, genome=None, options=None):
         k = r.get('antigen_source')
         return ('(missing)' if cells.missing(k) else str(k).strip())
 
-    rows_no_gene_name = [r for r in rows if cells.missing(r.get('gene_name'))]
+    rows_no_gene_name = [r for r in rows if cells.missing(r.get('gene'))]
     rows_no_transcript = [r for r in rows if cells.missing(r.get('transcript_id'))]
     if n_no_pep_context:
         logger.warning(

--- a/vaxrank/external_prediction.py
+++ b/vaxrank/external_prediction.py
@@ -70,7 +70,7 @@ def pvacseq_variant_id(row) -> str:
 
 def lens_variant_id(row) -> str:
     """Return a LENS variant identity including alleles when available."""
-    coords = external_text(row.get("variant_coords"))
+    coords = external_text(row.get("variant"))
     ref = (
         external_text(row.get("snv_ref_allele"))
         or external_text(row.get("indel_ref_allele"))
@@ -223,14 +223,14 @@ class ExternalPredictionKey:
                 row.get("all_gene_ids_encoding_peptide"),
             ),
             gene_names=external_values(
-                row.get("gene_name"),
+                row.get("gene"),
                 row.get("all_gene_names_encoding_peptide"),
             ),
             transcript_ids=external_values(
                 row.get("transcript_id"),
                 row.get("all_transcript_ids_encoding_peptide"),
             ),
-            primary_gene_name=cells.text(row.get("gene_name")),
+            primary_gene_name=cells.text(row.get("gene")),
             primary_transcript_id=cells.text(row.get("transcript_id")),
             species=external_text(row.get("species")),
             peptide=peptide,

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.2.1"
+__version__ = "3.3.0"
 
 
 def print_version():


### PR DESCRIPTION
Closes #359. **Draft — blocked by [openvax/topiary#208](https://github.com/openvax/topiary/issues/208).**

> **Blocker.** topiary strips the version from the normalized column name, so a LENS file carrying two versions of one tool (`netmhcpan_4.1b.aff_nm` and `netmhcpan_4.2.aff_nm`) collides into one column, pandas drops one, and the resulting frame yields **zero predictions**. vaxrank's own sniffer bucketed by `(tool, version)` and produced both. vaxrank's DSL addresses versions individually — `affinity['netmhcpan', '4.2']` — so this is a capability regression, not a cosmetic one.
>
> ```
> via read_lens 5.28.0 : []
> own sniffer (main)   : [('netmhcpan','4.1b',75.0), ('netmhcpan','4.2',120.0)]
> ```
>
> A failing test (`test_two_versions_of_one_tool_are_kept_apart`) is committed to hold the line. This is the complement the fixture snapshot could not catch: it proved nothing was lost across all eight LENS fixtures, but none of them carries two versions of one tool.

vaxrank parsed LENS itself — a `<tool>_<version>.<metric>` regex, a per-tool registry of metric-name preferences, `DetectedPredictor`, and a canonical-predictor picker — while topiary shipped `read_lens` and vaxrank already used its `read_pvacseq` for the other format. The asymmetry was history, not a decision.

## topiary's reader drops nothing

Checked column by column against the real v1.4 / v1.5 / v1.9 fixtures. The nine raw columns absent from its frame are five predictor columns it normalizes, plus four renames:

| raw | topiary | |
|---|---|---|
| `gene_name` | `gene` | identical values |
| `variant_coords` | `variant` | identical values |
| `variant_effect` | `effect` | identical values |
| `tpm` | `gene_tpm` | identical numerically, **and correctly typed** — topiary coerces to float, so fusion-row composites like `ENST00000357997.10:14.540458-ENST00000008527.10:33.840149` become NaN instead of being carried as text |

Those four are now read under topiary's names, so LENS rows and ordinary topiary output speak one vocabulary.

## Two behaviour changes, both fixes

**netMHCpan's eluted-ligand percentile was being reported as its affinity percentile.** The tool emits `perc_rank_el` (eluted ligand — a *presentation* signal) and `perc_rank_ba` (binding affinity). Our registry listed `perc_rank_el` **first** among the affinity percentiles:

```python
"netmhcpan": {"kind": "pMHC_affinity",
              "percentile_cols": ("perc_rank_el", "perc_rank_ba")}
```

so an EL percentile was filed as affinity and could win "best affinity" over a real one. topiary files each under its own kind. Measured across the fixtures:

| fixture | peptide | was | now |
|---|---|---|---|
| `lens_example` | LATEKSRWS | 0.4 | 0.3 |
| `lens_multi_row_per_variant` | MIDDLEEEEE | 2.5 | 2.8 |
| `lens_v1.4_real_subset` | ALKFFRFQL | 1.776 | 2.93 |
| `lens_v1.5_real_subset` | ALSPAGVQGF | 1.935 | 1.854 |

**netMHCpan presentation is now surfaced at all.** Our registry had no presentation entry for that tool, so `score_el` / `perc_rank_el` were read only — and wrongly — as affinity. Five of eight fixtures gain a `pMHC_presentation` leaf.

## What did not change

Diffed a full before/after snapshot of every LENS fixture — epitopes, source windows, offsets, patient alleles, every prediction leaf, and per-allele scores:

| | |
|---|---|
| Identity | **same on all 8** — so every `prediction_id` is byte-identical |
| `per_allele_scores` | **same on all 8** |
| Leaves lost | **none, on any fixture** |
| Predictor versions | preserved (read from `result.metadata.models`) |

## One regression, found and now fixed upstream

`read_lens` used to normalize a binding column only when it recognized the version string, passing an unrecognized one through verbatim — so `netmhcpan_4.1.aff_nm` (no `b`) dropped netMHCpan's entire affinity axis with nothing in the logs. Filed as [openvax/topiary#206](https://github.com/openvax/topiary/issues/206), now **fixed and closed**: topiary matches structurally.

This PR briefly carried a bridge that remapped residual predictor-shaped columns by metric. That is deleted. Confirmed which release fixed it by loading both published wheels in isolation rather than trusting the note:

```
5.27.0  netmhcpan_4.1.aff_nm -> ['netmhcpan_4.1.aff_nm']       (unmapped)
5.28.0  netmhcpan_4.1.aff_nm -> ['netmhcpan_affinity_value']   (mapped)
```

So the floor is **`topiary>=5.28.0`**, not 5.26.0 — 5.27.0 would still lose the predictor. The bridge's test is repurposed rather than deleted: it now pins the *capability*, so a future revert to version-keyed matching would fail loudly instead of silently removing a predictor from scoring and the report.

## Also

`_pick_canonical_predictor` defers to topiary's `CANONICAL_METHOD_PREFERENCE`, so the report's headline affinity names the same model the DSL resolves an unqualified reference to.

Deleted: `_LENS_COLUMN_RE`, `_LENS_PREDICTOR_REGISTRY`, the per-metric preference lists, and the local canonical-preference order. `DetectedPredictor` survives but is now one entry per `(tool, kind)` built from topiary's normalized columns, so a predictor topiary learns to read needs no change here.

## Verification

1050 passed, 1 skipped, ruff clean, on topiary 5.28.0. Re-verified the full before/after fixture snapshot after the rebase: identity, per-allele scores and prediction leaves unchanged on all eight LENS fixtures. Version 3.2.1 → 3.3.0 — the netMHCpan percentile correction changes reported values.
