### PR TITLE
Say what n_alt_reads counted, on every path that fills it

### DIFF
--- a/tests/test_read_count_provenance.py
+++ b/tests/test_read_count_provenance.py
@@ -127,3 +127,45 @@ def test_pvacseq_claims_no_protein_supporting_count():
     fragment = result.ranked[0][1][0].mutant_protein_fragment
 
     assert fragment.n_alt_reads_supporting_protein_sequence == 0
+
+
+def test_delegating_the_split_did_not_move_any_number():
+    """Migrating to topiary's arithmetic must be value-preserving.
+
+    The local copy was ``int(round(depth * vaf))``. Python's ``round`` is
+    banker's rounding, and nothing had checked that topiary agrees — so
+    this pins that it does, at the ``.5`` boundaries where the two could
+    differ. The reason to delegate is that a private copy of an upstream
+    rule drifts, not that this one had drifted.
+    """
+    import pandas as pd
+    from topiary import split_reads_by_vaf
+
+    cases = [(1, 0.5), (3, 0.5), (5, 0.5), (7, 0.5),
+             (2, 0.25), (10, 0.05), (100, 0.005)]
+    depth = pd.Series([c[0] for c in cases], dtype="Float64")
+    vaf = pd.Series([c[1] for c in cases], dtype="Float64")
+
+    alt, _ref = split_reads_by_vaf(depth, vaf)
+
+    assert [int(a) for a in alt] == [
+        int(round(d * v)) for d, v in cases]
+
+
+def test_an_absent_vaf_yields_no_split_rather_than_zero():
+    """Both halves are NA when either input is missing.
+
+    The local copy returned 0 for a missing VAF and derived the reference
+    count as ``max(0, depth - 0)`` — the whole depth, as if every read
+    supported the reference. topiary returns NA for both, which is what
+    lets the caller record "no estimate" instead of a confident zero.
+    """
+    import pandas as pd
+    from topiary import split_reads_by_vaf
+
+    alt, ref = split_reads_by_vaf(
+        pd.Series([100.0], dtype="Float64"),
+        pd.Series([None], dtype="Float64"))
+
+    assert pd.isna(alt.iloc[0])
+    assert pd.isna(ref.iloc[0])

