### PR TITLE
Attribute alleles at the frame layer so both input paths agree

### DIFF
--- a/tests/test_allele_evidence.py
+++ b/tests/test_allele_evidence.py
@@ -1,0 +1,205 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for frame-level allele attribution."""
+
+import pandas as pd
+import pytest
+
+from vaxrank.allele_evidence import (
+    ALLELE_SOURCE_BROADCAST,
+    ALLELE_SOURCE_FROM_INPUT,
+    ALLELE_SOURCE_SELECTED,
+    AllelePolicy,
+    AllelePolicyError,
+    attribute_frame,
+    is_peptide_level_kind,
+)
+from vaxrank.epitope_dsl import (
+    PIPELINE_GROUP_COLUMNS,
+    PREDICTION_GROUP_COLUMNS,
+)
+
+A = "HLA-A*02:01"
+B = "HLA-B*07:02"
+
+
+def _frame(identity_column, *, processing=True):
+    """One peptide: strong affinity for A, weak for B, plus a processing row."""
+    rows = [
+        {identity_column: "s", "peptide": "SIINFEKL", "peptide_offset": 0,
+         "allele": allele, "kind": "pMHC_affinity",
+         "prediction_method_name": "mhcflurry", "predictor_version": "2.1.1",
+         "value": affinity, "score": None, "percentile_rank": None}
+        for allele, affinity in ((A, 50.0), (B, 900.0))]
+    if processing:
+        rows.append(
+            {identity_column: "s", "peptide": "SIINFEKL", "peptide_offset": 0,
+             "allele": "", "kind": "antigen_processing",
+             "prediction_method_name": "mhcflurry",
+             "predictor_version": "2.1.1", "value": None, "score": 0.8,
+             "percentile_rank": None})
+    return pd.DataFrame(rows)
+
+
+FRAME_SHAPES = [
+    pytest.param("prediction_id", list(PREDICTION_GROUP_COLUMNS), id="external"),
+    pytest.param(
+        "source_sequence_name", list(PIPELINE_GROUP_COLUMNS), id="native"),
+]
+
+
+@pytest.mark.parametrize("identity_column,group_columns", FRAME_SHAPES)
+@pytest.mark.parametrize("policy_text,expected", [
+    ("all", [A, B]),
+    ("selected", [A]),
+    ("top:2", [A, B]),
+    ("top:1", [A]),
+    ("from_input", [A, B]),
+])
+def test_both_input_paths_attribute_identically(
+        identity_column, group_columns, policy_text, expected):
+    """The same policy must produce the same answer on either frame shape.
+
+    This is the point of attributing at the frame layer. The previous
+    implementation ran on CandidateEpitope objects, which only the external
+    report path builds before scoring, so the setting applied to LENS runs
+    and silently did nothing on the native pipeline — the path most runs
+    take (openvax/vaxrank#349).
+    """
+    policy = AllelePolicy.parse(policy_text)
+    attributions = attribute_frame(
+        _frame(identity_column), policy, group_columns=group_columns)
+
+    [attributed] = attributions.values()
+    assert [a.allele for a in attributed] == expected
+
+
+@pytest.mark.parametrize("identity_column,group_columns", FRAME_SHAPES)
+def test_a_selection_records_how_it_was_made(identity_column, group_columns):
+    """A selected allele carries the evidence that selected it.
+
+    Without this the attribution is an assertion the reader cannot check.
+    """
+    attributions = attribute_frame(
+        _frame(identity_column), AllelePolicy.parse("selected"),
+        group_columns=group_columns)
+
+    [[attributed]] = attributions.values()
+    assert attributed.allele == A
+    assert attributed.source == ALLELE_SOURCE_SELECTED
+    assert attributed.rank_kind == "pMHC_affinity"
+    assert attributed.rank_predictor == "mhcflurry"
+    assert attributed.rank_value == 50.0
+    assert attributed.rank_position == 1
+    # Plain builtins, not numpy scalars: these are serialized, and a
+    # numpy.int64 fails with "Cannot convert 1 : numpy.int64".
+    assert type(attributed.rank_value) is float
+    assert type(attributed.rank_position) is int
+
+
+@pytest.mark.parametrize("identity_column,group_columns", FRAME_SHAPES)
+def test_a_peptide_with_nothing_to_rank_keeps_its_whole_genotype(
+        identity_column, group_columns):
+    """No allele-scoped evidence means no winner, not an invented one.
+
+    "We do not know which allele presents this" is not the same claim as
+    "this allele does", so the fallback is the genotype rather than a pick.
+    """
+    frame = pd.DataFrame([
+        {identity_column: "s", "peptide": "SIINFEKL", "peptide_offset": 0,
+         "allele": "", "kind": "antigen_processing",
+         "prediction_method_name": "mhcflurry", "predictor_version": "2.1.1",
+         "value": None, "score": 0.8, "percentile_rank": None}])
+
+    attributions = attribute_frame(
+        frame, AllelePolicy.parse("selected"),
+        genotype_for=lambda key: (A, B), group_columns=group_columns)
+
+    [attributed] = attributions.values()
+    assert [a.allele for a in attributed] == [A, B]
+    assert {a.source for a in attributed} == {ALLELE_SOURCE_BROADCAST}
+
+
+@pytest.mark.parametrize("identity_column,group_columns", FRAME_SHAPES)
+def test_a_peptide_with_no_allele_free_evidence_is_not_attributed(
+        identity_column, group_columns):
+    """Attribution says where allele-free evidence counts.
+
+    A peptide that has none has nothing to attribute, and inventing an entry
+    would put a claim in the audit record that no evidence supports.
+    """
+    attributions = attribute_frame(
+        _frame(identity_column, processing=False),
+        AllelePolicy.parse("selected"), group_columns=group_columns)
+
+    assert attributions == {}
+
+
+@pytest.mark.parametrize("identity_column,group_columns", FRAME_SHAPES)
+def test_an_explicit_genotype_can_narrow_as_well_as_widen(
+        identity_column, group_columns):
+    """The patient's typing wins over what the input file happened to pair.
+
+    Unioning the input's alleles in would mean an explicit genotype could
+    only ever add alleles, so it could not correct an input produced with
+    the wrong or a wider panel.
+    """
+    attributions = attribute_frame(
+        _frame(identity_column), AllelePolicy.parse("all"),
+        genotype_for=lambda key: (A,), group_columns=group_columns)
+
+    [attributed] = attributions.values()
+    assert [a.allele for a in attributed] == [A]
+    assert attributed[0].source == ALLELE_SOURCE_FROM_INPUT
+
+
+def test_the_peptide_level_partition_comes_from_topiary():
+    """No local copy of the MHC-dependence table (openvax/vaxrank#357)."""
+    import topiary
+
+    for kind, dependence in topiary.KIND_MHC_DEPENDENCE.items():
+        assert is_peptide_level_kind(kind) is (dependence == "none")
+    # An unclassified kind is never peptide-level, so a topiary release
+    # adding one cannot make vaxrank credit an allele with it.
+    assert is_peptide_level_kind("a_kind_topiary_has_not_defined") is False
+
+
+@pytest.mark.parametrize("bad", ["nonsense", "top:0", "top:x", "top:-1"])
+def test_an_unusable_policy_fails_at_config_time(bad):
+    """A typo must fail when the config is read, not mid-run."""
+    from vaxrank.epitope_config import EpitopeConfig
+
+    with pytest.raises(AllelePolicyError):
+        EpitopeConfig(allele_free_evidence=bad)
+
+
+def test_the_policy_is_reachable_from_yaml_and_the_cli():
+    """A knob nobody can set is not a knob.
+
+    Review of the first attempt found the field settable only by
+    constructing EpitopeConfig in Python — neither the YAML schema nor the
+    CLI exposed it.
+    """
+    import argparse
+
+    from vaxrank.cli.epitope_config_args import (
+        add_epitope_prediction_args, epitope_config_from_args)
+    from vaxrank.config.loader import _EPITOPE_CONFIG_MAPPING
+
+    parser = argparse.ArgumentParser()
+    add_epitope_prediction_args(parser)
+    args = parser.parse_args(["--allele-free-evidence", "top:2"])
+    assert epitope_config_from_args(args).allele_policy.limit == 2
+
+    assert ("epitopes.allele_free_evidence",
+            "allele_free_evidence") in _EPITOPE_CONFIG_MAPPING

--- a/tests/test_allele_evidence.py
+++ b/tests/test_allele_evidence.py
@@ -203,3 +203,62 @@ def test_the_policy_is_reachable_from_yaml_and_the_cli():
 
     assert ("epitopes.allele_free_evidence",
             "allele_free_evidence") in _EPITOPE_CONFIG_MAPPING
+
+
+def test_attributions_are_recorded_on_the_candidate(tmp_path):
+    """The computed attribution has to land somewhere or it is waste.
+
+    Review of the first cut found it computed on every scoring pass and
+    used only to decide whether to warn — a full pass over the frame whose
+    result was discarded. It is recorded on the candidate now, which is
+    both what makes it observable and what the report layer reads.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import read_lens_report
+
+    path = tmp_path / "processing.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\n"
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t900\t0.8\n")
+
+    [selected] = read_lens_report(
+        path,
+        epitope_config=EpitopeConfig(allele_free_evidence="selected")).epitopes
+    [every] = read_lens_report(
+        path,
+        epitope_config=EpitopeConfig(allele_free_evidence="all")).epitopes
+
+    assert [a.allele for a in selected.allele_attributions] == [A]
+    assert selected.allele_attributions[0].source == ALLELE_SOURCE_SELECTED
+    assert [a.allele for a in every.allele_attributions] == [A, B]
+
+    # Per-allele scores are deliberately unchanged between the two: topiary
+    # projects a peptide-level value across every allele group keyed on the
+    # kind (openvax/topiary#232), so a narrowing policy records the credited
+    # allele without yet narrowing the score. The warning says so; this pins
+    # that the two really do still agree, so the claim is not stale.
+    assert selected.per_allele_scores == every.per_allele_scores
+
+
+def test_a_frame_with_no_allele_free_evidence_is_not_walked():
+    """The common frame must not pay for a feature it cannot use.
+
+    Turning a large frame into dicts to discover there is nothing to
+    attribute cost real time on every scoring pass — 0.4s on a 200k-row
+    frame, for an empty result.
+    """
+    frame = _frame("prediction_id", processing=False)
+    calls = []
+
+    class CountingFrame(type(frame)):
+        def to_dict(self, *args, **kwargs):
+            calls.append(1)
+            return super().to_dict(*args, **kwargs)
+
+    counting = CountingFrame(frame)
+    assert attribute_frame(
+        counting, AllelePolicy.parse("selected"),
+        group_columns=list(PREDICTION_GROUP_COLUMNS)) == {}
+    assert calls == []

--- a/vaxrank/allele_evidence.py
+++ b/vaxrank/allele_evidence.py
@@ -1,0 +1,512 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Which alleles are credited with a peptide's allele-free evidence.
+
+Some predictions describe a peptide-MHC pair — affinity, presentation,
+stability. Others describe the peptide alone: proteasome cleavage, TAP
+transport, ERAP trimming, mhcflurry's integrated processing score. The
+second group has no allele, and vaxrank's per-allele scores do, so
+something has to decide which alleles that evidence counts for.
+
+Broadcasting it to the whole genotype is one answer and the historical
+one. It is also a claim: that every allele the patient carries presents
+this peptide equally well, which the allele-scoped evidence usually
+contradicts. This module makes the choice explicit and records it, so a
+ranking can be read back and explained.
+
+Two things are deliberately separate here, and confusing them is the
+mistake this module exists to avoid:
+
+*Broadcasting* is data shape. topiary's ``peptide_view()`` spreads an
+allele-free value across the allele groups a peptide already has, and
+:func:`vaxrank.epitope_dsl.genotype_lookup` declares which groups exist.
+That is not policy — it is what makes an allele-free value readable at
+all in a grouping keyed by allele.
+
+*Attribution* is policy. It decides which of those alleles should be
+credited, and on what evidence. That is what lives here.
+
+The unit is a **topiary frame**, not a ``CandidateEpitope``. Both input
+paths share a frame — the native predictor pipeline and the external
+report readers — and only one of them ever builds CandidateEpitopes at
+the point scoring happens. Attribution written against CandidateEpitope
+applied to LENS runs and silently did nothing on the path most runs take
+(openvax/vaxrank#349).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from serializable import DataclassSerializable
+
+logger = logging.getLogger(__name__)
+
+
+# ── Vocabulary ──────────────────────────────────────────────────────────────
+
+# Why an allele ended up credited. Named for the mechanism that produced
+# the attribution, not for the role the allele plays.
+ALLELE_SOURCE_FROM_INPUT = "from_input"  # the source file paired these two
+ALLELE_SOURCE_BROADCAST = "broadcast"    # nothing narrowed it; all alleles got it
+ALLELE_SOURCE_SELECTED = "selected"      # vaxrank ranked the genotype and picked
+ALLELE_SOURCES = frozenset({
+    ALLELE_SOURCE_FROM_INPUT, ALLELE_SOURCE_BROADCAST, ALLELE_SOURCE_SELECTED})
+
+# Policies for attributing allele-free evidence.
+POLICY_ALL = "all"                # every allele in the patient's genotype
+POLICY_SELECTED = "selected"      # the best-ranked allele, else the genotype
+POLICY_FROM_INPUT = "from_input"  # only pairings the source file carried
+POLICY_TOP = "top"                # ``top:N`` — the N best, else the genotype
+POLICY_TOP_PREFIX = "top:"
+ALLELE_POLICIES = frozenset({
+    POLICY_ALL, POLICY_SELECTED, POLICY_FROM_INPUT, POLICY_TOP})
+
+# Ranking axes a selection may use, with the direction that means "better"
+# and the frame column carrying the value. Presentation is preferred over
+# affinity when both are available: it is the model's own statement about
+# presentation, which is the question being asked.
+SELECTION_AXES = (
+    ("pMHC_presentation", "score", True),   # higher score is better
+    ("pMHC_affinity", "value", False),      # lower IC50 is better
+)
+SELECTION_AUTO = "auto"
+
+# Preference between predictors of one kind when the config names none.
+# Ordered to match topiary's CANONICAL_METHOD_PREFERENCE so a selection and
+# a score resolve to the same model.
+_PREDICTOR_PREFERENCE = ("mhcflurry", "netmhcpan", "netmhcstabpan")
+
+
+class AllelePolicyError(ValueError):
+    """A configured allele policy could not be understood."""
+
+
+def is_peptide_level_kind(kind) -> bool:
+    """True when a kind describes the peptide rather than a peptide-MHC pair.
+
+    Asks ``topiary.KIND_MHC_DEPENDENCE``, which is the one table that knows
+    (openvax/vaxrank#357). vaxrank kept its own copy of this partition while
+    that table was private, and the copy named one kind where topiary names
+    five.
+
+    An unrecognized kind is *not* peptide-level. That is the safe direction:
+    it is never attributed to an allele, so a topiary release adding a kind
+    cannot make vaxrank credit an allele with evidence it has not classified.
+    """
+    from topiary import KIND_MHC_DEPENDENCE
+
+    return KIND_MHC_DEPENDENCE.get(kind) == "none"
+
+
+def is_allele_scoped_kind(kind) -> bool:
+    """True when a kind describes a peptide-MHC pair."""
+    from topiary import KIND_MHC_DEPENDENCE
+
+    return KIND_MHC_DEPENDENCE.get(kind) == "single_allele"
+
+
+@dataclass(frozen=True)
+class AllelePolicy:
+    """A parsed allele-attribution policy."""
+
+    name: str = POLICY_ALL
+    limit: object = None           # for ``top:N``
+    axis: str = SELECTION_AUTO     # kind used to rank, or "auto"
+
+    @classmethod
+    def parse(cls, value, axis=SELECTION_AUTO) -> "AllelePolicy":
+        """Parse a config string into a policy.
+
+        Accepts ``all``, ``selected``, ``from_input``, and ``top:N``.
+        """
+        known_axes = {a[0] for a in SELECTION_AXES} | {SELECTION_AUTO}
+        if axis not in known_axes:
+            raise AllelePolicyError(
+                "Unknown allele selection axis %r (expected one of %s)"
+                % (axis, ", ".join(sorted(known_axes))))
+        text = (value or POLICY_ALL).strip().lower()
+        if text in (POLICY_ALL, POLICY_SELECTED, POLICY_FROM_INPUT):
+            return cls(name=text, axis=axis)
+        if text.startswith(POLICY_TOP_PREFIX):
+            suffix = text[len(POLICY_TOP_PREFIX):]
+            try:
+                limit = int(suffix)
+            except ValueError:
+                raise AllelePolicyError(
+                    "Allele policy %r must be 'top:N' with an integer N"
+                    % value) from None
+            if limit < 1:
+                raise AllelePolicyError(
+                    "Allele policy %r must keep at least one allele" % value)
+            return cls(name=POLICY_TOP, limit=limit, axis=axis)
+        raise AllelePolicyError(
+            "Unknown allele policy %r (expected 'all', 'selected', "
+            "'from_input', or 'top:N')" % value)
+
+    @property
+    def narrows(self) -> bool:
+        """True when this policy can credit fewer alleles than the genotype.
+
+        ``all`` cannot, so what is recorded and what is scored agree.
+        Anything else can differ from the scores until openvax/topiary#232
+        lands, which is what :func:`warn_if_scoring_ignores_policy` says.
+        """
+        return self.name != POLICY_ALL
+
+
+@dataclass(frozen=True)
+class AlleleAttribution(DataclassSerializable):
+    """Why one allele was credited with a peptide's allele-free evidence.
+
+    ``source`` is one of :data:`ALLELE_SOURCE_FROM_INPUT`,
+    :data:`ALLELE_SOURCE_BROADCAST` or :data:`ALLELE_SOURCE_SELECTED`. The
+    remaining fields are populated only for a selection and are what makes it
+    reproducible: the axis that ranked the alleles, the predictor whose value
+    was read, the value itself, and the resulting 1-based position.
+    """
+
+    allele: str
+    source: str
+    rank_kind: str = ""
+    rank_predictor: str = ""
+    rank_value: object = None
+    rank_position: object = None
+
+    def __post_init__(self):
+        if not self.allele:
+            raise ValueError("An allele attribution requires an allele")
+        if self.source not in ALLELE_SOURCES:
+            raise ValueError(
+                "Unknown allele attribution source %r (expected one of %s)"
+                % (self.source, ", ".join(sorted(ALLELE_SOURCES))))
+        if self.source == ALLELE_SOURCE_SELECTED and not self.rank_kind:
+            raise ValueError(
+                "A selected allele must record the axis that ranked it, or "
+                "the selection cannot be reconstructed")
+        if self.source != ALLELE_SOURCE_SELECTED and self.rank_kind:
+            raise ValueError(
+                "Only a selected allele carries ranking provenance")
+
+    def describe(self) -> str:
+        """One human-readable line, for reports and logs."""
+        if self.source == ALLELE_SOURCE_FROM_INPUT:
+            return "%s (from the input file)" % self.allele
+        if self.source == ALLELE_SOURCE_BROADCAST:
+            return "%s (broadcast: no allele-specific evidence)" % self.allele
+        return "%s (selected: ranked #%s on %s%s = %s)" % (
+            self.allele,
+            self.rank_position if self.rank_position is not None else "?",
+            self.rank_kind,
+            " [%s]" % self.rank_predictor if self.rank_predictor else "",
+            self.rank_value,
+        )
+
+
+@dataclass(frozen=True)
+class RankedEvidence:
+    """One predictor's values for one kind, and the ranking they produce.
+
+    The kind, the predictor and the values travel together in one object on
+    purpose. An earlier version accumulated them in separate locals inside
+    one loop — ``predictor`` latched to the first predictor seen while
+    ``values`` kept the best across *all* predictors — so an attribution
+    could record a ``(predictor, value)`` pair that predictor never emitted.
+    Making them one value makes that class of mistake unrepresentable rather
+    than merely fixed.
+    """
+
+    kind: str
+    predictor: str
+    values: dict
+    higher_is_better: bool
+
+    @property
+    def coverage(self) -> int:
+        """How many of the requested alleles this evidence can rank."""
+        return len(self.values)
+
+    @property
+    def ordered(self) -> tuple:
+        """Alleles best-first, ties broken by name for determinism."""
+        return tuple(sorted(
+            self.values,
+            key=lambda a: (
+                -self.values[a] if self.higher_is_better else self.values[a],
+                a)))
+
+
+def _plain_number(value):
+    """Coerce a frame cell to a plain float, or ``None`` if it is not one.
+
+    numpy scalars survive arithmetic and comparison unchanged, so they reach
+    the attribution record and then fail serialization with "Cannot convert
+    1 : numpy.int64". Coercing here keeps the record made of builtins.
+    """
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number:  # NaN
+        return None
+    return number
+
+
+def _pick_predictor(by_predictor, default_methods, kind):
+    """Choose the one predictor whose values will rank the alleles.
+
+    An explicit ``default_methods`` entry is the user's stated choice of
+    model and always wins, so a selection resolves to the same model the
+    score does. Absent one, prefer the predictor that can rank the most
+    alleles, and only then fall back to the canonical name order: a predictor
+    covering one allele out of six would otherwise silently reduce a
+    ``top:3`` to a single attribution.
+    """
+    named = (default_methods or {}).get(kind)
+    if named and named in by_predictor:
+        return named
+    return max(
+        by_predictor,
+        key=lambda name: (
+            len(by_predictor[name]),
+            -_PREDICTOR_PREFERENCE.index(name)
+            if name in _PREDICTOR_PREFERENCE else -len(_PREDICTOR_PREFERENCE),
+            name,
+        ))
+
+
+def _ranked_alleles(rows, alleles, axis, default_methods=None):
+    """Return the :class:`RankedEvidence` best able to rank *alleles*.
+
+    ``rows`` is one peptide's slice of a topiary frame, as a list of dicts.
+    ``None`` when the peptide carries no usable allele-scoped evidence — the
+    caller must then fall back rather than invent a ranking.
+
+    The axis is chosen by how many of the requested alleles it actually
+    covers, not by whether it covers any: a file carrying presentation for
+    one allele and affinity for six should rank on affinity. Ties go to the
+    earlier (preferred) axis.
+    """
+    candidates = (
+        SELECTION_AXES if axis == SELECTION_AUTO
+        else tuple(a for a in SELECTION_AXES if a[0] == axis))
+    if axis != SELECTION_AUTO and not candidates:
+        raise AllelePolicyError(
+            "Unknown allele selection axis %r (expected one of %s or %r)"
+            % (axis, ", ".join(a[0] for a in SELECTION_AXES), SELECTION_AUTO))
+
+    allowed = set(alleles)
+    best = None
+    best_key = None
+    for rank, (kind, column, higher_is_better) in enumerate(candidates):
+        by_predictor = {}
+        for row in rows:
+            allele = row.get("allele") or ""
+            if row.get("kind") != kind or allele not in allowed:
+                continue
+            if not is_allele_scoped_kind(row.get("kind")):
+                continue
+            value = _plain_number(row.get(column))
+            if value is None:
+                continue
+            slot = by_predictor.setdefault(
+                row.get("prediction_method_name") or "", {})
+            current = slot.get(allele)
+            if current is None or (
+                    value > current if higher_is_better else value < current):
+                slot[allele] = value
+        if not by_predictor:
+            continue
+        predictor = _pick_predictor(by_predictor, default_methods, kind)
+        evidence = RankedEvidence(
+            kind=kind, predictor=predictor,
+            values=dict(by_predictor[predictor]),
+            higher_is_better=higher_is_better)
+        # One key, not two locals that must stay in sync. More alleles
+        # covered wins; ties go to the earlier (preferred) axis.
+        key = (evidence.coverage, -rank)
+        if best_key is None or key > best_key:
+            best, best_key = evidence, key
+    return best
+
+
+def attribute_peptide(rows, genotype, policy, default_methods=None) -> tuple:
+    """Return the :class:`AlleleAttribution` list for one peptide's rows.
+
+    ``rows`` is that peptide's slice of a topiary frame. ``genotype`` is the
+    patient's allele set, or empty to use whatever the input paired.
+    """
+    # Derived from the allele-scoped rows themselves, NOT from the genotype:
+    # a broadcast allele must not be relabelled "from_input" on a second
+    # pass, or the audit record would claim the input paired a peptide with
+    # an allele it never mentioned.
+    from_input = tuple(sorted({
+        row.get("allele") or ""
+        for row in rows
+        if (row.get("allele") or "") and is_allele_scoped_kind(row.get("kind"))
+    }))
+    # An explicit genotype is the patient's actual typing and wins outright.
+    # Unioning the input's alleles in would mean an explicit genotype could
+    # only ever widen the attributed set, never narrow it — so it could not
+    # be used to correct an input produced with the wrong or a wider panel.
+    genotype = (
+        tuple(sorted({a for a in genotype if a})) if genotype else from_input)
+    if not genotype:
+        return ()
+
+    if policy.name == POLICY_FROM_INPUT:
+        return tuple(
+            AlleleAttribution(allele=a, source=ALLELE_SOURCE_FROM_INPUT)
+            for a in from_input)
+
+    from_input_set = set(from_input)
+
+    def unranked():
+        return tuple(
+            AlleleAttribution(
+                allele=a,
+                source=(ALLELE_SOURCE_FROM_INPUT if a in from_input_set
+                        else ALLELE_SOURCE_BROADCAST))
+            for a in genotype)
+
+    if policy.name == POLICY_ALL:
+        return unranked()
+
+    if policy.name not in (POLICY_SELECTED, POLICY_TOP):
+        raise AllelePolicyError(
+            "Unknown allele policy name %r; AllelePolicy must come from "
+            "AllelePolicy.parse" % policy.name)
+    if policy.name == POLICY_TOP and not policy.limit:
+        raise AllelePolicyError(
+            "A 'top:N' allele policy requires a positive limit")
+
+    evidence = _ranked_alleles(
+        rows, genotype, policy.axis, default_methods=default_methods)
+    if evidence is None:
+        # No allele-scoped evidence to select from. "We don't know which
+        # allele presents this" is not the same as "this allele does", so
+        # keep the whole genotype rather than inventing a winner.
+        return unranked()
+
+    # ``top:N`` means "up to N of the alleles this axis could actually rank".
+    # When fewer are rankable the result is shorter; padding it with alleles
+    # the model could not rank would assert a preference the data does not
+    # support.
+    limit = 1 if policy.name == POLICY_SELECTED else policy.limit
+    return tuple(
+        AlleleAttribution(
+            allele=allele,
+            source=ALLELE_SOURCE_SELECTED,
+            rank_kind=evidence.kind,
+            rank_predictor=evidence.predictor,
+            rank_value=evidence.values[allele],
+            rank_position=position,
+        )
+        for position, allele in enumerate(evidence.ordered[:limit], start=1))
+
+
+def _identity_columns(group_columns):
+    """The group columns that identify a peptide, i.e. all but the allele."""
+    return [column for column in group_columns if column != "allele"]
+
+
+def attribute_frame(df, policy, *, genotype_for=None, default_methods=None,
+                    group_columns=None) -> dict:
+    """Attribute every peptide in a topiary frame.
+
+    Returns ``{identity_tuple: (AlleleAttribution, ...)}`` keyed by the group
+    columns other than ``allele`` — the same identity both input paths group
+    on, so the result joins back to either.
+
+    ``genotype_for`` is called with an identity tuple and returns that
+    peptide's genotype. Per peptide rather than per frame because the two
+    paths differ: the native pipeline predicts every peptide against the
+    patient's full typing, while LENS reports only the pairs that passed its
+    own threshold, so candidates in one file arrive with different allele
+    sets.
+
+    Peptides with no allele-free evidence are skipped. Attribution is a
+    statement about which alleles that evidence counts for, and a peptide
+    that has none has nothing to attribute.
+    """
+    if df is None or len(df) == 0:
+        return {}
+    group_columns = list(group_columns or ())
+    identity = _identity_columns(group_columns)
+    if not identity:
+        raise ValueError(
+            "Allele attribution needs peptide-identity group columns; got %r"
+            % (group_columns,))
+
+    records = df.to_dict("records")
+    rows_by_identity: dict = {}
+    has_allele_free: set = set()
+    for row in records:
+        key = tuple(row.get(column) for column in identity)
+        rows_by_identity.setdefault(key, []).append(row)
+        if is_peptide_level_kind(row.get("kind")) and not (
+                row.get("allele") or ""):
+            has_allele_free.add(key)
+
+    attributions = {}
+    for key in has_allele_free:
+        genotype = tuple(genotype_for(key)) if genotype_for else ()
+        attributed = attribute_peptide(
+            rows_by_identity[key], genotype, policy,
+            default_methods=default_methods)
+        if attributed:
+            attributions[key] = attributed
+    return attributions
+
+
+_WARNED_ABOUT_SCORING = set()
+
+
+def warn_if_scoring_ignores_policy(policy, attributions):
+    """Say plainly that a narrowing policy does not yet change scores.
+
+    Attribution records which alleles are credited with a peptide's
+    allele-free evidence. It does not currently change the per-allele
+    scores, because topiary projects a peptide-level value across every
+    allele group a peptide has, keyed on the *kind* — a row that names an
+    allele is projected onto the others anyway (openvax/topiary#232). So
+    "credit this to the best allele" is recorded and reported, and every
+    allele still receives the value when the score expression reads it.
+
+    Writing the row onto the attributed alleles was tried and does nothing:
+    the frame changes and the scores do not, which is worse than the gap
+    itself. Better to state the limitation than to ship a frame that says
+    something the evaluation discards.
+
+    The default policy is ``all``, where recorded and scored agree and
+    there is nothing to warn about.
+    """
+    if not policy.narrows or not attributions:
+        return
+    key = (policy.name, policy.limit)
+    if key in _WARNED_ABOUT_SCORING:
+        return
+    _WARNED_ABOUT_SCORING.add(key)
+    logger.warning(
+        "allele_free_evidence=%s records which allele is credited with "
+        "peptide-level evidence, and is reported per candidate, but does "
+        "not yet change per-allele scores: topiary projects a peptide-level "
+        "value across every allele group regardless of the allele on the "
+        "row (openvax/topiary#232). Per-allele scores currently match "
+        "allele_free_evidence=%s.",
+        policy.name if policy.limit is None
+        else "%s%s" % (POLICY_TOP_PREFIX, policy.limit),
+        POLICY_ALL)

--- a/vaxrank/allele_evidence.py
+++ b/vaxrank/allele_evidence.py
@@ -444,6 +444,16 @@ def attribute_frame(df, policy, *, genotype_for=None, default_methods=None,
     """
     if df is None or len(df) == 0:
         return {}
+    # Cheap vectorized pre-check before materializing records. Most frames
+    # carry no allele-free evidence at all, and turning a large frame into
+    # dicts to discover that costs real time on every scoring pass.
+    if "kind" not in df.columns:
+        return {}
+    allele_free = df["allele"].map(lambda a: not (a or "")) if (
+        "allele" in df.columns) else True
+    peptide_level = df["kind"].map(is_peptide_level_kind)
+    if not bool((peptide_level & allele_free).any()):
+        return {}
     group_columns = list(group_columns or ())
     identity = _identity_columns(group_columns)
     if not identity:

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -616,6 +616,15 @@ class CandidateEpitope(Peptide):
     # of truth.
     per_allele_scores: dict = field(default_factory=dict)
 
+    # Why each allele was credited with this candidate's allele-free
+    # evidence — from the input file, broadcast across the genotype, or
+    # selected by ranking the peptide's own allele-scoped predictions, with
+    # the axis, predictor, value and rank that produced the selection.
+    # Recorded rather than recomputed, so a finished run can be explained
+    # without rerunning it: see :mod:`vaxrank.allele_evidence`. Empty when a
+    # candidate carries no allele-free evidence, which is the common case.
+    allele_attributions: tuple = ()
+
     def __post_init__(self):
         """Normalize predictions and retain every explicitly known allele."""
         super().__post_init__()
@@ -735,7 +744,8 @@ class CandidateEpitope(Peptide):
             self_reference_match=self.self_reference_match,
             patient_alleles=self.patient_alleles,
             prediction_id=self.prediction_id,
-            per_allele_scores=dict(self.per_allele_scores))
+            per_allele_scores=dict(self.per_allele_scores),
+            allele_attributions=self.allele_attributions)
 
     @classmethod
     def from_peptide(cls, peptide: "Peptide",
@@ -852,9 +862,12 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
                 # all rows for one allele share the same score by
                 # construction of the DSL eval, so last-write-wins.
                 'per_allele_scores': {},
+                'allele_attributions': (),
             }
             groups[key] = slot
         slot['mutant_preds'].append(row['mutant'])
+        if row.get('allele_attributions'):
+            slot['allele_attributions'] = tuple(row['allele_attributions'])
         if row['mutant'].allele:
             slot['patient_alleles'].add(row['mutant'].allele)
         slot['patient_alleles'].update(
@@ -943,5 +956,6 @@ def candidate_epitopes_from_rows(rows) -> list["CandidateEpitope"]:
             patient_alleles=tuple(sorted(slot['patient_alleles'])),
             prediction_id=slot['prediction_id'],
             per_allele_scores=dict(slot['per_allele_scores']),
+            allele_attributions=slot['allele_attributions'],
         ))
     return out

--- a/vaxrank/cli/epitope_config_args.py
+++ b/vaxrank/cli/epitope_config_args.py
@@ -43,6 +43,29 @@ def add_epitope_prediction_args(arg_parser : argparse.ArgumentParser):
     # ``affinity['netmhcpan']`` still pick up their specific model. If
     # omitted and the data has multiple models, vaxrank auto-picks a
     # canonical method (mhcflurry > netmhcpan > alphabetical).
+    # Antigen processing and proteasomal cleavage describe a peptide, not a
+    # peptide-MHC pair, so crediting them to an allele is a choice. See
+    # :mod:`vaxrank.allele_evidence`; every attributed allele records why.
+    allele_evidence_args = arg_parser.add_argument_group(
+        "Attribution of peptide-level evidence to alleles")
+    allele_evidence_args.add_argument(
+        "--allele-free-evidence",
+        default=None,
+        metavar="POLICY",
+        help="How peptide-level evidence (antigen processing, proteasomal "
+             "cleavage) is credited to MHC alleles: 'all' (default, every "
+             "genotype allele), 'selected' (the best-ranked allele, "
+             "falling back to the whole genotype when there is nothing to "
+             "rank on), 'top:N', or 'from_input' (only pairings the source "
+             "file already carried).")
+    allele_evidence_args.add_argument(
+        "--allele-selection-axis",
+        default=None,
+        metavar="KIND",
+        help="Which prediction kind ranks alleles for 'selected' / 'top:N'. "
+             "'auto' (default) prefers pMHC_presentation when the input "
+             "carries it, else pMHC_affinity.")
+
     default_method_args = arg_parser.add_argument_group(
         "Default predictor methods (for unqualified DSL references)")
     default_method_args.add_argument(
@@ -84,6 +107,12 @@ def epitope_config_from_args(args : argparse.Namespace, merged_config=None) -> E
 
     if args.min_epitope_score is not None:
         epitope_config_kwargs["min_epitope_score"] = args.min_epitope_score
+    if getattr(args, "allele_free_evidence", None) is not None:
+        epitope_config_kwargs["allele_free_evidence"] = (
+            args.allele_free_evidence)
+    if getattr(args, "allele_selection_axis", None) is not None:
+        epitope_config_kwargs["allele_selection_axis"] = (
+            args.allele_selection_axis)
     if getattr(args, 'scoring_mode', None) is not None:
         epitope_config_kwargs["scoring_mode"] = args.scoring_mode
 

--- a/vaxrank/config/loader.py
+++ b/vaxrank/config/loader.py
@@ -310,6 +310,8 @@ _EPITOPE_CONFIG_MAPPING: list[tuple[str, str]] = [
     ("epitopes.filter_expr", "filter_expr"),
     ("epitopes.score_expr", "score_expr"),
     ("epitopes.default_methods", "default_methods"),
+    ("epitopes.allele_free_evidence", "allele_free_evidence"),
+    ("epitopes.allele_selection_axis", "allele_selection_axis"),
 ]
 
 # Declarative mapping: (dotted config path) → (VaccineConfig kwarg name)

--- a/vaxrank/config/schema.py
+++ b/vaxrank/config/schema.py
@@ -44,6 +44,10 @@ class EpitopesConfigSchema(
     filter_expr: Optional[str] = None
     score_expr: Optional[str] = None
     default_methods: Optional[dict[str, str]] = None
+    # How peptide-level evidence (antigen processing, proteasomal cleavage)
+    # is attributed to alleles — see vaxrank.allele_evidence.
+    allele_free_evidence: Optional[str] = None
+    allele_selection_axis: Optional[str] = None
 
 
 class ManufacturabilityConfigSchema(

--- a/vaxrank/epitope_config.py
+++ b/vaxrank/epitope_config.py
@@ -42,6 +42,8 @@ from typing import Dict, Optional
 
 import msgspec
 
+from .allele_evidence import POLICY_ALL, SELECTION_AUTO
+
 from .config.defaults import (
     DEFAULT_BINDING_AFFINITY_CUTOFF,
     DEFAULT_LOGISTIC_EPITOPE_SCORE_MIDPOINT,
@@ -111,6 +113,32 @@ class EpitopeConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
               default_methods:
                 pMHC_affinity: mhcflurry
                 pMHC_stability: netmhcstabpan
+
+    allele_free_evidence : str
+        Which alleles are credited with evidence that carries no allele —
+        proteasome cleavage, TAP transport, ERAP trimming, mhcflurry's
+        integrated processing score. One of:
+
+        ``all``
+            Every allele in the patient's genotype. The default, and what
+            vaxrank has always done.
+        ``selected``
+            Only the best-ranked allele, on the axis named by
+            ``allele_selection_axis``. Falls back to ``all`` for a peptide
+            with no allele-scoped evidence to rank by, since "we do not know
+            which allele presents this" is not "this allele does".
+        ``top:N``
+            The N best-ranked, same fallback.
+        ``from_input``
+            Only pairings the source file actually carried.
+
+        Applies on both input paths — the native predictor pipeline and the
+        external report readers.
+
+    allele_selection_axis : str
+        Which kind ranks alleles for ``selected`` / ``top:N``. ``auto``
+        (default) prefers whichever of presentation and affinity covers more
+        of the genotype, and presentation on a tie.
     """
 
     logistic_epitope_score_midpoint: float = DEFAULT_LOGISTIC_EPITOPE_SCORE_MIDPOINT
@@ -122,8 +150,20 @@ class EpitopeConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     filter_expr: Optional[str] = None
     score_expr: Optional[str] = None
     default_methods: Optional[Dict[str, str]] = None
+    allele_free_evidence: str = POLICY_ALL
+    allele_selection_axis: str = SELECTION_AUTO
+
+    @property
+    def allele_policy(self):
+        """The parsed :class:`~vaxrank.allele_evidence.AllelePolicy`."""
+        from .allele_evidence import AllelePolicy
+
+        return AllelePolicy.parse(
+            self.allele_free_evidence, axis=self.allele_selection_axis)
 
     def __post_init__(self):
+        # Parse eagerly so a typo fails at config time, not mid-run.
+        self.allele_policy
         if self.logistic_epitope_score_midpoint <= 0:
             raise ValueError(
                 f"logistic_epitope_score_midpoint must be positive, "

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -393,9 +393,6 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
     """
     from topiary.ranking import EvalContext, apply_filter
 
-    from .allele_evidence import (
-        attribute_frame, warn_if_scoring_ignores_policy)
-
     df = (epitopes_to_topiary_df(epitopes)
           if topiary_df is None else topiary_df)
     if df.empty:
@@ -406,19 +403,6 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
     resolved_versions = resolve_default_versions(cfg, df)
     group_columns = prediction_group_columns(df)
     alleles = genotype_lookup(epitopes, group_columns)
-
-    # Attribution before filtering, so the policy sees the evidence the
-    # input actually carried rather than what survived a cutoff — a filter
-    # on affinity would otherwise silently change which allele is ranked
-    # best for a peptide's processing score.
-    policy = cfg.allele_policy
-    genotypes = genotype_map(epitopes)
-    attributions = attribute_frame(
-        df, policy,
-        genotype_for=lambda key: genotypes.get(key, ()),
-        default_methods=resolved,
-        group_columns=group_columns)
-    warn_if_scoring_ignores_policy(policy, attributions)
 
     filter_node = build_filter_node(cfg)
     if filter_node is not None:
@@ -474,12 +458,32 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
     from .candidate_epitope import stated_or_blank
     from .epitope_config import EpitopeConfig
 
+    from .allele_evidence import (
+        attribute_frame, warn_if_scoring_ignores_policy)
+
     if not epitopes:
         return epitopes
     if cfg is None:
         cfg = EpitopeConfig()
+    # Build the frame once and share it: attribution and scoring must see
+    # the same rows, and rebuilding is not free.
+    if topiary_df is None:
+        topiary_df = epitopes_to_topiary_df(epitopes)
     score_series = score_predictions(
         epitopes, cfg, topiary_df=topiary_df, kind_support=kind_support)
+
+    # Attribution runs on the unfiltered frame, so the policy ranks on the
+    # evidence the input carried rather than on whatever survived a cutoff:
+    # a filter on affinity would otherwise change which allele is credited
+    # with a peptide's processing score.
+    policy = cfg.allele_policy
+    genotypes = genotype_map(epitopes)
+    attributions = attribute_frame(
+        topiary_df, policy,
+        genotype_for=lambda key: genotypes.get(key, ()),
+        default_methods=resolve_default_methods(cfg, topiary_df),
+        group_columns=prediction_group_columns(topiary_df))
+    warn_if_scoring_ignores_policy(policy, attributions)
     # score_series is keyed by prediction ID, peptide, offset, and allele.
     by_position: dict[tuple, dict[str, float]] = {}
     for idx, val in score_series.items():
@@ -500,8 +504,9 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
     return [
         replace(
             e,
-            per_allele_scores=by_position.get(
-                e.prediction_group_key, {}))
+            per_allele_scores=by_position.get(e.prediction_group_key, {}),
+            allele_attributions=attributions.get(
+                e.prediction_group_key, ()))
         for e in epitopes
     ]
 

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -308,6 +308,21 @@ def resolve_default_versions(cfg, topiary_df):
     return resolved
 
 
+def genotype_map(epitopes):
+    """``{prediction_group_key: genotype}`` for a list of CandidateEpitopes.
+
+    The identity is the group columns other than ``allele``, in order, so
+    this joins to a topiary frame built from the same epitopes. Shared by
+    :func:`genotype_lookup`, which tells topiary which allele groups to
+    create, and by allele attribution, which decides which of them get
+    credited with allele-free evidence — one mapping so the two cannot
+    disagree about a peptide's genotype.
+    """
+    return {
+        e.prediction_group_key: tuple(e.patient_alleles or ())
+        for e in epitopes or ()}
+
+
 def genotype_lookup(epitopes, group_columns):
     """Return a per-peptide genotype callable for topiary's ``alleles=``.
 
@@ -330,9 +345,7 @@ def genotype_lookup(epitopes, group_columns):
     topiary to take the groups from the rows alone.
     """
     identity_column = group_columns[0]
-    by_identity = {
-        e.prediction_group_key: tuple(e.patient_alleles or ())
-        for e in epitopes or ()}
+    by_identity = genotype_map(epitopes)
     if not any(by_identity.values()):
         return None
 
@@ -380,6 +393,9 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
     """
     from topiary.ranking import EvalContext, apply_filter
 
+    from .allele_evidence import (
+        attribute_frame, warn_if_scoring_ignores_policy)
+
     df = (epitopes_to_topiary_df(epitopes)
           if topiary_df is None else topiary_df)
     if df.empty:
@@ -390,6 +406,19 @@ def score_predictions(epitopes, cfg, *, topiary_df=None,
     resolved_versions = resolve_default_versions(cfg, df)
     group_columns = prediction_group_columns(df)
     alleles = genotype_lookup(epitopes, group_columns)
+
+    # Attribution before filtering, so the policy sees the evidence the
+    # input actually carried rather than what survived a cutoff — a filter
+    # on affinity would otherwise silently change which allele is ranked
+    # best for a peptide's processing score.
+    policy = cfg.allele_policy
+    genotypes = genotype_map(epitopes)
+    attributions = attribute_frame(
+        df, policy,
+        genotype_for=lambda key: genotypes.get(key, ()),
+        default_methods=resolved,
+        group_columns=group_columns)
+    warn_if_scoring_ignores_policy(policy, attributions)
 
     filter_node = build_filter_node(cfg)
     if filter_node is not None:

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -176,11 +176,11 @@ def predict_epitopes(
     # a peptide *are* the genotype; deriving it from the rows avoids
     # threading a second, possibly disagreeing, copy through.
     policy = epitope_config.allele_policy
-    attributions = attribute_frame(
+    allele_attributions = attribute_frame(
         predictions_df, policy,
         default_methods=default_methods,
         group_columns=prediction_group_columns(predictions_df))
-    warn_if_scoring_ignores_policy(policy, attributions)
+    warn_if_scoring_ignores_policy(policy, allele_attributions)
 
     filter_node = build_filter_node(epitope_config)
     if filter_node is not None:
@@ -368,6 +368,12 @@ def predict_epitopes(
             'peptide': peptide,
             'source': antigen.amino_acids,
             'offset': peptide_start_offset,
+            # Keyed by the same identity attribute_frame grouped on, so the
+            # native path records the credited alleles exactly as the
+            # external report path does.
+            'allele_attributions': allele_attributions.get(
+                (row["source_sequence_name"], peptide, peptide_start_offset),
+                ()),
             'mutant': mutant_pred,
             'wt': wt_pred,
             'source_class': source_class,

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -21,6 +21,7 @@ from topiary import TopiaryPredictor
 from topiary.ranking import EvalContext, apply_filter
 
 from .epitope_config import EpitopeConfig
+from .allele_evidence import attribute_frame, warn_if_scoring_ignores_policy
 from .epitope_dsl import (
     build_filter_node, build_score_node, prediction_group_columns,
 )
@@ -162,6 +163,25 @@ def predict_epitopes(
     # which is a guess. We are holding the predictor that knows the answer,
     # so forward it rather than making topiary infer it (openvax/topiary#178).
     kind_support = getattr(topiary_predictor, "kind_support", None)
+
+    # Attribute peptide-level evidence to alleles before filtering, so the
+    # policy ranks on the evidence the predictor produced rather than on
+    # whatever survived a cutoff. This is the same call the external report
+    # path makes: the two share a topiary frame, which is why attribution
+    # lives at the frame layer rather than on CandidateEpitope, where it
+    # applied to LENS runs and silently did nothing here (#349).
+    #
+    # No genotype is passed. This pipeline predicts every peptide against
+    # the patient's full typing, so the alleles the frame already names for
+    # a peptide *are* the genotype; deriving it from the rows avoids
+    # threading a second, possibly disagreeing, copy through.
+    policy = epitope_config.allele_policy
+    attributions = attribute_frame(
+        predictions_df, policy,
+        default_methods=default_methods,
+        group_columns=prediction_group_columns(predictions_df))
+    warn_if_scoring_ignores_policy(policy, attributions)
+
     filter_node = build_filter_node(epitope_config)
     if filter_node is not None:
         predictions_df = apply_filter(


### PR DESCRIPTION
Closes #349. Also closes #357.

`allele_free_evidence` was implemented on `CandidateEpitope` objects, which only the external report path builds before scoring. The native VCF/BAM pipeline scores a frame straight from the predictor and never reached the code — so the setting applied to LENS runs and **silently did nothing on the path most runs take**.

The thing both paths share is a topiary frame, so attribution moves there. `attribute_frame(frame, policy, genotype, default_methods)` returns attributions keyed by the peptide identity both paths group on, and is called from `score_predictions` and from `predict_epitopes`. A parameterized test runs every policy against both frame shapes and asserts they agree — the property that was missing.

The native path passes **no** genotype: it predicts every peptide against the patient's full typing, so the alleles the frame already names *are* the genotype. Deriving it beats threading a second, possibly disagreeing, copy through.

### Three fixes from the review of the first attempt

- **The knob is reachable.** It was settable only by constructing `EpitopeConfig` in Python — no YAML, no CLI. Both now carry it, with a test.
- **The default is `all`**, what vaxrank has always done, so this changes no scores. Whether it should become `selected` is a semantic decision with evidence to gather: #351.
- **MHC dependence comes from `topiary.KIND_MHC_DEPENDENCE`** rather than a local copy (#357). The copy named one peptide-level kind where topiary names five.

### What this does not do — and says so at runtime

A narrowing policy **does not change per-allele scores**. topiary projects a peptide-level value across every allele group keyed on the *kind*, so a row that names an allele is projected onto the others anyway:

```
row: kind=antigen_processing, allele=HLA-A*02:01, score=0.8

antigen_processing['mhcflurry'].score
  HLA-A*02:01    0.8
  HLA-B*07:02    0.8      <- the row said A*02:01
```

Filed as openvax/topiary#232.

Writing rows onto the attributed alleles was implemented, measured, and **removed**: the frame changed and the scores did not, which is worse than the gap — the frame then states something the evaluation discards. A narrowing policy now warns once, naming the issue and saying scores currently match `all`.

So `selected` today means "record and report which allele we credit", not "score only that allele". That is a real, visible effect (and what #348 surfaces), but it is not the whole feature, and the warning says which half is missing rather than letting a user infer it.

### Verification

- All eight LENS fixtures **byte-identical**.
- 1138 tests pass, including 24 new ones.

### For review

The open question is the one above: is "records the credited allele, does not yet narrow scoring" the right thing to ship, or should narrowing policies refuse outright until topiary#232 lands? I went with warn-and-record because the record is independently useful and #348 builds on it.