### PR TITLE
Carry both read units, and stop calling LENS's vaf a DNA fraction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.43.0,<6.0.0
+topiary>=5.45.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -1926,7 +1926,11 @@ def test_read_counts_arrive_with_the_derivation_that_produced_them(tmp_path):
     fragment = _fragment_for(path)
 
     assert fragment.n_alt_reads == 51
-    assert fragment.read_count_method == "rna_depth_x_vaf"
+    # rna_depth_x_source_vaf, not rna_depth_x_vaf: LENS names its read
+    # columns rna_* explicitly and leaves `vaf` bare, so the fraction's
+    # assay is unstated. The method says the split used the source's own
+    # VAF rather than asserting it was an RNA one.
+    assert fragment.rna_evidence_method == "rna_depth_x_source_vaf"
     assert fragment.sequence_source == "lens_pep_context"
 
 
@@ -1943,7 +1947,7 @@ def test_no_estimate_means_no_method_rather_than_a_confident_zero(tmp_path):
     fragment = _fragment_for(path)
 
     assert fragment.n_alt_reads == 0
-    assert fragment.read_count_method == ""
+    assert fragment.rna_evidence_method == ""
     # The sequence still has a known source; only the split is missing.
     assert fragment.sequence_source == "lens_pep_context"
 
@@ -1974,7 +1978,7 @@ def test_the_method_describes_the_row_whose_counts_were_used(tmp_path):
 
     # The winning row is the shallow one, so its depth and its label.
     assert (fragment.n_overlapping_reads, fragment.n_alt_reads) == (10, 9)
-    assert fragment.read_count_method == "rna_depth_x_vaf"
+    assert fragment.rna_evidence_method == "rna_depth_x_source_vaf"
 
 
 def test_pvacseq_estimates_are_labelled_too(tmp_path):
@@ -1998,7 +2002,7 @@ def test_pvacseq_estimates_are_labelled_too(tmp_path):
     fragment = result.ranked[0][1][0].mutant_protein_fragment
 
     assert fragment.n_alt_reads > 0
-    assert fragment.read_count_method == "rna_depth_x_vaf"
+    assert fragment.rna_evidence_method == "rna_depth_x_vaf"
 
 
 def test_a_pvacseq_row_with_no_rna_vaf_claims_no_derivation():

--- a/tests/test_read_count_provenance.py
+++ b/tests/test_read_count_provenance.py
@@ -28,7 +28,7 @@ from vaxrank.external_input import pvacseq_ranking_result
 from topiary import FRAGMENTS, READS
 
 from vaxrank.mutant_protein_fragment import (
-    READ_COUNT_METHOD_RNA_READS,
+    RNA_EVIDENCE_METHOD_ALIGNMENT,
     SEQUENCE_SOURCE_ISOVAR_ASSEMBLY,
     SEQUENCE_SOURCE_VARCODE_TRANSLATION,
     MutantProteinFragment,
@@ -43,28 +43,28 @@ def _fake_isovar_result():
     protein_sequence = types.SimpleNamespace(
         gene_name="BRAF", amino_acids="SIINFEKLAA",
         mutation_start_idx=2, mutation_end_idx=3,
-        num_supporting_fragments=7, transcripts=[])
+        num_supporting_fragments=7, num_supporting_reads=13, transcripts=[])
     return types.SimpleNamespace(
         variant=object(), top_protein_sequence=protein_sequence,
-        num_total_fragments=20, num_alt_fragments=8, num_ref_fragments=12)
+        num_total_fragments=20, num_alt_fragments=8, num_ref_fragments=12,
+        num_total_reads=38, num_alt_reads=15, num_ref_reads=23)
 
 
-def test_isovar_counts_are_labelled_as_fragments():
-    """The field says reads and the value is fragments, so the label must say.
+def test_isovar_counts_are_carried_in_both_units():
+    """Both units, each in the field named for it.
 
