### PR TITLE
Take LENS read counts from topiary instead of deriving them wrong

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.35.1,<6.0.0
+topiary>=5.37.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -1805,6 +1805,10 @@ def test_lens_read_counts_come_from_one_row(tmp_path):
     reported — total from a deep row, alt from a shallow one — and
     n_alt_reads feeds the combined-score DSL, so an incoherent count
     reorders the construct ranking.
+
+    The alt count is depth x VAF, which is why both rows carry a VAF. It
+    used to be the CDS-overlap column, which counts reads overlapping the
+    peptide's coding sequence rather than reads supporting the variant.
     """
     from vaxrank.epitope_config import EpitopeConfig
     from vaxrank.epitope_dsl import epitopes_for_ranking
@@ -1816,14 +1820,14 @@ def test_lens_read_counts_come_from_one_row(tmp_path):
         "peptide\tallele\tpep_context\tantigen_source\tvariant_coords\t"
         "snv_ref_allele\tsnv_alt_allele\tgene_name\t"
         "rna_reads_covering_genomic_origin\t"
-        "rna_reads_covering_genomic_origin_with_peptide_cds\t"
+        "rna_reads_covering_genomic_origin_with_peptide_cds\tvaf\t"
         "mhcflurry_2.1.1.aff\n"
-        # deep coverage, few supporting reads
+        # deep coverage, few supporting reads: 100 x 0.05 = 5 alt
         "SIINFEKL\tHLA-A02:01\tAASIINFEKLAA\tSNV\tchr1:100\tC\t[T]\tG\t"
-        "100\t5\t20\n"
-        # shallow coverage, many supporting reads
+        "100\t5\t0.05\t20\n"
+        # shallow coverage, many supporting reads: 10 x 0.9 = 9 alt
         "SIINFEKL\tHLA-B07:02\tAASIINFEKLAA\tSNV\tchr1:100\tC\t[T]\tG\t"
-        "10\t9\t25\n")
+        "10\t9\t0.9\t25\n")
 
     config = EpitopeConfig()
     report = read_lens_report(path, epitope_config=config)
@@ -1835,3 +1839,74 @@ def test_lens_read_counts_come_from_one_row(tmp_path):
     # (100, 9) that no row reported.
     assert (fragment.n_overlapping_reads, fragment.n_alt_reads) == (10, 9)
     assert fragment.n_ref_reads == 1
+
+
+def _lens_counts_file(tmp_path, name, *, depth, cds_overlap, vaf):
+    """One LENS row with the two read columns and an optional VAF."""
+    path = tmp_path / name
+    vaf_header = "\tvaf" if vaf is not None else ""
+    vaf_cell = "\t%s" % vaf if vaf is not None else ""
+    path.write_text(
+        "peptide\tallele\tpep_context\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\tsnv_alt_allele\tgene_name\t"
+        "rna_reads_covering_genomic_origin\t"
+        "rna_reads_covering_genomic_origin_with_peptide_cds"
+        + vaf_header + "\tmhcflurry_2.1.1.aff\n"
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLAA\tSNV\tchr1:100\tC\t[T]\tG\t"
+        "%s\t%s" % (depth, cds_overlap) + vaf_cell + "\t20\n")
+    return path
+
+
+def _fragment_for(path):
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import epitopes_for_ranking
+    from vaxrank.epitope_io import read_lens_report
+    from vaxrank.external_input import lens_ranking_result
+
+    config = EpitopeConfig()
+    report = read_lens_report(path, epitope_config=config)
+    result = lens_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+    return result.ranked[0][1][0].mutant_protein_fragment
+
+
+def test_alt_reads_are_depth_times_vaf_not_the_cds_overlap_count(tmp_path):
+    """The CDS-overlap column is not variant support.
+
+    ``rna_reads_covering_genomic_origin_with_peptide_cds`` counts reads
+    overlapping the peptide's coding sequence, not reads carrying the
+    variant allele. vaxrank assigned it straight to ``n_alt_reads``, which
+    feeds the combined-score DSL — ``sqrt(n_alt_reads) *
+    target_epitope_score`` is the documented canonical form.
+
+    The two disagree in both directions on real files: 2337x0.022 gives 51
+    alt reads where the CDS count says 2, and 291x0.258 gives 75 where it
+    says 166.
+    """
+    path = _lens_counts_file(
+        tmp_path, "split.tsv", depth=2337, cds_overlap=2, vaf=0.022)
+
+    fragment = _fragment_for(path)
+
+    assert fragment.n_overlapping_reads == 2337
+    assert fragment.n_alt_reads == 51        # 2337 x 0.022, not 2
+    assert fragment.n_ref_reads == 2286      # and the remainder, not 2335
+    # The CDS count is kept, under the name that describes it.
+    assert fragment.n_alt_reads_supporting_protein_sequence == 2
+
+
+def test_no_vaf_means_no_alt_estimate_rather_than_the_cds_count(tmp_path):
+    """A source that cannot answer must not be answered for.
+
+    An estimate needs both depth and VAF. Substituting the CDS-overlap
+    count because it is the only other number present is how a missing
+    value becomes a number nobody measured.
+    """
+    path = _lens_counts_file(
+        tmp_path, "no-vaf.tsv", depth=100, cds_overlap=40, vaf=None)
+
+    fragment = _fragment_for(path)
+
+    assert fragment.n_overlapping_reads == 100
+    assert fragment.n_alt_reads == 0
+    assert fragment.n_alt_reads_supporting_protein_sequence == 40

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -562,28 +562,41 @@ def peptide_offsets_in_context(peptide, peptide_context):
 
 
 def _read_counts_from_lens_row(row):
-    """Extract real RNA-read counts from a LENS row.
-
-    LENS columns:
-      - ``rna_reads_covering_genomic_origin``           → total reads at locus
-      - ``rna_reads_covering_genomic_origin_with_peptide_cds`` → reads
-        whose CDS produces this neoepitope (the alt-supporting count)
-      - ``vaf``                                          → variant allele
-        frequency (used only as a sanity check, not as a stand-in)
+    """Read the counts topiary derived from a LENS row.
 
     Returns ``(n_overlapping_reads, n_alt_reads, n_ref_reads,
-    n_alt_reads_supporting_protein_sequence)``. Missing columns yield
-    0 — honest "no read signal" rather than a fabricated 1.
+    n_alt_reads_supporting_protein_sequence)``.
+
+    vaxrank used to derive these itself, and got the central one wrong.
+    ``rna_reads_covering_genomic_origin_with_peptide_cds`` is a genuine
+    count, but of reads overlapping the peptide's coding sequence — not of
+    reads supporting the variant allele — and it was assigned straight to
+    ``n_alt_reads``, with ``n_ref_reads`` derived from that. The two are
+    different quantities and disagree in both directions:
+
+      depth   cds_overlap   vaf      was n_alt   depth x vaf
+       2337             2   0.022           2            51
+        765            12   0.008          12             6
+        291           166   0.258         166            75
+
+    ``n_alt_reads`` feeds the combined-score DSL — ``sqrt(n_alt_reads) *
+    target_epitope_score`` is the documented canonical form — so this
+    reordered vaccine peptides.
+
+    topiary populates the fields with the derivation named per field
+    (``read_count_method``): depth x VAF for the alt/ref split, and the
+    CDS-overlap count kept where it belongs, in
+    ``n_alt_reads_supporting_protein_sequence``. A row whose source could
+    not answer carries no estimate rather than a zero standing in for one;
+    the zero appears here only because the fragment field is not nullable.
     """
