### PR TITLE
Make a narrowing allele policy actually narrow the scores

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.37.0,<6.0.0
+topiary>=5.39.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_allele_evidence.py
+++ b/tests/test_allele_evidence.py
@@ -234,12 +234,12 @@ def test_attributions_are_recorded_on_the_candidate(tmp_path):
     assert selected.allele_attributions[0].source == ALLELE_SOURCE_SELECTED
     assert [a.allele for a in every.allele_attributions] == [A, B]
 
-    # Per-allele scores are deliberately unchanged between the two: topiary
-    # projects a peptide-level value across every allele group keyed on the
-    # kind (openvax/topiary#232), so a narrowing policy records the credited
-    # allele without yet narrowing the score. The warning says so; this pins
-    # that the two really do still agree, so the claim is not stale.
-    assert selected.per_allele_scores == every.per_allele_scores
+    # The default score expression reads pMHC_affinity and nothing else, so
+    # it cannot see this policy at all — both alleles keep their affinity
+    # score either way. Asserting the two agree here would pass forever
+    # while saying nothing; what the policy changes is pinned in
+    # test_a_narrowing_policy_changes_the_scores.
+    assert set(selected.per_allele_scores) == {A, B}
 
 
 def test_a_frame_with_no_allele_free_evidence_is_not_walked():
@@ -423,3 +423,45 @@ def test_annotating_the_report_keeps_the_frame_stored_on_it(tmp_path):
     annotated = annotate_credited_alleles(report, list(loaded.epitopes))
 
     assert annotated.attrs.get("topiary_df") == "sentinel"
+
+
+@pytest.mark.parametrize("policy_text,expected_b", [
+    ("all", 0.8),          # broadcast to the whole genotype
+    ("top:2", 0.8),        # both alleles ranked and credited
+    ("from_input", 0.8),   # the file paired the peptide with both
+    ("selected", 0.0),     # only the best-ranked allele is credited
+])
+def test_a_narrowing_policy_changes_the_scores(tmp_path, policy_text,
+                                               expected_b):
+    """The policy has to reach the scores, or it is a note on a result.
+
+    This shipped unable to do that: topiary projected a peptide-level value
+    across every allele group keyed on the *kind*, so writing the row onto
+    the credited allele was discarded and every policy produced identical
+    per-allele scores (openvax/topiary#232, fixed in 5.39.0).
+
+    The score expression reads only the peptide-level evidence, because
+    that is the evidence the policy governs. The default expression reads
+    pMHC_affinity alone and is unaffected by any of these settings — which
+    is why a test written against the default would pass under every policy
+    and pin nothing.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import read_lens_report
+
+    source = tmp_path / "processing.tsv"
+    source.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\t"
+        "mhcflurry_2.1.1.proc_score\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.8\n"
+        "SIINFEKL\tHLA-B07:02\tXXSIINFEKLXX\t900\t0.8\n")
+
+    [scored] = read_lens_report(
+        source,
+        epitope_config=EpitopeConfig(
+            allele_free_evidence=policy_text,
+            score_expr="processing[mhcflurry].score")).epitopes
+
+    # A*02:01 is the better binder, so it is the one 'selected' credits.
+    assert scored.per_allele_scores[A] == pytest.approx(0.8)
+    assert scored.per_allele_scores[B] == pytest.approx(expected_b)

--- a/vaxrank/allele_evidence.py
+++ b/vaxrank/allele_evidence.py
@@ -159,9 +159,10 @@ class AllelePolicy:
     def narrows(self) -> bool:
         """True when this policy can credit fewer alleles than the genotype.
 
-        ``all`` cannot, so what is recorded and what is scored agree.
-        Anything else can differ from the scores until openvax/topiary#232
-        lands, which is what :func:`warn_if_scoring_ignores_policy` says.
+        ``all`` cannot, so the frame is left alone and topiary broadcasts
+        as it already does. Anything else needs the allele-free rows
+        written onto the credited alleles, because broadcasting reaches
+        every group a peptide has and cannot be told to reach only some.
         """
         return self.name != POLICY_ALL
 
@@ -491,41 +492,44 @@ def attribute_frame(df, policy, *, genotype_for=None, default_methods=None,
     return attributions
 
 
-_WARNED_ABOUT_SCORING = set()
+def apply_attribution(df, attributions, policy, *, group_columns=None):
+    """Write allele-free rows onto the alleles they were attributed to.
 
