### PR TITLE
Normalize predictions at the boundary, not at the call sites

### DIFF
--- a/tests/test_epitope_dsl.py
+++ b/tests/test_epitope_dsl.py
@@ -1001,3 +1001,59 @@ def test_a_named_allele_beside_an_unstated_one_does_not_raise(unstated):
 
     assert epitope.patient_alleles == ("HLA-A*02:01",)
     assert len(epitope.predictions_flat()) == 2
+
+
+@pytest.mark.parametrize("unstated", UNSTATED_SPELLINGS)
+def test_the_record_itself_is_normalized_not_just_the_keys(unstated):
+    """Every reader of ``p.allele`` must see a stated value or blank.
+
+    The first pass applied the rule only where vaxrank keyed or ordered on
+    these fields, which fixed the buckets and the sorts and nothing else —
+    around sixty call sites read ``p.allele`` directly, and every one that
+    asks ``if p.allele`` to mean "is this allele-scoped" is wrong for NaN
+    and for the string "nan", both truthy. ``alleles_for`` is one: it
+    returned a phantom allele rather than the empty tuple.
+    """
+    from vaxrank.candidate_epitope import CandidateEpitope
+
+    epitope = CandidateEpitope(
+        sequence="SIINFEKL", offset=0, prediction_id="x",
+        patient_alleles=("HLA-A*02:01",),
+        predictions=(_processing(unstated, 0.8),))
+
+    [leaf] = epitope.predictions_flat()
+    assert leaf.allele == ""
+    assert epitope.alleles_for("antigen_processing") == ()
+
+
+@pytest.mark.parametrize("unstated", UNSTATED_SPELLINGS)
+def test_a_caller_supplied_frame_cannot_add_a_phantom_allele(unstated):
+    """per_allele_scores must reject an unstated allele from any frame.
+
+    Normalizing predictions on the way into a CandidateEpitope does not
+    cover this path: pVACseq passes its own topiary frame, which never went
+    through that boundary. topiary collapses a stringified null in a group
+    key to a real null, and NaN is truthy, so a bare ``if allele`` wrote it
+    into a map whose contract is per patient allele.
+    """
+    from vaxrank.candidate_epitope import CandidateEpitope
+    from vaxrank.epitope_dsl import attach_per_allele_scores
+
+    frame = pd.DataFrame([{
+        "prediction_id": "x", "source_sequence_name": "s",
+        "peptide": "SIINFEKL", "peptide_offset": 0, "peptide_length": 8,
+        "allele": unstated, "prediction_method_name": "mhcflurry",
+        "predictor_version": "2.1.1", "kind": "antigen_processing",
+        "value": None, "score": 0.8}])
+    epitope = CandidateEpitope(
+        sequence="SIINFEKL", offset=0, prediction_id="x",
+        patient_alleles=("HLA-A*02:01",), predictions=())
+
+    [scored] = attach_per_allele_scores(
+        [epitope],
+        EpitopeConfig(
+            score_expr="peptide_view(processing[mhcflurry].score)"),
+        topiary_df=frame)
+
+    assert dict(scored.per_allele_scores) == {
+        "HLA-A*02:01": pytest.approx(0.8)}

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -86,7 +86,7 @@ from __future__ import annotations
 
 import copy
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace as _dc_replace
 from typing import TYPE_CHECKING, Optional
 
 from packaging.version import InvalidVersion, Version
@@ -170,6 +170,30 @@ def stated_or_blank(value):
     return value if is_stated(value) else ""
 
 
+def canonical_prediction(prediction):
+    """Return ``prediction`` with its identity fields stated or blank.
+
+    :func:`stated_or_blank` was first applied only where vaxrank keyed or
+    ordered on these fields, leaving the record itself carrying whatever
+    the producer wrote. That fixed the buckets and the sorts and nothing
+    else: roughly sixty call sites read ``p.allele`` directly, and each one
+    that asks ``if p.allele`` to mean "is this allele-scoped" gets the wrong
+    answer for NaN and for the string "nan", both of which are truthy.
+
+    Normalizing the record once, on the way in, makes the invariant hold
+    everywhere instead of at whichever call sites were remembered. Nothing
+    is lost: the four spellings carry no information beyond "the producer
+    stated nothing", and which way it said nothing is not a fact worth
+    keeping.
+    """
+    allele = stated_or_blank(prediction.allele)
+    version = stated_or_blank(prediction.predictor_version)
+    if allele == prediction.allele and version == prediction.predictor_version:
+        return prediction
+    return _dc_replace(
+        prediction, allele=allele, predictor_version=version)
+
+
 def _group_predictions(predictions) -> dict:
     """Flat ``Sequence[Prediction]`` → nested
     ``{kind: {predictor: {version: tuple}}}``. Producer-friendly:
@@ -177,9 +201,10 @@ def _group_predictions(predictions) -> dict:
     coming out of mhctools / topiary."""
     nested: dict = {}
     for p in predictions:
