### PR TITLE
Say in the report which allele the processing score counts for

### DIFF
--- a/tests/test_allele_evidence.py
+++ b/tests/test_allele_evidence.py
@@ -329,3 +329,97 @@ def test_a_reload_does_not_re_derive_under_the_default_policy(tmp_path):
     # And the ranking provenance is intact, not just the allele name.
     assert reloaded.allele_attributions[0].rank_predictor == "mhcflurry"
     assert reloaded.allele_attributions[0].rank_value == 50.0
+
+
+def _processing_report(tmp_path, policy_text):
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import read_lens_report
+
+    source = tmp_path / "processing.tsv"
+    source.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\n"
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t900\t0.8\n")
+    return read_lens_report(
+        source,
+        epitope_config=EpitopeConfig(allele_free_evidence=policy_text))
+
+
+def test_the_report_says_which_allele_the_processing_score_counts_for(tmp_path):
+    """The number alone cannot tell a credited allele from a shown one.
+
+    A peptide's processing score is printed on every allele row, because
+    that is what an allele-free value is. Under a narrowing policy only one
+    of those alleles is credited with it, and without a column saying so the
+    two rows look identical.
+    """
+    from vaxrank.epitope_io import ALLELE_CREDIT_COLUMN
+
+    report = _processing_report(tmp_path, "selected").report_df
+    by_allele = {
+        row["Allele"]: row[ALLELE_CREDIT_COLUMN]
+        for _, row in report.iterrows()}
+
+    # Both rows still print the same processing score ...
+    assert list(report["mhcflurry processing score"]) == [
+        pytest.approx(0.8), pytest.approx(0.8)]
+    # ... and the report now distinguishes them.
+    assert by_allele[A].startswith("selected: ranked #1 on pMHC_affinity")
+    assert by_allele[B] == "no"
+
+
+def test_the_credit_column_reports_the_reason_not_just_the_verdict(tmp_path):
+    """An attribution the reader cannot check is an assertion.
+
+    The axis, predictor and value that produced the selection travel into
+    the report, so a ranking can be argued with rather than trusted.
+    """
+    from vaxrank.epitope_io import ALLELE_CREDIT_COLUMN
+
+    report = _processing_report(tmp_path, "selected").report_df
+    credited = next(
+        row[ALLELE_CREDIT_COLUMN] for _, row in report.iterrows()
+        if row["Allele"] == A)
+
+    assert "pMHC_affinity" in credited
+    assert "mhcflurry" in credited
+    assert "50.0" in credited
+
+
+def test_no_credit_column_when_there_is_nothing_to_attribute(tmp_path):
+    """Do not add a column of "n/a" to every report that has no such evidence.
+
+    Matches how the per-predictor value columns already behave: present when
+    the input carries that signal, absent otherwise.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import ALLELE_CREDIT_COLUMN, read_lens_report
+
+    source = tmp_path / "affinity-only.tsv"
+    source.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\n")
+
+    report = read_lens_report(
+        source, epitope_config=EpitopeConfig()).report_df
+
+    assert ALLELE_CREDIT_COLUMN not in report.columns
+
+
+def test_annotating_the_report_keeps_the_frame_stored_on_it(tmp_path):
+    """``report_df.attrs['topiary_df']`` must survive the annotation.
+
+    pVACseq stores its own topiary frame there, and the scorer reads it
+    back; losing it would silently rebuild from CandidateEpitopes and drop
+    the passthrough annotation columns that only exist on the stored frame.
+    """
+    from vaxrank.epitope_io import annotate_credited_alleles
+
+    loaded = _processing_report(tmp_path, "selected")
+    report = loaded.report_df
+    report.attrs["topiary_df"] = "sentinel"
+
+    annotated = annotate_credited_alleles(report, list(loaded.epitopes))
+
+    assert annotated.attrs.get("topiary_df") == "sentinel"

--- a/vaxrank/allele_evidence.py
+++ b/vaxrank/allele_evidence.py
@@ -199,19 +199,28 @@ class AlleleAttribution(DataclassSerializable):
             raise ValueError(
                 "Only a selected allele carries ranking provenance")
 
-    def describe(self) -> str:
-        """One human-readable line, for reports and logs."""
+    def reason(self) -> str:
+        """Why this allele was credited, without naming it.
+
+        Separate from :meth:`describe` because the report already has an
+        Allele column, and the alternative was slicing the allele back off
+        the front of ``describe()`` — string surgery that would break
+        silently the first time the sentence changed.
+        """
         if self.source == ALLELE_SOURCE_FROM_INPUT:
-            return "%s (from the input file)" % self.allele
+            return "from the input file"
         if self.source == ALLELE_SOURCE_BROADCAST:
-            return "%s (broadcast: no allele-specific evidence)" % self.allele
-        return "%s (selected: ranked #%s on %s%s = %s)" % (
-            self.allele,
+            return "broadcast: no allele-specific evidence"
+        return "selected: ranked #%s on %s%s = %s" % (
             self.rank_position if self.rank_position is not None else "?",
             self.rank_kind,
             " [%s]" % self.rank_predictor if self.rank_predictor else "",
             self.rank_value,
         )
+
+    def describe(self) -> str:
+        """One human-readable line, for reports and logs."""
+        return "%s (%s)" % (self.allele, self.reason())
 
 
 @dataclass(frozen=True)

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -1264,9 +1264,7 @@ def annotate_credited_alleles(report_df, epitopes):
             # Attributed, but not to this allele. Saying so is the point:
             # the processing score printed on this row is not credited here.
             return "no"
-        # describe() leads with the allele, which is already this row's
-        # Allele column.
-        return entry.describe().split(" ", 1)[1].strip("()")
+        return entry.reason()
 
     report_df = report_df.copy()
     report_df[ALLELE_CREDIT_COLUMN] = [

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -682,6 +682,7 @@ def read_pvacseq_report(path, epitope_config=None):
     from .epitope_dsl import attach_per_allele_scores
     epitopes = attach_per_allele_scores(
         epitopes, epitope_config, topiary_df=topiary_df)
+    report_df = annotate_credited_alleles(report_df, epitopes)
     logger.info(
         "Loaded %d epitope(s) (%d row(s), %s flavor) from pVACseq file %s",
         len(epitopes), n_rows, result.extra.get("pvacseq_format"), path)
@@ -1141,6 +1142,7 @@ def read_lens_report(path, epitope_config=None):
     # downstream ranking sees zero-scored epitopes and drops everything.
     from .epitope_dsl import attach_per_allele_scores
     epitopes = attach_per_allele_scores(epitopes, epitope_config)
+    report_df = annotate_credited_alleles(report_df, epitopes)
     logger.info(
         "Loaded %d epitope(s) (%d row(s) × %d predictor(s)) from %s",
         len(epitopes), len(report_df), len(chosen), path)
@@ -1223,6 +1225,54 @@ def _build_lens_report_row(row, allele, peptide, prediction_id,
 
 
 # ── Shared report writer ─────────────────────────────────────────────────────
+
+ALLELE_CREDIT_COLUMN = "Peptide-level evidence credited"
+
+
+def annotate_credited_alleles(report_df, epitopes):
+    """Add a column saying whether this row's allele was credited, and why.
+
+    The report already prints a peptide's allele-free evidence — the
+    processing score — on *every* allele row, because that is what an
+    allele-free value is. Which of those alleles vaxrank actually credits is
+    a decision (``allele_free_evidence``), and until it appears next to the
+    number the reader cannot tell a credited allele from one that is merely
+    being shown the same value.
+
+    Blank where there is no allele-free evidence to attribute, which is the
+    common case and not worth a column of "n/a".
+    """
+    if report_df is None or len(report_df) == 0:
+        return report_df
+    by_position = {
+        e.prediction_group_key: {a.allele: a for a in e.allele_attributions}
+        for e in epitopes or ()
+        if e.allele_attributions}
+    if not by_position:
+        return report_df
+
+    def describe(row):
+        attributed = by_position.get((
+            cells.text(row.get("Prediction identity")),
+            cells.text(row.get("Mutant peptide sequence")),
+            int(cells.number(row.get("Peptide offset")) or 0)))
+        if not attributed:
+            return ""
+        allele = cells.text(row.get("Allele"))
+        entry = attributed.get(allele)
+        if entry is None:
+            # Attributed, but not to this allele. Saying so is the point:
+            # the processing score printed on this row is not credited here.
+            return "no"
+        # describe() leads with the allele, which is already this row's
+        # Allele column.
+        return entry.describe().split(" ", 1)[1].strip("()")
+
+    report_df = report_df.copy()
+    report_df[ALLELE_CREDIT_COLUMN] = [
+        describe(row) for _, row in report_df.iterrows()]
+    return report_df
+
 
 def _ensure_parent_dir(path):
     """Create the parent directory of an output file if it's missing.