-    For paired-end data a fragment is two reads, so this is roughly half
-    the read count for the same evidence — a different quantity from a
-    LENS depth x VAF estimate, not a different way of obtaining one.
-    Nothing converts, because the conversion needs to know whether the
-    library was paired-end and isovar does not say.
+    vaxrank stored isovar's *fragment* counts in the fields named for
+    reads, and then described the discrepancy as a subject a caller had to
+    ask about. isovar reports every count in both units — the reads were
+    never unavailable, and the accessor that explained their absence was
+    describing a lie rather than a limitation (openvax/topiary#239).
     """
     fragment = MutantProteinFragment.from_isovar_result(_fake_isovar_result())
 
-    assert fragment.n_alt_reads == 8            # fragments, per isovar
-    # Two axes, not one. rna_reads says the count came from an alignment
-    # and deliberately fixes no subject; the subject says what was counted.
-    assert fragment.read_count_method == READ_COUNT_METHOD_RNA_READS
-    assert fragment.read_count_subject == FRAGMENTS
+    assert fragment.n_alt_reads == 15           # isovar's num_alt_reads
+    assert fragment.n_alt_fragments == 8        # isovar's num_alt_fragments
+    assert fragment.rna_evidence_method == RNA_EVIDENCE_METHOD_ALIGNMENT
+    assert fragment.rna_evidence_subject == FRAGMENTS
     assert fragment.sequence_source == SEQUENCE_SOURCE_ISOVAR_ASSEMBLY
 
 
@@ -80,19 +80,21 @@ def test_the_sequence_source_terms_are_read_from_topiary():
     assert SEQUENCE_SOURCE_VARCODE_TRANSLATION in SEQUENCE_SOURCES
 
 
-def test_a_count_cannot_be_read_in_the_wrong_subject():
-    """Asking for the other unit returns nothing, never a conversion.
+def test_the_rna_accessors_prefer_fragments():
+    """``n_rna_alt`` is the number to weight, and it prefers fragments.
 
-    vaxrank asked topiary for an ``rna_fragments`` *method* and that was
-    the wrong shape (openvax/topiary#239): a subject is not a derivation,
-    and a term alongside the methods would have left n_alt_reads ambiguous
-    on the isovar path while looking resolved. The subject is its own axis
-    now, and ``count_in`` is how a caller states which bar it means.
+    Two mates of one fragment are one piece of evidence, so a read count
+    overstates paired-end support by roughly two — the wrong input to a
+    diminishing-returns weight like sqrt(). Where a source has only reads,
+    reads are what n_rna_alt reports, and the subject says which.
     """
     fragment = MutantProteinFragment.from_isovar_result(_fake_isovar_result())
 
-    assert fragment.count_in("n_alt_reads", FRAGMENTS) == 8
-    assert fragment.count_in("n_alt_reads", READS) is None
+    assert fragment.n_rna_alt == 8              # fragments win
+    assert fragment.n_rna_ref == 12
+    assert fragment.n_rna_overlapping == 20
+    assert fragment.n_rna_supporting_protein_sequence == 7
+    assert fragment.rna_evidence_subject == FRAGMENTS
 
 
 def test_pvacseq_reference_reads_come_from_the_same_split_as_the_alt():
@@ -114,7 +116,7 @@ def test_pvacseq_reference_reads_come_from_the_same_split_as_the_alt():
     assert fragment.n_alt_reads > 0
     assert fragment.n_alt_reads + fragment.n_ref_reads == (
         fragment.n_overlapping_reads)
-    assert fragment.read_count_method == "rna_depth_x_vaf"
+    assert fragment.rna_evidence_method == "rna_depth_x_vaf"
 
 
 def test_pvacseq_claims_no_protein_supporting_count():
@@ -194,18 +196,19 @@ def test_the_external_paths_state_reads():
 
     fragment = result.ranked[0][1][0].mutant_protein_fragment
 
-    assert fragment.read_count_subject == READS
-    assert fragment.count_in("n_alt_reads", READS) == fragment.n_alt_reads
-    assert fragment.count_in("n_alt_reads", FRAGMENTS) is None
+    assert fragment.rna_evidence_subject == READS
+    # No fragment counts, so the accessors report the reads.
+    assert fragment.n_alt_fragments is None
+    assert fragment.n_rna_alt == fragment.n_alt_reads
 
 
-def test_a_fragment_that_states_no_subject_answers_either():
-    """Silence is not a claim about the unit.
+def test_a_fragment_that_states_no_subject_still_reports_its_counts():
+    """Silence about the unit does not hide the numbers.
 
-    The varcode path consulted no RNA, so its zeros have no subject. A
-    caller asking for one gets the value rather than None, because there is
-    no competing claim to contradict — refusing would treat "not stated" as
-    "stated to be the other thing".
+    The varcode path consulted no RNA, so its zeros have no subject. The
+    accessors still answer, because there is no competing claim to
+    contradict — treating "not stated" as "stated to be the other thing"
+    would make an unlabelled zero unreadable.
     """
     fragment = MutantProteinFragment(
         variant=object(), gene_name="BRAF", amino_acids="SIINFEKL",
@@ -214,6 +217,61 @@ def test_a_fragment_that_states_no_subject_answers_either():
         n_overlapping_reads=0, n_alt_reads=0, n_ref_reads=0,
         n_alt_reads_supporting_protein_sequence=0)
 
-    assert fragment.read_count_subject == ""
-    assert fragment.count_in("n_alt_reads", READS) == 0
-    assert fragment.count_in("n_alt_reads", FRAGMENTS) == 0
+    assert fragment.rna_evidence_subject == ""
+    assert fragment.n_rna_alt == 0
+
+
+def test_lens_vaf_is_not_recorded_as_a_dna_fraction(tmp_path):
+    """LENS leaves `vaf` unqualified, so nothing may call it DNA.
+
+    LENS names its read columns ``rna_*`` explicitly and leaves ``vaf``
+    bare. vaxrank filed it as ``dna_vaf`` and the report printed it under
+    "DNA VAF", asserting an assay the file never stated — and topiary was
+    using the same column as both an RNA and a DNA fraction, which is how
+    the ambiguity surfaced.
+
+    It is kept under its own name now, and the split that uses it says
+    ``rna_depth_x_source_vaf`` rather than claiming the fraction was RNA.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import read_lens_report
+    from vaxrank.external_input import lens_ranking_result
+
+    path = tmp_path / "vaf.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\tantigen_source\tvariant_coords\t"
+        "snv_ref_allele\tsnv_alt_allele\tgene_name\t"
+        "rna_reads_covering_genomic_origin\tvaf\tmhcflurry_2.1.1.aff\n"
+        "SIINFEKL\tHLA-A02:01\tAASIINFEKLAA\tSNV\tchr1:100\tC\t[T]\tG\t"
+        "100\t0.4\t20\n")
+
+    config = EpitopeConfig()
+    report = read_lens_report(path, epitope_config=config)
+    result = lens_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+
+    assert result.dna_vaf_by_variant == {}
+    assert set(result.source_vaf_by_variant.values()) == {0.4}
+
+    fragment = result.ranked[0][1][0].mutant_protein_fragment
+    assert fragment.rna_evidence_method == "rna_depth_x_source_vaf"
+
+
+def test_pvacseq_keeps_its_qualified_dna_vaf():
+    """pVACseq names the assay, so the DNA fraction stays a DNA fraction.
+
+    The LENS fix must not collapse a source that *did* say which assay it
+    measured into the same unqualified bucket.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import read_pvacseq_report
+    from vaxrank.external_input import pvacseq_ranking_result
+
+    config = EpitopeConfig()
+    report = read_pvacseq_report(
+        os.path.join(DATA_DIR, "pvacseq_example.tsv"), epitope_config=config)
+    result = pvacseq_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+
+    assert result.dna_vaf_by_variant
+    assert result.source_vaf_by_variant == {}

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -42,7 +42,6 @@ import logging
 import os
 
 import pandas as pd
-from topiary import READS
 
 from . import cells
 from .amino_acids import has_only_standard_amino_acids
@@ -238,7 +237,12 @@ class ExternalVariantEntry:
     had_transcript_ids: bool = False
     resolved_transcript: bool = False
     annotation: object = None       # (gene_ok, effect_ok, label) or None
-    dna_vaf: object = None          # float or None
+    dna_vaf: object = None          # float or None, from a DNA-qualified column
+    # A variant fraction whose assay the source did not state. LENS names
+    # its read columns rna_* and leaves `vaf` bare, so filing it as DNA
+    # asserts something the file never said. Kept apart from dna_vaf so the
+    # report can label it honestly rather than by guess.
+    source_vaf: object = None       # float or None
     has_rna_support: bool = False
     unparseable: bool = False
 
@@ -258,6 +262,7 @@ class ExternalRankingResult:
 
     ranked: list = dataclasses.field(default_factory=list)
     dna_vaf_by_variant: dict = dataclasses.field(default_factory=dict)
+    source_vaf_by_variant: dict = dataclasses.field(default_factory=dict)
     input_summary: ExternalInputSummary = dataclasses.field(
         default_factory=ExternalInputSummary)
 
@@ -585,31 +590,39 @@ def _read_counts_from_lens_row(row):
     reordered vaccine peptides.
 
     topiary populates the fields with the derivation named per field
-    (``read_count_method``): depth x VAF for the alt/ref split, and the
+    (``rna_evidence_method``): depth x VAF for the alt/ref split, and the
     CDS-overlap count kept where it belongs, in
     ``n_alt_reads_supporting_protein_sequence``. A row whose source could
     not answer carries no estimate rather than a zero standing in for one;
     the zero appears here only because the fragment field is not nullable.
     """
     return (
-        cells.integer(row.get('n_overlapping_reads'), default=0),
-        cells.integer(row.get('n_alt_reads'), default=0),
-        cells.integer(row.get('n_ref_reads'), default=0),
+        cells.integer(row.get('n_rna_overlapping'), default=0),
+        cells.integer(row.get('n_rna_alt'), default=0),
+        cells.integer(row.get('n_rna_ref'), default=0),
+        # topiary dropped its supporting-count column as duplicative of
+        # n_rna_* for single-unit sources, so this comes from the LENS
+        # column directly. It is a pass-through of a number the file
+        # states, not a derivation — and it counts reads overlapping the
+        # peptide's CDS, which is why it lives in this field and not in
+        # n_rna_alt.
         cells.integer(
-            row.get('n_alt_reads_supporting_protein_sequence'), default=0),
+            row.get('rna_reads_covering_genomic_origin_with_peptide_cds'),
+            default=0),
     )
 
 
 def _read_provenance_from_lens_row(row):
