### PR TITLE
Weight native RNA evidence by independent fragments

### DIFF
--- a/tests/test_combined_score_dsl.py
+++ b/tests/test_combined_score_dsl.py
@@ -120,9 +120,16 @@ def test_default_reorders_duplicate_heavy_locus_behind_clean_locus():
         target_epitope_score=1.0,
     )
 
+    from vaxrank.core_logic import ranked_vaccine_peptides
+
     assert duplicate_heavy.expression_score == pytest.approx(3.0)
     assert clean.expression_score == pytest.approx(4.0)
-    assert clean.combined_score > duplicate_heavy.combined_score
+    default_ranked = ranked_vaccine_peptides({
+        "duplicate-heavy": [duplicate_heavy],
+        "clean": [clean],
+    })
+    assert [variant for variant, _ in default_ranked] == [
+        "clean", "duplicate-heavy"]
 
     read_weighted = "sqrt(n_alt_reads) * target_epitope_score"
     duplicate_heavy_reads = _make_vp(
@@ -137,7 +144,12 @@ def test_default_reorders_duplicate_heavy_locus_behind_clean_locus():
         target_epitope_score=1.0,
         combined_score_expr=read_weighted,
     )
-    assert duplicate_heavy_reads.combined_score > clean_reads.combined_score
+    read_ranked = ranked_vaccine_peptides({
+        "duplicate-heavy": [duplicate_heavy_reads],
+        "clean": [clean_reads],
+    })
+    assert [variant for variant, _ in read_ranked] == [
+        "duplicate-heavy", "clean"]
 
 
 def test_dsl_supports_math_functions():

--- a/tests/test_combined_score_dsl.py
+++ b/tests/test_combined_score_dsl.py
@@ -8,10 +8,10 @@
 
 Pins:
 - The grammar (allowed nodes / functions; rejected constructs).
-- Parity between the documented default expression and the three
-  legacy pre-3.1 mode formulas, all expressed as DSL strings.
-- That a user-supplied expression is the only mechanism — the
-  default formula travels the same code path.
+- The fragment-aware default and the three legacy pre-3.1 mode formulas,
+  all expressed as DSL strings.
+- That a user-supplied expression is the only mechanism — the default
+  formula travels the same code path.
 """
 
 import math
@@ -20,6 +20,7 @@ import pytest
 
 def _make_vp(
         n_alt_reads=10,
+        n_alt_fragments=None,
         n_overlapping_reads=20,
         target_epitope_score=2.5,
         n_alt_reads_supporting_protein_sequence=8,
@@ -44,6 +45,7 @@ def _make_vp(
         n_ref_reads=max(0, n_overlapping_reads - n_alt_reads),
         n_alt_reads_supporting_protein_sequence=
             n_alt_reads_supporting_protein_sequence,
+        n_alt_fragments=n_alt_fragments,
     )
     vp = VaccinePeptide(
         mutant_protein_fragment=frag,
@@ -63,7 +65,8 @@ def test_dsl_legacy_formulas_round_trip_as_expressions():
     ``n_alt_reads``) or the arithmetic semantics."""
     n_alt = 16
     epitope = 3.0
-    # sqrt_reads_times_epitope ≡ default (DEFAULT_COMBINED_SCORE_EXPR)
+    # On a reads-only source, the historical reads expression and the
+    # fragment-aware default see the same evidence count.
     vp_default = _make_vp(
         n_alt_reads=n_alt, target_epitope_score=epitope,
         combined_score_expr=None)
@@ -85,20 +88,56 @@ def test_dsl_legacy_formulas_round_trip_as_expressions():
     assert vp_only.combined_score == pytest.approx(3.0)
 
 
-def test_default_expression_is_canonical_legacy_formula():
-    """The default ``combined_score_expr`` resolves to the canonical
-    pre-3.1 ``sqrt_reads_times_epitope`` formula. Single source of
-    truth: ``DEFAULT_COMBINED_SCORE_EXPR`` is what every default
-    VaccinePeptide evaluates."""
+def test_default_expression_uses_portable_rna_evidence():
+    """The default weights independent RNA evidence, not raw reads."""
     from vaxrank.vaccine_config import DEFAULT_COMBINED_SCORE_EXPR
     assert DEFAULT_COMBINED_SCORE_EXPR == (
-        "sqrt(n_alt_reads) * target_epitope_score")
+        "sqrt(n_rna_alt) * target_epitope_score")
     vp = _make_vp(n_alt_reads=9, target_epitope_score=2.0,
                   combined_score_expr=None)
     # __post_init__ resolved the default
     assert vp.combined_score_expr == DEFAULT_COMBINED_SCORE_EXPR
     # And the score is sqrt(9) * 2 = 6
     assert vp.combined_score == pytest.approx(6.0)
