### PR TITLE
Let topiary broadcast allele-free evidence per candidate

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.31.0,<6.0.0
+topiary>=5.33.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_epitope_dsl.py
+++ b/tests/test_epitope_dsl.py
@@ -446,16 +446,19 @@ def test_epitopes_to_topiary_df_schema_pinned():
     assert by_peptide['SIINFEKM'] == 12
 
 
-def test_allele_free_evidence_is_projected_onto_patient_alleles():
+def test_allele_free_evidence_still_produces_per_allele_scores():
     """Processing-only evidence must still produce per-allele scores.
 
-    topiary 5.18's ``peptide_view()`` broadcasts an allele-free value across
-    allele groups that already exist, but a peptide whose only evidence is
-    allele-free has no such groups — its single group is keyed on an empty
-    allele, and the patient's genotype is not in the frame at all
-    (openvax/topiary#182). Dropping this projection in favor of
-    ``peptide_view()`` would silently score such candidates 0 and drop them,
-    which is the failure mode of vaxrank#295.
+    A peptide whose only evidence is allele-free has one group, keyed on an
+    empty allele, and the patient's genotype is not in the frame at all — so
+    it would score 0 and be dropped, which is the failure mode of
+    vaxrank#295. topiary takes the genotype and adds the groups
+    (openvax/topiary#182, #219); vaxrank used to duplicate the rows itself.
+
+    The assertion is on the scores rather than on the frame's shape: which
+    rows exist is topiary's business and changed once already, while "a
+    processing-only candidate scores against both alleles" is the property
+    that has to hold either way.
     """
     from mhctools.pred import Prediction
 
@@ -475,13 +478,11 @@ def test_allele_free_evidence_is_projected_onto_patient_alleles():
             predictor_version="2.1.1", allele="", peptide="SIINFEKL",
             value=None, score=0.77),))
 
-    # The canonical leaf stays allele-free on the object ...
+    # The canonical leaf stays allele-free, on the object and in the frame:
+    # vaxrank states what was predicted and lets topiary add the groups.
     [leaf] = epitope.predictions_for("antigen_processing", predictor="mhcflurry")
     assert leaf.allele == ""
