### PR TITLE
Carry how the read counts were obtained, not just the counts

### DIFF
--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -1975,3 +1975,42 @@ def test_the_method_describes_the_row_whose_counts_were_used(tmp_path):
     # The winning row is the shallow one, so its depth and its label.
     assert (fragment.n_overlapping_reads, fragment.n_alt_reads) == (10, 9)
     assert fragment.read_count_method == "rna_depth_x_vaf"
+
+
+def test_pvacseq_estimates_are_labelled_too(tmp_path):
+    """pVACseq reports a depth and a fraction, never an alt-read count.
+
+    vaxrank multiplies them, which is the same estimate the LENS path
+    makes — so it carries the same label. It was computing it inline and
+    unlabelled, which is the bug #375 describes, one path over.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_dsl import epitopes_for_ranking
+    from vaxrank.epitope_io import read_pvacseq_report
+    from vaxrank.external_input import pvacseq_ranking_result
+
+    config = EpitopeConfig()
+    report = read_pvacseq_report(
+        os.path.join(DATA_DIR, "pvacseq_example.tsv"), epitope_config=config)
+    result = pvacseq_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+
+    fragment = result.ranked[0][1][0].mutant_protein_fragment
+
+    assert fragment.n_alt_reads > 0
+    assert fragment.read_count_method == "rna_depth_x_vaf"
+
+
+def test_a_pvacseq_row_with_no_rna_vaf_claims_no_derivation():
+    """Absent is not zero.
+
+    ``pvacseq_rna_vaf`` used to default to 0.0, which made "the variant was
+    looked for and not seen" indistinguishable from "no RNA data" — and
+    would have labelled the second one ``rna_depth_x_vaf``, asserting an
+    estimate that was never made.
+    """
+    from vaxrank.external_input import pvacseq_rna_vaf
+
+    assert pvacseq_rna_vaf({"rna_vaf": 0.0}) == 0.0
+    assert pvacseq_rna_vaf({}) is None
+    assert pvacseq_rna_vaf({"rna_vaf": ""}) is None

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -1910,3 +1910,68 @@ def test_no_vaf_means_no_alt_estimate_rather_than_the_cds_count(tmp_path):
     assert fragment.n_overlapping_reads == 100
     assert fragment.n_alt_reads == 0
     assert fragment.n_alt_reads_supporting_protein_sequence == 40
+
+
+def test_read_counts_arrive_with_the_derivation_that_produced_them(tmp_path):
+    """An estimate and a measurement are the same integer, not the same claim.
+
+    After #374 a LENS ``n_alt_reads`` is depth x VAF, rounded. On another
+    source the same field may be counted from an alignment. The report
+    prints the same number either way and ``sqrt(n_alt_reads)`` weights
+    them identically, so the label is what lets a reader tell them apart.
+    """
+    path = _lens_counts_file(
+        tmp_path, "labelled.tsv", depth=2337, cds_overlap=2, vaf=0.022)
+
+    fragment = _fragment_for(path)
+
+    assert fragment.n_alt_reads == 51
+    assert fragment.read_count_method == "rna_depth_x_vaf"
+    assert fragment.sequence_source == "lens_pep_context"
+
+
+def test_no_estimate_means_no_method_rather_than_a_confident_zero(tmp_path):
+    """A row that could not be split must not claim a derivation.
+
+    Labelling a zero ``rna_depth_x_vaf`` would assert that the estimate was
+    made and came out zero, which is a different statement from "the source
+    did not carry a VAF".
+    """
+    path = _lens_counts_file(
+        tmp_path, "unlabelled.tsv", depth=100, cds_overlap=40, vaf=None)
+
+    fragment = _fragment_for(path)
+
+    assert fragment.n_alt_reads == 0
+    assert fragment.read_count_method == ""
+    # The sequence still has a known source; only the split is missing.
+    assert fragment.sequence_source == "lens_pep_context"
+
+
+def test_the_method_describes_the_row_whose_counts_were_used(tmp_path):
+    """Provenance travels with the counts, from one observation.
+
+    The counts already come from a single best-supported row rather than
+    per-field maxima. Reading the label separately would reintroduce that
+    problem one field over: a method describing a row whose numbers were
+    not the ones used.
+    """
+    path = tmp_path / "two-rows.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\tsnv_alt_allele\tgene_name\t"
+        "rna_reads_covering_genomic_origin\t"
+        "rna_reads_covering_genomic_origin_with_peptide_cds\tvaf\t"
+        "mhcflurry_2.1.1.aff\n"
+        # deep row, no VAF: no estimate, so no method
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLAA\tSNV\tchr1:100\tC\t[T]\tG\t"
+        "1000\t5\t\t20\n"
+        # shallow row with a VAF: 10 x 0.9 = 9 alt, and it wins
+        "SIINFEKL\tHLA-B07:02\tAASIINFEKLAA\tSNV\tchr1:100\tC\t[T]\tG\t"
+        "10\t9\t0.9\t25\n")
+
+    fragment = _fragment_for(path)
+
+    # The winning row is the shallow one, so its depth and its label.
+    assert (fragment.n_overlapping_reads, fragment.n_alt_reads) == (10, 9)
+    assert fragment.read_count_method == "rna_depth_x_vaf"

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -1204,8 +1204,14 @@ def pvacseq_rna_depth(row):
 
 
 def pvacseq_rna_vaf(row):
-    """RNA variant allele fraction reported by either pVACseq flavor."""
-    return cells.first_number(row, *_PVACSEQ_RNA_VAF_COLUMNS, default=0.0)
+    """RNA variant allele fraction reported by either pVACseq flavor.
+
+    ``None`` when neither flavor's column carries one. Not 0.0: a fraction
+    of zero says the variant was looked for and not seen, and an absent
+    fraction says it was not looked for, and the two produce different
+    read-count provenance.
+    """
+    return cells.first_number(row, *_PVACSEQ_RNA_VAF_COLUMNS)
 
 
 def pvacseq_dna_vaf(row):
@@ -1300,13 +1306,21 @@ def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None):
             "is empty or contains non-standard residues.",
             key.variant_id, key.source_sequence)
         return metadata
-    # Same rule as the LENS path: both counts come from one row.
-    counts = []
+    # Same rule as the LENS path: the counts and the label describing them
+    # come from one row.
+    observations = []
     for record in selection.records:
         depth = pvacseq_rna_depth(record.row)
-        counts.append((depth, int(round(depth * pvacseq_rna_vaf(record.row)))))
-    n_total, n_alt_reads = max(
-        counts, key=lambda c: (c[1], c[0]), default=(0, 0))
+        vaf = pvacseq_rna_vaf(record.row)
+        # depth x VAF is an estimate, not a count, and says so. pVACseq
+        # reports a depth and a fraction; it does not report alt reads.
+        alt = int(round(depth * vaf)) if vaf is not None else 0
+        method = "rna_depth_x_vaf" if vaf is not None else ""
+        source = cells.text(record.row.get("sequence_source"))
+        observations.append(((depth, alt), (method, source)))
+    (n_total, n_alt_reads), provenance = max(
+        observations, key=lambda o: (o[0][1], o[0][0]),
+        default=((0, 0), ("", "")))
     metadata.vaccine_peptide = external_vaccine_peptide(
         variant=metadata.variant,
         selection=selection,
@@ -1320,6 +1334,7 @@ def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None):
             key.ordered_transcript_ids, genome),
         counts=(
             n_total, n_alt_reads, max(0, n_total - n_alt_reads), n_alt_reads),
+        provenance=provenance,
         options=options,
     )
     return metadata

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -599,6 +599,19 @@ def _read_counts_from_lens_row(row):
     )
 
 
+def _read_provenance_from_lens_row(row):
+    """``(read_count_method, sequence_source)`` for a LENS row.
+
+    Read alongside the counts rather than derived: topiary labels each
+    field with how it was obtained, and dropping the label leaves an
+    estimate indistinguishable from a measurement (#375).
+    """
+    return (
+        cells.text(row.get('read_count_method')),
+        cells.text(row.get('sequence_source')),
+    )
+
+
 @dataclasses.dataclass
 class ExternalRankingAccumulator:
     """Fold per-variant entries into a ranking result.
@@ -778,7 +791,7 @@ class ExternalConstructOptions:
 
 def external_vaccine_peptide(variant, selection, context, mutant_start,
                              mutant_end, gene_name, transcripts, counts,
-                             options):
+                             options, provenance=("", "")):
     """Assemble one ``VaccinePeptide`` from an external construct window.
 
     Shared by every external format so a construct built from a LENS
@@ -822,6 +835,7 @@ def external_vaccine_peptide(variant, selection, context, mutant_start,
         for epitope in epitopes
     ]
     n_total, n_alt, n_ref, n_alt_protein = counts
+    read_count_method, sequence_source = provenance
     fragment = MutantProteinFragment(
         variant=variant,
         gene_name=gene_name,
@@ -834,6 +848,8 @@ def external_vaccine_peptide(variant, selection, context, mutant_start,
         n_ref_reads=n_ref,
         n_alt_reads_supporting_protein_sequence=n_alt_protein,
         placeholder_alleles=False,
+        read_count_method=read_count_method,
+        sequence_source=sequence_source,
     )
     return VaccinePeptide(
         mutant_protein_fragment=fragment,
@@ -877,10 +893,16 @@ def lens_vaccine_entry(metadata, selection, genome=None, options=None):
     # deep row, alt from a shallow one — and n_alt_reads feeds the
     # combined-score DSL, so an incoherent count reorders the ranking.
     # Best-supported row wins: most alt reads, then most coverage.
-    counts = [_read_counts_from_lens_row(record.row)
-              for record in selection.records]
-    n_total, n_alt_reads, n_ref_reads, n_alt_protein = max(
-        counts, key=lambda c: (c[1], c[0]), default=(0, 0, 0, 0))
+    # The provenance travels with the counts, from the same row. Reading
+    # it separately would be the per-field maximum problem again, one field
+    # over: a method label describing a row whose numbers were not used.
+    observations = [
+        (_read_counts_from_lens_row(record.row),
+         _read_provenance_from_lens_row(record.row))
+        for record in selection.records]
+    (n_total, n_alt_reads, n_ref_reads, n_alt_protein), provenance = max(
+        observations, key=lambda o: (o[0][1], o[0][0]),
+        default=((0, 0, 0, 0), ("", "")))
     metadata.vaccine_peptide = external_vaccine_peptide(
         variant=metadata.variant,
         selection=selection,
@@ -894,6 +916,7 @@ def lens_vaccine_entry(metadata, selection, genome=None, options=None):
         # it as depth minus alt: that subtraction was only ever correct if
         # the alt count was variant support, which is exactly what was wrong.
         counts=(n_total, n_alt_reads, n_ref_reads, n_alt_protein),
+        provenance=provenance,
         options=options,
     )
     return metadata

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -124,6 +124,26 @@ class MutantProteinFragment(DataclassSerializable):
     # supplies real alleles.
     placeholder_alleles: bool = False
 
+    # How the read counts above were obtained, in topiary's vocabulary:
+    # "rna_reads" (counted from an alignment), "rna_depth_x_vaf" (depth
+    # times VAF, rounded — an estimate), "cds_overlap_reads" (counted, but
+    # of CDS overlap rather than variant support), "tpm_x_dna_vaf" (an
+    # expression proxy). Blank when the source did not say.
+    #
+    # The number alone cannot distinguish a measurement from an estimate,
+    # and the combined-score DSL weights them identically —
+    # sqrt(n_alt_reads) does not know that 51 was arithmetic rather than
+    # observation. Carrying the label is what lets a reader tell.
+    read_count_method: str = ""
+
+    # How the protein sequence was obtained: "lens_pep_context",
+    # "pvacseq_epitope", "varcode_translation", "isovar_assembly",
+    # "caller_supplied". Distinct from the antigen's biological kind —
+    # this is method, not biology. "Assembled from RNA" versus "translated
+    # from reference" is the first question when auditing a ranking, and
+    # was previously answerable only for a whole file.
+    sequence_source: str = ""
+
     @staticmethod
     def slp_window_around_mutation(
             protein_aa, mut_start, mut_end, target_length):

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -279,6 +279,15 @@ class TemplateDataCreator(object):
             ('RNA reads supporting reference allele', mutant_protein_fragment.n_ref_reads),
             ('RNA reads supporting other alleles', mutant_protein_fragment.n_other_reads),
         ])
+        # Say how those counts were obtained. "51 reads" from an alignment
+        # and "51" from depth x VAF are the same integer and not the same
+        # claim, and the combined-score DSL weights them identically.
+        if mutant_protein_fragment.read_count_method:
+            variant_data['RNA read count method'] = (
+                mutant_protein_fragment.read_count_method)
+        if mutant_protein_fragment.sequence_source:
+            variant_data['Protein sequence source'] = (
+                mutant_protein_fragment.sequence_source)
         return variant_data
 
     def effect_data(self, predicted_effect, selected_effect=None):


### PR DESCRIPTION
Closes #375.

#374 fixed *which* number `n_alt_reads` is. It did not carry across *how that number was obtained*, and topiary labels it per field.

After #374 a LENS `n_alt_reads` of 51 means **depth × VAF, rounded** — an estimate. On another source the same field is counted from an alignment. The report prints the same integer either way, and the combined-score DSL weights them identically: `sqrt(n_alt_reads)` does not know that 51 was arithmetic rather than observation.

### What changes

`read_count_method` and `sequence_source` are now fields on `MutantProteinFragment`, populated from the LENS row and shown in the report:

```
n_alt=51  method='rna_depth_x_vaf'  source='lens_pep_context'
n_alt=0   method=''                 source='lens_pep_context'
```

The second line is the distinction worth having. A row with no VAF gets **no estimate and no method**, rather than a zero labelled `rna_depth_x_vaf` — which would assert that the estimate was made and came out zero.

### The label travels with the counts

From the same row. The counts already come from one best-supported observation rather than per-field maxima; reading the label separately would reintroduce that problem one field over — a method describing a row whose numbers were not the ones used. A test pins it with a deep unlabelled row and a shallow labelled one.

### Scope

Both fields default to `""` so nothing existing changes shape, and the report omits the rows when a source did not say.

**Not covered:** the native VCF/BAM pipeline builds fragments from varcode and isovar rather than from a frame, so its fragments carry no label yet. That half genuinely does wait on openvax/topiary#102 — unlike the LENS half, which I had wrongly assumed was blocked upstream when the columns were already arriving on the rows.

1154 tests pass.