### PR TITLE
Carry DNA evidence, mirroring RNA

### DIFF
--- a/tests/test_read_count_provenance.py
+++ b/tests/test_read_count_provenance.py
@@ -465,3 +465,31 @@ def test_the_report_shows_dna_counts_only_where_they_exist():
     rows = variant_data_for(
         aggregated_peptide.mutant_protein_fragment, aggregated_peptide)
     assert 'DNA reads supporting variant allele' not in rows
+
+
+def test_the_reported_dna_vaf_comes_from_the_row_its_counts_came_from():
+    """One observation, not a fraction and a depth from different rows.
+
+    The report used to read the DNA VAF from a per-variant map while the
+    counts came from a specific row. They agree today, and nothing enforced
+    it — a variant group whose rows disagreed would print a fraction beside
+    a depth that never produced it, which is the per-field maximum problem
+    one field over.
+    """
+    from vaxrank.report import TemplateDataCreator
+
+    fragment = _all_epitopes_fragment()
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    # A deliberately contradictory map: the fragment's own value must win.
+    creator.dna_vaf_by_variant = {fragment.variant: 0.999}
+    creator.source_vaf_by_variant = {}
+    creator.gene_pathway_check = None
+
+    class _Peptide:
+        mutant_protein_fragment = fragment
+        combined_score = 1.0
+
+    rows = creator._variant_data(fragment.variant, _Peptide())
+
+    assert rows['DNA VAF'] == '%.3f' % fragment.dna_vaf
+    assert rows['DNA reads covering the position'] == fragment.n_dna_overlapping

--- a/tests/test_read_count_provenance.py
+++ b/tests/test_read_count_provenance.py
@@ -349,3 +349,119 @@ def test_what_counts_as_measured_is_topiarys_rule():
         fragment = dataclasses.replace(base, rna_evidence_method=method)
         assert fragment.reference_count_was_measured is (
             provenance_for_method(method) == "measured"), method
+
+
+def _all_epitopes_fragment():
+    import pathlib
+    import tempfile
+
+    from tests.test_epitope_io import _write_pvacseq_all_epitopes_fixture
+
+    path = _write_pvacseq_all_epitopes_fixture(
+        pathlib.Path(tempfile.mkdtemp()))
+    config = EpitopeConfig()
+    report = read_pvacseq_report(path, epitope_config=config)
+    result = pvacseq_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+    return result.ranked[0][1][0].mutant_protein_fragment
+
+
+def test_dna_evidence_mirrors_rna_where_the_source_reports_a_depth():
+    """A variant fraction alone cannot say how well a call is backed.
+
+    0.45 from two reads and 0.45 from two hundred are not the same claim,
+    and the report carried only the fraction. pVACseq's all_epitopes
+    flavour reports a DNA depth, so the same depth x VAF split that
+    produces the RNA counts produces these (openvax/topiary#248).
+    """
+    fragment = _all_epitopes_fragment()
+
+    assert (fragment.n_dna_overlapping, fragment.n_dna_alt,
+            fragment.n_dna_ref) == (1233, 372, 861)
+    assert fragment.n_dna_alt + fragment.n_dna_ref == fragment.n_dna_overlapping
+    assert fragment.dna_evidence_method == "dna_depth_x_vaf"
+    assert fragment.dna_evidence_subject == "reads"
+
+
+def test_a_fraction_without_a_depth_yields_no_dna_counts():
+    """The aggregated flavour reports a DNA VAF and no DNA depth.
+
+    Deriving counts from the fraction alone would invent the denominator,
+    which is the substitution this whole series exists to prevent.
+    """
+    config = EpitopeConfig()
+    report = read_pvacseq_report(
+        os.path.join(DATA_DIR, "pvacseq_example.tsv"), epitope_config=config)
+    result = pvacseq_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+
+    fragment = result.ranked[0][1][0].mutant_protein_fragment
+
+    assert fragment.dna_vaf is not None      # the fraction is reported
+    assert fragment.n_dna_alt is None        # the depth is not
+    assert fragment.n_dna_overlapping is None
+    assert fragment.dna_evidence_method == ""
+
+
+def test_lens_gets_no_dna_evidence_at_all():
+    """LENS states no assay for its one fraction, so nothing may be DNA.
+
+    Populating DNA counts from an unqualified fraction asserts the assay
+    the file declined to name — the same reason its RNA split is labelled
+    rna_depth_x_source_vaf rather than rna_depth_x_vaf.
+    """
+    from vaxrank.epitope_io import read_lens_report
+    from vaxrank.external_input import lens_ranking_result
+
+    config = EpitopeConfig()
+    report = read_lens_report(
+        os.path.join(DATA_DIR, "real_lens_subsets",
+                     "lens_v1.4_real_subset.tsv"), epitope_config=config)
+    result = lens_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+
+    fragment = result.ranked[0][1][0].mutant_protein_fragment
+
+    assert fragment.dna_vaf is None
+    assert fragment.n_dna_alt is None
+    assert fragment.dna_evidence_method == ""
+
+
+def test_the_report_shows_dna_counts_only_where_they_exist():
+    """Mirrors the RNA rows, and omits rather than zero-fills."""
+    from vaxrank.report import TemplateDataCreator
+
+    def variant_data_for(fragment, peptide):
+        creator = TemplateDataCreator.__new__(TemplateDataCreator)
+        creator.dna_vaf_by_variant = {}
+        creator.source_vaf_by_variant = {}
+        creator.gene_pathway_check = None
+        return creator._variant_data(fragment.variant, peptide)
+
+    import pathlib
+    import tempfile
+
+    from tests.test_epitope_io import _write_pvacseq_all_epitopes_fixture
+
+    config = EpitopeConfig()
+    path = _write_pvacseq_all_epitopes_fixture(
+        pathlib.Path(tempfile.mkdtemp()))
+    report = read_pvacseq_report(path, epitope_config=config)
+    result = pvacseq_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+    peptide = result.ranked[0][1][0]
+
+    rows = variant_data_for(peptide.mutant_protein_fragment, peptide)
+    assert rows['DNA reads supporting variant allele'] == 372
+    assert rows['DNA read count method'] == 'dna_depth_x_vaf'
+
+    aggregated_report = read_pvacseq_report(
+        os.path.join(DATA_DIR, "pvacseq_example.tsv"), epitope_config=config)
+    aggregated = pvacseq_ranking_result(
+        aggregated_report,
+        epitopes_for_ranking(list(aggregated_report.epitopes), config))
+    aggregated_peptide = aggregated.ranked[0][1][0]
+
+    rows = variant_data_for(
+        aggregated_peptide.mutant_protein_fragment, aggregated_peptide)
+    assert 'DNA reads supporting variant allele' not in rows

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -617,6 +617,26 @@ def _read_counts_from_lens_row(row):
     )
 
 