+
+
+def test_default_reorders_duplicate_heavy_locus_behind_clean_locus():
+    """Fragments prevent paired reads and duplicates receiving extra weight.
+
+    Both candidates have the same epitope score. The duplicate-heavy locus
+    wins under explicit read weighting (40 > 25), while the default correctly
+    ranks the clean locus first because it has more independent fragments
+    (16 > 9). This is the between-variant reordering that settled #394.
+    """
+    duplicate_heavy = _make_vp(
+        n_alt_reads=40,
+        n_alt_fragments=9,
+        target_epitope_score=1.0,
+    )
+    clean = _make_vp(
+        n_alt_reads=25,
+        n_alt_fragments=16,
+        target_epitope_score=1.0,
+    )
+
+    assert duplicate_heavy.expression_score == pytest.approx(3.0)
+    assert clean.expression_score == pytest.approx(4.0)
+    assert clean.combined_score > duplicate_heavy.combined_score
+
+    read_weighted = "sqrt(n_alt_reads) * target_epitope_score"
+    duplicate_heavy_reads = _make_vp(
+        n_alt_reads=40,
+        n_alt_fragments=9,
+        target_epitope_score=1.0,
+        combined_score_expr=read_weighted,
+    )
+    clean_reads = _make_vp(
+        n_alt_reads=25,
+        n_alt_fragments=16,
+        target_epitope_score=1.0,
+        combined_score_expr=read_weighted,
+    )
+    assert duplicate_heavy_reads.combined_score > clean_reads.combined_score
 
 
 def test_dsl_supports_math_functions():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -761,14 +761,12 @@ def test_manufacturability_config_rejects_unknown_rule():
         ManufacturabilityConfig(rules=("bogus_rule",))
 
 
-def test_vaccine_config_combined_score_expr_default_is_legacy_formula():
-    """The default must be the canonical legacy formula expressed as a
-    DSL string — single source of truth for the default combined score.
-    """
+def test_vaccine_config_combined_score_expr_default_uses_rna_evidence():
+    """The default weights the portable independent-evidence binding."""
     from vaxrank.vaccine_config import DEFAULT_COMBINED_SCORE_EXPR
     config = VaccineConfig()
     eq_(config.combined_score_expr, DEFAULT_COMBINED_SCORE_EXPR)
-    eq_(config.combined_score_expr, "sqrt(n_alt_reads) * target_epitope_score")
+    eq_(config.combined_score_expr, "sqrt(n_rna_alt) * target_epitope_score")
 
 
 def test_vaccine_config_combined_score_expr_accepts_legacy_equivalents():

--- a/tests/test_external_input.py
+++ b/tests/test_external_input.py
@@ -1876,8 +1876,8 @@ def test_alt_reads_are_depth_times_vaf_not_the_cds_overlap_count(tmp_path):
     ``rna_reads_covering_genomic_origin_with_peptide_cds`` counts reads
     overlapping the peptide's coding sequence, not reads carrying the
     variant allele. vaxrank assigned it straight to ``n_alt_reads``, which
-    feeds the combined-score DSL — ``sqrt(n_alt_reads) *
-    target_epitope_score`` is the documented canonical form.
+    fed the default combined score at the time. It remains available for
+    explicit read-based score expressions.
 
     The two disagree in both directions on real files: 2337x0.022 gives 51
     alt reads where the CDS count says 2, and 291x0.258 gives 75 where it
@@ -1917,8 +1917,9 @@ def test_read_counts_arrive_with_the_derivation_that_produced_them(tmp_path):
 
     After #374 a LENS ``n_alt_reads`` is depth x VAF, rounded. On another
     source the same field may be counted from an alignment. The report
