### PR TITLE
Reject a version pin that names no version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.33.0,<6.0.0
+topiary>=5.34.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_epitope_dsl.py
+++ b/tests/test_epitope_dsl.py
@@ -830,3 +830,58 @@ def test_a_candidate_is_never_scored_against_another_candidates_alleles():
         {"HLA-A*02:01": pytest.approx(0.8)},
         {"HLA-B*07:02": pytest.approx(0.8)},
     ]
+
+
+@pytest.mark.parametrize("stored", ["nan", "NaN", "", "   ", None, np.nan])
+def test_a_pin_matching_no_named_version_is_rejected(stored):
+    """Validation must not accept a pin that selects nothing.
+
+    A cell that records no version is NaN, None, blank — or the literal
+    string "nan", which survives dropna() and a truthiness test. That last
+    shape once counted as a real version in vaxrank's resolver and dropped
+    the rows carrying it from scoring.
+
+    Here the consequence is the shape this validator exists to prevent:
+    ``affinity['netmhcpan', 'nan']`` would pass validation and then select
+    nothing, so the run reports a score of zero for a formula that looked
+    checked.
+    """
+    from vaxrank.epitope_dsl import validate_dsl_against_predictions
+
+    df = pd.DataFrame([{
+        "prediction_id": "p", "source_sequence_name": "s",
+        "peptide": "SIINFEKL", "peptide_offset": 0, "peptide_length": 8,
+        "allele": "HLA-A*02:01", "prediction_method_name": "netmhcpan",
+        "predictor_version": stored, "kind": "pMHC_affinity",
+        "value": 50.0, "score": None}])
+
+    with pytest.raises(ValueError, match="predictor version"):
+        validate_dsl_against_predictions(
+            EpitopeConfig(score_expr="affinity['netmhcpan', 'nan'].value"),
+            [], topiary_df=df)
+
+
+def test_vaxrank_and_topiary_agree_on_what_names_a_version():
+    """The local rule must match topiary's, since a pin crosses both.
+
+    vaxrank decides whether a pin is valid; topiary decides whether it
+    selects any rows. If the two disagree, an expression either validates
+    and matches nothing or is rejected for a version that would have
+    worked. topiary 5.31.0 fixed its resolver and 5.34.0 its selection path
+    for exactly this string, so the rule is only safe while it is one rule.
+    """
+    from topiary import describe_default_versions
+
+    from vaxrank.epitope_dsl import names_a_version
+
+    for candidate in ["4.2", "nan", "NaN", "", "   ", None, np.nan, "1.0.0"]:
+        # describe_default_versions reports a model as ambiguous only when it
+        # sees two *named* versions, so pairing the candidate with one known
+        # version asks topiary the same question directly.
+        df = pd.DataFrame([{
+            "prediction_id": "p", "peptide": "SIINFEKL", "peptide_offset": 0,
+            "allele": "HLA-A*02:01", "kind": "pMHC_affinity",
+            "prediction_method_name": "netmhcpan", "predictor_version": v,
+            "value": 50.0} for v in ("9.9", candidate)])
+        topiary_says = bool(describe_default_versions(df))
+        assert names_a_version(candidate) is topiary_says, candidate

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -563,6 +563,27 @@ def collect_dsl_references(node):
     return {"columns": columns, "kinds": kinds}
 
 
+def names_a_version(value):
+    """True when a ``predictor_version`` cell actually names a version.
+
+    NaN, None and blank are the obvious absences. The literal string
+    ``"nan"`` is the one that gets through: it survives ``dropna()`` and a
+    truthiness test, which is how it once counted as a real version in
+    vaxrank's own resolver and dropped every row carrying it from scoring.
+
+    Same rule topiary applies, so a pin either validates here and selects
+    there or fails in both. Kept in agreement by a test, not by care.
+
+    Temporary. topiary 5.35.0 exports ``is_named_version``; this goes away
+    and the import takes its place, because one rule in two repos is how
+    the last three version bugs happened.
+    """
+    if value is None:
+        return False
+    text = str(value).strip()
+    return bool(text) and text.lower() != "nan"
+
+
 def validate_dsl_against_predictions(cfg, epitopes, *, topiary_df=None):
     """Error early when ``filter_expr`` / ``score_expr`` references a
     predictor the loaded epitopes don't expose.
@@ -590,14 +611,15 @@ def validate_dsl_against_predictions(cfg, epitopes, *, topiary_df=None):
     available_methods = (
         set(df["prediction_method_name"].dropna().unique())
         if not df.empty else set())
-    # Drop the "no version known" sentinel so a formula pinning a specific
+    # Drop the "no version known" sentinels so a formula pinning a specific
     # version against predictions that don't carry any version errors out,
     # and so the error message's version list matches what we actually
     # checked against.
     available_versions = set()
     if not df.empty:
         available_versions = {
-            v for v in df["predictor_version"].dropna().unique() if v
+            v for v in df["predictor_version"].dropna().unique()
+            if names_a_version(v)
         }
 
     for node in nodes:


### PR DESCRIPTION
`validate_dsl_against_predictions` built its set of available versions with `dropna()` plus a truthiness test — the same rule whose subtlety let the literal string `"nan"` count as a real version in the resolver two releases ago, and drop every row carrying it from scoring.

```
version is NaN       rejected
version is ''        rejected
version is None      rejected
version is 'nan'     ACCEPTED  affinity['netmhcpan','nan'] as a real pin
```

topiary 5.34.0 fixed its *selection* path for the same string, so an accepted pin now selects nothing: validation passes, the formula looks checked, and the run reports zero. That is precisely the shape this validator exists to prevent.

### Reachability

Not reachable through vaxrank's own builders — they write `""` for a missing version, and no LENS fixture carries the string. It arrives on a frame built elsewhere, which is exactly what the pVACseq path passes via `report_df.attrs["topiary_df"]`.

### `names_a_version` is deliberately temporary

topiary 5.35.0 exports `is_named_version`; this gets deleted for the import. Keeping a private copy of a rule that also lives upstream is how the last three version bugs happened — so rather than restating the rule in a test, a test asks topiary directly whether it considers each candidate a version and asserts the two answers match. Removing the `"nan"` clause fails *that* test, not just the local one:

```
FAILED test_a_pin_matching_no_named_version_is_rejected[nan0]
FAILED test_vaxrank_and_topiary_agree_on_what_names_a_version
```

### Floor moves to topiary>=5.34.0

Also stops `read_pvacseq` fabricating variant ids like `chr1-154590262-nan-A` from a blank coordinate. A stable fabricated id silently groups every row sharing the gap, and those ids reach vaxrank's identity join.

### Verification

- All eight LENS fixtures **byte-identical**.
- 1071 tests pass.