### PR TITLE
Give the combined score a threshold that means one thing everywhere

### DIFF
--- a/tests/test_combined_score_dsl.py
+++ b/tests/test_combined_score_dsl.py
@@ -315,3 +315,73 @@ def test_dsl_eval_error_warns_when_headline_binding_missing():
                 "binding; got: %r" % [r.getMessage() for r in warnings])
     finally:
         dsl_mod.combined_score_bindings = real_extractor
+
+
+def _isovar_backed_peptide():
+    """A stub vaccine peptide whose fragment came from isovar.
+
+    Only the attributes ``combined_score_bindings`` reads are needed, and
+    a real VaccinePeptide would drag in epitope selection irrelevant here.
+    """
+    import types
+
+    from vaxrank.mutant_protein_fragment import MutantProteinFragment
+
+    protein_sequence = types.SimpleNamespace(
+        gene_name="BRAF", amino_acids="SIINFEKLAA",
+        mutation_start_idx=2, mutation_end_idx=3,
+        num_supporting_fragments=7, num_supporting_reads=13, transcripts=[])
+    fragment = MutantProteinFragment.from_isovar_result(types.SimpleNamespace(
+        variant=object(), top_protein_sequence=protein_sequence,
+        num_total_fragments=20, num_alt_fragments=8, num_ref_fragments=12,
+        num_total_reads=38, num_alt_reads=15, num_ref_reads=23))
+    return types.SimpleNamespace(
+        target_epitope_score=1.0, self_epitope_score=0.0,
+        expression_score=1.0, mutant_protein_fragment=fragment)
+
+
+def test_the_portable_name_reports_what_the_source_counted():
+    """``n_rna_alt`` is the unit the run actually has; ``n_alt_reads`` is not.
+
+    On the isovar path the two are different numbers for the same
+    evidence — 8 fragments and 15 reads — and ``sqrt()`` weights whichever
+    it is given identically. A threshold naming ``n_alt_reads`` therefore
+    means a different bar depending on where the file came from, which is
+    the portability problem (#385). ``n_rna_alt`` means one thing
+    everywhere: what the source counted.
+    """
+    from vaxrank.combined_score_dsl import combined_score_bindings
+
+    bindings = combined_score_bindings(_isovar_backed_peptide())
+
+    assert bindings['n_alt_reads'] == 15.0     # reads, isovar's own
+    assert bindings['n_rna_alt'] == 8.0        # fragments, what it counted
+
+
+def test_a_fragment_with_no_rna_binds_zeros_rather_than_failing():
+    """The varcode path consults no RNA, and must still score.
+
+    n_rna_alt is None there rather than 0, so binding it unguarded would
+    raise on exactly the runs that have no RNA — a config that works until
+    someone runs without a BAM.
+    """
+    import types
+
+    from vaxrank.combined_score_dsl import combined_score_bindings
+    from vaxrank.mutant_protein_fragment import MutantProteinFragment
+
+    fragment = MutantProteinFragment(
+        variant=object(), gene_name="BRAF", amino_acids="SIINFEKL",
+        mutant_amino_acid_start_offset=0, mutant_amino_acid_end_offset=1,
+        supporting_reference_transcripts=[], n_overlapping_reads=0,
+        n_alt_reads=0, n_ref_reads=0,
+        n_alt_reads_supporting_protein_sequence=0)
+    peptide = types.SimpleNamespace(
+        target_epitope_score=1.0, self_epitope_score=0.0,
+        expression_score=0.0, mutant_protein_fragment=fragment)
+
+    bindings = combined_score_bindings(peptide)
+
+    assert bindings['n_rna_alt'] == 0.0
+    assert bindings['n_dna_alt'] == 0.0
+    assert 'rna_evidence_subject' not in bindings

--- a/vaxrank/combined_score_dsl.py
+++ b/vaxrank/combined_score_dsl.py
@@ -41,11 +41,32 @@ their expression references one of these unavailable mutation fields.
       ``sqrt_reads_times_epitope`` mode is exactly
       ``expression_score * target_epitope_score``.
 
+  ``n_rna_alt``, ``n_rna_ref``, ``n_rna_overlapping``,
+  ``n_rna_supporting_protein_sequence``
+      RNA evidence in whatever unit the source counted: fragments
+      where it reports them, reads otherwise. **Prefer these.** A
+      threshold written against one means the same thing on every
+      input path, which is not true of the ``*_reads`` names below.
+      The unit is on the fragment as ``rna_evidence_subject`` and in
+      the report, so a config that travels can record which bar it
+      was written for — five fragments and five reads are different
+      bars.
+
+  ``n_dna_alt``, ``n_dna_ref``, ``n_dna_overlapping``
+      DNA support for the variant call itself, where the source
+      reports a depth to derive it from. 0 where it does not: LENS
+      states no assay for its one fraction, and pVACseq's aggregated
+      flavour reports a fraction with no depth.
+
   ``n_alt_reads``