-    """``(read_count_method, sequence_source)`` for a LENS row.
+    """``(rna_evidence_method, sequence_source, rna_evidence_subject)``.
 
     Read alongside the counts rather than derived: topiary labels each
     field with how it was obtained, and dropping the label leaves an
     estimate indistinguishable from a measurement (#375).
     """
     return (
-        cells.text(row.get('read_count_method')),
+        cells.text(row.get('rna_evidence_method')),
         cells.text(row.get('sequence_source')),
+        cells.text(row.get('rna_evidence_subject')),
     )
 
 
@@ -627,6 +640,7 @@ class ExternalRankingAccumulator:
 
     ranked: list = dataclasses.field(default_factory=list)
     dna_vaf_by_variant: dict = dataclasses.field(default_factory=dict)
+    source_vaf_by_variant: dict = dataclasses.field(default_factory=dict)
     annotation_results: list = dataclasses.field(default_factory=list)
     n_unparseable: int = 0
     n_parseable: int = 0
@@ -652,6 +666,8 @@ class ExternalRankingAccumulator:
             self.n_with_rna += 1
         if entry.dna_vaf is not None:
             self.dna_vaf_by_variant[entry.variant] = entry.dna_vaf
+        if entry.source_vaf is not None:
+            self.source_vaf_by_variant[entry.variant] = entry.source_vaf
         if entry.vaccine_peptide is not None:
             self.ranked.append((entry.variant, [entry.vaccine_peptide]))
 
@@ -664,6 +680,7 @@ class ExternalRankingAccumulator:
         return ExternalRankingResult(
             ranked=ranked_sorted_by_target_score(self.ranked),
             dna_vaf_by_variant=self.dna_vaf_by_variant,
+            source_vaf_by_variant=self.source_vaf_by_variant,
             input_summary=ExternalInputSummary(
                 num_somatic_variants=self.n_parseable,
                 num_coding_effect_variants=self.n_resolved_transcripts,
@@ -729,7 +746,14 @@ def lens_variant_metadata(variant_id, group_rows, genome=None):
         if cells.missing(value):
             continue
         try:
-            entry.dna_vaf = float(value)
+            # LENS names its read columns rna_* explicitly and leaves this
+            # one bare, so the assay is unstated. Recorded as the source's
+            # own fraction rather than as a DNA VAF: calling it DNA asserts
+            # an assay the file never claimed, and the report printed it
+            # under "DNA VAF" on that basis. topiary reached the same
+            # conclusion for its own use of this column, which is why the
+            # LENS split is rna_depth_x_source_vaf.
+            entry.source_vaf = float(value)
             break
         except (TypeError, ValueError):
             continue
@@ -792,7 +816,7 @@ class ExternalConstructOptions:
 
 def external_vaccine_peptide(variant, selection, context, mutant_start,
                              mutant_end, gene_name, transcripts, counts,
-                             options, provenance=("", "")):
+                             options, provenance=("", "", "")):
     """Assemble one ``VaccinePeptide`` from an external construct window.
 
     Shared by every external format so a construct built from a LENS
@@ -836,12 +860,10 @@ def external_vaccine_peptide(variant, selection, context, mutant_start,
         for epitope in epitopes
     ]
     n_total, n_alt, n_ref, n_alt_protein = counts
-    read_count_method, sequence_source = provenance
-    # Both external readers estimate from a depth and a fraction, or count
-    # CDS overlap; either way the unit is reads. Stated rather than left
-    # blank so a threshold copied from a native run can tell it is a
-    # different bar (openvax/topiary#239).
-    read_count_subject = READS if read_count_method else ""
+    # The subject comes from the reader rather than being assumed here:
+    # both external sources happen to count reads, but that is a fact about
+    # them, not something this function should assert on their behalf.
+    rna_evidence_method, sequence_source, rna_evidence_subject = provenance
     fragment = MutantProteinFragment(
         variant=variant,
         gene_name=gene_name,
@@ -854,8 +876,8 @@ def external_vaccine_peptide(variant, selection, context, mutant_start,
         n_ref_reads=n_ref,
         n_alt_reads_supporting_protein_sequence=n_alt_protein,
         placeholder_alleles=False,
-        read_count_method=read_count_method,
-        read_count_subject=read_count_subject,
+        rna_evidence_method=rna_evidence_method,
+        rna_evidence_subject=rna_evidence_subject,
         sequence_source=sequence_source,
     )
     return VaccinePeptide(
@@ -1335,11 +1357,12 @@ def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None):
             (int(depths[index] or 0),
              int(alt) if stated else 0,
              int(ref) if not pd.isna(ref) else 0),
-            ("rna_depth_x_vaf" if stated else "",
-             cells.text(record.row.get("sequence_source")))))
+            (cells.text(record.row.get("rna_evidence_method")),
+             cells.text(record.row.get("sequence_source")),
+             cells.text(record.row.get("rna_evidence_subject")))))
     (n_total, n_alt_reads, n_ref_reads), provenance = max(
         observations, key=lambda o: (o[0][1], o[0][0]),
-        default=((0, 0, 0), ("", "")))
+        default=((0, 0, 0), ("", "", "")))
     metadata.vaccine_peptide = external_vaccine_peptide(
         variant=metadata.variant,
         selection=selection,

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -64,9 +64,9 @@ def find_mutation_region(reference_protein, mutant_protein):
 
 # Read-count vocabulary, all of it topiary's. Two orthogonal axes:
 #
-#   read_count_method    how the number was obtained -- rna_reads,
+#   rna_evidence_method    how the number was obtained -- rna_reads,
 #                        rna_depth_x_vaf, cds_overlap_reads, ...
-#   read_count_subject   what it counted -- reads or fragments
+#   rna_evidence_subject   what it counted -- reads or fragments
 #
 # vaxrank asked for an ``rna_fragments`` *method* and that was the wrong
 # shape (openvax/topiary#239): a subject is not a derivation, and a term
@@ -98,8 +98,13 @@ SEQUENCE_SOURCE_ISOVAR_ASSEMBLY = _sequence_source("isovar_assembly")
 SEQUENCE_SOURCE_VARCODE_TRANSLATION = _sequence_source("varcode_translation")
 
 
-def _read_count_method(name):
-    """Return a topiary read-count method term, failing loudly if it is gone."""
+def _rna_evidence_method(name):
+    """Return a topiary RNA-evidence method term, failing loudly if it is gone.
+
+    The guard earned itself: ``rna_reads`` was renamed to ``rna_alignment``
+    in topiary 5.45.0, and this raised at import across the whole test suite
+    rather than stamping fragments with a term nothing recognizes.
+    """
     from topiary import READ_COUNT_METHODS
 
     if name not in READ_COUNT_METHODS:
@@ -109,7 +114,9 @@ def _read_count_method(name):
     return name
 
 
-READ_COUNT_METHOD_RNA_READS = _read_count_method("rna_reads")
+# Counted from an alignment. Says how, not what — the subject is separate,
+# because an aligner can count either reads or fragments.
+RNA_EVIDENCE_METHOD_ALIGNMENT = _rna_evidence_method("rna_alignment")
 
 
 @dataclass
@@ -185,7 +192,7 @@ class MutantProteinFragment(DataclassSerializable):
     # and the combined-score DSL weights them identically —
     # sqrt(n_alt_reads) does not know that 51 was arithmetic rather than
     # observation. Carrying the label is what lets a reader tell.
-    read_count_method: str = ""
+    rna_evidence_method: str = ""
 
     # What those counts counted: topiary's FRAGMENTS or READS, blank when
     # the source did not say. Separate from the method because how a number
@@ -193,7 +200,18 @@ class MutantProteinFragment(DataclassSerializable):
     # count may be either. Five fragments and five reads are different bars,
     # and converting between them needs library information no source
     # carries, so this is stated rather than normalized.
-    read_count_subject: str = ""
+    rna_evidence_subject: str = ""
+
+    # The same counts in fragments, where the source has them. isovar
+    # reports every count in both units; vaxrank stored only the fragment
+    # numbers, in the fields named for reads, and then described that as a
+    # subject the caller had to ask about. The reads were never
+    # unavailable — carrying both is what makes the subject a fact about
+    # the source rather than a workaround for a lie (openvax/topiary#239).
+    n_overlapping_fragments: Any = None
+    n_alt_fragments: Any = None
+    n_ref_fragments: Any = None
+    n_alt_fragments_supporting_protein_sequence: Any = None
 
     # How the protein sequence was obtained: "lens_pep_context",
     # "pvacseq_epitope", "varcode_translation", "isovar_assembly",
@@ -267,25 +285,22 @@ class MutantProteinFragment(DataclassSerializable):
             mutant_amino_acid_start_offset=protein_sequence.mutation_start_idx,
             mutant_amino_acid_end_offset=protein_sequence.mutation_end_idx,
 
-            # These are FRAGMENT counts, and the fields are named for
-            # reads. For paired-end data a fragment is two reads, so these
-            # are roughly half the read count for the same evidence.
-            #
-            # Not converted, because the conversion needs to know whether
-            # the library was paired-end and isovar does not say. Labelled
-            # instead: read_count_method carries the subject so a consumer
-            # comparing this against a LENS estimate can see they are
-            # different quantities rather than inferring it from the field
-            # name, which asserts the wrong one (#382).
-            n_overlapping_reads=isovar_result.num_total_fragments,
-            n_alt_reads=isovar_result.num_alt_fragments,
-            n_ref_reads=isovar_result.num_ref_fragments,
-            n_alt_reads_supporting_protein_sequence=protein_sequence.num_supporting_fragments,
-            # Counted from an alignment (rna_reads), and what it counted
-            # is fragments. Two axes, because "how" and "what" are
-            # independent: another aligner-derived count could be reads.
-            read_count_method=READ_COUNT_METHOD_RNA_READS,
-            read_count_subject=FRAGMENTS,
+            # isovar reports every count in both units, so carry both.
+            # vaxrank used to store the fragment numbers in the read fields
+            # and call the discrepancy a subject the caller had to ask
+            # about — but the reads were there the whole time.
+            n_overlapping_reads=isovar_result.num_total_reads,
+            n_alt_reads=isovar_result.num_alt_reads,
+            n_ref_reads=isovar_result.num_ref_reads,
+            n_alt_reads_supporting_protein_sequence=protein_sequence.num_supporting_reads,
+            n_overlapping_fragments=isovar_result.num_total_fragments,
+            n_alt_fragments=isovar_result.num_alt_fragments,
+            n_ref_fragments=isovar_result.num_ref_fragments,
+            n_alt_fragments_supporting_protein_sequence=protein_sequence.num_supporting_fragments,
+            # Counted from an alignment; the subject says which unit the
+            # n_rna_* accessors report, which is fragments when both exist.
+            rna_evidence_method=RNA_EVIDENCE_METHOD_ALIGNMENT,
+            rna_evidence_subject=FRAGMENTS,
             sequence_source=SEQUENCE_SOURCE_ISOVAR_ASSEMBLY,
             supporting_reference_transcripts=protein_sequence.transcripts)
 