+def _dna_evidence_from_row(row):
+    """DNA counts and their labels, or blanks when the source has none.
+
+    Only pVACseq answers this, and only its all_epitopes flavour, which
+    reports a DNA depth alongside the fraction. The aggregated flavour
+    carries a fraction with no depth, so the counts stay absent rather than
+    being invented from the fraction alone. LENS states no assay for its
+    single fraction and gets no DNA evidence at all.
+    """
+    return {
+        "n_dna_overlapping": cells.integer(
+            row.get("n_dna_overlapping"), default=None),
+        "n_dna_alt": cells.integer(row.get("n_dna_alt"), default=None),
+        "n_dna_ref": cells.integer(row.get("n_dna_ref"), default=None),
+        "dna_vaf": cells.number(row.get("dna_vaf")),
+        "dna_evidence_method": cells.text(row.get("dna_evidence_method")),
+        "dna_evidence_subject": cells.text(row.get("dna_evidence_subject")),
+    }
+
+
 def _read_provenance_from_lens_row(row):
     """``(rna_evidence_method, sequence_source, rna_evidence_subject)``.
 
@@ -826,7 +846,8 @@ class ExternalConstructOptions:
 
 def external_vaccine_peptide(variant, selection, context, mutant_start,
                              mutant_end, gene_name, transcripts, counts,
-                             options, provenance=("", "", "")):
+                             options, provenance=("", "", ""),
+                             dna_evidence=None):
     """Assemble one ``VaccinePeptide`` from an external construct window.
 
     Shared by every external format so a construct built from a LENS
@@ -874,6 +895,7 @@ def external_vaccine_peptide(variant, selection, context, mutant_start,
     # both external sources happen to count reads, but that is a fact about
     # them, not something this function should assert on their behalf.
     rna_evidence_method, sequence_source, rna_evidence_subject = provenance
+    dna_evidence = dna_evidence or {}
     fragment = MutantProteinFragment(
         variant=variant,
         gene_name=gene_name,
@@ -889,6 +911,7 @@ def external_vaccine_peptide(variant, selection, context, mutant_start,
         rna_evidence_method=rna_evidence_method,
         rna_evidence_subject=rna_evidence_subject,
         sequence_source=sequence_source,
+        **dna_evidence,
     )
     return VaccinePeptide(
         mutant_protein_fragment=fragment,
@@ -1359,11 +1382,12 @@ def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None):
           cells.integer(record.row.get("n_rna_ref"), default=0)),
          (cells.text(record.row.get("rna_evidence_method")),
           cells.text(record.row.get("sequence_source")),
-          cells.text(record.row.get("rna_evidence_subject"))))
+          cells.text(record.row.get("rna_evidence_subject"))),
+         _dna_evidence_from_row(record.row))
         for record in selection.records]
-    (n_total, n_alt_reads, n_ref_reads), provenance = max(
+    (n_total, n_alt_reads, n_ref_reads), provenance, dna_evidence = max(
         observations, key=lambda o: (o[0][1], o[0][0]),
-        default=((0, 0, 0), ("", "", "")))
+        default=((0, 0, 0), ("", "", ""), {}))
     metadata.vaccine_peptide = external_vaccine_peptide(
         variant=metadata.variant,
         selection=selection,
@@ -1383,6 +1407,7 @@ def pvacseq_vaccine_entry(metadata, selection, genome=None, options=None):
         # genuinely different count (cds_overlap_reads).
         counts=(n_total, n_alt_reads, n_ref_reads, 0),
         provenance=provenance,
+        dna_evidence=dna_evidence,
         options=options,
     )
     return metadata

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -213,6 +213,23 @@ class MutantProteinFragment(DataclassSerializable):
     n_ref_fragments: Any = None
     n_alt_fragments_supporting_protein_sequence: Any = None
 