### PR DESCRIPTION
The neoepitope report prints a peptide's allele-free evidence — the processing score — on **every** allele row, because that is what an allele-free value is. Under a narrowing policy only one of those alleles is credited with it, and the two rows looked identical.

```
before                        after (allele_free_evidence=selected)
HLA-A*02:01  processing 0.8   HLA-A*02:01  0.8  selected: ranked #1 on
                                                pMHC_affinity [mhcflurry] = 50.0
HLA-B*07:02  processing 0.8   HLA-B*07:02  0.8  no
```

So the attribution recorded in #371 and round-tripped in #372 is now visible to the person reading the output, not just to a programmatic consumer. The **reason** travels with it — axis, predictor, value — because an attribution the reader cannot check is an assertion.

### Notes

- Added *after* attribution rather than in the row builder: report rows are assembled while the file is being read, before any scoring or attribution has happened, so the builder cannot know the answer.
- The column is **absent** when a file carries no allele-free evidence — matching how the per-predictor value columns already behave (present when the input has that signal), rather than adding a column of "n/a" to every report.
- `report_df.attrs` survives the annotation, with a test. pVACseq stores its own topiary frame there and the scorer reads it back; losing it would silently rebuild from CandidateEpitopes and drop the passthrough annotation columns that only exist on the stored frame.

### Verification

Measured across all eight LENS fixtures: **exactly one column added** on the four that carry processing evidence, nothing removed, and no other recorded field differs anywhere — same epitopes, offsets, leaves, per-allele scores.

1149 tests pass.