### PR TITLE
Report other-allele reads only where the reference was counted

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ mhctools>=3.13.3,<4.0.0
 # netmhcpan) without pre-subsetting the frame.
 # 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
 # categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.45.0,<6.0.0
+topiary>=5.47.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -524,7 +524,7 @@ def test_pvacseq_source_keyed_filtered_scores_do_not_broadcast(tmp_path):
     report_df, epitopes = _loaded.report_df, list(_loaded.epitopes)
     csv_path = tmp_path / "filtered.csv"
     cfg = EpitopeConfig(
-        filter_expr="tumor_dna_vaf > 0.5",
+        filter_expr="pvacseq_tumor_dna_vaf > 0.5",
         score_expr="affinity.value")
 
     write_neoepitope_report(

--- a/tests/test_read_count_provenance.py
+++ b/tests/test_read_count_provenance.py
@@ -275,3 +275,58 @@ def test_pvacseq_keeps_its_qualified_dna_vaf():
 
     assert result.dna_vaf_by_variant
     assert result.source_vaf_by_variant == {}
+
+
+def test_other_allele_reads_are_absent_when_the_reference_was_derived():
+    """A subtraction of a subtraction is not an observation.
+
+    Where a source reports a depth and a fraction, the reference count is
+    ``depth - alt``, so ``depth - (ref + alt)`` is structurally zero — and
+    the report printed that zero as a fact about the locus. Worse when the
+    source reports no fraction: alt and ref are both 0 and the subtraction
+    returns the whole depth, rendering a clean locus as one where every
+    read supports a third allele.
+    """
+    config = EpitopeConfig()
+    report = read_pvacseq_report(
+        os.path.join(DATA_DIR, "pvacseq_example.tsv"), epitope_config=config)
+    result = pvacseq_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+
+    fragment = result.ranked[0][1][0].mutant_protein_fragment
+
+    assert fragment.n_ref_reads > 0        # derived, not counted
+    assert fragment.reference_count_was_measured is False
+    assert fragment.n_other_reads is None
+
+
+def test_other_allele_reads_survive_where_the_reference_was_counted():
+    """isovar counts the reference independently, so the number is real."""
+    fragment = MutantProteinFragment.from_isovar_result(_fake_isovar_result())
+
+    assert fragment.reference_count_was_measured is True
+    # 38 total reads, 15 alt, 23 ref — nothing left for a third allele here,
+    # but the zero is an observation rather than an artifact of the method.
+    assert fragment.n_other_reads == 0
+
+
+def test_the_report_omits_the_row_when_there_is_nothing_to_report():
+    """An absent measurement is not a zero on the page."""
+    from vaxrank.report import TemplateDataCreator
+
+    config = EpitopeConfig()
+    report = read_pvacseq_report(
+        os.path.join(DATA_DIR, "pvacseq_example.tsv"), epitope_config=config)
+    result = pvacseq_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+    vaccine_peptide = result.ranked[0][1][0]
+
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.dna_vaf_by_variant = {}
+    creator.source_vaf_by_variant = {}
+    creator.gene_pathway_check = None
+    variant_data = creator._variant_data(
+        vaccine_peptide.mutant_protein_fragment.variant, vaccine_peptide)
+
+    assert 'RNA reads supporting other alleles' not in variant_data
+    assert 'RNA reads supporting variant allele' in variant_data

--- a/tests/test_read_count_provenance.py
+++ b/tests/test_read_count_provenance.py
@@ -330,3 +330,22 @@ def test_the_report_omits_the_row_when_there_is_nothing_to_report():
 
     assert 'RNA reads supporting other alleles' not in variant_data
     assert 'RNA reads supporting variant allele' in variant_data
+
+
+def test_what_counts_as_measured_is_topiarys_rule():
+    """No local copy of which methods count.
+
+    Only a direct count qualifies today, so naming ``rna_alignment`` here
+    would agree — and would silently exclude any measured method topiary
+    adds later, which is the drift this series has spent its length
+    removing.
+    """
+    import dataclasses
+
+    from topiary import READ_COUNT_METHODS, provenance_for_method
+
+    base = MutantProteinFragment.from_isovar_result(_fake_isovar_result())
+    for method in sorted(READ_COUNT_METHODS):
+        fragment = dataclasses.replace(base, rna_evidence_method=method)
+        assert fragment.reference_count_was_measured is (
+            provenance_for_method(method) == "measured"), method

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -607,7 +607,12 @@ def _read_counts_from_lens_row(row):
         # peptide's CDS, which is why it lives in this field and not in
         # n_rna_alt.
         cells.integer(
-            row.get('rna_reads_covering_genomic_origin_with_peptide_cds'),
+            cells.first(
+                row,
+                # topiary 5.47.0 prefixes each tool's own columns with the
+                # tool name; the bare spelling is the pre-5.47 one.
+                'lens_rna_reads_covering_genomic_origin_with_peptide_cds',
+                'rna_reads_covering_genomic_origin_with_peptide_cds'),
             default=0),
     )
 
