### PR TITLE
Give "no version" one spelling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.34.0,<6.0.0
+topiary>=5.35.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_epitope_dsl.py
+++ b/tests/test_epitope_dsl.py
@@ -860,28 +860,75 @@ def test_a_pin_matching_no_named_version_is_rejected(stored):
             EpitopeConfig(score_expr="affinity['netmhcpan', 'nan'].value"),
             [], topiary_df=df)
 
+NO_VERSION_SPELLINGS = [
+    pytest.param(None, id="None"),          # mhctools
+    pytest.param(np.nan, id="NaN"),         # a frame column
+    pytest.param("", id="empty"),           # vaxrank's own builders
+    pytest.param("nan", id="nan-string"),   # anything through astype(str)
+]
 
-def test_vaxrank_and_topiary_agree_on_what_names_a_version():
-    """The local rule must match topiary's, since a pin crosses both.
 
-    vaxrank decides whether a pin is valid; topiary decides whether it
-    selects any rows. If the two disagree, an expression either validates
-    and matches nothing or is rejected for a version that would have
-    worked. topiary 5.31.0 fixed its resolver and 5.34.0 its selection path
-    for exactly this string, so the rule is only safe while it is one rule.
+def _affinity(version, value):
+    from mhctools.pred import Prediction
+
+    return Prediction(
+        kind="pMHC_affinity", predictor_name="netmhcpan",
+        predictor_version=version, allele="HLA-A*02:01",
+        peptide="SIINFEKL", value=value, score=None)
+
+
+def _candidate(*predictions):
+    from vaxrank.candidate_epitope import CandidateEpitope
+
+    return CandidateEpitope(
+        sequence="SIINFEKL", offset=0, prediction_id="x",
+        patient_alleles=("HLA-A*02:01",), predictions=predictions)
+
+
+@pytest.mark.parametrize("missing", NO_VERSION_SPELLINGS)
+def test_every_spelling_of_no_version_reaches_the_frame_the_same_way(missing):
+    """One meaning, one representation.
+
+    Four producers spell "this prediction has no version" four ways, and
+    they used to reach the frame as three different values:
+    ``p.predictor_version or ""`` passes NaN straight through, because NaN
+    is truthy, and passes the string "nan" through as if it named a version.
     """
-    from topiary import describe_default_versions
+    from vaxrank.epitope_dsl import epitopes_to_topiary_df
 
-    from vaxrank.epitope_dsl import names_a_version
+    frame = epitopes_to_topiary_df([_candidate(_affinity(missing, 50.0))])
 
-    for candidate in ["4.2", "nan", "NaN", "", "   ", None, np.nan, "1.0.0"]:
-        # describe_default_versions reports a model as ambiguous only when it
-        # sees two *named* versions, so pairing the candidate with one known
-        # version asks topiary the same question directly.
-        df = pd.DataFrame([{
-            "prediction_id": "p", "peptide": "SIINFEKL", "peptide_offset": 0,
-            "allele": "HLA-A*02:01", "kind": "pMHC_affinity",
-            "prediction_method_name": "netmhcpan", "predictor_version": v,
-            "value": 50.0} for v in ("9.9", candidate)])
-        topiary_says = bool(describe_default_versions(df))
-        assert names_a_version(candidate) is topiary_says, candidate
+    assert list(frame["predictor_version"]) == [""]
+
+
+@pytest.mark.parametrize("second", NO_VERSION_SPELLINGS)
+@pytest.mark.parametrize("first", NO_VERSION_SPELLINGS)
+def test_two_spellings_of_no_version_are_one_bucket(first, second):
+    """Unversioned predictions from two producers form one group.
+
+    The nested store keys on ``predictor_version`` directly, so each
+    spelling opened its own bucket — one predictor's evidence split in two,
+    where unqualified access resolves to a single version and sees one half.
+    """
+    epitope = _candidate(_affinity(first, 50.0), _affinity(second, 60.0))
+
+    buckets = epitope.predictions["pMHC_affinity"]["netmhcpan"]
+    assert list(buckets) == [""]
+    assert len(buckets[""]) == 2
+
+
+@pytest.mark.parametrize("missing", NO_VERSION_SPELLINGS)
+def test_a_named_version_beside_an_unnamed_one_does_not_raise(missing):
+    """Mixed version types must not break candidate construction.
+
+    ``predictions_flat`` sorts on ``predictor_version``, so a predictor
+    reporting a version on one record and nothing on another raised
+    ``TypeError: '<' not supported between instances of 'NoneType' and
+    'str'`` from the constructor, before any scoring happened.
+    """
+    epitope = _candidate(_affinity("4.1b", 50.0), _affinity(missing, 60.0))
+
+    # The named version keeps its own bucket; only the unnamed collapse.
+    assert sorted(epitope.predictions["pMHC_affinity"]["netmhcpan"]) == [
+        "", "4.1b"]
+    assert len(epitope.predictions_flat()) == 2

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -144,6 +144,25 @@ def sort_versions(versions) -> list:
     return sorted(fallback) + [v for _, v in sorted(parsed)]
 
 
+def canonical_predictor_version(value):
+    """Collapse every spelling of "no version" onto one.
+
+    A missing ``predictor_version`` arrives as ``None`` from mhctools, as
+    ``NaN`` from a frame, as ``""`` from vaxrank's own builders, and as the
+    literal string ``"nan"`` from anything that has been through
+    ``astype(str)``. They all mean the same thing and were behaving three
+    different ways: separate buckets in the nested store, three spellings in
+    the DSL frame, and a ``TypeError`` from :meth:`predictions_flat` when two
+    types met in the sort key.
+
+    ``topiary.is_named_version`` decides what counts as named, so vaxrank and
+    topiary cannot disagree about which pins are real.
+    """
+    from topiary import is_named_version
+
+    return value if is_named_version(value) else ""
+
+
 def _group_predictions(predictions) -> dict:
     """Flat ``Sequence[Prediction]`` → nested
     ``{kind: {predictor: {version: tuple}}}``. Producer-friendly:
@@ -153,7 +172,8 @@ def _group_predictions(predictions) -> dict:
     for p in predictions:
         (nested.setdefault(p.kind, {})
                .setdefault(p.predictor_name, {})
-               .setdefault(p.predictor_version, [])
+               .setdefault(canonical_predictor_version(
+                   p.predictor_version), [])
                .append(p))
     return {
         k: {pn: {pv: tuple(records) for pv, records in by_version.items()}
@@ -413,7 +433,11 @@ class Peptide:
         records, the score / value / %-rank tail breaks ties
         without falling back on input order. Float keys are wrapped
         with ``_nan_safe`` because mhctools sometimes emits NaN
-        for ``percentile_rank`` and ``sorted`` is undefined on NaN."""
+        for ``percentile_rank`` and ``sorted`` is undefined on NaN;
+        the version goes through
+        :func:`canonical_predictor_version` because a missing one
+        arrives as ``None``, ``NaN`` or ``""`` depending on the
+        producer, and ``sorted`` cannot compare those to a string."""
         flat = (
             p
             for by_predictor in self.predictions.values()
@@ -421,7 +445,8 @@ class Peptide:
             for records in by_version.values()
             for p in records)
         return tuple(sorted(flat, key=lambda p: (
-            p.kind, p.predictor_name, p.predictor_version, p.allele,
+            p.kind, p.predictor_name,
+            canonical_predictor_version(p.predictor_version), p.allele,
             _nan_safe(p.score), _nan_safe(p.value),
             _nan_safe(p.percentile_rank))))
 

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -139,6 +139,8 @@ def epitopes_to_topiary_df(epitopes):
     are NOT emitted as rows. The DSL frame is mutant-only by
     convention — comparator data stays on the CandidateEpitope for display.
     """
+    from .candidate_epitope import canonical_predictor_version
+
     rows = []
     for e in epitopes:
         ctx = e
@@ -155,7 +157,8 @@ def epitopes_to_topiary_df(epitopes):
                 "n_flank": ctx.n_flank,
                 "c_flank": ctx.c_flank,
                 "prediction_method_name": p.predictor_name,
-                "predictor_version": p.predictor_version or "",
+                "predictor_version": canonical_predictor_version(
+                    p.predictor_version),
                 "kind": p.kind,
                 "value": p.value,
                 "affinity": p.value,
@@ -563,27 +566,6 @@ def collect_dsl_references(node):
     return {"columns": columns, "kinds": kinds}
 
 
-def names_a_version(value):
-    """True when a ``predictor_version`` cell actually names a version.
-
-    NaN, None and blank are the obvious absences. The literal string
-    ``"nan"`` is the one that gets through: it survives ``dropna()`` and a
-    truthiness test, which is how it once counted as a real version in
-    vaxrank's own resolver and dropped every row carrying it from scoring.
-
-    Same rule topiary applies, so a pin either validates here and selects
-    there or fails in both. Kept in agreement by a test, not by care.
-
-    Temporary. topiary 5.35.0 exports ``is_named_version``; this goes away
-    and the import takes its place, because one rule in two repos is how
-    the last three version bugs happened.
-    """
-    if value is None:
-        return False
-    text = str(value).strip()
-    return bool(text) and text.lower() != "nan"
-
-
 def validate_dsl_against_predictions(cfg, epitopes, *, topiary_df=None):
     """Error early when ``filter_expr`` / ``score_expr`` references a
     predictor the loaded epitopes don't expose.
@@ -611,6 +593,8 @@ def validate_dsl_against_predictions(cfg, epitopes, *, topiary_df=None):
     available_methods = (
         set(df["prediction_method_name"].dropna().unique())
         if not df.empty else set())
+    from topiary import is_named_version
+
     # Drop the "no version known" sentinels so a formula pinning a specific
     # version against predictions that don't carry any version errors out,
     # and so the error message's version list matches what we actually
@@ -619,7 +603,7 @@ def validate_dsl_against_predictions(cfg, epitopes, *, topiary_df=None):
     if not df.empty:
         available_versions = {
             v for v in df["predictor_version"].dropna().unique()
-            if names_a_version(v)
+            if is_named_version(v)
         }
 
     for node in nodes:


### PR DESCRIPTION
Four producers say a prediction has no version four ways — `None` from mhctools, `NaN` from a frame, `""` from vaxrank's own builders, and the string `"nan"` from anything through `astype(str)`. vaxrank treated them as three or four different things.

| | before |
|---|---|
| frame cell | `NaN`→`nan`, `'nan'`→`'nan'`, `None`→`''`, `''`→`''` |
| nested store | four separate version buckets for one predictor |
| `predictions_flat` | `TypeError` comparing `str` to `NoneType`/`float` |

### The crash

In the `CandidateEpitope` constructor, before any scoring, whenever one predictor reports a version on one record and nothing on another:

```
'4.1b' + None  -> TypeError: '<' not supported between instances of 'NoneType' and 'str'
'4.1b' + NaN   -> TypeError
'4.1b' + ''    -> two buckets, no error
```

`predictions_flat` sorts on `(kind, predictor_name, predictor_version, ...)`. Its docstring already explains that float keys go through `_nan_safe` because sorting is undefined on NaN — the version key had the same problem and no guard.

### The quieter one

The bucket split is worse than the crash. Unqualified access resolves to a *single* version, so half of a predictor's unversioned evidence was unreachable while still looking present in the nested store.

### Fix

`canonical_predictor_version` collapses all four onto `""`, asking `topiary.is_named_version` what counts as named so the two can't disagree about which pins are real. Applied where vaxrank **keys or orders** on a version — nested store, flatten sort, frame cell — while the `Prediction` keeps whatever the producer said.

`names_a_version`, the stand-in added last release, is deleted for the import it was standing in for. Floor moves to `topiary>=5.35.0`.

### Reachability

Not reachable from any LENS fixture — the reader emits only real version strings (`1.0`, `2.1.1`, `4.1b`), which is why all eight stay **byte-identical**. It arrives on a frame built elsewhere, or from a predictor that reports its version inconsistently.

Found because the user asked why the four spellings behaved differently in #367, which had only made them agree in the validator.