-      RNA reads supporting the variant allele.
+      RNA *reads* supporting the variant allele — but on the isovar
+      path this field holds fragments, which is roughly half the read
+      count for the same paired-end evidence. Kept because existing
+      configs name it; ``n_rna_alt`` is the portable one.
 
   ``n_ref_reads``
-      RNA reads supporting the reference allele at the locus.
+      RNA reads supporting the reference allele at the locus. Derived
+      as depth minus alt on both external paths rather than counted.
 
   ``n_overlapping_reads``
       Total reads spanning the locus (ref + alt + other).
@@ -208,6 +229,11 @@ def combined_score_binding_names(expr_or_tree):
     )
 
 
+def _count(fragment, name):
+    """A fragment count as a float, 0 when absent or unknown."""
+    return float(getattr(fragment, name, None) or 0)
+
+
 def combined_score_bindings(vp):
     """Read-only namespace of the scalars exposed to the DSL.
 
@@ -226,11 +252,36 @@ def combined_score_bindings(vp):
         return bindings
     bindings.update({
         'expression_score': float(vp.expression_score),
+        # Unit-specific, and only meaningful once you know which unit the
+        # run counted. Kept because existing configs name them.
         'n_alt_reads': float(frag.n_alt_reads or 0),
         'n_ref_reads': float(frag.n_ref_reads or 0),
         'n_overlapping_reads': float(frag.n_overlapping_reads or 0),
         'n_alt_reads_supporting_protein_sequence': float(
             frag.n_alt_reads_supporting_protein_sequence or 0),
+        # Portable. n_rna_alt is whatever the source counted -- fragments
+        # where it has them, reads otherwise -- so a threshold written
+        # against it means the same thing on every input path, which
+        # n_alt_reads does not: it holds isovar fragments on the native
+        # path and read estimates on both external ones, and sqrt() weights
+        # them identically (#385).
+        #
+        # The unit itself is not bound here: this grammar is arithmetic
+        # only, so a string would be a name no expression could use.
+        # rna_evidence_subject is on the fragment and in the report, which
+        # is where a config author reads which bar their threshold cleared.
+        # getattr because callers pass stand-ins for the fragment as well
+        # as the real dataclass, and these names are newer than some of
+        # them. A missing one binds 0 rather than raising, which matches
+        # how a real fragment with no RNA behaves.
+        'n_rna_alt': _count(frag, 'n_rna_alt'),
+        'n_rna_ref': _count(frag, 'n_rna_ref'),
+        'n_rna_overlapping': _count(frag, 'n_rna_overlapping'),
+        'n_rna_supporting_protein_sequence': _count(
+            frag, 'n_rna_supporting_protein_sequence'),
+        'n_dna_alt': _count(frag, 'n_dna_alt'),
+        'n_dna_ref': _count(frag, 'n_dna_ref'),
+        'n_dna_overlapping': _count(frag, 'n_dna_overlapping'),
         'n_mutant_amino_acids': float(
             frag.mutant_amino_acid_end_offset
             - frag.mutant_amino_acid_start_offset),


### PR DESCRIPTION
Closes #385.

`sqrt(n_alt_reads) * target_epitope_score` is the documented canonical form, and `n_alt_reads` holds a **different quantity per input path**: isovar fragments on the native path, read estimates on both external ones. `sqrt()` weights them identically, so a documented threshold or a config copied between projects silently changes what it measures.

`n_rna_alt` / `n_rna_ref` / `n_rna_overlapping` / `n_rna_supporting_protein_sequence` are bound now — each is whatever the source counted, so a threshold against one means the same thing everywhere. On an isovar fragment the difference is visible:

```
n_alt_reads  15    reads, isovar's own
n_rna_alt     8    fragments, what it counted
```

### The unit is deliberately not bound

I added `rna_evidence_subject` as a binding first, then removed it: this grammar is **arithmetic only**, so a string is a name no expression can use, and the validator rejects the comparison that would consume it —

```
ValueError: Disallowed expression element Compare ...
```

Binding it would advertise a capability the grammar forbids. `rna_evidence_subject` is on the fragment and in the report, which is where a config author reads which bar their threshold cleared.

### Also

- `n_dna_alt` / `n_dna_ref` / `n_dna_overlapping` follow #392, so an expression can weight how well a *call* is backed and not only how well it is expressed.
- The `*_reads` names stay — existing configs name them — and their docstrings now say what they actually hold rather than what their names suggest.
- Counts are read with `getattr`: callers pass stand-ins for the fragment as well as the real dataclass, and a missing name binds `0` the way a real fragment with no RNA does.

### Verification

- LENS fixtures byte-identical.
- 1185 tests pass; ruff clean.