-    prints the same number either way and ``sqrt(n_alt_reads)`` weights
-    them identically, so the label is what lets a reader tell them apart.
+    prints the same number either way and an explicit ``sqrt(n_alt_reads)``
+    expression weights them identically, so the label is what lets a reader
+    tell them apart.
     """
     path = _lens_counts_file(
         tmp_path, "labelled.tsv", depth=2337, cds_overlap=2, vaf=0.022)

--- a/tests/test_mutant_protein_sequence.py
+++ b/tests/test_mutant_protein_sequence.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 from dataclasses import fields
+from math import sqrt
 
 from mhctools import RandomBindingPredictor
 from topiary import FRAGMENTS
@@ -166,6 +167,11 @@ def test_mutant_amino_acids_in_mm10_chrX_8125624_refC_altA_pS460I():
             reads=(73, 25, 48),
             fragments=(65, 21, 44),
             protein_support=(25, 21))
+        almost_eq_(vaccine_peptide.expression_score, sqrt(21))
+        almost_eq_(
+            vaccine_peptide.combined_score,
+            sqrt(21) * vaccine_peptide.target_epitope_score)
+
 
 def test_mutant_amino_acids_in_mm10_chr9_82927102_refGT_altTG_pT441H():
     # In the Isovar repository this test is weird because the VCF only
@@ -195,6 +201,11 @@ def test_mutant_amino_acids_in_mm10_chr9_82927102_refGT_altTG_pT441H():
             reads=(56, 17, 39),
             fragments=(52, 15, 37),
             protein_support=(17, 15))
+        almost_eq_(vaccine_peptide.expression_score, sqrt(15))
+        almost_eq_(
+            vaccine_peptide.combined_score,
+            sqrt(15) * vaccine_peptide.target_epitope_score)
+
 
 def test_keep_top_k_epitopes():
     arg_parser = make_vaxrank_arg_parser()

--- a/tests/test_read_count_provenance.py
+++ b/tests/test_read_count_provenance.py
@@ -10,12 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""What ``n_alt_reads`` holds, and how a consumer can tell.
+"""What RNA evidence fields hold, and how a consumer can tell.
 
