### PR TITLE
Record what the read counts counted, not just how

### DIFF
--- a/tests/test_read_count_provenance.py
+++ b/tests/test_read_count_provenance.py
@@ -25,8 +25,10 @@ from vaxrank.epitope_config import EpitopeConfig
 from vaxrank.epitope_dsl import epitopes_for_ranking
 from vaxrank.epitope_io import read_pvacseq_report
 from vaxrank.external_input import pvacseq_ranking_result
+from topiary import FRAGMENTS, READS
+
 from vaxrank.mutant_protein_fragment import (
-    READ_COUNT_METHOD_RNA_FRAGMENTS,
+    READ_COUNT_METHOD_RNA_READS,
     SEQUENCE_SOURCE_ISOVAR_ASSEMBLY,
     SEQUENCE_SOURCE_VARCODE_TRANSLATION,
     MutantProteinFragment,
@@ -59,7 +61,10 @@ def test_isovar_counts_are_labelled_as_fragments():
     fragment = MutantProteinFragment.from_isovar_result(_fake_isovar_result())
 
     assert fragment.n_alt_reads == 8            # fragments, per isovar
-    assert fragment.read_count_method == READ_COUNT_METHOD_RNA_FRAGMENTS
+    # Two axes, not one. rna_reads says the count came from an alignment
+    # and deliberately fixes no subject; the subject says what was counted.
+    assert fragment.read_count_method == READ_COUNT_METHOD_RNA_READS
+    assert fragment.read_count_subject == FRAGMENTS
     assert fragment.sequence_source == SEQUENCE_SOURCE_ISOVAR_ASSEMBLY
 
 
@@ -75,17 +80,19 @@ def test_the_sequence_source_terms_are_read_from_topiary():
     assert SEQUENCE_SOURCE_VARCODE_TRANSLATION in SEQUENCE_SOURCES
 
 
-def test_the_fragments_term_is_marked_as_not_yet_upstream():
-    """``rna_fragments`` is a local extension, and should stay a visible one.
+def test_a_count_cannot_be_read_in_the_wrong_subject():
+    """Asking for the other unit returns nothing, never a conversion.
 
-    topiary's READ_COUNT_METHODS has no term for fragment counts
-    (openvax/topiary#239). Until it does, this constant is vaxrank's, and
-    the test exists so that adopting the upstream term is a deliberate
-    change rather than something nobody notices is still pending.
+    vaxrank asked topiary for an ``rna_fragments`` *method* and that was
+    the wrong shape (openvax/topiary#239): a subject is not a derivation,
+    and a term alongside the methods would have left n_alt_reads ambiguous
+    on the isovar path while looking resolved. The subject is its own axis
+    now, and ``count_in`` is how a caller states which bar it means.
     """
-    from topiary import READ_COUNT_METHODS
+    fragment = MutantProteinFragment.from_isovar_result(_fake_isovar_result())
 
-    assert READ_COUNT_METHOD_RNA_FRAGMENTS not in READ_COUNT_METHODS
+    assert fragment.count_in("n_alt_reads", FRAGMENTS) == 8
+    assert fragment.count_in("n_alt_reads", READS) is None
 
 
 def test_pvacseq_reference_reads_come_from_the_same_split_as_the_alt():
@@ -169,3 +176,44 @@ def test_an_absent_vaf_yields_no_split_rather_than_zero():
 
     assert pd.isna(alt.iloc[0])
     assert pd.isna(ref.iloc[0])
+
+
+def test_the_external_paths_state_reads():
+    """A depth x VAF estimate is in reads, and says so.
+
+    Without this, a threshold written against a native run and copied to a
+    LENS run silently changes what it means — the portability harm the
+    subject axis exists to prevent. Within one run the unit is consistent
+    and the ranking is unaffected either way.
+    """
+    config = EpitopeConfig()
+    report = read_pvacseq_report(
+        os.path.join(DATA_DIR, "pvacseq_example.tsv"), epitope_config=config)
+    result = pvacseq_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+
+    fragment = result.ranked[0][1][0].mutant_protein_fragment
+
+    assert fragment.read_count_subject == READS
+    assert fragment.count_in("n_alt_reads", READS) == fragment.n_alt_reads
+    assert fragment.count_in("n_alt_reads", FRAGMENTS) is None
+
+
+def test_a_fragment_that_states_no_subject_answers_either():
+    """Silence is not a claim about the unit.
+
+    The varcode path consulted no RNA, so its zeros have no subject. A
+    caller asking for one gets the value rather than None, because there is
+    no competing claim to contradict — refusing would treat "not stated" as
+    "stated to be the other thing".
+    """
+    fragment = MutantProteinFragment(
+        variant=object(), gene_name="BRAF", amino_acids="SIINFEKL",
+        mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=1,
+        supporting_reference_transcripts=[],
+        n_overlapping_reads=0, n_alt_reads=0, n_ref_reads=0,
+        n_alt_reads_supporting_protein_sequence=0)
+
+    assert fragment.read_count_subject == ""
+    assert fragment.count_in("n_alt_reads", READS) == 0
+    assert fragment.count_in("n_alt_reads", FRAGMENTS) == 0

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -42,6 +42,7 @@ import logging
 import os
 
 import pandas as pd
+from topiary import READS
 
 from . import cells
 from .amino_acids import has_only_standard_amino_acids
@@ -836,6 +837,11 @@ def external_vaccine_peptide(variant, selection, context, mutant_start,
     ]
     n_total, n_alt, n_ref, n_alt_protein = counts
     read_count_method, sequence_source = provenance
+    # Both external readers estimate from a depth and a fraction, or count
+    # CDS overlap; either way the unit is reads. Stated rather than left
+    # blank so a threshold copied from a native run can tell it is a
+    # different bar (openvax/topiary#239).
+    read_count_subject = READS if read_count_method else ""
     fragment = MutantProteinFragment(
         variant=variant,
         gene_name=gene_name,
@@ -849,6 +855,7 @@ def external_vaccine_peptide(variant, selection, context, mutant_start,
         n_alt_reads_supporting_protein_sequence=n_alt_protein,
         placeholder_alleles=False,
         read_count_method=read_count_method,
+        read_count_subject=read_count_subject,
         sequence_source=sequence_source,
     )
     return VaccinePeptide(

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from serializable import DataclassSerializable
 from varcode.effects import top_priority_effect
+from topiary import FRAGMENTS
 
 from .varcode_effects import (
     OUTCOME_SELECTION_HIGHEST_PRIORITY,
@@ -61,20 +62,22 @@ def find_mutation_region(reference_protein, mutant_protein):
     return start, mut_i
 
 
-# Read-count derivations. topiary owns this vocabulary
-# (``topiary.READ_COUNT_METHODS``) and vaxrank uses its terms rather than
-# inventing parallel ones.
+# Read-count vocabulary, all of it topiary's. Two orthogonal axes:
 #
-# ``rna_fragments`` is the exception, and deliberately marked as one:
-# isovar counts fragments, topiary has no term for that yet, and a
-# fragment count is a different quantity from a read count rather than a
-# different way of obtaining one. Requested upstream as
-# openvax/topiary#239; when it lands this constant should become an
-# import, the way ``is_named_version`` replaced a local stand-in.
-READ_COUNT_METHOD_RNA_FRAGMENTS = "rna_fragments"
-
-# Sequence provenance. This one topiary already defines, so it is read
-# from there rather than restated.
+#   read_count_method    how the number was obtained -- rna_reads,
+#                        rna_depth_x_vaf, cds_overlap_reads, ...
+#   read_count_subject   what it counted -- reads or fragments
+#
+# vaxrank asked for an ``rna_fragments`` *method* and that was the wrong
+# shape (openvax/topiary#239): a subject is not a derivation, and a term
+# alongside the methods would have left n_alt_reads ambiguous on the
+# isovar path while looking resolved. ``rna_reads`` deliberately fixes no
+# subject -- it says a count came from an alignment, not whether the
+# aligner counted reads or fragments -- so the producer states the
+# subject separately.
+#
+# Read from topiary rather than restated, so a rename upstream fails at
+# import instead of stamping a term nothing recognizes.
 def _sequence_source(name):
     """Return a topiary sequence-source term, failing loudly if it is gone.
 
@@ -93,6 +96,20 @@ def _sequence_source(name):
 
 SEQUENCE_SOURCE_ISOVAR_ASSEMBLY = _sequence_source("isovar_assembly")
 SEQUENCE_SOURCE_VARCODE_TRANSLATION = _sequence_source("varcode_translation")
+
+
+def _read_count_method(name):
+    """Return a topiary read-count method term, failing loudly if it is gone."""
+    from topiary import READ_COUNT_METHODS
+
+    if name not in READ_COUNT_METHODS:
+        raise ValueError(
+            "topiary.READ_COUNT_METHODS no longer defines %r, which vaxrank "
+            "stamps on the fragments it builds" % name)
+    return name
+
+
+READ_COUNT_METHOD_RNA_READS = _read_count_method("rna_reads")
 
 
 @dataclass
@@ -169,6 +186,14 @@ class MutantProteinFragment(DataclassSerializable):
     # sqrt(n_alt_reads) does not know that 51 was arithmetic rather than
     # observation. Carrying the label is what lets a reader tell.
     read_count_method: str = ""
+
+    # What those counts counted: topiary's FRAGMENTS or READS, blank when
+    # the source did not say. Separate from the method because how a number
+    # was obtained and what it counted are independent — an alignment-derived
+    # count may be either. Five fragments and five reads are different bars,
+    # and converting between them needs library information no source
+    # carries, so this is stated rather than normalized.
+    read_count_subject: str = ""
 
     # How the protein sequence was obtained: "lens_pep_context",
     # "pvacseq_epitope", "varcode_translation", "isovar_assembly",
@@ -256,7 +281,11 @@ class MutantProteinFragment(DataclassSerializable):
             n_alt_reads=isovar_result.num_alt_fragments,
             n_ref_reads=isovar_result.num_ref_fragments,
             n_alt_reads_supporting_protein_sequence=protein_sequence.num_supporting_fragments,
-            read_count_method=READ_COUNT_METHOD_RNA_FRAGMENTS,
+            # Counted from an alignment (rna_reads), and what it counted
+            # is fragments. Two axes, because "how" and "what" are
+            # independent: another aligner-derived count could be reads.
+            read_count_method=READ_COUNT_METHOD_RNA_READS,
+            read_count_subject=FRAGMENTS,
             sequence_source=SEQUENCE_SOURCE_ISOVAR_ASSEMBLY,
             supporting_reference_transcripts=protein_sequence.transcripts)
 
@@ -370,6 +399,23 @@ class MutantProteinFragment(DataclassSerializable):
             sequence_source=SEQUENCE_SOURCE_VARCODE_TRANSLATION,
             supporting_reference_transcripts=[transcript],
         )
+
+    def count_in(self, name, subject):
+        """``name``'s value if it counts ``subject``, else ``None``.
+
+        Mirrors ``topiary.ProteinFragment.count_in`` so a caller holding
+        either kind of fragment asks the same question the same way.
+
+        ``None`` rather than a converted number: turning a read estimate
+        into fragments needs library information no source carries, so a
+        fragment whose counts are in the other unit says it cannot answer.
+        Callers weighting these must decide what an unanswerable count
+        means for them — treating it as zero would reintroduce exactly the
+        substitution this exists to prevent.
+        """
+        if self.read_count_subject and self.read_count_subject != subject:
+            return None
+        return getattr(self, name)
 
     def __len__(self):
         return len(self.amino_acids)

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -285,6 +285,11 @@ class TemplateDataCreator(object):
         if mutant_protein_fragment.read_count_method:
             variant_data['RNA read count method'] = (
                 mutant_protein_fragment.read_count_method)
+        # What those counts counted. Five fragments and five reads are
+        # different bars, and the rows above say neither on their own.
+        if mutant_protein_fragment.read_count_subject:
+            variant_data['RNA read count subject'] = (
+                mutant_protein_fragment.read_count_subject)
         if mutant_protein_fragment.sequence_source:
             variant_data['Protein sequence source'] = (
                 mutant_protein_fragment.sequence_source)


### PR DESCRIPTION
topiary settled the question raised in openvax/topiary#239, and settled it **differently than asked** — correctly.

vaxrank wanted an `rna_fragments` *method* term. That was the wrong shape: a subject is not a derivation, and a term alongside the methods would have left `n_alt_reads` ambiguous on the isovar path while looking resolved. Two independent axes now:

```
read_count_method    how the number was obtained
read_count_subject   what it counted — reads or fragments
```

`rna_reads` deliberately fixes no subject: it says a count came from an alignment, not whether the aligner counted reads or fragments. So the isovar path is `(rna_reads, fragments)` rather than one term meaning both, and another alignment-derived count could be `(rna_reads, reads)` without a new method.

```
isovar    n_alt 8    rna_reads         fragments
lens      n_alt 4    rna_depth_x_vaf   reads
pvacseq   n_alt 68   rna_depth_x_vaf   reads
```

### `count_in`

Mirrors `topiary.ProteinFragment.count_in` so a caller holding either kind of fragment asks the same question the same way. Returns `None` for the wrong subject rather than converting — that needs library information no source carries.

A fragment that states **no** subject answers either: silence is not a claim about the unit, and refusing there would treat "not stated" as "stated to be the other thing".

### A limit of the tripwire technique, worth recording

The local `READ_COUNT_METHOD_RNA_FRAGMENTS` had a test written to fail once topiary shipped a term. **It would not have fired** — topiary shipped a different *axis* rather than the term I predicted, so `rna_fragments not in READ_COUNT_METHODS` stayed true and the stand-in would have sat there indefinitely looking guarded.

A tripwire only catches the resolution you predicted. The constant is gone; that test now pins the accessor instead.

### Not fixed here

The combined-score namespace still exposes bare `n_alt_reads`, which is where the portability harm actually lands — a documented `n_alt_reads > 5` is a different bar per path. Filed as #385 rather than half-fixed: making it unavailable on the isovar path would break every existing config, and coercing an unanswerable count to zero would reintroduce the substitution the subject axis exists to prevent.

### Verification

- LENS fixtures byte-identical.
- 1172 tests pass.