@@ -742,7 +747,12 @@ def lens_variant_metadata(variant_id, group_rows, genome=None):
         ) + (str(variant_id),)),
     )
     for row in group_rows:
-        value = row.get("vaf")
+        # lens_vaf is topiary's source-prefixed original; `vaf` is the
+        # pre-5.47 spelling. Deliberately not `rna_vaf`, which topiary also
+        # publishes on LENS frames as a verbatim copy of this column —
+        # reading that would inherit an assay assertion the file never made
+        # and this function exists to avoid.
+        value = cells.first(row, "lens_vaf", "vaf")
         if cells.missing(value):
             continue
         try:
@@ -1335,31 +1345,22 @@ def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None):
             "is empty or contains non-standard residues.",
             key.variant_id, key.source_sequence)
         return metadata
-    # Same rule as the LENS path: the counts and the label describing them
-    # come from one row.
-    # depth x VAF is an estimate, not a count: pVACseq reports a depth and
-    # a fraction and never an alt-read count. The arithmetic is topiary's
-    # rather than ours — the LENS path already reads its derived columns,
-    # and a local copy of an upstream rule is the shape that produced every
-    # version bug in this file's history (#383).
-    from topiary import split_reads_by_vaf
-
-    depths = [pvacseq_rna_depth(record.row) for record in selection.records]
-    vafs = [pvacseq_rna_vaf(record.row) for record in selection.records]
-    alt_series, ref_series = split_reads_by_vaf(
-        pd.Series(depths, dtype="Float64"), pd.Series(vafs, dtype="Float64"))
-    observations = []
-    for index, record in enumerate(selection.records):
-        alt = alt_series.iloc[index]
-        ref = ref_series.iloc[index]
-        stated = not pd.isna(alt)
-        observations.append((
-            (int(depths[index] or 0),
-             int(alt) if stated else 0,
-             int(ref) if not pd.isna(ref) else 0),
-            (cells.text(record.row.get("rna_evidence_method")),
-             cells.text(record.row.get("sequence_source")),
-             cells.text(record.row.get("rna_evidence_subject")))))
+    # Read the counts topiary derived rather than deriving them here. The
+    # LENS path has done this since #374; pVACseq kept a local depth x VAF
+    # because topiary published no derived counts for it. topiary 5.47.0
+    # does, so the last hand-rolled split goes (#383).
+    #
+    # The counts and the label describing them still come from one row: a
+    # method describing a row whose numbers were not used is the per-field
+    # maximum problem one field over.
+    observations = [
+        ((cells.integer(record.row.get("n_rna_overlapping"), default=0),
+          cells.integer(record.row.get("n_rna_alt"), default=0),
+          cells.integer(record.row.get("n_rna_ref"), default=0)),
+         (cells.text(record.row.get("rna_evidence_method")),
+          cells.text(record.row.get("sequence_source")),
+          cells.text(record.row.get("rna_evidence_subject"))))
+        for record in selection.records]
     (n_total, n_alt_reads, n_ref_reads), provenance = max(
         observations, key=lambda o: (o[0][1], o[0][0]),
         default=((0, 0, 0), ("", "", "")))

