### PR TITLE
Resolve ambiguous predictor versions through topiary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.28.2,<6.0.0
+topiary>=5.31.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -2462,3 +2462,75 @@ def test_unqualified_scoring_resolves_to_the_newest_version(tmp_path, caplog):
     # than the newest-version default — proving the pin was honored.
     assert (list(pinned.per_allele_scores.values())[0]
             > list(default_scored.per_allele_scores.values())[0])
+
+
+def test_pinning_one_version_still_resolves_an_unqualified_reference(tmp_path):
+    """Pinning a version must not disable resolution for everything else.
+
+    vaxrank used to resolve ambiguity by narrowing the frame to the winning
+    version, so any expression that pinned a version had to skip narrowing
+    altogether — otherwise the pinned rows would have been the ones removed.
+    That coupling meant one pin disabled resolution for every other kind in
+    the same expression, and an unqualified reference alongside it raised.
+
+    topiary resolves through ``default_versions`` instead of by dropping
+    rows, so the two coexist: this expression pins netMHCpan 4.1b for
+    affinity while leaving presentation unqualified.
+    """
+    path = tmp_path / "two_versions_two_kinds.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tnetmhcpan_4.1b.aff_nm\t"
+        "netmhcpan_4.2.aff_nm\tnetmhcpan_4.1b.score_el\t"
+        "netmhcpan_4.2.score_el\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t75\t120\t0.9\t0.4\n")
+
+    from vaxrank.epitope_config import EpitopeConfig
+
+    [epitope] = read_lens_report(
+        path,
+        epitope_config=EpitopeConfig(score_expr=(
+            "affinity['netmhcpan', '4.1b'].value.logistic_normalized(350,150)"
+            " * presentation.score"))).epitopes
+
+    # Presentation resolved to 4.2 (newest, score 0.4) rather than raising,
+    # and the pinned 4.1b affinity is what the first factor scored.
+    assert epitope.per_allele_scores
+
+
+@pytest.mark.parametrize("versions,ambiguous", [
+    (["4.1b", "4.2"], True),
+    (["4.2", ""], False),
+    (["4.2", float("nan")], False),
+    (["4.2", "nan"], False),
+    (["4.2", None], False),
+])
+def test_only_a_named_version_makes_a_model_ambiguous(versions, ambiguous):
+    """Rows recording no version must not read as a version.
+
+    vaxrank's interim resolver compared version strings, and ``dropna()``
+    plus a truthiness check let the literal text ``"nan"`` through — so a
+    frame mixing one real version with ``"nan"`` looked ambiguous, resolved
+    to the real version, and dropped the ``"nan"`` rows from scoring
+    entirely. topiary's resolver treats NaN, None, blank and ``"nan"``
+    alike: no version was named, so there is nothing to disambiguate.
+    """
+    import pandas as pd
+
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import resolve_default_versions
+
+    df = pd.DataFrame({
+        "prediction_id": ["p"] * len(versions),
+        "peptide": ["SIINFEKL"] * len(versions),
+        "peptide_offset": [0] * len(versions),
+        "allele": ["HLA-A*02:01"] * len(versions),
+        "kind": ["pMHC_affinity"] * len(versions),
+        "prediction_method_name": ["netmhcpan"] * len(versions),
+        "predictor_version": versions,
+        "value": [50.0] * len(versions)})
+
+    resolved = resolve_default_versions(EpitopeConfig(), df)
+    assert bool(resolved) is ambiguous
+    if ambiguous:
+        assert resolved[("pMHC_affinity", "netmhcpan")] == "4.2"
+

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -289,71 +289,53 @@ def validate_default_methods(cfg, topiary_df):
                 % (kind, method, error)) from error
 
 
-def dsl_pins_a_version(cfg):
-    """True when a configured expression names an explicit predictor version."""
-    for expr in (cfg.filter_expr, cfg.score_expr):
-        if expr is None:
-            continue
-        refs = collect_dsl_references(parse_epitope_expression(expr))
-        if any(version for _kind, _method, version in refs["kinds"]):
-            return True
-    return False
-
-
 def resolve_default_versions(cfg, topiary_df):
-    """Narrow a frame to one predictor version per ``(kind, model)``.
+    """Return the ``default_versions`` mapping for an ambiguous frame.
 
     topiary raises on an unqualified reference when a model appears at more