@@ -390,7 +405,7 @@ class MutantProteinFragment(DataclassSerializable):
             mutant_amino_acid_start_offset=local_mut_start,
             mutant_amino_acid_end_offset=local_mut_end,
             # No RNA was consulted, so there is nothing to label: zero
-            # here means "no reads counted", and read_count_method stays
+            # here means "no reads counted", and rna_evidence_method stays
             # blank rather than claiming a derivation produced the zeros.
             n_overlapping_reads=0,
             n_alt_reads=0,
@@ -400,22 +415,42 @@ class MutantProteinFragment(DataclassSerializable):
             supporting_reference_transcripts=[transcript],
         )
 
-    def count_in(self, name, subject):
-        """``name``'s value if it counts ``subject``, else ``None``.
+    # ── RNA evidence, in whichever unit the source actually has ──────────
+    #
+    # Fragments where a source reports them, reads otherwise. Fragments win
+    # because two mates of one fragment are one piece of evidence, so a
+    # read count overstates paired-end support by roughly two — the wrong
+    # thing to feed a diminishing-returns weight like sqrt().
+    #
+    # These replace a ``count_in(name, subject)`` accessor, which existed
+    # only because fragments were stored under the reads name and something
+    # had to explain that reads were unavailable. They were not
+    # unavailable. Naming both is what isovar always did.
 
-        Mirrors ``topiary.ProteinFragment.count_in`` so a caller holding
-        either kind of fragment asks the same question the same way.
+    def _rna(self, fragments_value, reads_value):
+        return fragments_value if fragments_value is not None else reads_value
 
-        ``None`` rather than a converted number: turning a read estimate
-        into fragments needs library information no source carries, so a
-        fragment whose counts are in the other unit says it cannot answer.
-        Callers weighting these must decide what an unanswerable count
-        means for them — treating it as zero would reintroduce exactly the
-        substitution this exists to prevent.
-        """
-        if self.read_count_subject and self.read_count_subject != subject:
-            return None
-        return getattr(self, name)
+    @property
+    def n_rna_alt(self):
+        """Alt-supporting RNA evidence, fragments preferred."""
+        return self._rna(self.n_alt_fragments, self.n_alt_reads)
+
+    @property
+    def n_rna_ref(self):
+        """Reference-supporting RNA evidence, fragments preferred."""
+        return self._rna(self.n_ref_fragments, self.n_ref_reads)
+
+    @property
+    def n_rna_overlapping(self):
+        """RNA evidence covering the position, fragments preferred."""
+        return self._rna(self.n_overlapping_fragments,
+                         self.n_overlapping_reads)
+
+    @property
+    def n_rna_supporting_protein_sequence(self):
+        """RNA evidence spanning the assembled sequence, fragments preferred."""
+        return self._rna(self.n_alt_fragments_supporting_protein_sequence,
+                         self.n_alt_reads_supporting_protein_sequence)
 
     def __len__(self):
         return len(self.amino_acids)

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -118,6 +118,7 @@ class TemplateDataCreator(object):
             input_json_file,
             cosmic_vcf_filename=None,
             dna_vaf_by_variant=None,
