### PR TITLE
Preserve evidence and provenance on protein subsequences

### DIFF
--- a/tests/test_mutant_protein_sequence.py
+++ b/tests/test_mutant_protein_sequence.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import fields
+
 from mhctools import RandomBindingPredictor
 
 from vaxrank.cli import make_vaxrank_arg_parser, run_vaxrank_from_parsed_args
@@ -19,6 +21,52 @@ from .common import eq_, almost_eq_
 from .testing_helpers import data_path
 
 random_binding_predictor = RandomBindingPredictor(["H-2-Kb", "H-2-Db"])
+
+
+def test_generate_subsequences_preserves_evidence_and_provenance():
+    from varcode import Variant
+
+    fragment = MutantProteinFragment(
+        variant=Variant("1", 1000, "A", "G", ensembl=None),
+        gene_name="GENE1",
+        amino_acids="ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        mutant_amino_acid_start_offset=12,
+        mutant_amino_acid_end_offset=13,
+        supporting_reference_transcripts=["ENST000001"],
+        n_overlapping_reads=101,
+        n_alt_reads=31,
+        n_ref_reads=61,
+        n_alt_reads_supporting_protein_sequence=29,
+        placeholder_alleles=True,
+        rna_evidence_method="rna_alignment",
+        rna_evidence_subject="fragments",
+        n_overlapping_fragments=55,
+        n_alt_fragments=21,
+        n_ref_fragments=30,
+        n_alt_fragments_supporting_protein_sequence=20,
+        n_dna_overlapping=80,
+        n_dna_alt=32,
+        n_dna_ref=48,
+        dna_vaf=0.4,
+        dna_evidence_method="dna_depth_x_vaf",
+        dna_evidence_subject="reads",
+        sequence_source="isovar_assembly")
+
+    offset, subsequence = list(fragment.generate_subsequences(15))[5]
+
+    assert offset == 5
+    assert subsequence.amino_acids == fragment.amino_acids[5:20]
+    assert subsequence.mutant_amino_acid_start_offset == 7
+    assert subsequence.mutant_amino_acid_end_offset == 8
+
+    changed_fields = {
+        "amino_acids",
+        "mutant_amino_acid_start_offset",
+        "mutant_amino_acid_end_offset",
+    }
+    for field in fields(MutantProteinFragment):
+        if field.name not in changed_fields:
+            assert getattr(subsequence, field.name) == getattr(fragment, field.name)
 
 
 def check_mutant_amino_acids(variant, mutant_protein_fragment):

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -12,7 +12,7 @@
 
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from serializable import DataclassSerializable
@@ -583,18 +583,11 @@ class MutantProteinFragment(DataclassSerializable):
                     max(
                         0,
                         self.mutant_amino_acid_end_offset - subsequence_start_offset))
-                n_supporting_reads = self.n_alt_reads_supporting_protein_sequence
-                subsequence_mutant_protein_fragment = MutantProteinFragment(
-                    variant=self.variant,
-                    gene_name=self.gene_name,
+                subsequence_mutant_protein_fragment = replace(
+                    self,
                     amino_acids=amino_acids,
                     mutant_amino_acid_start_offset=mutant_amino_acid_start_offset,
-                    mutant_amino_acid_end_offset=mutant_amino_acid_end_offset,
-                    n_overlapping_reads=self.n_overlapping_reads,
-                    n_ref_reads=self.n_ref_reads,
-                    n_alt_reads=self.n_alt_reads,
-                    n_alt_reads_supporting_protein_sequence=n_supporting_reads,
-                    supporting_reference_transcripts=self.supporting_reference_transcripts)
+                    mutant_amino_acid_end_offset=mutant_amino_acid_end_offset)
                 yield subsequence_start_offset, subsequence_mutant_protein_fragment
 
     def sorted_subsequences(

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.2"
+__version__ = "3.13.3"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

- clone protein-fragment subsequences from the complete parent dataclass
- change only the amino-acid window and mutation offsets
- add a regression covering every current evidence and provenance field
- bump the package version to 3.13.3

## Impact

Long native fragments previously lost RNA fragment counts, DNA evidence, evidence method and subject, sequence source, and placeholder-allele provenance when they were sliced to vaccine-peptide length. This made `n_rna_alt` fall back to read counts and could hide provenance in reports.

Using `dataclasses.replace` also ensures fields added later are retained without extending a manual constructor.

## Verification

- `./lint.sh`
- `./test.sh` — 1,192 passed

Fixes #398.
Related to #394 and #397.