### PR TITLE
Carry a LENS file's own columns onto the DSL frame

### DIFF
--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -2537,3 +2537,81 @@ def test_only_a_named_version_makes_a_model_ambiguous(versions, ambiguous):
     if ambiguous:
         assert resolved[("pMHC_affinity", "netmhcpan")] == "4.2"
 
+
+
+def test_lens_annotations_are_addressable_in_dsl_expressions(tmp_path):
+    """A file's own columns must be nameable in an expression.
+
+    vaxrank built its evaluation frame from CandidateEpitope objects, which
+    know about predictions and nothing else — so every annotation the
+    reader had in hand was dropped before an expression could reach it, and
+    a filter on expression or VAF failed against a file that carries both.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+
+    path = tmp_path / "annotated.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\ttpm\tvaf\tmhcflurry_2.1.1.aff\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t0.4\t20\n"
+        "AAAAAAAAA\tHLA-A02:01\tXXAAAAAAAAAXX\t0.2\t0.01\t20\n")
+
+    scored = list(read_lens_report(
+        path,
+        epitope_config=EpitopeConfig(
+            score_expr=(
+                "affinity.value.logistic_normalized(350,150) * "
+                "(gene_tpm > 1)"))).epitopes)
+
+    by_peptide = {e.sequence: e for e in scored}
+    # The expressed peptide keeps its score; the one below the cutoff is
+    # zeroed by its own annotation, not by anything about its binding.
+    assert any(by_peptide["SIINFEKL"].per_allele_scores.values())
+    assert not any(by_peptide["AAAAAAAAA"].per_allele_scores.values())
+
+
+def test_the_annotation_column_is_gene_tpm_not_tpm(tmp_path):
+    """topiary renames on the way in, and the rename is load-bearing.
+
+    LENS writes fusion rows as composite strings like
+    ``ENST...:14.54-ENST...:33.84``, so ``tpm`` cannot be numeric for every
+    row. topiary coerces to ``gene_tpm`` and keeps the original text as
+    ``gene_tpm_raw``, which is why the DSL name is ``gene_tpm`` — a filter
+    written against ``tpm`` finds nothing.
+    """
+    path = tmp_path / "renamed.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\ttpm\tmhcflurry_2.1.1.aff\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t20\n")
+
+    frame = read_lens_report(path).report_df.attrs["topiary_df"]
+
+    assert "gene_tpm" in frame.columns
+    assert "tpm" not in frame.columns
+
+
+def test_an_annotation_never_overwrites_a_prediction_column(tmp_path):
+    """A source column that shares a name with a frame column must not win.
+
+    Prediction and annotation columns can collide, and letting the source
+    replace a value the DSL depends on would swap it for a lookalike —
+    openvax/topiary#217, arriving from the other side.
+    """
+    from vaxrank.epitope_dsl import epitopes_to_topiary_df
+    from vaxrank.epitope_io import attach_source_annotations
+    from vaxrank.external_report import ExternalRecord
+
+    path = tmp_path / "collide.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tmhcflurry_2.1.1.aff\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t20\n")
+    loaded = read_lens_report(path)
+    epitopes = list(loaded.epitopes)
+    frame = epitopes_to_topiary_df(epitopes)
+    original = list(frame["value"])
+
+    hostile = [
+        ExternalRecord(key=record.key,
+                       row={**record.row, "value": "clobbered"})
+        for record in loaded.records]
+
+    assert list(attach_source_annotations(frame, hostile)["value"]) == original

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -1140,8 +1140,17 @@ def read_lens_report(path, epitope_config=None):
     # per-(peptide, allele) scoring to the DSL and stored the result on
     # CandidateEpitope.per_allele_scores. Loaders must populate it or
     # downstream ranking sees zero-scored epitopes and drops everything.
-    from .epitope_dsl import attach_per_allele_scores
-    epitopes = attach_per_allele_scores(epitopes, epitope_config)
+    from .epitope_dsl import attach_per_allele_scores, epitopes_to_topiary_df
+    # Build the evaluation frame here rather than letting the scorer rebuild
+    # it, so the source file's own columns can be carried onto it before
+    # anything reads it. Stored on report_df.attrs the way pVACseq already
+    # does, so the validator, the scorer and the report writer all see one
+    # frame.
+    scoring_df = attach_source_annotations(
+        epitopes_to_topiary_df(epitopes), records)
+    report_df.attrs["topiary_df"] = scoring_df
+    epitopes = attach_per_allele_scores(
+        epitopes, epitope_config, topiary_df=scoring_df)
     report_df = annotate_credited_alleles(report_df, epitopes)
     logger.info(
         "Loaded %d epitope(s) (%d row(s) × %d predictor(s)) from %s",
@@ -1227,6 +1236,55 @@ def _build_lens_report_row(row, allele, peptide, prediction_id,
 # ── Shared report writer ─────────────────────────────────────────────────────
 
 ALLELE_CREDIT_COLUMN = "Peptide-level evidence credited"
+
+
+def attach_source_annotations(df, records):
+    """Carry a source file's own columns onto the DSL frame.
+
+    vaxrank builds its evaluation frame from ``CandidateEpitope`` objects,
+    which know about predictions and nothing else — so every annotation the
+    reader had in hand was dropped before any expression could name it, and
+    ``gene_tpm > 1`` failed against a file that carries ``gene_tpm``
+    (openvax/vaxrank#353).
+
+    Joined on ``prediction_id``, which is the identity the frame already
+    groups on, so a column lands on exactly the rows it described.
+
+    Columns already on the frame are skipped rather than overwritten. A
+    prediction column and an annotation column can share a name, and
+    letting the source win would replace a value the DSL depends on with a
+    lookalike — the collision openvax/topiary#217 was about, arriving from
+    the other side.
+    """
+    if df is None or len(df) == 0 or not records:
+        return df
+    existing = set(df.columns)
+    by_id = {}
+    for record in records:
+        prediction_id = cells.text(record.row.get("prediction_id"))
+        if prediction_id and prediction_id not in by_id:
+            by_id[prediction_id] = record.row
+    if not by_id:
+        return df
+
+    names = []
+    for row in by_id.values():
+        for name in row:
+            if name not in existing and name not in names:
+                names.append(name)
+    if not names:
+        return df
+
+    from .epitope_dsl import PREDICTION_ID_COLUMN
+
+    # One concat rather than a column at a time: a LENS file can carry
+    # dozens of annotation columns, and inserting them individually
+    # fragments the frame badly enough that pandas warns about it.
+    ids = list(df[PREDICTION_ID_COLUMN])
+    added = pd.DataFrame(
+        {name: [by_id.get(i, {}).get(name) for i in ids] for name in names},
+        index=df.index)
+    return pd.concat([df, added], axis=1)
 
 
 def annotate_credited_alleles(report_df, epitopes):


### PR DESCRIPTION
Closes #353.

vaxrank built its evaluation frame from `CandidateEpitope` objects, which know about predictions and nothing else. Every annotation the reader had in hand was dropped before an expression could name it:

```
vaxrank's DSL frame: affinity, allele, c_flank, kind, n_flank, peptide,
peptide_length, peptide_offset, percentile_rank, prediction_id,
prediction_method_name, predictor_version, score, source_sequence_name, value
```

Fifteen fixed columns. `gene_tpm`, `vaf` and `n_alt_reads` were all on the frame topiary handed us, and none survived the rebuild — so a filter on expression or VAF failed against a file carrying both.

Joined on `prediction_id`, the identity the frame already groups on, so a column lands on exactly the rows it described. Now working:

```
affinity.value.logistic_normalized(350,150) * (gene_tpm > 1)
affinity.value.logistic_normalized(350,150) * (vaf > 0.1)
```

### It is `gene_tpm`, not `tpm`

topiary renames on the way in, and the rename is load-bearing: LENS writes fusion rows as composite strings like `ENST…:14.54-ENST…:33.84`, so the numeric column cannot cover every row and the original text is kept as `gene_tpm_raw`. A filter written against `tpm` finds nothing. A test pins the name so nobody rediscovers this.

### Collisions

Columns already on the frame are skipped, never overwritten. A prediction column and an annotation column can share a name, and letting the source win would replace a value the DSL depends on with a lookalike — openvax/topiary#217, arriving from the other side. A test feeds a record whose row carries a hostile `value` column and asserts the frame's own values survive.

### Why not by symmetry with pVACseq

That was the obvious-looking fix and it is wrong. pVACseq stores its topiary frame on `report_df.attrs` and passes it through; topiary's **LENS** frame is *wide* — one row per (peptide, allele) with a column per predictor metric — and would not score.

`from_wide` does produce the long form with annotations intact, but without vaxrank's `prediction_id`, and swapping the scoring substrate would change row multiplicity. Carrying the columns onto the existing frame leaves every score untouched.

### Verification

- All eight LENS fixtures **byte-identical**.
- 1163 tests pass.