-The field feeds the combined-score DSL, where ``sqrt(n_alt_reads) *
-target_epitope_score`` is the documented canonical form. It holds a
-different quantity per input path, and these tests pin that each one says
-which (openvax/vaxrank#379, #382, #383).
+The default combined score uses ``n_rna_alt``, which prefers independent
+fragments and falls back to reads. Explicit read-based expressions can still
+use ``n_alt_reads``. These tests pin both values and their provenance
+(openvax/vaxrank#379, #382, #383, #394).
 """
 
 import os

--- a/tests/test_vaccine_peptide_config.py
+++ b/tests/test_vaccine_peptide_config.py
@@ -29,7 +29,7 @@ from vaxrank.candidate_epitope import CandidateEpitope, Peptide
 from vaxrank.vaccine_peptide import VaccinePeptide
 
 
-def _make_fragment(seq="A" * 25, n_alt_reads=9):
+def _make_fragment(seq="A" * 25, n_alt_reads=9, n_alt_fragments=None):
     """Minimal duck-typed MutantProteinFragment for VaccinePeptide tests.
 
     Must expose every binding the combined_score DSL evaluator looks up
@@ -40,6 +40,8 @@ def _make_fragment(seq="A" * 25, n_alt_reads=9):
     return SimpleNamespace(
         amino_acids=seq,
         n_alt_reads=n_alt_reads,
+        n_rna_alt=(
+            n_alt_reads if n_alt_fragments is None else n_alt_fragments),
         n_ref_reads=0,
         n_overlapping_reads=n_alt_reads,
         n_alt_reads_supporting_protein_sequence=n_alt_reads,
@@ -143,13 +145,13 @@ def test_custom_rules_shorten_tuple():
     assert len(tup) == 2
 
 
-def test_combined_score_default_mode_is_legacy():
-    fragment = _make_fragment(n_alt_reads=9)
+def test_combined_score_default_uses_fragments_when_available():
+    fragment = _make_fragment(n_alt_reads=16, n_alt_fragments=9)
     vp = VaccinePeptide(
         mutant_protein_fragment=fragment,
         epitopes=[_make_mutant_epitope()],
     )
-    # Legacy: sqrt(9) * target_epitope_score
+    # Independent fragments, not paired reads, weight the default score.
     assert vp.expression_score == pytest.approx(np.sqrt(9))
     assert vp.combined_score == pytest.approx(np.sqrt(9) * vp.target_epitope_score)
 

--- a/tests/test_variant_ranking.py
+++ b/tests/test_variant_ranking.py
@@ -11,19 +11,26 @@
 # limitations under the License.
 
 """Tests for the variant-level sort in ``ranked_vaccine_peptides`` —
-verifies the three-level tiebreak (combined_score, n_alt_reads,
-target_epitope_score) introduced for vaxrank#151."""
+verifies the three-level tiebreak (combined_score, n_rna_alt,
+target_epitope_score) introduced for vaxrank#151 and refined in #394."""
 
 from types import SimpleNamespace
 
 from vaxrank.core_logic import ranked_vaccine_peptides
 
 
-def _fake_peptide(combined_score, n_alt_reads, target_epitope_score):
+def _fake_peptide(
+        combined_score,
+        n_alt_reads,
+        target_epitope_score,
+        n_rna_alt=None):
     return SimpleNamespace(
         combined_score=combined_score,
         target_epitope_score=target_epitope_score,
-        mutant_protein_fragment=SimpleNamespace(n_alt_reads=n_alt_reads),
+        mutant_protein_fragment=SimpleNamespace(
+            n_alt_reads=n_alt_reads,
+            n_rna_alt=n_alt_reads if n_rna_alt is None else n_rna_alt,
+        ),
     )
 
 
@@ -38,21 +45,30 @@ def test_primary_sort_by_combined_score():
     assert [variant for variant, _ in ranked] == [v_high, v_low]
 
 
-def test_tiebreak_by_n_alt_reads_when_combined_score_ties():
-    """When combined_score ties (e.g. both zero because one factor is
-    zero), n_alt_reads is the first tiebreak — high RNA support wins."""
-    v_reads = "v_reads"
-    v_no_reads = "v_no_reads"
+def test_tiebreak_uses_independent_rna_evidence_when_combined_score_ties():
+    """A duplicate-heavy locus does not win an otherwise tied score."""
+    v_duplicate_heavy = "v_duplicate_heavy"
+    v_clean = "v_clean"
     d = {
-        v_no_reads: [_fake_peptide(combined_score=0.0, n_alt_reads=0, target_epitope_score=0.5)],
-        v_reads: [_fake_peptide(combined_score=0.0, n_alt_reads=50, target_epitope_score=0.5)],
+        v_duplicate_heavy: [_fake_peptide(
+            combined_score=0.0,
+            n_alt_reads=40,
+            n_rna_alt=9,
+            target_epitope_score=0.5,
+        )],
+        v_clean: [_fake_peptide(
+            combined_score=0.0,
+            n_alt_reads=25,
+            n_rna_alt=16,
+            target_epitope_score=0.5,
+        )],
     }
     ranked = ranked_vaccine_peptides(d)
-    assert [variant for variant, _ in ranked] == [v_reads, v_no_reads]
+    assert [variant for variant, _ in ranked] == [v_clean, v_duplicate_heavy]
 
 
 def test_tiebreak_by_target_epitope_score_when_higher_tiers_tie():
-    """When combined_score and n_alt_reads both tie, target_epitope_score
+    """When combined_score and n_rna_alt both tie, target_epitope_score
     breaks the tie — higher MHC binding score wins."""
     v_low_epitope = "v_low_epitope"
     v_high_epitope = "v_high_epitope"

--- a/vaxrank/combined_score_dsl.py
+++ b/vaxrank/combined_score_dsl.py
@@ -15,7 +15,7 @@
 Mirrors the per-epitope DSL in :mod:`vaxrank.epitope_dsl` but at the
 ``VaccinePeptide`` scope. Lets users write expressions like::
 
-    combined_score_expr: "sqrt(n_alt_reads) * target_epitope_score"
+    combined_score_expr: "sqrt(n_rna_alt) * target_epitope_score"
     combined_score_expr: "n_alt_reads * target_epitope_score"
     combined_score_expr: "log1p(n_alt_reads) * target_epitope_score
                           + 0.1 * n_alt_reads_supporting_protein_sequence"
@@ -36,9 +36,8 @@ mutation-specific and exist only when the VaccinePeptide carries a real
 their expression references one of these unavailable mutation fields.
 
   ``expression_score``
-      ``sqrt(n_alt_reads)`` — the canonical "expression strength"
-      surrogate; available so the legacy
-      ``sqrt_reads_times_epitope`` mode is exactly
+      ``sqrt(n_rna_alt)`` — the canonical "expression strength"
+      surrogate; available so the default score is exactly
       ``expression_score * target_epitope_score``.
 
   ``n_rna_alt``, ``n_rna_ref``, ``n_rna_overlapping``,
@@ -59,10 +58,10 @@ their expression references one of these unavailable mutation fields.
       flavour reports a fraction with no depth.
 
   ``n_alt_reads``
-      RNA *reads* supporting the variant allele — but on the isovar
-      path this field holds fragments, which is roughly half the read
-      count for the same paired-end evidence. Kept because existing
-      configs name it; ``n_rna_alt`` is the portable one.
+      RNA reads supporting the variant allele. Kept as a distinct binding
+      for configs that intentionally want to weight reads;
+      ``n_rna_alt`` is the independent-evidence binding because it prefers
+      fragments when the source reports them.
 
   ``n_ref_reads``
       RNA reads supporting the reference allele at the locus. Derived
@@ -96,13 +95,15 @@ all rejected. The whole expression must be a single
 
 Same precedence relationship as the per-epitope DSL: when
 ``vaccine_peptides.combined_score_expr`` is set, it supersedes
-``combined_score_mode``. The three legacy modes are equivalent to
+``combined_score_mode``. The old modes can be written explicitly as
 these expressions:
 
   ``epitope_only``               ≡ ``target_epitope_score``
   ``reads_times_epitope``        ≡ ``n_alt_reads * target_epitope_score``
-  ``sqrt_reads_times_epitope``   ≡ ``expression_score * target_epitope_score``
-                                 ≡ ``sqrt(n_alt_reads) * target_epitope_score``
+  ``sqrt_reads_times_epitope``   ≡ ``sqrt(n_alt_reads) * target_epitope_score``
+
+The current default is ``expression_score * target_epitope_score``, where
+``expression_score`` is ``sqrt(n_rna_alt)``.
 """
 
 import ast
@@ -252,19 +253,16 @@ def combined_score_bindings(vp):
         return bindings
     bindings.update({
         'expression_score': float(vp.expression_score),
-        # Unit-specific, and only meaningful once you know which unit the
-        # run counted. Kept because existing configs name them.
+        # Unit-specific. Kept because existing configs name them and some
+        # users may intentionally want to weight read observations.
         'n_alt_reads': float(frag.n_alt_reads or 0),
         'n_ref_reads': float(frag.n_ref_reads or 0),
         'n_overlapping_reads': float(frag.n_overlapping_reads or 0),
         'n_alt_reads_supporting_protein_sequence': float(
             frag.n_alt_reads_supporting_protein_sequence or 0),
-        # Portable. n_rna_alt is whatever the source counted -- fragments
-        # where it has them, reads otherwise -- so a threshold written
-        # against it means the same thing on every input path, which
-        # n_alt_reads does not: it holds isovar fragments on the native
-        # path and read estimates on both external ones, and sqrt() weights
-        # them identically (#385).
+        # Portable. n_rna_alt is the independent-evidence unit -- fragments
+        # where the source has them, reads otherwise -- so paired mates do
+        # not receive double weight on the native Isovar path (#394).
         #
         # The unit itself is not bound here: this grammar is arithmetic
         # only, so a string would be a name no expression could use.

--- a/vaxrank/config/default.yaml
+++ b/vaxrank/config/default.yaml
@@ -157,15 +157,18 @@ vaccine_peptides:
   # DSL expression evaluated per VaccinePeptide to produce
   # combined_score (used to rank variants).
   # Bindings: target_epitope_score, self_epitope_score,
-  # expression_score, n_alt_reads, n_ref_reads, n_overlapping_reads,
-  # n_alt_reads_supporting_protein_sequence, n_mutant_amino_acids.
+  # expression_score, n_rna_alt, n_rna_ref, n_rna_overlapping,
+  # n_rna_supporting_protein_sequence, n_alt_reads, n_ref_reads,
+  # n_overlapping_reads, n_alt_reads_supporting_protein_sequence,
+  # n_dna_alt, n_dna_ref, n_dna_overlapping, n_mutant_amino_acids.
   # Functions: sqrt, log, log1p, exp, min, max, abs, pow.
   # The default below IS the canonical formula — there is no
   # separate mode enum. Sample alternatives:
   #   "target_epitope_score"                        (epitope-only)
-  #   "n_alt_reads * target_epitope_score"          (linear in reads)
-  #   "log1p(n_alt_reads) * target_epitope_score"   (log-compressed)
-  combined_score_expr: "sqrt(n_alt_reads) * target_epitope_score"
+  #   "n_rna_alt * target_epitope_score"            (linear in RNA evidence)
+  #   "sqrt(n_alt_reads) * target_epitope_score"    (explicit read weighting)
+  #   "log1p(n_rna_alt) * target_epitope_score"     (log-compressed)
+  combined_score_expr: "sqrt(n_rna_alt) * target_epitope_score"
   # Keep candidates whose score is at least this fraction of the best
   # before lexicographic tie-breaking.
   score_fraction_of_best: 0.99

--- a/vaxrank/core_logic.py
+++ b/vaxrank/core_logic.py
@@ -411,10 +411,11 @@ def ranked_vaccine_peptides(variant_to_vaccine_peptides_dict):
 
     Variants are ranked by their top vaccine peptide using a three-level
     tiebreak (see vaxrank#151): primarily by ``combined_score``, then by
-    ``n_alt_reads`` (RNA support), then by ``target_epitope_score`` (MHC
-    binding). The extra tiers matter when ``combined_score`` ties (common
-    when either factor is zero) so that the downstream report order is
-    stable and intuitively favors better-supported variants.
+    ``n_rna_alt`` (independent RNA support), then by
+    ``target_epitope_score`` (MHC binding). The extra tiers matter when
+    ``combined_score`` ties (common when either factor is zero) so that the
+    downstream report order is stable and intuitively favors
+    better-supported variants.
 
     Parameters
     ----------
@@ -430,12 +431,14 @@ def ranked_vaccine_peptides(variant_to_vaccine_peptides_dict):
         if len(vaccine_peptides) == 0:
             return (0.0, 0, 0.0)
         top_vaccine_peptide = vaccine_peptides[0]
+        fragment = top_vaccine_peptide.mutant_protein_fragment
+        n_rna_alt = getattr(fragment, "n_rna_alt", fragment.n_alt_reads)
         return (
             top_vaccine_peptide.combined_score,
-            top_vaccine_peptide.mutant_protein_fragment.n_alt_reads,
+            n_rna_alt or 0,
             top_vaccine_peptide.target_epitope_score,
         )
 
-    # sort in descending order by (combined_score, n_alt_reads, target_epitope_score)
+    # Descending by (combined score, independent RNA evidence, epitope score).
     result_list.sort(key=sort_key, reverse=True)
     return result_list

--- a/vaxrank/external_input.py
+++ b/vaxrank/external_input.py
@@ -585,9 +585,9 @@ def _read_counts_from_lens_row(row):
         765            12   0.008          12             6
         291           166   0.258         166            75
 
-    ``n_alt_reads`` feeds the combined-score DSL — ``sqrt(n_alt_reads) *
-    target_epitope_score`` is the documented canonical form — so this
-    reordered vaccine peptides.
+    ``n_alt_reads`` fed the default combined score at the time, so this
+    reordered vaccine peptides. It remains available for explicit read-based
+    score expressions; the current default uses ``n_rna_alt``.
 
     topiary populates the fields with the derivation named per field
     (``rna_evidence_method``): depth x VAF for the alt/ref split, and the

--- a/vaxrank/vaccine_config.py
+++ b/vaxrank/vaccine_config.py
@@ -126,8 +126,8 @@ class VaccineConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     score_fraction_of_best: float = DEFAULT_VACCINE_PEPTIDE_SCORE_FRACTION_OF_BEST
     # DSL expression evaluated to produce each vaccine peptide's
     # ``combined_score``. See :mod:`vaxrank.combined_score_dsl` for
-    # grammar + bindings (``target_epitope_score``, ``n_alt_reads``,
-    # ``expression_score``, etc.). The default is
+    # grammar + bindings (``target_epitope_score``, ``n_rna_alt``,
+    # ``n_alt_reads``, ``expression_score``, etc.). The default is
     # :data:`DEFAULT_COMBINED_SCORE_EXPR` — the fragment-aware
     # ``sqrt(n_rna_alt) * target_epitope_score`` formula. There is no
     # separate mode enum: the expression IS the mechanism.

--- a/vaxrank/vaccine_config.py
+++ b/vaxrank/vaccine_config.py
@@ -45,7 +45,7 @@ from .ranking import RANKING_RULE_REGISTRY
 # Single source of truth for the default vaccine-peptide combined score.
 # Everything that computes ``combined_score`` reads this constant (or a
 # user-supplied override) via the DSL — no parallel hardcoded branch.
-DEFAULT_COMBINED_SCORE_EXPR = "sqrt(n_alt_reads) * target_epitope_score"
+DEFAULT_COMBINED_SCORE_EXPR = "sqrt(n_rna_alt) * target_epitope_score"
 
 
 class VaccineConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
@@ -128,9 +128,9 @@ class VaccineConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     # ``combined_score``. See :mod:`vaxrank.combined_score_dsl` for
     # grammar + bindings (``target_epitope_score``, ``n_alt_reads``,
     # ``expression_score``, etc.). The default is
-    # :data:`DEFAULT_COMBINED_SCORE_EXPR` — the legacy
-    # ``sqrt(n_alt_reads) * target_epitope_score`` formula. There is
-    # no separate mode enum: the expression IS the mechanism.
+    # :data:`DEFAULT_COMBINED_SCORE_EXPR` — the fragment-aware
+    # ``sqrt(n_rna_alt) * target_epitope_score`` formula. There is no
+    # separate mode enum: the expression IS the mechanism.
     combined_score_expr: str = DEFAULT_COMBINED_SCORE_EXPR
     ranking_rules: Optional[tuple[str, ...]] = None
     # When True (default, legacy behavior), variants whose vaccine peptides

--- a/vaxrank/vaccine_peptide.py
+++ b/vaxrank/vaccine_peptide.py
@@ -348,15 +348,21 @@ class VaccinePeptide(DataclassSerializable):
 
     @property
     def expression_score(self):
-        # Honest expression metric. ``sqrt(n_alt_reads)`` is a binding
-        # the default combined-score expression uses; if the user
-        # writes a different ``combined_score_expr`` that doesn't
-        # reference it, this property is still queryable for reports.
+        # Honest expression metric. Prefer fragments when the source reports
+        # them: paired mates are one independent observation, and rewarding
+        # both would bias the score toward duplicate-heavy loci. If the user
+        # writes a different ``combined_score_expr`` that doesn't reference
+        # this property, it is still queryable for reports.
         if self.mutant_protein_fragment is None:
             raise ValueError(
                 "Mutation RNA expression_score is unavailable for this antigen"
             )
-        return np.sqrt(self.mutant_protein_fragment.n_alt_reads)
+        fragment = self.mutant_protein_fragment
+        # ``VaccinePeptide`` has long supported fragment-like inputs in the
+        # public API. Fall back for callers built against the older shape;
+        # current MutantProteinFragment instances always expose n_rna_alt.
+        n_rna_alt = getattr(fragment, "n_rna_alt", fragment.n_alt_reads)
+        return np.sqrt(n_rna_alt or 0)
 
     @property
     def combined_score(self):

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.4"
+__version__ = "3.13.5"
 
 
 def print_version():


### PR DESCRIPTION
Fixes #394.

Vaxrank now weights the default combined score with sqrt(n_rna_alt) instead of sqrt(n_alt_reads). Current native Isovar results expose both units, so this uses fragments as independent observations rather than rewarding paired reads or duplicate-heavy loci. External inputs are unchanged because n_rna_alt falls back to their read count.

The public expression_score and the variant-level exact-score tiebreak use the same fragment-aware evidence. Explicit read weighting remains available with sqrt(n_alt_reads), and fragment-like objects built against the older API fall back to n_alt_reads.

Regression coverage includes the decisive reorder: a duplicate-heavy 40-read/9-fragment locus ranks behind a cleaner 25-read/16-fragment locus under the default, while explicit read weighting produces the old order. The native B16 tests pin Wdr13 at sqrt(21 fragments), not sqrt(25 reads), and Phip at sqrt(15 fragments), not sqrt(17 reads).

This release bumps Vaxrank to 3.13.5.

Verification:
- ./lint.sh
- Topiary 5.48.1: ./test.sh (1193 passed)