+    Only when the policy narrows. Under ``all`` the frame is returned
+    unchanged and topiary broadcasts, which is both the historical
+    behaviour and the honest one: the frame keeps saying what was
+    predicted, and the broadcast stays data shape rather than a claim in
+    the data.
 
-def warn_if_scoring_ignores_policy(policy, attributions):
-    """Say plainly that a narrowing policy does not yet change scores.
+    A narrowing policy has to be written into the frame, because
+    broadcasting has no way to reach only some of a peptide's alleles.
+    Naming the allele on the row is how the policy says "credit this
+    evidence here"; topiary then lands it in that group and nowhere else.
 
-    Attribution records which alleles are credited with a peptide's
-    allele-free evidence. It does not currently change the per-allele
-    scores, because topiary projects a peptide-level value across every
-    allele group a peptide has, keyed on the *kind* — a row that names an
-    allele is projected onto the others anyway (openvax/topiary#232). So
-    "credit this to the best allele" is recorded and reported, and every
-    allele still receives the value when the score expression reads it.
-
-    Writing the row onto the attributed alleles was tried and does nothing:
-    the frame changes and the scores do not, which is worse than the gap
-    itself. Better to state the limitation than to ship a frame that says
-    something the evaluation discards.
-
-    The default policy is ``all``, where recorded and scored agree and
-    there is nothing to warn about.
+    This was implemented, measured as a no-op and removed once already:
+    topiary projected a peptide-level value across every allele group keyed
+    on the *kind*, so a row naming an allele was projected onto the others
+    anyway and every policy produced identical scores (openvax/topiary#232).
+    Shipping the frame rewrite then would have meant the frame stating
+    something the evaluation discarded. It is honest as of topiary 5.39.0,
+    which is why the floor moved.
     """
     if not policy.narrows or not attributions:
-        return
-    key = (policy.name, policy.limit)
-    if key in _WARNED_ABOUT_SCORING:
-        return
-    _WARNED_ABOUT_SCORING.add(key)
-    logger.warning(
-        "allele_free_evidence=%s records which allele is credited with "
-        "peptide-level evidence, and is reported per candidate, but does "
-        "not yet change per-allele scores: topiary projects a peptide-level "
-        "value across every allele group regardless of the allele on the "
-        "row (openvax/topiary#232). Per-allele scores currently match "
-        "allele_free_evidence=%s.",
-        policy.name if policy.limit is None
-        else "%s%s" % (POLICY_TOP_PREFIX, policy.limit),
-        POLICY_ALL)
+        return df
+
+    import pandas as pd
+
+    group_columns = list(group_columns or ())
+    identity = _identity_columns(group_columns)
+    out = []
+    for row in df.to_dict("records"):
+        key = tuple(row.get(column) for column in identity)
+        attributed = attributions.get(key)
+        if (attributed is None
+                or not is_peptide_level_kind(row.get("kind"))
+                or (row.get("allele") or "")):
+            out.append(row)
+            continue
+        for attribution in attributed:
+            out.append({**row, "allele": attribution.allele})
+    return pd.DataFrame(out, columns=df.columns)

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -458,8 +458,7 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
     from .candidate_epitope import stated_or_blank
     from .epitope_config import EpitopeConfig
 
-    from .allele_evidence import (
-        attribute_frame, warn_if_scoring_ignores_policy)
+    from .allele_evidence import apply_attribution, attribute_frame
 
     if not epitopes:
         return epitopes
@@ -469,21 +468,28 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
     # the same rows, and rebuilding is not free.
     if topiary_df is None:
         topiary_df = epitopes_to_topiary_df(epitopes)
-    score_series = score_predictions(
-        epitopes, cfg, topiary_df=topiary_df, kind_support=kind_support)
 
     # Attribution runs on the unfiltered frame, so the policy ranks on the
     # evidence the input carried rather than on whatever survived a cutoff:
     # a filter on affinity would otherwise change which allele is credited
     # with a peptide's processing score.