+        p = canonical_prediction(p)
         (nested.setdefault(p.kind, {})
                .setdefault(p.predictor_name, {})
-               .setdefault(stated_or_blank(p.predictor_version), [])
+               .setdefault(p.predictor_version, [])
                .append(p))
     return {
         k: {pn: {pv: tuple(records) for pv, records in by_version.items()}
@@ -451,8 +476,7 @@ class Peptide:
             for records in by_version.values()
             for p in records)
         return tuple(sorted(flat, key=lambda p: (
-            p.kind, p.predictor_name,
-            stated_or_blank(p.predictor_version), stated_or_blank(p.allele),
+            p.kind, p.predictor_name, p.predictor_version, p.allele,
             _nan_safe(p.score), _nan_safe(p.value),
             _nan_safe(p.percentile_rank))))
 
@@ -795,6 +819,11 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
     """
     groups: dict = {}
     for row in rows:
+        # Normalize before anything reads mutant.allele. The group's
+        # patient_alleles and allele_score are both decided by a truthiness
+        # test on it below, and two spellings of blank are truthy.
+        if row.get('mutant') is not None:
+            row = {**row, 'mutant': canonical_prediction(row['mutant'])}
         peptide = row['peptide']
         prediction_id = row.get('prediction_id') or ''
         key = (prediction_id, peptide, row['source'], row['offset'])
@@ -829,7 +858,9 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
         if row['mutant'].allele:
             slot['patient_alleles'].add(row['mutant'].allele)
         slot['patient_alleles'].update(
-            allele for allele in (row.get('patient_alleles') or ()) if allele)
+            stated
+            for allele in (row.get('patient_alleles') or ())
+            if (stated := stated_or_blank(allele)))
         for allele, score in (row.get('per_allele_scores') or {}).items():
             score = float(score)
             existing_score = slot['per_allele_scores'].get(allele)

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -442,6 +442,7 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
     objects alone, e.g. pVACseq passthrough annotation columns.
     """
     from dataclasses import replace
+    from .candidate_epitope import stated_or_blank
     from .epitope_config import EpitopeConfig
 
     if not epitopes:
@@ -454,11 +455,16 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
     by_position: dict[tuple, dict[str, float]] = {}
     for idx, val in score_series.items():
         src_name, peptide, offset, allele = idx
-        # Allele-independent processing predictions use ``allele=''``.
-        # They belong in the nested prediction model, but never in a map
-        # whose public contract is explicitly per patient allele. This
-        # filter stays even once openvax/topiary#182 lands: an unprojected
-        # allele-free row still produces an empty-allele group.
+        # Allele-independent predictions use a blank allele. They belong in
+        # the nested prediction model, but never in a map whose public
+        # contract is explicitly per patient allele.
+        #
+        # stated_or_blank rather than a truthiness test: this index comes
+        # from the frame, which a caller may have built (pVACseq passes its
+        # own), and topiary collapses a stringified null in a group key to a
+        # real null — which is truthy. A bare ``if allele`` let NaN through
+        # as a patient allele.
+        allele = stated_or_blank(allele)
         if allele:
             by_position.setdefault(
                 (src_name, peptide, offset), {})[allele] = float(val)


### PR DESCRIPTION
Asked whether the unstated-value problem was fully fixed, the answer was **no**.

#369 applied the rule where vaxrank *keyed or ordered* on allele and version, and left the record itself carrying whatever the producer wrote — leaving ~60 call sites reading `p.allele` directly. Every one that asks `if p.allele` to mean "is this allele-scoped" is wrong for `NaN` and for the string `"nan"`, both truthy.

Still broken after #369:

| site | symptom |
|---|---|
| `alleles_for()` | returned a phantom allele instead of `()` |
| `candidate_epitopes_from_rows` | `'nan'` became a patient allele, and got an `allele_score` written under it |
| retain-alleles filtering | allele-free evidence spelled `'nan'` read as allele-scoped and was **dropped** |
| `attach_per_allele_scores` | a caller-supplied frame put `NaN` in `per_allele_scores` |

### The fix is the boundary, not the sites

Fixing those individually is the same mistake at a different scale. The record is normalized **once** — on the way into the nested store, and at the row loader's intake — so the invariant holds for readers nobody enumerated.

Nothing is lost: the four spellings carry no information beyond "the producer stated nothing", and *which way* it said nothing is not a fact worth keeping.

### One path can't be covered that way

`attach_per_allele_scores` reads a frame the **caller** may have built, which never crossed that boundary — pVACseq passes its own via `report_df.attrs`. topiary collapses a stringified null in a group key to a real null, and NaN is truthy, so a bare `if allele` wrote it straight into a map whose contract is per patient allele. Fixed directly.

### Verification

- All eight LENS fixtures **byte-identical**, seventh time running. These are absences, and a corpus of real files cannot contain a value nobody wrote.
- 1114 tests pass.