+    # DNA evidence, mirroring the RNA fields above. A variant's DNA support
+    # says how well the call itself is backed, which is a different question
+    # from how well it is expressed — and until now vaxrank carried only a
+    # DNA VAF, so a report could show a fraction with no idea what depth it
+    # came from. 0.5 from two reads and 0.5 from two hundred are not the
+    # same claim.
+    #
+    # ``None`` rather than 0 throughout: absent means the source did not
+    # answer. LENS never does — its single fraction states no assay, so
+    # deriving DNA counts from it would assert one (openvax/topiary#248).
+    n_dna_overlapping: Any = None
+    n_dna_alt: Any = None
+    n_dna_ref: Any = None
+    dna_vaf: Any = None
+    dna_evidence_method: str = ""
+    dna_evidence_subject: str = ""
+
     # How the protein sequence was obtained: "lens_pep_context",
     # "pvacseq_epitope", "varcode_translation", "isovar_assembly",
     # "caller_supplied". Distinct from the antigen's biological kind —

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -270,7 +270,15 @@ class TemplateDataCreator(object):
         top_score = _sanitize(top_vaccine_peptide.combined_score)
         igv_locus = "chr%s:%d" % (variant.contig, variant.start)
         rna_vaf = mutant_protein_fragment.rna_vaf
-        dna_vaf = self.dna_vaf_by_variant.get(variant)
+        # The fragment's own DNA VAF wins: it comes from the same row as
+        # the DNA counts below, so the fraction and the depth it came from
+        # describe one observation. The per-variant map is the fallback for
+        # sources that report a fraction without counts, and taking it
+        # first would let a report show a VAF from one row beside counts
+        # from another.
+        dna_vaf = mutant_protein_fragment.dna_vaf
+        if dna_vaf is None:
+            dna_vaf = self.dna_vaf_by_variant.get(variant)
         source_vaf = self.source_vaf_by_variant.get(variant)
         variant_data = OrderedDict([
             ('IGV locus', igv_locus),

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -281,6 +281,24 @@ class TemplateDataCreator(object):
             ('RNA reads supporting variant allele', mutant_protein_fragment.n_alt_reads),
             ('RNA reads supporting reference allele', mutant_protein_fragment.n_ref_reads),
         ])
+        # DNA support for the call itself, where the source reports a
+        # depth to derive it from. A fraction alone cannot say how well a
+        # variant is backed: 0.45 from two reads and 0.45 from two hundred
+        # are not the same claim, and until now the report showed only the
+        # fraction. Absent where the source did not answer — LENS never
+        # does, since its single fraction states no assay.
+        if mutant_protein_fragment.n_dna_alt is not None:
+            variant_data['DNA reads supporting variant allele'] = (
+                mutant_protein_fragment.n_dna_alt)
+        if mutant_protein_fragment.n_dna_ref is not None:
+            variant_data['DNA reads supporting reference allele'] = (
+                mutant_protein_fragment.n_dna_ref)
+        if mutant_protein_fragment.n_dna_overlapping is not None:
+            variant_data['DNA reads covering the position'] = (
+                mutant_protein_fragment.n_dna_overlapping)
+        if mutant_protein_fragment.dna_evidence_method:
+            variant_data['DNA read count method'] = (
+                mutant_protein_fragment.dna_evidence_method)
         # Only when the reference count was counted rather than derived.
         # Where a source reports a depth and a fraction, ref is depth minus
         # alt, so this subtraction is structurally zero — and the whole


### PR DESCRIPTION
Addresses the DNA half of openvax/topiary#248, which was written partly in answer to vaxrank asks.

vaxrank carried a DNA VAF and nothing else, so a report could show a fraction with no idea what depth produced it. **0.45 from two reads and 0.45 from two hundred are not the same claim** about how well a variant call is backed, and only the fraction reached the page.

topiary 5.47.0 derives DNA counts the same way it derives the RNA ones — from a reported depth and fraction — and labels them. `MutantProteinFragment` carries them now, read from the same winning row as the RNA counts:

```
pvacseq all_epitopes   dna(total, alt, ref) = (1233, 372, 861)
                       vaf 0.302   dna_depth_x_vaf
pvacseq aggregated     (None, None, None)   vaf 0.45   no method
lens                   (None, None, None)   vaf None   no method
```

### The two absences are the point

- The **aggregated** flavour reports a DNA fraction and no DNA depth, so deriving counts would invent the denominator.
- **LENS** states no assay for its single fraction at all, so giving it DNA evidence would assert the one thing that column cannot say — the same reason its RNA split is `rna_depth_x_source_vaf`.

The report gains DNA rows mirroring the RNA ones, each omitted rather than zero-filled where the source did not answer.

### Verification

- LENS fixtures byte-identical.
- 1182 tests pass; ruff clean.