--- a/tests/test_read_count_provenance.py
+++ b/tests/test_read_count_provenance.py
@@ -1,0 +1,129 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""What ``n_alt_reads`` holds, and how a consumer can tell.
+
+The field feeds the combined-score DSL, where ``sqrt(n_alt_reads) *
+target_epitope_score`` is the documented canonical form. It holds a
+different quantity per input path, and these tests pin that each one says
+which (openvax/vaxrank#379, #382, #383).
+"""
+
+import os
+import types
+
+from vaxrank.epitope_config import EpitopeConfig
+from vaxrank.epitope_dsl import epitopes_for_ranking
+from vaxrank.epitope_io import read_pvacseq_report
+from vaxrank.external_input import pvacseq_ranking_result
+from vaxrank.mutant_protein_fragment import (
+    READ_COUNT_METHOD_RNA_FRAGMENTS,
+    SEQUENCE_SOURCE_ISOVAR_ASSEMBLY,
+    SEQUENCE_SOURCE_VARCODE_TRANSLATION,
+    MutantProteinFragment,
+)
+
+DATA_DIR = os.path.join(
+    os.path.dirname(__file__), "data", "epitope_fixtures")
+
+
+def _fake_isovar_result():
+    """Minimal stand-in exposing only what from_isovar_result reads."""
+    protein_sequence = types.SimpleNamespace(
+        gene_name="BRAF", amino_acids="SIINFEKLAA",
+        mutation_start_idx=2, mutation_end_idx=3,
+        num_supporting_fragments=7, transcripts=[])
+    return types.SimpleNamespace(
+        variant=object(), top_protein_sequence=protein_sequence,
+        num_total_fragments=20, num_alt_fragments=8, num_ref_fragments=12)
+
+
+def test_isovar_counts_are_labelled_as_fragments():
+    """The field says reads and the value is fragments, so the label must say.
+
+    For paired-end data a fragment is two reads, so this is roughly half
+    the read count for the same evidence — a different quantity from a
+    LENS depth x VAF estimate, not a different way of obtaining one.
+    Nothing converts, because the conversion needs to know whether the
+    library was paired-end and isovar does not say.
+    """
+    fragment = MutantProteinFragment.from_isovar_result(_fake_isovar_result())
+
+    assert fragment.n_alt_reads == 8            # fragments, per isovar
+    assert fragment.read_count_method == READ_COUNT_METHOD_RNA_FRAGMENTS
+    assert fragment.sequence_source == SEQUENCE_SOURCE_ISOVAR_ASSEMBLY
+
+
+def test_the_sequence_source_terms_are_read_from_topiary():
+    """No private copy of a controlled vocabulary.
+
+    A rename upstream should break the import rather than silently stamp
+    fragments with a term nothing recognizes.
+    """
+    from topiary import SEQUENCE_SOURCES
+
+    assert SEQUENCE_SOURCE_ISOVAR_ASSEMBLY in SEQUENCE_SOURCES
+    assert SEQUENCE_SOURCE_VARCODE_TRANSLATION in SEQUENCE_SOURCES
+
+
+def test_the_fragments_term_is_marked_as_not_yet_upstream():
+    """``rna_fragments`` is a local extension, and should stay a visible one.
+
+    topiary's READ_COUNT_METHODS has no term for fragment counts
+    (openvax/topiary#239). Until it does, this constant is vaxrank's, and
+    the test exists so that adopting the upstream term is a deliberate
+    change rather than something nobody notices is still pending.
+    """
+    from topiary import READ_COUNT_METHODS
+
+    assert READ_COUNT_METHOD_RNA_FRAGMENTS not in READ_COUNT_METHODS
+
+
+def test_pvacseq_reference_reads_come_from_the_same_split_as_the_alt():
+    """alt and ref are two halves of one estimate, not one and a remainder.
+
+    The reference count was ``max(0, depth - alt)``, which clamps a
+    negative to zero and so hides an inconsistent depth/VAF pair instead of
+    surfacing it. topiary's split_reads_by_vaf returns both halves, and
+    NA when either input is missing.
+    """
+    config = EpitopeConfig()
+    report = read_pvacseq_report(
+        os.path.join(DATA_DIR, "pvacseq_example.tsv"), epitope_config=config)
+    result = pvacseq_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+
+    fragment = result.ranked[0][1][0].mutant_protein_fragment
+
+    assert fragment.n_alt_reads > 0
+    assert fragment.n_alt_reads + fragment.n_ref_reads == (
+        fragment.n_overlapping_reads)
+    assert fragment.read_count_method == "rna_depth_x_vaf"
+
+
+def test_pvacseq_claims_no_protein_supporting_count():
+    """pVACseq does not report reads spanning the assembled sequence.
+
+    That field used to be set to ``n_alt_reads``, asserting that every
+    variant-supporting read also spans the peptide — a measurement this
+    source never made, and one the LENS path fills with a genuinely
+    different count (cds_overlap_reads).
+    """
+    config = EpitopeConfig()
+    report = read_pvacseq_report(
+        os.path.join(DATA_DIR, "pvacseq_example.tsv"), epitope_config=config)
+    result = pvacseq_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+
+    fragment = result.ranked[0][1][0].mutant_protein_fragment
+
+    assert fragment.n_alt_reads_supporting_protein_sequence == 0

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -1308,19 +1308,31 @@ def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None):
         return metadata
     # Same rule as the LENS path: the counts and the label describing them
     # come from one row.
+    # depth x VAF is an estimate, not a count: pVACseq reports a depth and
+    # a fraction and never an alt-read count. The arithmetic is topiary's
+    # rather than ours — the LENS path already reads its derived columns,
+    # and a local copy of an upstream rule is the shape that produced every
+    # version bug in this file's history (#383).
+    from topiary import split_reads_by_vaf
+
+    depths = [pvacseq_rna_depth(record.row) for record in selection.records]
+    vafs = [pvacseq_rna_vaf(record.row) for record in selection.records]
+    alt_series, ref_series = split_reads_by_vaf(
+        pd.Series(depths, dtype="Float64"), pd.Series(vafs, dtype="Float64"))
     observations = []
-    for record in selection.records:
-        depth = pvacseq_rna_depth(record.row)
-        vaf = pvacseq_rna_vaf(record.row)
-        # depth x VAF is an estimate, not a count, and says so. pVACseq
-        # reports a depth and a fraction; it does not report alt reads.
-        alt = int(round(depth * vaf)) if vaf is not None else 0
-        method = "rna_depth_x_vaf" if vaf is not None else ""
-        source = cells.text(record.row.get("sequence_source"))
-        observations.append(((depth, alt), (method, source)))
-    (n_total, n_alt_reads), provenance = max(
+    for index, record in enumerate(selection.records):
+        alt = alt_series.iloc[index]
+        ref = ref_series.iloc[index]
+        stated = not pd.isna(alt)
+        observations.append((
+            (int(depths[index] or 0),
+             int(alt) if stated else 0,
+             int(ref) if not pd.isna(ref) else 0),
+            ("rna_depth_x_vaf" if stated else "",
+             cells.text(record.row.get("sequence_source")))))
+    (n_total, n_alt_reads, n_ref_reads), provenance = max(
         observations, key=lambda o: (o[0][1], o[0][0]),
-        default=((0, 0), ("", "")))
+        default=((0, 0, 0), ("", "")))
     metadata.vaccine_peptide = external_vaccine_peptide(
         variant=metadata.variant,
         selection=selection,
@@ -1332,8 +1344,13 @@ def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None):
         gene_name=key.primary_gene_name,
         transcripts=resolve_external_transcripts(
             key.ordered_transcript_ids, genome),
-        counts=(
-            n_total, n_alt_reads, max(0, n_total - n_alt_reads), n_alt_reads),
+        # The fourth count is reads spanning the assembled protein
+        # sequence. pVACseq does not report one, and setting it to
+        # n_alt_reads asserted that every variant-supporting read also
+        # spans the peptide — a measurement this source never made. Zero
+        # says it was not measured; on the LENS path the field holds a
+        # genuinely different count (cds_overlap_reads).
+        counts=(n_total, n_alt_reads, n_ref_reads, 0),
         provenance=provenance,
         options=options,
     )

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -61,6 +61,40 @@ def find_mutation_region(reference_protein, mutant_protein):
     return start, mut_i
 
 
+# Read-count derivations. topiary owns this vocabulary
+# (``topiary.READ_COUNT_METHODS``) and vaxrank uses its terms rather than
+# inventing parallel ones.
+#
+# ``rna_fragments`` is the exception, and deliberately marked as one:
+# isovar counts fragments, topiary has no term for that yet, and a
+# fragment count is a different quantity from a read count rather than a
+# different way of obtaining one. Requested upstream as
+# openvax/topiary#239; when it lands this constant should become an
+# import, the way ``is_named_version`` replaced a local stand-in.
+READ_COUNT_METHOD_RNA_FRAGMENTS = "rna_fragments"
+
+# Sequence provenance. This one topiary already defines, so it is read
+# from there rather than restated.
+def _sequence_source(name):
+    """Return a topiary sequence-source term, failing loudly if it is gone.
+
+    Reading the name from topiary rather than restating it, so a rename
+    upstream surfaces here as an import-time error instead of silently
+    stamping fragments with a term nothing recognizes.
+    """
+    from topiary import SEQUENCE_SOURCES
+
+    if name not in SEQUENCE_SOURCES:
+        raise ValueError(
+            "topiary.SEQUENCE_SOURCES no longer defines %r, which vaxrank "
+            "stamps on the fragments it builds" % name)
+    return name
+
+
+SEQUENCE_SOURCE_ISOVAR_ASSEMBLY = _sequence_source("isovar_assembly")
+SEQUENCE_SOURCE_VARCODE_TRANSLATION = _sequence_source("varcode_translation")
+
+
 @dataclass
 class MutantProteinFragment(DataclassSerializable):
     """
@@ -208,11 +242,22 @@ class MutantProteinFragment(DataclassSerializable):
             mutant_amino_acid_start_offset=protein_sequence.mutation_start_idx,
             mutant_amino_acid_end_offset=protein_sequence.mutation_end_idx,
 
-            # TODO: distinguish reads and fragments in Vaxrank?
+            # These are FRAGMENT counts, and the fields are named for
+            # reads. For paired-end data a fragment is two reads, so these
+            # are roughly half the read count for the same evidence.
+            #
+            # Not converted, because the conversion needs to know whether
+            # the library was paired-end and isovar does not say. Labelled
+            # instead: read_count_method carries the subject so a consumer
+            # comparing this against a LENS estimate can see they are
+            # different quantities rather than inferring it from the field
+            # name, which asserts the wrong one (#382).
             n_overlapping_reads=isovar_result.num_total_fragments,
             n_alt_reads=isovar_result.num_alt_fragments,
             n_ref_reads=isovar_result.num_ref_fragments,
             n_alt_reads_supporting_protein_sequence=protein_sequence.num_supporting_fragments,
+            read_count_method=READ_COUNT_METHOD_RNA_FRAGMENTS,
+            sequence_source=SEQUENCE_SOURCE_ISOVAR_ASSEMBLY,
             supporting_reference_transcripts=protein_sequence.transcripts)
 
     @classmethod
@@ -315,10 +360,14 @@ class MutantProteinFragment(DataclassSerializable):
             amino_acids=amino_acids,
             mutant_amino_acid_start_offset=local_mut_start,
             mutant_amino_acid_end_offset=local_mut_end,
+            # No RNA was consulted, so there is nothing to label: zero
+            # here means "no reads counted", and read_count_method stays
+            # blank rather than claiming a derivation produced the zeros.
             n_overlapping_reads=0,
             n_alt_reads=0,
             n_ref_reads=0,
             n_alt_reads_supporting_protein_sequence=0,
+            sequence_source=SEQUENCE_SOURCE_VARCODE_TRANSLATION,
             supporting_reference_transcripts=[transcript],
         )
 