-    than one version, and offers no ``default_versions`` to resolve it the
-    way ``default_methods`` resolves an ambiguous model
-    (openvax/topiary#214). Without this a multi-version LENS table cannot be
-    scored with a default configuration at all — the default ``score_expr``
-    references ``affinity.value``, which is exactly the unqualified form.
+    than one version. :func:`topiary.resolve_default_versions` picks one per
+    ``(kind, model)`` — newest by PEP 440 — which is the same rule
+    ``CandidateEpitope`` uses for unqualified access, so the DSL and the
+    object API agree.
 
-    Newest wins, by PEP 440 ordering. That is not an arbitrary pick: it is
-    what ``CandidateEpitope`` already does for unqualified access, so
-    resolving the same way makes the DSL and the object API agree where they
-    currently disagree (openvax/vaxrank#362).
+    vaxrank carried its own version of this while topiary lacked one
+    (openvax/topiary#214). Two reasons the delegation is not merely
+    de-duplication:
 
-    Left alone when a configured expression pins a version — that caller has
-    said which one they want, and dropping rows would break the reference
-    they wrote.
+    * It resolves without dropping rows. The interim implementation narrowed
+      the frame to the winning version, which silently removed the losing
+      rows — so an expression pinning the older version in the same run
+      found nothing.
+    * It agrees with topiary about what counts as a version being named at
+      all. The interim compared version strings, so a frame mixing one real
+      version with rows recording none as the literal text ``"nan"`` treated
+      that as a second version and dropped those rows.
+
+    ``cfg`` is unused today — no setting pins a version, so there is nothing
+    to layer over topiary's answer the way ``resolve_default_methods``
+    layers ``epitopes.default_methods`` over its canonical pick. It is kept
+    so the three resolvers read the same and so that setting, when it
+    arrives, has an obvious home.
     """
-    if topiary_df.empty or "predictor_version" not in topiary_df.columns:
-        return topiary_df
-    versions_by_model = {}
-    for (kind, method), group in topiary_df.groupby(
-            ["kind", "prediction_method_name"], sort=False):
-        found = {v for v in group["predictor_version"].dropna().unique() if v}
-        if len(found) > 1:
-            versions_by_model[(kind, method)] = found
-    if not versions_by_model:
-        return topiary_df
-    if dsl_pins_a_version(cfg):
-        return topiary_df
+    from topiary import resolve_default_versions as topiary_resolve
 
-    from .candidate_epitope import sort_versions
-
-    keep = {}
-    for (kind, method), found in versions_by_model.items():
-        newest = sort_versions(found)[-1]
-        keep[(kind, method)] = newest
+    if topiary_df.empty:
+        return {}
+    resolved = dict(topiary_resolve(topiary_df))
+    for (kind, method), version in sorted(resolved.items()):
+        available = sorted(
+            str(v) for v in
+            topiary_df.loc[
+                (topiary_df["kind"] == kind)
+                & (topiary_df["prediction_method_name"] == method),
+                "predictor_version"].dropna().unique()
+            if str(v).strip())
         logger.warning(
-            "%s appears at versions %s for kind %s. No configured expression "
-            "names one, so the newest (%r) is used and the others are "
-            "excluded from scoring — matching how CandidateEpitope resolves "
-            "unqualified access. Write affinity[%r, %r] to choose "
-            "explicitly.",
-            method, sorted(found), kind, newest, method, sorted(found)[0])
-
-    # Vectorized rather than a row-wise apply: this runs on every scoring
-    # pass, and the frames are one row per prediction leaf.
-    chosen = pd.Series(
-        list(zip(topiary_df["kind"], topiary_df["prediction_method_name"]))
-    ).map(keep)
-    keep_mask = chosen.isna().to_numpy() | (
-        chosen.to_numpy() == topiary_df["predictor_version"].to_numpy())
-    return topiary_df[keep_mask].reset_index(drop=True)
+            "%s reports %s at versions %s; scoring an unqualified reference "
+            "with %s (newest). Name a version in the expression to pin one — "
+            "every version stays available.",
+            method, kind, ", ".join(available), version)
+    return resolved
 
 
 def score_predictions(epitopes, cfg, *, topiary_df=None,
@@ -393,9 +375,9 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
     if df.empty:
         return pd.Series(dtype=float)
 
-    df = resolve_default_versions(cfg, df)
     validate_default_methods(cfg, df)
     resolved = resolve_default_methods(cfg, df)
+    resolved_versions = resolve_default_versions(cfg, df)
 
     filter_node = build_filter_node(cfg)
     if filter_node is not None:
@@ -403,6 +385,7 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
             df, filter_node,
             group_keys=prediction_group_columns(df),
             default_methods=resolved,
+            default_versions=resolved_versions,
             kind_support=kind_support)
         if df.empty:
             return pd.Series(dtype=float)
@@ -412,6 +395,7 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
         df,
         group_keys=prediction_group_columns(df),
         default_methods=resolved,
+        default_versions=resolved_versions,
         kind_support=kind_support,
     )
     return (


### PR DESCRIPTION
topiary 5.31.0 adds `resolve_default_versions`, which is what vaxrank was standing in for (openvax/topiary#214). Adopting it is not just de-duplication — the interim implementation was wrong in two ways.

### It dropped the losing rows

It resolved by narrowing the frame to the winning version. To keep a pinned reference working it then had to skip resolution *entirely* whenever any configured expression named any version — so one pin disabled resolution for every other kind in the same expression:

```
affinity['netmhcpan','4.1b'].value.logistic_normalized(350,150) * presentation.score

interim   ValueError: Ambiguous: pMHC_presentation is present at more than
          one predictor version
topiary   scores; presentation resolves to 4.2, affinity stays pinned
```

topiary passes `default_versions` instead of dropping rows, so pinning and resolving coexist and every version stays reachable.

### It treated `"nan"` as a version

The ambiguity check compared version strings, where `dropna()` plus a truthiness test admits the literal text `"nan"`. One real version alongside rows recording none looked ambiguous, resolved to the real version, and silently dropped the rest from scoring:

```
two real versions        in=2 out=1 kept=['4.2']
one real + blank string  in=2 out=2 kept=['4.2', '']
one real + NaN           in=2 out=2 kept=['4.2', nan]
one real + string 'nan'  in=2 out=1 kept=['4.2']   <- rows dropped
one real + None          in=2 out=2 kept=['4.2', None]
```

Verified topiary's resolver against all five shapes plus a non-PEP-440 version and 4.9-vs-4.10 ordering: only two genuinely named versions resolve, and `4.10` sorts above `4.9`. The topiary session hit this shape on their side first and flagged it; the check here confirmed vaxrank had it too.

### Notes

- Which version won is still announced — that is the user's business, and not something topiary can know how to phrase.
- Fixtures are **byte-identical** across all eight LENS files. None of them carries two versions of one tool, which is exactly the blind spot that let this ship, so both regressions are pinned with synthetic tests rather than fixtures.
- Floor moves to `topiary>=5.31.0`.

Closes #362 — the DSL and `CandidateEpitope` now resolve unqualified access by the same rule.