### PR TITLE
Apply the unstated-value rule to alleles too

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.35.0,<6.0.0
+topiary>=5.35.1,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_epitope_dsl.py
+++ b/tests/test_epitope_dsl.py
@@ -860,7 +860,7 @@ def test_a_pin_matching_no_named_version_is_rejected(stored):
             EpitopeConfig(score_expr="affinity['netmhcpan', 'nan'].value"),
             [], topiary_df=df)
 
-NO_VERSION_SPELLINGS = [
+UNSTATED_SPELLINGS = [
     pytest.param(None, id="None"),          # mhctools
     pytest.param(np.nan, id="NaN"),         # a frame column
     pytest.param("", id="empty"),           # vaxrank's own builders
@@ -885,7 +885,7 @@ def _candidate(*predictions):
         patient_alleles=("HLA-A*02:01",), predictions=predictions)
 
 
-@pytest.mark.parametrize("missing", NO_VERSION_SPELLINGS)
+@pytest.mark.parametrize("missing", UNSTATED_SPELLINGS)
 def test_every_spelling_of_no_version_reaches_the_frame_the_same_way(missing):
     """One meaning, one representation.
 
@@ -901,8 +901,8 @@ def test_every_spelling_of_no_version_reaches_the_frame_the_same_way(missing):
     assert list(frame["predictor_version"]) == [""]
 
 
-@pytest.mark.parametrize("second", NO_VERSION_SPELLINGS)
-@pytest.mark.parametrize("first", NO_VERSION_SPELLINGS)
+@pytest.mark.parametrize("second", UNSTATED_SPELLINGS)
+@pytest.mark.parametrize("first", UNSTATED_SPELLINGS)
 def test_two_spellings_of_no_version_are_one_bucket(first, second):
     """Unversioned predictions from two producers form one group.
 
@@ -917,7 +917,7 @@ def test_two_spellings_of_no_version_are_one_bucket(first, second):
     assert len(buckets[""]) == 2
 
 
-@pytest.mark.parametrize("missing", NO_VERSION_SPELLINGS)
+@pytest.mark.parametrize("missing", UNSTATED_SPELLINGS)
 def test_a_named_version_beside_an_unnamed_one_does_not_raise(missing):
     """Mixed version types must not break candidate construction.
 
@@ -931,4 +931,73 @@ def test_a_named_version_beside_an_unnamed_one_does_not_raise(missing):
     # The named version keeps its own bucket; only the unnamed collapse.
     assert sorted(epitope.predictions["pMHC_affinity"]["netmhcpan"]) == [
         "", "4.1b"]
+    assert len(epitope.predictions_flat()) == 2
+
+
+def _processing(allele, score):
+    from mhctools.pred import Prediction
+
+    return Prediction(
+        kind="antigen_processing", predictor_name="mhcflurry",
+        predictor_version="2.1.1", allele=allele, peptide="SIINFEKL",
+        value=None, score=score)
+
+
+@pytest.mark.parametrize("unstated", UNSTATED_SPELLINGS)
+def test_an_unstated_allele_never_becomes_a_patient_allele(unstated):
+    """A blank allele means peptide-level evidence, not a genotype entry.
+
+    ``__post_init__`` derives ``patient_alleles`` from the alleles its
+    predictions carry, filtered on truthiness — and two spellings of blank
+    are truthy. NaN sorted against the real allele names and raised
+    ``TypeError``; the string "nan" became a patient allele that no model
+    ever scored, which is a per-allele score for a peptide-MHC pair that was
+    never predicted.
+    """
+    from vaxrank.candidate_epitope import CandidateEpitope
+
+    epitope = CandidateEpitope(
+        sequence="SIINFEKL", offset=0, prediction_id="x",
+        patient_alleles=("HLA-A*02:01",),
+        predictions=(_processing(unstated, 0.8),))
+
+    assert epitope.patient_alleles == ("HLA-A*02:01",)
+
+
+@pytest.mark.parametrize("unstated", UNSTATED_SPELLINGS)
+def test_an_unstated_allele_reaches_the_frame_as_blank(unstated):
+    """One spelling in the frame, so one group.
+
+    topiary keys its groups on the allele column, so a stringified null
+    there is a group of its own — allele-free evidence split across buckets
+    that peptide_view cannot broadcast from.
+    """
+    from vaxrank.candidate_epitope import CandidateEpitope
+    from vaxrank.epitope_dsl import epitopes_to_topiary_df
+
+    epitope = CandidateEpitope(
+        sequence="SIINFEKL", offset=0, prediction_id="x",
+        patient_alleles=("HLA-A*02:01",),
+        predictions=(_processing(unstated, 0.8),))
+
+    assert list(epitopes_to_topiary_df([epitope])["allele"]) == [""]
+
+
+@pytest.mark.parametrize("unstated", UNSTATED_SPELLINGS)
+def test_a_named_allele_beside_an_unstated_one_does_not_raise(unstated):
+    """Mixed allele types must not break candidate construction.
+
+    Same shape as the version axis: both are sorted, and a producer that
+    spells blank differently from vaxrank's own builders made ``sorted``
+    compare a float to a string.
+    """
+    from vaxrank.candidate_epitope import CandidateEpitope
+
+    epitope = CandidateEpitope(
+        sequence="SIINFEKL", offset=0, prediction_id="x",
+        patient_alleles=(),
+        predictions=(_processing("HLA-A*02:01", 0.9),
+                     _processing(unstated, 0.8)))
+
+    assert epitope.patient_alleles == ("HLA-A*02:01",)
     assert len(epitope.predictions_flat()) == 2

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -144,23 +144,30 @@ def sort_versions(versions) -> list:
     return sorted(fallback) + [v for _, v in sorted(parsed)]
 
 
-def canonical_predictor_version(value):
-    """Collapse every spelling of "no version" onto one.
+def stated_or_blank(value):
+    """Collapse every spelling of "the source stated nothing" onto ``""``.
 
-    A missing ``predictor_version`` arrives as ``None`` from mhctools, as
-    ``NaN`` from a frame, as ``""`` from vaxrank's own builders, and as the
-    literal string ``"nan"`` from anything that has been through
-    ``astype(str)``. They all mean the same thing and were behaving three
-    different ways: separate buckets in the nested store, three spellings in
-    the DSL frame, and a ``TypeError`` from :meth:`predictions_flat` when two
-    types met in the sort key.
+    A missing identity field arrives as ``None`` from mhctools, as ``NaN``
+    from a frame, as ``""`` from vaxrank's own builders, and as the literal
+    string ``"nan"`` from anything through ``astype(str)``. They mean one
+    thing and have to behave as one thing, because vaxrank both *keys* on
+    these fields (the nested prediction store, the DSL frame's group
+    columns) and *orders* on them (:meth:`predictions_flat`). Four spellings
+    meant one predictor's evidence split across buckets that unqualified
+    access could not reach, and ``sorted`` raising ``TypeError`` as soon as
+    two of the spellings had different types.
 
-    ``topiary.is_named_version`` decides what counts as named, so vaxrank and
-    topiary cannot disagree about which pins are real.
+    ``topiary.is_stated`` decides what counts as stated, so the two packages
+    cannot disagree about which values are real.
+
+    ``""`` is the right target on both axes, for different reasons. A
+    version nobody stated is simply absent. An allele nobody stated is
+    *allele-free* — a legitimate, load-bearing value: peptide-level
+    predictions have no allele, and ``""`` is the group they live in.
     """
-    from topiary import is_named_version
+    from topiary import is_stated
 
-    return value if is_named_version(value) else ""
+    return value if is_stated(value) else ""
 
 
 def _group_predictions(predictions) -> dict:
@@ -172,8 +179,7 @@ def _group_predictions(predictions) -> dict:
     for p in predictions:
         (nested.setdefault(p.kind, {})
                .setdefault(p.predictor_name, {})
-               .setdefault(canonical_predictor_version(
-                   p.predictor_version), [])
+               .setdefault(stated_or_blank(p.predictor_version), [])
                .append(p))
     return {
         k: {pn: {pv: tuple(records) for pv, records in by_version.items()}
@@ -434,10 +440,10 @@ class Peptide:
         without falling back on input order. Float keys are wrapped
         with ``_nan_safe`` because mhctools sometimes emits NaN
         for ``percentile_rank`` and ``sorted`` is undefined on NaN;
-        the version goes through
-        :func:`canonical_predictor_version` because a missing one
-        arrives as ``None``, ``NaN`` or ``""`` depending on the
-        producer, and ``sorted`` cannot compare those to a string."""
+        the version and allele go through
+        :func:`stated_or_blank` because a missing one arrives as
+        ``None``, ``NaN`` or ``""`` depending on the producer, and
+        ``sorted`` cannot compare those to a string."""
         flat = (
             p
             for by_predictor in self.predictions.values()
@@ -446,7 +452,7 @@ class Peptide:
             for p in records)
         return tuple(sorted(flat, key=lambda p: (
             p.kind, p.predictor_name,
-            canonical_predictor_version(p.predictor_version), p.allele,
+            stated_or_blank(p.predictor_version), stated_or_blank(p.allele),
             _nan_safe(p.score), _nan_safe(p.value),
             _nan_safe(p.percentile_rank))))
 
@@ -589,18 +595,25 @@ class CandidateEpitope(Peptide):
     def __post_init__(self):
         """Normalize predictions and retain every explicitly known allele."""
         super().__post_init__()
+        # Every source goes through stated_or_blank before the truthiness
+        # test. A blank allele means peptide-level evidence and is not a
+        # genotype entry, but "blank" has four spellings and two of them are
+        # truthy: NaN sorts against the real names and raises, and the string
+        # "nan" becomes a patient allele that no model ever scored.
         alleles = {
-            allele
+            stated
             for allele in self.patient_alleles
-            if allele
+            if (stated := stated_or_blank(allele))
         }
         alleles.update(
-            prediction.allele
+            stated
             for prediction in self.predictions_flat()
-            if prediction.allele
+            if (stated := stated_or_blank(prediction.allele))
         )
         alleles.update(
-            allele for allele in self.per_allele_scores if allele)
+            stated
+            for allele in self.per_allele_scores
+            if (stated := stated_or_blank(allele)))
         object.__setattr__(self, 'patient_alleles', tuple(sorted(alleles)))
 
     @property

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -139,7 +139,7 @@ def epitopes_to_topiary_df(epitopes):
     are NOT emitted as rows. The DSL frame is mutant-only by
     convention — comparator data stays on the CandidateEpitope for display.
     """
-    from .candidate_epitope import canonical_predictor_version
+    from .candidate_epitope import stated_or_blank
 
     rows = []
     for e in epitopes:
@@ -153,11 +153,11 @@ def epitopes_to_topiary_df(epitopes):
                 "peptide": p.peptide,
                 "peptide_offset": ctx.offset,
                 "peptide_length": len(p.peptide),
-                "allele": p.allele,
+                "allele": stated_or_blank(p.allele),
                 "n_flank": ctx.n_flank,
                 "c_flank": ctx.c_flank,
                 "prediction_method_name": p.predictor_name,
-                "predictor_version": canonical_predictor_version(
+                "predictor_version": stated_or_blank(
                     p.predictor_version),
                 "kind": p.kind,
                 "value": p.value,


### PR DESCRIPTION
The topiary session found the same bug on their allele axis after reading #368, and asked whether vaxrank had it. It does, in two places — and one of them **manufactured a patient allele**.

`CandidateEpitope.__post_init__` derives `patient_alleles` from the alleles its predictions carry, filtered on truthiness. Two spellings of blank are truthy:

```
allele=NaN     TypeError sorting float against the real allele names
allele='nan'   becomes a patient allele no model ever scored
allele=None    frame carries None rather than "", so scoring raised
allele=''      correct
```

A blank allele is not missing data here — it means **peptide-level evidence**, a value this codebase depends on. So a stringified null entering the genotype is a per-allele score for a peptide-MHC pair that was never predicted: the same phantom as the split version bucket, one axis over.

### One rule, not a second copy

`canonical_predictor_version` becomes `stated_or_blank` and serves both axes, because the rule was never about versions. It delegates to `topiary.is_stated`.

`""` is the right target on both, for reasons worth keeping straight: a version nobody stated is **absent**; an allele nobody stated is **allele-free**. topiary makes the same distinction (`NULL_TEXT` vs `NOT_STATED`), and it's load-bearing on their side too.

Applied everywhere vaxrank keys or orders on these fields — nested store, `predictions_flat` sort, genotype derivation, and the frame's version and allele columns.

### Floor moves to topiary>=5.35.1

vaxrank needs this on its own account: `--prediction-cache` uses `CachedPredictor`, whose cache key was splitting allele-free evidence across three buckets before that release. **A cache written by an older topiary should be rebuilt rather than trusted.**

### Verification

- All eight LENS fixtures **byte-identical**, again — the readers emit real allele names, so no fixture contains the absence.
- 1094 tests pass, plus 12 new parameterized cases across both axes.