--- a/vaxrank/external_prediction.py
+++ b/vaxrank/external_prediction.py
@@ -38,9 +38,16 @@ external_values = cells.values
 # both onto one of these names. Rows only ever reach this module already
 # normalized, so the raw pVACseq spellings are deliberately absent — listing
 # them would imply a second vocabulary is still in play here.
-_PVACSEQ_RNA_DEPTH_COLUMNS = ("rna_depth", "tumor_rna_depth")
-_PVACSEQ_RNA_VAF_COLUMNS = ("rna_vaf", "tumor_rna_vaf")
-_PVACSEQ_DNA_VAF_COLUMNS = ("dna_vaf", "tumor_dna_vaf")
+# Canonical names first, then the source-prefixed originals topiary 5.47.0
+# publishes alongside them, then the pre-5.47 spellings. Canonical first
+# because it means the same thing from every reader; the originals are the
+# fallback for a frame that carries only what the tool printed.
+_PVACSEQ_RNA_DEPTH_COLUMNS = (
+    "pvacseq_tumor_rna_depth", "rna_depth", "tumor_rna_depth")
+_PVACSEQ_RNA_VAF_COLUMNS = (
+    "rna_vaf", "pvacseq_tumor_rna_vaf", "tumor_rna_vaf")
+_PVACSEQ_DNA_VAF_COLUMNS = (
+    "dna_vaf", "pvacseq_tumor_dna_vaf", "tumor_dna_vaf")
 
 
 def pvacseq_variant_id(row) -> str:

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -471,10 +471,39 @@ class MutantProteinFragment(DataclassSerializable):
         return self.n_mutant_amino_acids == 0 and self.variant.is_deletion
 
     @property
+    def reference_count_was_measured(self) -> bool:
+        """True when the reference count was counted, not derived.
+
+        Only an alignment counts reference support independently. Every
+        other method reaches the reference side by subtracting the alt
+        estimate from a depth, which makes anything derived from it a
+        restatement of that subtraction rather than a new observation.
+        """
+        return self.rna_evidence_method == RNA_EVIDENCE_METHOD_ALIGNMENT
+
+    @property
     def n_other_reads(self):
+        """Reads supporting alleles which are neither ref nor alt.
+
+        ``None`` when the reference count was derived rather than counted,
+        because the subtraction then has no content. Where a source reports
+        a depth and a fraction, topiary splits it as ``ref = depth - alt``,
+        so:
+
+            other = depth - (ref + alt) = depth - ((depth - alt) + alt) = 0
+
+        A structural zero, printed as an observation about the locus. Worse
+        when the source reports no fraction at all: alt and ref are both 0,
+        and the subtraction returns the entire depth — a clean locus
+        rendered as one where every read supports a third allele.
+
+        topiary reached the same conclusion for its frames, where
+        ``n_rna_other`` is absent unless the source counted the reference
+        independently. The native isovar path does count it, and keeps
+        this number.
         """
-        Number of reads supporting alleles which are neither ref nor alt
-        """
+        if not self.reference_count_was_measured:
+            return None
         return self.n_overlapping_reads - (self.n_ref_reads + self.n_alt_reads)
 
     @property

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -474,12 +474,18 @@ class MutantProteinFragment(DataclassSerializable):
     def reference_count_was_measured(self) -> bool:
         """True when the reference count was counted, not derived.
 