+            source_vaf_by_variant=None,
             processing_predictions_by_key=None,
             mrna_ranking_decisions=None,
             vaccine_constructions=None,
@@ -136,6 +137,7 @@ class TemplateDataCreator(object):
         self.ranked_variants_with_vaccine_peptides = ranked_variants_with_vaccine_peptides
         self.patient_info = patient_info
         self.dna_vaf_by_variant = dna_vaf_by_variant or {}
+        self.source_vaf_by_variant = source_vaf_by_variant or {}
         self.processing_predictions_by_key = (
             processing_predictions_by_key or {})
         # Issue #270: mRNA ranking-decisions section. Legacy field;
@@ -269,6 +271,7 @@ class TemplateDataCreator(object):
         igv_locus = "chr%s:%d" % (variant.contig, variant.start)
         rna_vaf = mutant_protein_fragment.rna_vaf
         dna_vaf = self.dna_vaf_by_variant.get(variant)
+        source_vaf = self.source_vaf_by_variant.get(variant)
         variant_data = OrderedDict([
             ('IGV locus', igv_locus),
             ('Gene name', mutant_protein_fragment.gene_name),
@@ -279,17 +282,24 @@ class TemplateDataCreator(object):
             ('RNA reads supporting reference allele', mutant_protein_fragment.n_ref_reads),
             ('RNA reads supporting other alleles', mutant_protein_fragment.n_other_reads),
         ])
