### PR TITLE
Reject an unavailable column when the config is read

### DIFF
--- a/tests/test_epitope_dsl.py
+++ b/tests/test_epitope_dsl.py
@@ -1057,3 +1057,75 @@ def test_a_caller_supplied_frame_cannot_add_a_phantom_allele(unstated):
 
     assert dict(scored.per_allele_scores) == {
         "HLA-A*02:01": pytest.approx(0.8)}
+
+
+def test_an_unavailable_column_fails_when_the_config_is_read(tmp_path):
+    """Naming a column the input lacks must fail early and name the setting.
+
+    topiary raises on this too, with a better "did you mean" list than
+    vaxrank would generate — but at eval time, mid-run, and without saying
+    which config key produced the reference. That is the half topiary
+    cannot know and the half the user needs (#388).
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import read_lens_report
+
+    path = tmp_path / "annotated.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\ttpm\tmhcflurry_2.1.1.aff\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t20\n")
+
+    config = EpitopeConfig(
+        score_expr=(
+            "affinity.value.logistic_normalized(350,150) * (nope > 1)"))
+
+    with pytest.raises(ValueError) as excinfo:
+        read_lens_report(path, epitope_config=config)
+
+    message = str(excinfo.value)
+    assert "epitopes.score_expr" in message      # which key to edit
+    assert "nope" in message                     # what was wrong
+    assert "gene_tpm" in message                 # what is available
+
+
+def test_a_column_the_input_does_carry_is_accepted(tmp_path):
+    """The check must not reject a working expression.
+
+    ``gene_tpm`` is on a LENS frame, so a filter naming it is valid — the
+    point is to reject references the input cannot answer, not to narrow
+    what an expression may name.
+    """
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import read_lens_report
+
+    path = tmp_path / "annotated.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\ttpm\tmhcflurry_2.1.1.aff\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t20\n")
+
+    loaded = read_lens_report(
+        path,
+        epitope_config=EpitopeConfig(
+            score_expr=(
+                "affinity.value.logistic_normalized(350,150) * "
+                "(gene_tpm > 1)")))
+
+    assert list(loaded.epitopes)
+
+
+def test_the_failing_setting_is_named_even_when_both_are_set(tmp_path):
+    """filter_expr and score_expr are distinguished, not conflated."""
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_io import read_lens_report
+
+    path = tmp_path / "annotated.tsv"
+    path.write_text(
+        "peptide\tallele\tpep_context\ttpm\tmhcflurry_2.1.1.aff\n"
+        "SIINFEKL\tHLA-A02:01\tXXSIINFEKLXX\t50\t20\n")
+
+    config = EpitopeConfig(
+        filter_expr="missing_here > 0",
+        score_expr="affinity.value.logistic_normalized(350,150)")
+
+    with pytest.raises(ValueError, match="epitopes.filter_expr"):
+        read_lens_report(path, epitope_config=config)

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -469,6 +469,13 @@ def attach_per_allele_scores(epitopes, cfg=None, *, topiary_df=None,
     if topiary_df is None:
         topiary_df = epitopes_to_topiary_df(epitopes)
 
+    # Validate before scoring, not only in the report writer. topiary
+    # raises on a bad reference too, with a good "did you mean" list, but
+    # mid-run and without naming the setting — and the reader path scores
+    # long before any report is written, so that is where a user meets the
+    # error (#388).
+    validate_dsl_against_predictions(cfg, epitopes, topiary_df=topiary_df)
+
     # Attribution runs on the unfiltered frame, so the policy ranks on the
     # evidence the input carried rather than on whatever survived a cutoff:
     # a filter on affinity would otherwise change which allele is credited
@@ -625,12 +632,18 @@ def validate_dsl_against_predictions(cfg, epitopes, *, topiary_df=None):
     Pass ``topiary_df`` to reuse an already-built frame rather than
     rebuilding it from ``epitopes``.
     """
-    nodes = []
+    # Paired with the setting each came from, so an error can name the key
+    # to edit. topiary reports what the data lacks, which is the half it
+    # can know; which config key produced the reference is the half it
+    # cannot, and is the half the user needs.
+    sources = []
     if cfg.filter_expr is not None:
-        nodes.append(parse_epitope_expression(cfg.filter_expr))
+        sources.append(("epitopes.filter_expr", cfg.filter_expr,
+                        parse_epitope_expression(cfg.filter_expr)))
     if cfg.score_expr is not None:
-        nodes.append(parse_epitope_expression(cfg.score_expr))
-    if not nodes:
+        sources.append(("epitopes.score_expr", cfg.score_expr,
+                        parse_epitope_expression(cfg.score_expr)))
+    if not sources:
         return
 
     df = (epitopes_to_topiary_df(epitopes)
@@ -652,8 +665,27 @@ def validate_dsl_against_predictions(cfg, epitopes, *, topiary_df=None):
             if is_named_version(v)
         }
 
-    for node in nodes:
+    available_columns = set(df.columns)
+
+    for setting, expr, node in sources:
         refs = collect_dsl_references(node)
+        # Column references. topiary raises on these too, at eval time and
+        # with a good "did you mean" list — but mid-run rather than when
+        # the config is read, and without naming the setting. Which columns
+        # exist depends on the source: pVACseq's aggregated flavour carries
+        # no gene_expression where all_epitopes does, so one export makes a
+        # working config and another makes a crash (#388).
+        for column in sorted(refs["columns"]):
+            if column in available_columns:
+                continue
+            raise ValueError(
+                f"{setting} references column {column!r}, which the loaded "
+                f"input does not carry. Expression: {expr!r}. Columns "
+                f"available on this input: {sorted(available_columns)}. "
+                f"Which columns exist depends on the source and its "
+                f"flavour, so an expression that works on one export may "
+                f"not on another."
+            )
         for kind, method, version in refs["kinds"]:
             if kind not in available_kinds:
                 raise ValueError(


### PR DESCRIPTION
Closes #388.

Since #380, LENS annotation columns are addressable in filter and score expressions. A config naming one the input lacks failed loudly — but from topiary, at eval time, and without saying which setting produced the reference.

That last part is the half topiary cannot know. It reports what the data lacks, with a better "did you mean" list than vaxrank would generate; **which config key to edit** is what the user needs, and is the same division `validate_default_methods` already makes.

### The timing mattered more than it looked

Validation ran only in the report writer, and both readers score during load — so a user met the error mid-run rather than when their config was read. It runs before scoring now, on every path.

```
epitopes.score_expr references column 'nope', which the loaded input does not
carry. Expression: '...'. Columns available on this input: [...]. Which columns
exist depends on the source and its flavour, so an expression that works on one
export may not on another.
```

That closing sentence is not decoration. Which columns exist genuinely varies: pVACseq's **aggregated** flavour carries no `gene_expression` where **all_epitopes** does, so the same expression is a working config on one export from one tool and a crash on another.

`collect_dsl_references` already returned the column set and nothing read it — its docstring said topiary validated these, which was true and not sufficient.

### Verification

- LENS fixtures byte-identical.
- 1188 tests pass; ruff clean.
