### PR TITLE
Project every allele-free kind across the patient's alleles

### DIFF
--- a/tests/test_epitope_dsl.py
+++ b/tests/test_epitope_dsl.py
@@ -23,6 +23,7 @@ import math
 import numpy as np
 import pandas as pd
 import pytest
+import topiary
 from topiary.ranking import EvalContext, apply_filter
 
 from vaxrank.epitope_config import EpitopeConfig
@@ -739,3 +740,64 @@ def test_typo_in_a_default_methods_kind_is_rejected():
         validate_default_methods(
             EpitopeConfig(default_methods={"pMHC_affinty": "mhcflurry"}),
             frame)
+
+
+@pytest.mark.parametrize("kind", sorted(
+    k for k, v in topiary.KIND_MHC_DEPENDENCE.items() if v == "none"))
+def test_every_allele_free_kind_reaches_every_patient_allele(kind):
+    """Allele-free evidence must score against the patient's alleles.
+
+    A prediction that describes the peptide rather than a peptide-MHC pair
+    carries no allele, so it forms a group keyed on the empty string and
+    contributes to no per-allele score — the candidate scores 0 and is
+    dropped (openvax/topiary#182). vaxrank sidesteps that by projecting such
+    evidence across the patient's alleles when it builds the frame.
+
+    That projection used to name ``antigen_processing`` literally, because
+    the set of allele-free kinds lived in a private topiary table. There are
+    five, so the other four were silently dropped from scoring: mhctools
+    ships netcleave, deeptap, eramer and proteasome_predictor, all of which
+    emit them. No LENS fixture carries one, which is why nothing caught it.
+    """
+    from mhctools import Prediction
+
+    from vaxrank.candidate_epitope import CandidateEpitope
+    from vaxrank.epitope_dsl import attach_per_allele_scores
+
+    alleles = ("HLA-A*02:01", "HLA-B*07:02")
+    epitope = CandidateEpitope(
+        sequence="SIINFEKL", offset=0, patient_alleles=alleles,
+        predictions=(Prediction(
+            kind=kind, score=0.8, peptide="SIINFEKL", allele="",
+            predictor_name="mhcflurry", predictor_version="2.1.1"),))
+
+    [scored] = attach_per_allele_scores(
+        [epitope],
+        EpitopeConfig(score_expr="%s[mhcflurry].score" % kind))
+
+    assert dict(scored.per_allele_scores) == {a: 0.8 for a in alleles}
+
+
+def test_an_unrecognized_kind_is_not_projected_across_alleles():
+    """A kind topiary does not classify must not be broadcast.
+
+    Projecting an unknown kind would invent per-allele evidence a model
+    never produced, so a topiary release adding a kind fails by scoring
+    nothing rather than by fabricating a number.
+    """
+    from mhctools import Prediction
+
+    from vaxrank.candidate_epitope import CandidateEpitope
+    from vaxrank.epitope_dsl import epitopes_to_topiary_df
+
+    epitope = CandidateEpitope(
+        sequence="SIINFEKL", offset=0,
+        patient_alleles=("HLA-A*02:01", "HLA-B*07:02"),
+        predictions=(Prediction(
+            kind="a_kind_topiary_has_not_defined", score=0.8,
+            peptide="SIINFEKL", allele="", predictor_name="x",
+            predictor_version="1"),))
+
+    df = epitopes_to_topiary_df([epitope])
+
+    assert sorted(set(df["allele"])) == [""]

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -115,6 +115,23 @@ def prediction_kind_for_method(method_name):
 
 
 
+def is_peptide_level_kind(kind):
+    """True when a kind describes the peptide itself, not a peptide-MHC pair.
+
+    Reads topiary's ``KIND_MHC_DEPENDENCE``, which is the one place that
+    knows which kinds are allele-free. vaxrank named a single kind here for
+    as long as that table was private, and the four other allele-free kinds
+    were left out of the projection below (openvax/topiary#195).
+
+    An unrecognized kind is *not* treated as peptide-level. That is the safe
+    direction: it is never projected across alleles, so a topiary release
+    adding a kind cannot make vaxrank fabricate per-allele evidence for it.
+    """
+    from topiary import KIND_MHC_DEPENDENCE
+
+    return KIND_MHC_DEPENDENCE.get(kind) == "none"
+
+
 def epitopes_to_topiary_df(epitopes):
     """Convert a list of :class:`vaxrank.candidate_epitope.CandidateEpitope` into the
     topiary long-format DataFrame consumed by
@@ -122,8 +139,8 @@ def epitopes_to_topiary_df(epitopes):
     :func:`topiary.ranking.apply_filter`.
 
     One row per allele-scoped leaf ``mhctools.Prediction`` in each
-    CandidateEpitope's mutant context. Allele-independent antigen-processing
-    evidence is projected into every allele group in this evaluation view while
+    CandidateEpitope's mutant context. Allele-independent evidence — any
+    kind topiary reports as MHC-independent — is projected into every allele group in this evaluation view while
     remaining one canonical leaf on the CandidateEpitope. A single
     CandidateEpitope can therefore emit N rows (one per allele x predictor x
     kind). When multiple predictions share a (peptide,
@@ -165,7 +182,7 @@ def epitopes_to_topiary_df(epitopes):
             evaluation_alleles = (
                 patient_alleles
                 if (
-                    p.kind == "antigen_processing"
+                    is_peptide_level_kind(p.kind)
                     and not p.allele
                     and patient_alleles
                 )


### PR DESCRIPTION
A prediction that describes the peptide rather than a peptide-MHC pair carries no allele, so it forms a group keyed on the empty string and contributes to no per-allele score — the candidate scores 0 and is dropped (openvax/topiary#182). `epitopes_to_topiary_df` sidesteps that by projecting such evidence across the patient's alleles.

It named `antigen_processing` **literally**, because the set of allele-free kinds lived in a private topiary table. There are five, so four were dropped from scoring. With one allele-free leaf and two patient alleles:

| kind | before | after |
|---|---|---|
| `antigen_processing` | `{'HLA-A*02:01': 0.8, 'HLA-B*07:02': 0.8}` | unchanged |
| `endolysosomal_cleavage` | `{}` | `{'HLA-A*02:01': 0.8, 'HLA-B*07:02': 0.8}` |
| `erap_trimming` | `{}` | `{'HLA-A*02:01': 0.8, 'HLA-B*07:02': 0.8}` |
| `proteasome_cleavage` | `{}` | `{'HLA-A*02:01': 0.8, 'HLA-B*07:02': 0.8}` |
| `tap_transport` | `{}` | `{'HLA-A*02:01': 0.8, 'HLA-B*07:02': 0.8}` |

### This is reachable today

Not hypothetical — mhctools ships predictors emitting every one of the four:

```
endolysosomal_cleavage   netcleave
erap_trimming            eramer, annotate
proteasome_cleavage      netcleave, proteasome_predictor
tap_transport            deeptap, annotate
```

Configure any of them on the native predictor path and their evidence silently contributes to nothing.

### The fix

topiary 5.31.0 makes `KIND_MHC_DEPENDENCE` public (openvax/topiary#195), so the question is asked of the one table that knows the answer rather than answered from a literal here.

An unrecognized kind is **not** peptide-level — the safe direction. A topiary release adding a kind fails by scoring nothing rather than by fabricating per-allele evidence for it.

### Verification

- All eight LENS fixtures **byte-identical**. None carries any of the four, which is exactly why nothing caught this.
- Pinned with tests parameterized over topiary's table, so a kind added upstream is covered without editing the test.