-    n_total = cells.integer(
-        row.get('rna_reads_covering_genomic_origin'), default=0)
-    n_alt_cds = cells.integer(
-        row.get('rna_reads_covering_genomic_origin_with_peptide_cds'),
-        default=0)
-    n_alt_reads = n_alt_cds
-    n_ref_reads = max(0, n_total - n_alt_reads)
-    n_alt_supporting_protein = n_alt_cds
-    return n_total, n_alt_reads, n_ref_reads, n_alt_supporting_protein
+    return (
+        cells.integer(row.get('n_overlapping_reads'), default=0),
+        cells.integer(row.get('n_alt_reads'), default=0),
+        cells.integer(row.get('n_ref_reads'), default=0),
+        cells.integer(
+            row.get('n_alt_reads_supporting_protein_sequence'), default=0),
+    )
 
 
 @dataclasses.dataclass
@@ -866,7 +879,7 @@ def lens_vaccine_entry(metadata, selection, genome=None, options=None):
     # Best-supported row wins: most alt reads, then most coverage.
     counts = [_read_counts_from_lens_row(record.row)
               for record in selection.records]
-    n_total, n_alt_reads, _, n_alt_protein = max(
+    n_total, n_alt_reads, n_ref_reads, n_alt_protein = max(
         counts, key=lambda c: (c[1], c[0]), default=(0, 0, 0, 0))
     metadata.vaccine_peptide = external_vaccine_peptide(
         variant=metadata.variant,
@@ -877,9 +890,10 @@ def lens_vaccine_entry(metadata, selection, genome=None, options=None):
         gene_name=key.primary_gene_name,
         transcripts=resolve_external_transcripts(
             key.ordered_transcript_ids, genome),
-        counts=(
-            n_total, n_alt_reads, max(0, n_total - n_alt_reads),
-            n_alt_protein),
+        # Use the reference count topiary derived rather than recomputing
+        # it as depth minus alt: that subtraction was only ever correct if
+        # the alt count was variant support, which is exactly what was wrong.
+        counts=(n_total, n_alt_reads, n_ref_reads, n_alt_protein),
         options=options,
     )
     return metadata


### PR DESCRIPTION
`rna_reads_covering_genomic_origin_with_peptide_cds` is a genuine count, but of reads overlapping the peptide's **coding sequence** — not of reads supporting the **variant allele**. vaxrank assigned it straight to `n_alt_reads` and derived `n_ref_reads` as depth minus that.

Its own docstring called the column "the alt-supporting count", and said `vaf` was "used only as a sanity check, not as a stand-in". `vaf` is the other half of the estimate, not a check on it.

### The two are different quantities, in both directions

| depth | cds_overlap | vaf | was `n_alt` | depth × vaf |
|---|---|---|---|---|
| 2337 | 2 | 0.022 | **2** | 51 |
| 765 | 12 | 0.008 | **12** | 6 |
| 291 | 166 | 0.258 | **166** | 75 |

Every row of every real LENS fixture carrying both changes: **9/9, 12/12, 10/10, 45/45**.

### It reaches the ranking

`n_alt_reads` feeds the combined-score DSL, where `sqrt(n_alt_reads) * target_epitope_score` is the documented canonical form. Under that expression the construct ranking changes on **three of the four** real fixtures, including the top pick on two:

```
lens_v1.5   old top: QGTCEYLLSAPC   new top: LDVDNRFLTLMG
lens_v1.9…  old top: LAITSCWCWRNK   new top: KYWHIILGGGRV
```

The *default* expression does not read the counts, so default runs keep their order — but the counts they report were wrong either way.

### Fix

topiary 5.37.0 populates these with the derivation named per field: depth × VAF for the alt/ref split (`rna_depth_x_vaf`), and the CDS-overlap count kept under `n_alt_reads_supporting_protein_sequence` (`cds_overlap_reads`). A row with no VAF now carries **no alt estimate** rather than the CDS count standing in for one.

Floor moves to `topiary>=5.37.0`.

### On verification

The epitope-level fixture snapshot is **identical** through this change, and is the wrong instrument: it records peptides, offsets, leaves and per-allele scores, none of which read counts touch. The measurement that mattered was ranking constructs under a reads-weighted score, old against new.

The existing one-row-per-observation test still holds and still matters; its fixture needed a VAF so its alt counts are real rather than borrowed from the CDS column.

Found because the topiary session flagged what that column actually counts.