### PR DESCRIPTION
Closes #379, #382, #383 — one problem in three places.

`n_alt_reads` feeds the combined-score DSL, where `sqrt(n_alt_reads) * target_epitope_score` is the documented canonical form. It held three different quantities and named none of them:

| path | quantity | label before | label after |
|---|---|---|---|
| native (isovar) | **fragments** | — | `rna_fragments` |
| LENS | depth × VAF | `rna_depth_x_vaf` | unchanged |
| pVACseq | depth × VAF, hand-rolled | `rna_depth_x_vaf` | topiary's `split_reads_by_vaf` |

### The native path is the one the field name misleads about

isovar counts fragments. For paired-end data a fragment is two reads, so those numbers are roughly **half** the read count for the same evidence, sitting in four fields named "reads". The code carried a `TODO` asking whether to distinguish them — fair to defer while one path existed, and not once #374/#376 put read-based estimates into the same field.

**Not converted:** the conversion needs to know whether the library was paired-end, and isovar does not say. Labelled instead, so a consumer sees the quantities differ rather than inferring it from a field name that asserts the wrong one.

`rna_fragments` is a **local extension**, marked as one, with a test that fails when topiary adopts a term (openvax/topiary#239) — same shape as the `is_named_version` stand-in that was deleted for the import once upstream landed.

### Sequence source on both native constructors

`isovar_assembly` and `varcode_translation`, read from `topiary.SEQUENCE_SOURCES` rather than restated, so a rename upstream fails at import instead of stamping an unrecognized term. The varcode path leaves `read_count_method` blank — no RNA was consulted, so its zeros are "nothing counted", not a derivation that produced zero.

### pVACseq's split is topiary's now

Two things the local copy got wrong beyond being a copy:

- `int(round(depth * vaf))` was never checked against topiary's rounding.
- The reference count was `max(0, depth - alt)`, which clamps a negative to zero — hiding an inconsistent depth/VAF pair instead of surfacing it.

Both halves come from `split_reads_by_vaf`, and alt + ref now sums to depth:

```
pvacseq  n_total 200  n_alt 68   n_ref 132  n_prot 0
lens     n_total 446  n_alt 4    n_ref 442  n_prot 9
```

`n_alt_reads_supporting_protein_sequence` was set to `n_alt_reads` on the pVACseq path, asserting every variant-supporting read also spans the assembled peptide — a measurement pVACseq never makes. Zero now; on the LENS path that field holds a genuinely different count (`cds_overlap_reads`).

### Verification

- LENS fixtures byte-identical.
- 1168 tests pass, including 5 new ones in `tests/test_read_count_provenance.py`.