### PR TITLE
Report RNA reads and fragments separately

### DIFF
--- a/tests/test_read_count_provenance.py
+++ b/tests/test_read_count_provenance.py
@@ -40,12 +40,16 @@ DATA_DIR = os.path.join(
 
 def _fake_isovar_result():
     """Minimal stand-in exposing only what from_isovar_result reads."""
+    class VariantStub:
+        contig = "7"
+        start = 140453136
+
     protein_sequence = types.SimpleNamespace(
         gene_name="BRAF", amino_acids="SIINFEKLAA",
         mutation_start_idx=2, mutation_end_idx=3,
         num_supporting_fragments=7, num_supporting_reads=13, transcripts=[])
     return types.SimpleNamespace(
-        variant=object(), top_protein_sequence=protein_sequence,
+        variant=VariantStub(), top_protein_sequence=protein_sequence,
         num_total_fragments=20, num_alt_fragments=8, num_ref_fragments=12,
         num_total_reads=38, num_alt_reads=15, num_ref_reads=23)
 
@@ -330,6 +334,57 @@ def test_the_report_omits_the_row_when_there_is_nothing_to_report():
 
     assert 'RNA reads supporting other alleles' not in variant_data
     assert 'RNA reads supporting variant allele' in variant_data
+
+
+def test_the_report_separates_isovar_read_and_fragment_counts():
+    """Native RNA evidence must not label read values as fragments."""
+    from vaxrank.report import TemplateDataCreator
+
+    fragment = MutantProteinFragment.from_isovar_result(_fake_isovar_result())
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.dna_vaf_by_variant = {}
+    creator.source_vaf_by_variant = {}
+    creator.gene_pathway_check = None
+
+    class _Peptide:
+        mutant_protein_fragment = fragment
+        combined_score = 1.0
+
+    rows = creator._variant_data(fragment.variant, _Peptide())
+
+    assert rows['RNA reads supporting variant allele'] == 15
+    assert rows['RNA reads supporting reference allele'] == 23
+    assert rows['RNA reads supporting other alleles'] == 0
+    assert rows['RNA fragments supporting variant allele'] == 8
+    assert rows['RNA fragments supporting reference allele'] == 12
+    assert rows['RNA fragments supporting other alleles'] == 0
+    assert rows['RNA evidence method'] == RNA_EVIDENCE_METHOD_ALIGNMENT
+    assert rows['Preferred RNA evidence unit'] == FRAGMENTS
+    assert 'RNA read count method' not in rows
+    assert 'RNA read count subject' not in rows
+
+
+def test_the_report_does_not_invent_fragments_for_external_inputs():
+    """A reads-only source prints only rows for evidence it supplies."""
+    from vaxrank.report import TemplateDataCreator
+
+    config = EpitopeConfig()
+    report = read_pvacseq_report(
+        os.path.join(DATA_DIR, "pvacseq_example.tsv"), epitope_config=config)
+    result = pvacseq_ranking_result(
+        report, epitopes_for_ranking(list(report.epitopes), config))
+    vaccine_peptide = result.ranked[0][1][0]
+    fragment = vaccine_peptide.mutant_protein_fragment
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.dna_vaf_by_variant = {}
+    creator.source_vaf_by_variant = {}
+    creator.gene_pathway_check = None
+
+    rows = creator._variant_data(fragment.variant, vaccine_peptide)
+
+    assert rows['RNA reads supporting variant allele'] == fragment.n_alt_reads
+    assert not any(key.startswith('RNA fragments') for key in rows)
+    assert rows['Preferred RNA evidence unit'] == READS
 
 
 def test_what_counts_as_measured_is_topiarys_rule():

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -530,6 +530,25 @@ class MutantProteinFragment(DataclassSerializable):
         return self.n_overlapping_reads - (self.n_ref_reads + self.n_alt_reads)
 
     @property
+    def n_other_fragments(self):
+        """Fragments supporting alleles which are neither ref nor alt.
+
+        Mirrors :attr:`n_other_reads` when the source reports fragment
+        counts. ``None`` means the source did not measure enough of the
+        split to make the subtraction an observation.
+        """
+        if not self.reference_count_was_measured:
+            return None
+        counts = (
+            self.n_overlapping_fragments,
+            self.n_ref_fragments,
+            self.n_alt_fragments,
+        )
+        if any(value is None for value in counts):
+            return None
+        return counts[0] - (counts[1] + counts[2])
+
+    @property
     def rna_vaf(self):
         """
         RNA variant allele frequency.

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -315,6 +315,15 @@ class TemplateDataCreator(object):
         if mutant_protein_fragment.n_other_reads is not None:
             variant_data['RNA reads supporting other alleles'] = (
                 mutant_protein_fragment.n_other_reads)
+        if mutant_protein_fragment.n_alt_fragments is not None:
+            variant_data['RNA fragments supporting variant allele'] = (
+                mutant_protein_fragment.n_alt_fragments)
+        if mutant_protein_fragment.n_ref_fragments is not None:
+            variant_data['RNA fragments supporting reference allele'] = (
+                mutant_protein_fragment.n_ref_fragments)
+        if mutant_protein_fragment.n_other_fragments is not None:
+            variant_data['RNA fragments supporting other alleles'] = (
+                mutant_protein_fragment.n_other_fragments)
         # A variant fraction the source did not qualify. Shown under its
         # own label rather than as DNA VAF, which is what LENS's bare
         # `vaf` used to be printed as — asserting an assay the file never
@@ -326,12 +335,12 @@ class TemplateDataCreator(object):
         # and "51" from depth x VAF are the same integer and not the same
         # claim, and the combined-score DSL weights them identically.
         if mutant_protein_fragment.rna_evidence_method:
-            variant_data['RNA read count method'] = (
+            variant_data['RNA evidence method'] = (
                 mutant_protein_fragment.rna_evidence_method)
-        # What those counts counted. Five fragments and five reads are
-        # different bars, and the rows above say neither on their own.
+        # Which unit backs the canonical n_rna_* accessors. Counts above name
+        # their own units, so don't attach this preference to read-valued rows.
         if mutant_protein_fragment.rna_evidence_subject:
-            variant_data['RNA read count subject'] = (
+            variant_data['Preferred RNA evidence unit'] = (
                 mutant_protein_fragment.rna_evidence_subject)
         if mutant_protein_fragment.sequence_source:
             variant_data['Protein sequence source'] = (

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.5"
+__version__ = "3.13.6"
 
 
 def print_version():


### PR DESCRIPTION
Fixes #400.

## Summary
- render native Isovar read and fragment evidence in separately labelled rows
- rename acquisition provenance to RNA evidence method
- describe the canonical accessor unit as Preferred RNA evidence unit instead of attaching fragments to read counts
- omit fragment rows for reads-only external inputs
- bump Vaxrank to 3.13.6

## Verification
- ./lint.sh
- ./test.sh: 1,195 passed
- B16 end-to-end smoke across ASCII, HTML, PDF, XLSX, JSON, and CSV outputs
- visually inspected all 7 PDF pages; no clipped or overlapping evidence rows