+    #
+    # And it runs before scoring, because a narrowing policy rewrites the
+    # frame the scores are computed from — that is what makes it a policy
+    # about scoring rather than a note attached to the result.
     policy = cfg.allele_policy
     genotypes = genotype_map(epitopes)
+    group_columns = prediction_group_columns(topiary_df)
     attributions = attribute_frame(
         topiary_df, policy,
         genotype_for=lambda key: genotypes.get(key, ()),
         default_methods=resolve_default_methods(cfg, topiary_df),
-        group_columns=prediction_group_columns(topiary_df))
-    warn_if_scoring_ignores_policy(policy, attributions)
+        group_columns=group_columns)
+    scoring_df = apply_attribution(
+        topiary_df, attributions, policy, group_columns=group_columns)
+
+    score_series = score_predictions(
+        epitopes, cfg, topiary_df=scoring_df, kind_support=kind_support)
     # score_series is keyed by prediction ID, peptide, offset, and allele.
     by_position: dict[tuple, dict[str, float]] = {}
     for idx, val in score_series.items():

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -21,7 +21,7 @@ from topiary import TopiaryPredictor
 from topiary.ranking import EvalContext, apply_filter
 
 from .epitope_config import EpitopeConfig
-from .allele_evidence import attribute_frame, warn_if_scoring_ignores_policy
+from .allele_evidence import apply_attribution, attribute_frame
 from .epitope_dsl import (
     build_filter_node, build_score_node, prediction_group_columns,
 )
@@ -180,7 +180,9 @@ def predict_epitopes(
         predictions_df, policy,
         default_methods=default_methods,
         group_columns=prediction_group_columns(predictions_df))
-    warn_if_scoring_ignores_policy(policy, allele_attributions)
+    predictions_df = apply_attribution(
+        predictions_df, allele_attributions, policy,
+        group_columns=prediction_group_columns(predictions_df))
 
     filter_node = build_filter_node(epitope_config)
     if filter_node is not None:


### PR DESCRIPTION
#371 shipped `allele_free_evidence` able to **record** which allele it credited and unable to **act** on it. topiary projected a peptide-level value across every allele group keyed on the *kind*, so writing the row onto the credited allele was discarded and every policy produced identical per-allele scores. The frame rewrite was implemented, measured as a no-op, and removed rather than shipped — with a warning saying scores still matched `all`.

topiary 5.39.0 fixes that (openvax/topiary#232): a peptide-level row that names an allele lands in that group and nowhere else, while a blank one still broadcasts. So the rewrite is honest now, and it is back.

```
score_expr = processing[mhcflurry].score

all         A*02:01 0.8   B*07:02 0.8
selected    A*02:01 0.8   B*07:02 0.0
top:2       A*02:01 0.8   B*07:02 0.8
from_input  A*02:01 0.8   B*07:02 0.8
```

The warning is deleted along with the gap it described. Floor moves to `topiary>=5.39.0`.

### One test needed correcting, and it is the point

It asserted `selected` and `all` produce identical per-allele scores — written deliberately so the warning's claim would fail once it stopped being true.

**It did not fail.** It now passes for an unrelated reason: the default score expression reads `pMHC_affinity` and nothing else, so it cannot see this policy at all. A test written against the default expression passes under every policy and pins nothing.

The replacement reads the evidence the policy actually governs, parameterized over all four policies. Exactly the "passes for the wrong reason" hazard topiary flagged, found by checking rather than by the suite going red.

### Their three warnings, checked

- **Projection warning text changed** — no string matching on it anywhere; the greps hit my own prose.
- **Differently-allele'd rows triggering a blank-allele conflict** — the one conflict test here is vaxrank's own load-time collapse of a per-allele processing column, not topiary's blank-allele check. Unaffected.
- **`haplotype` exempt** — both selection axes are `single_allele`, and topiary's table has no `haplotype` entries today.

### Verification

- Fixtures byte-identical under the default policy, which is `all`.
- 1160 tests pass.