-        Only an alignment counts reference support independently. Every
-        other method reaches the reference side by subtracting the alt
-        estimate from a depth, which makes anything derived from it a
-        restatement of that subtraction rather than a new observation.
+        Asks ``topiary.provenance_for_method`` rather than naming the
+        measured method here. Only a direct count qualifies today, so the
+        two agree — but which methods count is topiary's rule, and a local
+        copy of it would silently exclude any measured method added later.
+        An unstated method is not measured: the varcode path consults no
+        RNA, so its zeros are unknowns rather than observations.
         """
-        return self.rna_evidence_method == RNA_EVIDENCE_METHOD_ALIGNMENT
+        from topiary import provenance_for_method
+
+        if not self.rna_evidence_method:
+            return False
+        return provenance_for_method(self.rna_evidence_method) == "measured"
 
     @property
     def n_other_reads(self):

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -280,8 +280,15 @@ class TemplateDataCreator(object):
             ('RNA VAF', '%.3f' % rna_vaf if rna_vaf is not None else 'n/a'),
             ('RNA reads supporting variant allele', mutant_protein_fragment.n_alt_reads),
             ('RNA reads supporting reference allele', mutant_protein_fragment.n_ref_reads),
-            ('RNA reads supporting other alleles', mutant_protein_fragment.n_other_reads),
         ])
+        # Only when the reference count was counted rather than derived.
+        # Where a source reports a depth and a fraction, ref is depth minus
+        # alt, so this subtraction is structurally zero — and the whole
+        # depth when no fraction was reported at all. Printing either as
+        # "reads supporting other alleles" describes the locus wrongly.
+        if mutant_protein_fragment.n_other_reads is not None:
+            variant_data['RNA reads supporting other alleles'] = (
+                mutant_protein_fragment.n_other_reads)
         # A variant fraction the source did not qualify. Shown under its
         # own label rather than as DNA VAF, which is what LENS's bare
         # `vaf` used to be printed as — asserting an assay the file never


### PR DESCRIPTION
Closes #389.

`n_other_reads` is `n_overlapping_reads - (n_ref_reads + n_alt_reads)`, printed as **"RNA reads supporting other alleles"**. On both external paths the reference count is not measured — topiary splits a reported depth and fraction as `ref = depth - alt`. Substitute and the subtraction collapses:

```
other = depth - (ref + alt) = depth - ((depth - alt) + alt) = 0
```

A structural zero, printed as an observation about the locus. Measured on the real fixtures before this change:

```
lens     (446,  4,   442,  0)
         (2337, 51,  2286, 0)
         (67,   0,   0,    67)   <- no VAF reported
pvacseq  (200,  68,  132,  0)
```

The last LENS row is the worse case: no fraction means no split was made, so alt and ref are both zero and the subtraction returns **the whole depth** — a clean locus rendered as one where every read supports a third allele.

It is `None` now unless the reference was counted, and the report omits the row. `rna_evidence_method` already distinguishes the two: `rna_alignment` means counted, everything else means the reference side came from arithmetic. The native isovar path counts reference reads independently and keeps the number.

topiary reached the same conclusion for its own frames in 5.47.0, where `n_rna_other` is absent unless the source counted the reference.

### 5.47.0 adoption, folded in

Not optional — the floor admits it and it renames what these paths read.

- **pVACseq reads topiary's `n_rna_*`** rather than deriving depth × VAF. The LENS path has done this since #374; pVACseq kept a local copy only because topiary published no derived counts for it, and 5.47.0 does. That was the last hand-rolled split (#383).
- **Source-prefixed columns**: the pVACseq depth and the LENS CDS-overlap count are read under both spellings.
- **LENS's unqualified fraction comes from `lens_vaf`** — deliberately *not* `rna_vaf`, which topiary also publishes on LENS frames as a verbatim copy of it. Reading that would inherit an assay assertion the file never made, which is exactly what `source_vaf` exists to avoid.

### Verification

- LENS fixtures byte-identical.
- 1177 tests pass; ruff clean. Floor moves to `topiary>=5.47.0`.