+        # A variant fraction the source did not qualify. Shown under its
+        # own label rather than as DNA VAF, which is what LENS's bare
+        # `vaf` used to be printed as — asserting an assay the file never
+        # stated.
+        if source_vaf is not None:
+            variant_data['Variant fraction (assay unstated)'] = (
+                '%.3f' % source_vaf)
         # Say how those counts were obtained. "51 reads" from an alignment
         # and "51" from depth x VAF are the same integer and not the same
         # claim, and the combined-score DSL weights them identically.
-        if mutant_protein_fragment.read_count_method:
+        if mutant_protein_fragment.rna_evidence_method:
             variant_data['RNA read count method'] = (
-                mutant_protein_fragment.read_count_method)
+                mutant_protein_fragment.rna_evidence_method)
         # What those counts counted. Five fragments and five reads are
         # different bars, and the rows above say neither on their own.
-        if mutant_protein_fragment.read_count_subject:
+        if mutant_protein_fragment.rna_evidence_subject:
             variant_data['RNA read count subject'] = (
-                mutant_protein_fragment.read_count_subject)
+                mutant_protein_fragment.rna_evidence_subject)
         if mutant_protein_fragment.sequence_source:
             variant_data['Protein sequence source'] = (
                 mutant_protein_fragment.sequence_source)