-
-    # ... and is projected onto both patient alleles in the evaluation frame.
-    frame = epitopes_to_topiary_df([epitope])
-    assert set(frame["allele"]) == set(alleles)
+    assert set(epitopes_to_topiary_df([epitope])["allele"]) == {""}
 
     [scored] = attach_per_allele_scores(
         [epitope],
@@ -778,26 +779,54 @@ def test_every_allele_free_kind_reaches_every_patient_allele(kind):
     assert dict(scored.per_allele_scores) == {a: 0.8 for a in alleles}
 
 
-def test_an_unrecognized_kind_is_not_projected_across_alleles():
-    """A kind topiary does not classify must not be broadcast.
+def test_a_candidate_is_never_scored_against_another_candidates_alleles():
+    """Each candidate's genotype is its own, not the frame's union.
 
-    Projecting an unknown kind would invent per-allele evidence a model
-    never produced, so a topiary release adding a kind fails by scoring
-    nothing rather than by fabricating a number.
+    LENS emits one row per (peptide, allele) that passed its own threshold,
+    so candidates in one file arrive having been reported against different
+    alleles — every LENS fixture here holds between two and eight distinct
+    sets. Declaring the union frame-wide would add a group pairing each
+    peptide with alleles it was never scored against.
+
+    The union is invisible under the default score expression, because it
+    contains an affinity term and the invented groups carry no affinity
+    rows, so they read NaN and score nothing. An expression reading only
+    peptide-level evidence puts a real number in every one of them, which
+    is what this pins.
     """
-    from mhctools import Prediction
+    from mhctools.pred import Prediction
 
     from vaxrank.candidate_epitope import CandidateEpitope
-    from vaxrank.epitope_dsl import epitopes_to_topiary_df
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import attach_per_allele_scores
 
-    epitope = CandidateEpitope(
-        sequence="SIINFEKL", offset=0,
-        patient_alleles=("HLA-A*02:01", "HLA-B*07:02"),
-        predictions=(Prediction(
-            kind="a_kind_topiary_has_not_defined", score=0.8,
-            peptide="SIINFEKL", allele="", predictor_name="x",
-            predictor_version="1"),))
+    def candidate(name, peptide, allele):
+        return CandidateEpitope(
+            sequence=peptide, offset=0, prediction_id=name,
+            patient_alleles=(allele,),
+            predictions=(
+                Prediction(
+                    kind="pMHC_affinity", predictor_name="mhcflurry",
+                    predictor_version="2.1.1", allele=allele, peptide=peptide,
+                    value=50.0, score=None),
+                Prediction(
+                    kind="proteasome_cleavage", predictor_name="mhcflurry",
+                    predictor_version="2.1.1", allele="", peptide=peptide,
+                    value=None, score=0.8)))
 
-    df = epitopes_to_topiary_df([epitope])
+    epitopes = [
+        candidate("a", "SIINFEKLA", "HLA-A*02:01"),
+        candidate("b", "AAAAAAAAA", "HLA-B*07:02"),
+    ]
 
-    assert sorted(set(df["allele"])) == [""]
+    scored = attach_per_allele_scores(
+        epitopes,
+        EpitopeConfig(score_expr="proteasome_cleavage[mhcflurry].score"))
+
+    # Each candidate scores against its own allele only. Under a frame-wide
+    # union both would carry both alleles — four scores, two of them for
+    # pairings no model ever saw.
+    assert [dict(e.per_allele_scores) for e in scored] == [
+        {"HLA-A*02:01": pytest.approx(0.8)},
+        {"HLA-B*07:02": pytest.approx(0.8)},
+    ]

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -766,11 +766,12 @@ def test_lens_processing_dsl_scores_every_patient_allele(tmp_path):
     assert len(processing) == 1
     assert processing[0].allele == ""
 
+    # One allele-free row in the frame, not one per allele: the frame
+    # states what was predicted and topiary adds the per-allele groups.
     topiary_df = epitopes_to_topiary_df(epitopes)
     processing_rows = topiary_df[
         topiary_df["kind"] == "antigen_processing"]
-    assert set(processing_rows["allele"]) == {
-        "HLA-A*02:01", "HLA-B*07:02"}
+    assert set(processing_rows["allele"]) == {""}
 
     scored = attach_per_allele_scores(
         epitopes,
@@ -809,9 +810,11 @@ def test_lens_processing_only_rows_preserve_alleles_scores_and_report_rows(
     assert len(processing) == 1
     assert processing[0].allele == ""
 
+    # The whole file is allele-free evidence, so the frame is one
+    # allele-free row. The genotype reaches it via topiary's alleles=,
+    # which is why the scores below are per-allele anyway.
     topiary_df = epitopes_to_topiary_df(epitopes)
-    assert set(topiary_df["allele"]) == {
-        "HLA-A*02:01", "HLA-B*07:02"}
+    assert set(topiary_df["allele"]) == {""}
     config = EpitopeConfig(
         score_expr="processing[mhcflurry].score")
     scored = attach_per_allele_scores(epitopes, config)

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -115,35 +115,18 @@ def prediction_kind_for_method(method_name):
 
 
 
-def is_peptide_level_kind(kind):
-    """True when a kind describes the peptide itself, not a peptide-MHC pair.
-
-    Reads topiary's ``KIND_MHC_DEPENDENCE``, which is the one place that
-    knows which kinds are allele-free. vaxrank named a single kind here for
-    as long as that table was private, and the four other allele-free kinds
-    were left out of the projection below (openvax/topiary#195).
-
-    An unrecognized kind is *not* treated as peptide-level. That is the safe
-    direction: it is never projected across alleles, so a topiary release
-    adding a kind cannot make vaxrank fabricate per-allele evidence for it.
-    """
-    from topiary import KIND_MHC_DEPENDENCE
-
-    return KIND_MHC_DEPENDENCE.get(kind) == "none"
-
-
 def epitopes_to_topiary_df(epitopes):
     """Convert a list of :class:`vaxrank.candidate_epitope.CandidateEpitope` into the
     topiary long-format DataFrame consumed by
     :class:`topiary.ranking.EvalContext` and
     :func:`topiary.ranking.apply_filter`.
 
-    One row per allele-scoped leaf ``mhctools.Prediction`` in each
-    CandidateEpitope's mutant context. Allele-independent evidence — any
-    kind topiary reports as MHC-independent — is projected into every allele group in this evaluation view while
-    remaining one canonical leaf on the CandidateEpitope. A single
-    CandidateEpitope can therefore emit N rows (one per allele x predictor x
-    kind). When multiple predictions share a (peptide,
+    One row per leaf ``mhctools.Prediction`` in each CandidateEpitope's
+    mutant context — the frame says what was predicted, and nothing else.
+    Allele-free evidence stays one allele-free row; the patient's genotype
+    reaches it through :func:`genotype_lookup`, which
+    :func:`score_predictions` hands to topiary. When multiple predictions
+    share a (peptide,
     allele) pair (e.g. MHCflurry and netMHCpan rows from a LENS file),
     DSL expressions can select between them via
     ``affinity['mhcflurry']`` / ``affinity['netmhcpan']``, and when
@@ -156,56 +139,29 @@ def epitopes_to_topiary_df(epitopes):
     are NOT emitted as rows. The DSL frame is mutant-only by
     convention — comparator data stays on the CandidateEpitope for display.
     """
-    # Allele-independent evidence is projected into every patient allele here
-    # while remaining one canonical leaf on the CandidateEpitope. topiary
-    # 5.18's ``peptide_view()`` broadcasts an allele-free value across the
-    # allele groups that already exist, which covers a peptide that also has
-    # affinity rows — but two gaps keep this projection necessary:
-    #
-    #   openvax/topiary#182 — a peptide whose *only* evidence is allele-free
-    #     has one group, keyed on an empty allele. The patient's genotype is
-    #     not in the frame, so per-allele scores cannot be produced and the
-    #     candidate scores 0 and is dropped. LENS emits such rows.
-    #   openvax/topiary#183 — an allele-free row is its own group, so any
-    #     filter predicated on an allele-scoped kind removes it; a later
-    #     ``peptide_view()`` in the score expression then reads NaN.
-    #
-    # Do not delete this projection in favor of ``peptide_view()`` until both
-    # are closed; the failure is silent in both cases.
     rows = []
     for e in epitopes:
         ctx = e
         prediction_id = ctx.prediction_group_source
         predictions = ctx.predictions_flat()
-        patient_alleles = ctx.patient_alleles
         for p in predictions:
-            evaluation_alleles = (
-                patient_alleles
-                if (
-                    is_peptide_level_kind(p.kind)
-                    and not p.allele
-                    and patient_alleles
-                )
-                else (p.allele,)
-            )
-            for allele in evaluation_alleles:
-                rows.append({
-                    PREDICTION_ID_COLUMN: prediction_id,
-                    "source_sequence_name": ctx.source_sequence or ctx.sequence,
-                    "peptide": p.peptide,
-                    "peptide_offset": ctx.offset,
-                    "peptide_length": len(p.peptide),
-                    "allele": allele,
-                    "n_flank": ctx.n_flank,
-                    "c_flank": ctx.c_flank,
-                    "prediction_method_name": p.predictor_name,
-                    "predictor_version": p.predictor_version or "",
-                    "kind": p.kind,
-                    "value": p.value,
-                    "affinity": p.value,
-                    "percentile_rank": p.percentile_rank,
-                    "score": p.score,
-                })
+            rows.append({
+                PREDICTION_ID_COLUMN: prediction_id,
+                "source_sequence_name": ctx.source_sequence or ctx.sequence,
+                "peptide": p.peptide,
+                "peptide_offset": ctx.offset,
+                "peptide_length": len(p.peptide),
+                "allele": p.allele,
+                "n_flank": ctx.n_flank,
+                "c_flank": ctx.c_flank,
+                "prediction_method_name": p.predictor_name,
+                "predictor_version": p.predictor_version or "",
+                "kind": p.kind,
+                "value": p.value,
+                "affinity": p.value,
+                "percentile_rank": p.percentile_rank,
+                "score": p.score,
+            })
     return pd.DataFrame(rows)
 
 
@@ -334,25 +290,59 @@ def resolve_default_versions(cfg, topiary_df):
     so the three resolvers read the same and so that setting, when it
     arrives, has an obvious home.
     """
-    from topiary import resolve_default_versions as topiary_resolve
+    from topiary import describe_default_versions, resolve_default_versions
 
     if topiary_df.empty:
         return {}
-    resolved = dict(topiary_resolve(topiary_df))
+    resolved = dict(resolve_default_versions(topiary_df))
+    candidates = describe_default_versions(topiary_df)
     for (kind, method), version in sorted(resolved.items()):
-        available = sorted(
-            str(v) for v in
-            topiary_df.loc[
-                (topiary_df["kind"] == kind)
-                & (topiary_df["prediction_method_name"] == method),
-                "predictor_version"].dropna().unique()
-            if str(v).strip())
         logger.warning(
             "%s reports %s at versions %s; scoring an unqualified reference "
             "with %s (newest). Name a version in the expression to pin one — "
             "every version stays available.",
-            method, kind, ", ".join(available), version)
+            method, kind, ", ".join(candidates[(kind, method)]), version)
     return resolved
+
+
+def genotype_lookup(epitopes, group_columns):
+    """Return a per-peptide genotype callable for topiary's ``alleles=``.
+
+    Evidence that describes the peptide rather than a peptide-MHC pair
+    carries no allele, so it forms a group keyed on the empty string and
+    contributes to no per-allele score. topiary closes that by taking the
+    genotype each peptide should be evaluated against and adding the groups
+    itself (openvax/topiary#182, #219).
+
+    The genotype has to be *per peptide*, not per frame. LENS emits one row
+    per (peptide, allele) that passed its own threshold, so each candidate
+    arrives having been reported against only some of the patient's
+    alleles — every LENS fixture in this repo holds between two and eight
+    distinct allele sets. Declaring the union instead would add groups
+    pairing a peptide with alleles it was never scored against, and any
+    expression reading only peptide-level evidence would put a real number
+    in every one of them.
+
+    Returns ``None`` when no epitope declares a genotype, which leaves
+    topiary to take the groups from the rows alone.
+    """
+    identity_column = group_columns[0]
+    by_identity = {
+        e.prediction_group_key: tuple(e.patient_alleles or ())
+        for e in epitopes or ()}
+    if not any(by_identity.values()):
+        return None
+
+    def lookup(keys):
+        # An identity absent from the map declares nothing rather than
+        # inheriting another candidate's genotype: the frame may have been
+        # built elsewhere (pVACseq passes its own), and borrowing a genotype
+        # is the failure this signature exists to prevent.
+        return by_identity.get(
+            (keys[identity_column], keys["peptide"], keys["peptide_offset"]),
+            ())
+
+    return lookup
 
 
 def score_predictions(epitopes, cfg, *, topiary_df=None,
@@ -395,14 +385,17 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
     validate_default_methods(cfg, df)
     resolved = resolve_default_methods(cfg, df)
     resolved_versions = resolve_default_versions(cfg, df)
+    group_columns = prediction_group_columns(df)
+    alleles = genotype_lookup(epitopes, group_columns)
 
     filter_node = build_filter_node(cfg)
     if filter_node is not None:
         df = apply_filter(
             df, filter_node,
-            group_keys=prediction_group_columns(df),
+            group_keys=group_columns,
             default_methods=resolved,
             default_versions=resolved_versions,
+            alleles=alleles,
             kind_support=kind_support)
         if df.empty:
             return pd.Series(dtype=float)
@@ -410,9 +403,10 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
     score_node = build_score_node(cfg)
     ctx = EvalContext(
         df,
-        group_keys=prediction_group_columns(df),
+        group_keys=group_columns,
         default_methods=resolved,
         default_versions=resolved_versions,
+        alleles=alleles,
         kind_support=kind_support,
     )
     return (


### PR DESCRIPTION
`epitopes_to_topiary_df` duplicated every allele-free prediction once per the candidate's alleles, because a peptide whose only evidence is allele-free forms one group keyed on the empty string and scores nothing (openvax/topiary#182 — the failure mode of #295). topiary 5.33.0 takes the genotype and adds those groups itself, so the frame goes back to saying what was predicted and nothing else.

Closes #365.

### The genotype is per candidate, not per frame

This is the whole reason the swap waited on openvax/topiary#219. LENS emits one row per (peptide, allele) that passed *its own* threshold, so candidates in a single file arrive reported against different alleles:

```
lens_example.tsv                  3 epitopes,  2 distinct sets
lens_v1.9_real_subset.tsv        28 epitopes,  8 distinct sets
lens_v1.9_with_stop_codons.tsv   49 epitopes,  6 distinct sets
...all eight files vary
```

Declaring the union frame-wide would pair each peptide with alleles no model ever scored it against.

**That difference is invisible under the default score expression**: it contains an affinity term, the invented groups carry no affinity rows, so they read NaN and score nothing — and all eight fixtures come out byte-identical either way. An expression reading only peptide-level evidence (`proteasome_cleavage[mhcflurry].score`) puts a real number in every invented group.

So the new test was checked in both directions — it fails on a frame-wide union (each candidate gets both alleles) and passes per-candidate. The difference is pinned, not argued.

### Tests that asserted the wrong thing

Three tests asserted the row duplication rather than the outcome:

```python
assert set(frame["allele"]) == {"HLA-A*02:01", "HLA-B*07:02"}   # frame shape
```

They now assert the frame is one allele-free row **and** the per-allele scores are still both — the property that holds whichever side does the broadcasting.

### Also

- Adopts `describe_default_versions` (openvax/topiary#220) for the ambiguous-version warning. The six lines it replaces re-derived candidate versions from the frame, including a `str(v).strip()` test that was vaxrank's own copy of topiary's "was a version named at all" rule — the rule whose subtlety dropped rows two releases ago.
- `is_peptide_level_kind` goes with the projection that was its only caller. #357 wants that lookup in `allele_evidence.py`, which can read `KIND_MHC_DEPENDENCE` directly now that it's public.

### Verification

- All eight LENS fixtures **byte-identical**.
- 1064 tests pass. Floor moves to `topiary>=5.33.0`.