### PR TITLE
Round-trip allele attributions through the native format

### DIFF
--- a/tests/test_allele_evidence.py
+++ b/tests/test_allele_evidence.py
@@ -262,3 +262,70 @@ def test_a_frame_with_no_allele_free_evidence_is_not_walked():
         counting, AllelePolicy.parse("selected"),
         group_columns=list(PREDICTION_GROUP_COLUMNS)) == {}
     assert calls == []
+
+
+@pytest.mark.parametrize("policy_text", ["all", "selected", "top:2", "from_input"])
+def test_attributions_survive_a_native_round_trip(tmp_path, policy_text):
+    """A saved run must reload with the attribution it actually made.
+
+    The attribution depends on the policy in force when the candidate was
+    scored, and ``load_predictions`` takes no config — so recomputing on
+    load would silently answer a different question and present it as what
+    the run produced. Recording it is what makes a finished ranking
+    explainable later.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import (
+        load_predictions, read_lens_report, save_predictions)
+
+    source = tmp_path / "processing.tsv"
+    source.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\n"
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t900\t0.8\n")
+
+    [scored] = read_lens_report(
+        source,
+        epitope_config=EpitopeConfig(
+            allele_free_evidence=policy_text)).epitopes
+    assert scored.allele_attributions  # the test would pass vacuously otherwise
+
+    path = tmp_path / "native.csv"
+    save_predictions([scored], str(path))
+    [reloaded] = load_predictions(str(path))
+
+    assert reloaded.allele_attributions == scored.allele_attributions
+
+
+def test_a_reload_does_not_re_derive_under_the_default_policy(tmp_path):
+    """The recorded answer wins over what the loader would compute.
+
+    A run scored under 'selected' credits one allele. Reloading it must not
+    quietly produce the two-allele answer the default policy would give,
+    which is what recomputation on load would do.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import (
+        load_predictions, read_lens_report, save_predictions)
+
+    source = tmp_path / "processing.tsv"
+    source.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\n"
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t900\t0.8\n")
+
+    [scored] = read_lens_report(
+        source,
+        epitope_config=EpitopeConfig(allele_free_evidence="selected")).epitopes
+    path = tmp_path / "native.csv"
+    save_predictions([scored], str(path))
+
+    [reloaded] = load_predictions(str(path))
+
+    assert [a.allele for a in reloaded.allele_attributions] == [A]
+    assert reloaded.allele_attributions[0].source == ALLELE_SOURCE_SELECTED
+    # And the ranking provenance is intact, not just the allele name.
+    assert reloaded.allele_attributions[0].rank_predictor == "mhcflurry"
+    assert reloaded.allele_attributions[0].rank_value == 50.0

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -96,6 +96,12 @@ VAXRANK_COLUMNS = [
     # Explicit input-allele membership is necessary for canonical
     # allele-independent processing predictions.
     "patient_alleles",
+    # Why each allele was credited with this candidate's allele-free
+    # evidence. Recorded rather than recomputed: the attribution depends on
+    # the policy in force when the candidate was scored, so a reload under a
+    # different config would otherwise silently re-derive a different answer
+    # and present it as what the run produced.
+    "allele_attributions",
     # Preserve the exact configured DSL result so a native reload does not
     # silently revert to an unrelated default scoring formula.
     "per_allele_scores",
@@ -175,6 +181,9 @@ def epitope_prediction_rows(epitope):
             "prediction_offset": p.offset,
             "patient_alleles": json.dumps(
                 list(epitope.patient_alleles), separators=(",", ":")),
+            "allele_attributions": json.dumps(
+                [a.to_dict() for a in epitope.allele_attributions],
+                sort_keys=True, separators=(",", ":")),
             "per_allele_scores": json.dumps(
                 epitope.per_allele_scores,
                 sort_keys=True,
@@ -344,6 +353,15 @@ def load_predictions(path):
                 peptide=wt_peptide, value=wt_ic50, score=0.0,
                 percentile_rank=None,
             )
+        attributions_raw = string_or_empty(
+            row.get("allele_attributions", ""))
+        allele_attributions = ()
+        if attributions_raw:
+            from .allele_evidence import AlleleAttribution
+
+            allele_attributions = tuple(
+                AlleleAttribution.from_dict(entry)
+                for entry in json.loads(attributions_raw))
         patient_alleles_raw = string_or_empty(row.get("patient_alleles", ""))
         patient_alleles = (
             tuple(json.loads(patient_alleles_raw))
@@ -389,6 +407,7 @@ def load_predictions(path):
                 row.get("occurs_in_non_CTA_reference", occurs_in_ref)),
             'patient_alleles': patient_alleles,
             'per_allele_scores': per_allele_scores,
+            'allele_attributions': allele_attributions,
         })
     return candidate_epitopes_from_rows(rows)
 

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -70,6 +70,10 @@ def epitope_report_row_inputs(epitope):
             if prediction.kind != kind:
                 continue
             if not prediction.allele:
+                # An allele-scoped kind that arrived blank is malformed —
+                # see vaxrank.allele_evidence for the one definition of
+                # which kinds carry an allele, and epitope.allele_attributions
+                # for which alleles the allele-free kinds were credited to.
                 raise ValueError(
                     f"{kind} report evidence requires a patient allele")
             key = (


### PR DESCRIPTION
#371 records which alleles were credited with a candidate's allele-free evidence, and why. The native format dropped it, so a saved run reloaded without the answer it had made.

### Why it is stored rather than recomputed

The attribution depends on the policy in force when the candidate was **scored**, and `load_predictions` takes no config. A run scored under `selected` credits one allele; reloading it would quietly produce the two-allele answer the default gives — and present that as what the run produced.

The whole value of the record is explaining a finished ranking later, which needs the run's own answer, not a fresh derivation of a different question. Same property, and same reason, as `patient_alleles` and `per_allele_scores`, which it is serialized alongside.

### Verification

```
selected  round-trips=True  ['HLA-A*02:01 (selected: ranked #1 on pMHC_affinity [mhcflurry] = 50.0)']
top:2     round-trips=True  ['HLA-A*02:01 (#1 ... = 50.0)', 'HLA-B*07:02 (#2 ... = 900.0)']
all       round-trips=True  ['HLA-A*02:01 (from the input file)', 'HLA-B*07:02 (from the input file)']
```

Tests cover every policy and assert the **ranking provenance** survives, not just the allele name — an attribution without the axis, predictor and value that produced it is an assertion the reader cannot check.

- All eight LENS fixtures byte-identical.
- 1145 tests pass.