### PR DESCRIPTION
topiary 5.45.0 removed `count_in` and the subject accessor vaxrank mirrored, **because the premise under them was false.**

isovar exposes `num_alt_reads` beside `num_alt_fragments` — reads, fragments, ref, total, supporting, every count in both units. vaxrank stored only the fragment numbers, in the fields named for reads, and then offered an accessor to explain that reads were unavailable. They were never unavailable. The field was lying and the accessor was describing the lie.

### Both units, each in the field named for it

```
n_alt_reads      15     isovar's num_alt_reads
n_alt_fragments   8     isovar's num_alt_fragments
n_rna_alt         8     fragments preferred
```

Fragments win where a source has them: two mates of one fragment are one piece of evidence, so a read count overstates paired-end support by roughly two — the wrong input to a diminishing-returns weight like `sqrt()`. Reads are what `n_rna_*` reports where reads are all there is, and `rna_evidence_subject` says which.

```
isovar    reads 15  frags 8     n_rna_alt 8   rna_alignment           fragments
lens      reads 4   frags None  n_rna_alt 4   rna_depth_x_source_vaf  reads
pvacseq   reads 68  frags None  n_rna_alt 68  rna_depth_x_vaf         reads
```

`read_count_method`/`subject` become `rna_evidence_method`/`subject`, and the `rna_reads` term is now `rna_alignment` — it says a count came from an alignment, not which unit the aligner counted.

### The import guard earned itself

`rna_reads` disappearing from `READ_COUNT_METHODS` raised at import **across 42 test files**, rather than stamping fragments with a term nothing recognizes.

### The LENS `vaf`, which is our bug too

topiary flagged that LENS's bare `vaf` has no assay qualifier — LENS names its read columns `rna_*` explicitly and leaves this one bare. vaxrank assigned it to `dna_vaf`, and the report printed it under **"DNA VAF"**, asserting an assay the file never stated.

It is `source_vaf` now, shown as "Variant fraction (assay unstated)", and the split that uses it says `rna_depth_x_source_vaf` rather than claiming the fraction was RNA. pVACseq's VAFs *are* qualified and keep `dna_vaf`, with a test so the fix doesn't collapse a source that did say.

### Verification

- LENS fixtures byte-identical.
- 1174 tests pass. Floor moves to `topiary>=5.45.0`.