### PR TITLE
Read the LENS read-count column under the name topiary now uses

### DIFF
--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -2018,3 +2018,45 @@ def test_a_pvacseq_row_with_no_rna_vaf_claims_no_derivation():
     assert pvacseq_rna_vaf({"rna_vaf": 0.0}) == 0.0
     assert pvacseq_rna_vaf({}) is None
     assert pvacseq_rna_vaf({"rna_vaf": ""}) is None
+
+
+def test_present_rna_read_counts_are_not_reported_as_missing():
+    """A renamed column must not be reported as absent data.
+
+    topiary 5.47.0 prefixes each tool's own columns with the tool name.
+    Reading only the bare spelling counted every SNV/INDEL row as lacking
+    RNA reads and warned about it — a rename surfaced as a defect in the
+    input file, which is the worst kind of wrong: it sends the reader
+    upstream to look for a bug that is not there (#390).
+    """
+    from topiary import read_lens
+
+    from vaxrank import cells
+
+    frame = read_lens(os.path.join(
+        DATA_DIR, "real_lens_subsets", "lens_v1.9_real_subset.tsv")).df
+    rows = [
+        row for row in frame.to_dict("records")
+        if str(row.get("antigen_source", "")).upper() in {"SNV", "INDEL"}]
+    assert rows, "fixture must contain SNV/INDEL rows for this to mean anything"
+
+    missing = [
+        row for row in rows
+        if cells.missing(cells.first(
+            row,
+            "lens_rna_reads_covering_genomic_origin",
+            "rna_reads_covering_genomic_origin"))]
+
+    assert missing == []
+
+
+def test_the_pvacseq_depth_lookup_prefers_the_canonical_name():
+    """``n_rna_overlapping`` first, because "depth" presumes reads.
+
+    topiary's count may be fragments, which is why its own name for this
+    is not "depth". Reading the canonical column first means the lookup
+    keeps working when a source's own spelling changes again.
+    """
+    from vaxrank.external_prediction import _PVACSEQ_RNA_DEPTH_COLUMNS
+
+    assert _PVACSEQ_RNA_DEPTH_COLUMNS[0] == "n_rna_overlapping"

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -1136,7 +1136,15 @@ def lens_ranking_result(report, epitopes, genome=None, options=None):
     _SNV_OR_INDEL_KINDS = {'SNV', 'INDEL'}
     rows_no_reads = [
         r for r in rows
-        if cells.missing(r.get('rna_reads_covering_genomic_origin'))]
+        if cells.missing(cells.first(
+            r,
+            # topiary 5.47.0 prefixes each tool's own columns with the tool
+            # name. Reading only the bare spelling counted every row as
+            # lacking RNA reads and warned about data that was present
+            # under the other name — a rename reported as a defect in the
+            # input file (#390).
+            'lens_rna_reads_covering_genomic_origin',
+            'rna_reads_covering_genomic_origin'))]
     n_snv_indel_no_gene = sum(
         1 for r in rows_no_gene_name if _kind(r).upper() in _SNV_OR_INDEL_KINDS)
     n_snv_indel_no_transcript = sum(
@@ -1156,8 +1164,9 @@ def lens_ranking_result(report, epitopes, genome=None, options=None):
             n_snv_indel_no_transcript)
     if n_snv_indel_no_reads:
         logger.warning(
-            "%d SNV / INDEL row(s) lack rna_reads_covering_genomic_origin "
-            "— those kinds are expected to carry RNA-read counts.",
+            "%d SNV / INDEL row(s) lack RNA-read counts "
+            "(lens_rna_reads_covering_genomic_origin) — those kinds are "
+            "expected to carry them.",
             n_snv_indel_no_reads)
 
     # ── Load funnel summary ──────────────────────────────────────────

--- a/vaxrank/external_prediction.py
+++ b/vaxrank/external_prediction.py
@@ -43,6 +43,9 @@ external_values = cells.values
 # because it means the same thing from every reader; the originals are the
 # fallback for a frame that carries only what the tool printed.
 _PVACSEQ_RNA_DEPTH_COLUMNS = (
+    # Canonical first. "depth" presumes reads, and topiary's count may be
+    # fragments, which is why its own name for this is n_rna_overlapping.
+    "n_rna_overlapping",
     "pvacseq_tumor_rna_depth", "rna_depth", "tumor_rna_depth")
 _PVACSEQ_RNA_VAF_COLUMNS = (
     "rna_vaf", "pvacseq_tumor_rna_vaf", "tumor_rna_vaf")


### PR DESCRIPTION
Closes #390.

topiary 5.47.0 prefixes each tool's own columns with the tool name. vaxrank's SNV/INDEL completeness check read only the bare spelling, so **every such row counted as lacking RNA reads**:

```
SNV/INDEL rows: 10   counted as lacking RNA reads: 10
under the name topiary now uses:                    0
```

The data was fully present. The warning sent the reader upstream to look for a defect in the LENS file that was not there — worse than a silent miscount, because it spends someone else's time on a rename.

Two of #390's three sites were already fixed while adopting 5.47.0 in #391 (the pVACseq depth tuple and the LENS `vaf` read); this is the third.

The pVACseq depth lookup also gains `n_rna_overlapping` at the front — topiary's canonical name for that count. "Depth" presumes reads and the number may be fragments, which is why topiary does not call it depth.

### Verification

- LENS fixtures byte-identical.
- 1190 tests pass; ruff clean.
