### PR TITLE
Preserve presentation evidence across input paths

### DIFF
--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -381,6 +381,85 @@ def test_load_pvacseq_populates_per_allele_scores():
     assert e_strong.epitope_score > 0.0
 
 
+def test_load_pvacseq_preserves_upstream_presentation_rows():
+    """A multi-kind Topiary result keeps pVACseq presentation evidence."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    import pandas as pd
+
+    from vaxrank.coverage import compute_coverage
+    from vaxrank.epitope_config import EpitopeConfig
+
+    shared = {
+        "source_sequence_name": "chr1-100000-100001-A-T",
+        "variant": "chr1-100000-100001-A-T",
+        "gene": "TP53",
+        "transcript": "ENST00000269305",
+        "peptide": "SVVGSSSSS",
+        "peptide_length": 9,
+        "peptide_offset": 0,
+        "contains_mutant_residues": True,
+        "allele": "HLA-A*02:01",
+        "mhc_class": "I",
+        "predictor_version": "2.1.1",
+        "wt_peptide": "SVVGSSGSS",
+        "pvacseq_ref_match": False,
+    }
+    topiary_df = pd.DataFrame([
+        {
+            **shared,
+            "kind": "pMHC_presentation",
+            "prediction_method_name": "mhcflurry",
+            "value": None,
+            "affinity": None,
+            "score": 0.92,
+            "percentile_rank": 0.3,
+            "wt_value": None,
+            "wt_score": 0.41,
+            "wt_percentile_rank": 4.2,
+        },
+        {
+            **shared,
+            "kind": "pMHC_affinity",
+            "prediction_method_name": "mhcflurry",
+            "value": 76.11,
+            "affinity": 76.11,
+            "score": 76.11,
+            "percentile_rank": 0.5,
+            "wt_value": 4520.3,
+            "wt_score": 4520.3,
+            "wt_percentile_rank": 12.3,
+        },
+    ])
+    fake_result = SimpleNamespace(
+        df=topiary_df, extra={"pvacseq_format": "aggregated"})
+    path = os.path.join(DATA_DIR, "pvacseq_example.tsv")
+    config = EpitopeConfig(
+        score_expr="presentation[mhcflurry].score")
+
+    with patch("topiary.read_pvacseq", return_value=fake_result):
+        loaded = read_pvacseq_report(path, epitope_config=config)
+
+    assert len(loaded.report_df) == 1
+    assert "76.11 nM" in loaded.report_df.iloc[0][
+        "Predicted mutant pMHC affinity"]
+    assert len(loaded.epitopes) == 1
+    [epitope] = loaded.epitopes
+    [presentation] = epitope.predictions_for(
+        "pMHC_presentation", predictor="mhcflurry")
+    assert presentation.value is None
+    assert presentation.score == pytest.approx(0.92)
+    assert presentation.percentile_rank == pytest.approx(0.3)
+    [wt_presentation] = epitope.wt.predictions_for(
+        "pMHC_presentation", predictor="mhcflurry")
+    assert wt_presentation.score == pytest.approx(0.41)
+    assert wt_presentation.percentile_rank == pytest.approx(4.2)
+    coverage = compute_coverage(
+        loaded.epitopes, ["HLA-A*02:01"])["HLA-A*02:01"]
+    assert coverage.best_presentation_pct == pytest.approx(0.3)
+
+
 def test_load_pvacseq_missing_columns(tmp_path):
     bad_file = tmp_path / "bad.tsv"
     bad_file.write_text("Gene\tAA Change\nTP53\tG245S\n")

--- a/tests/test_epitope_prediction.py
+++ b/tests/test_epitope_prediction.py
@@ -220,14 +220,24 @@ def test_wt_prediction_uses_named_peptides_keyed_by_mutant(mouse_genome):
 
     # 9-mer at offset 8 covers [8, 17) — overlaps mutation at [12, 13).
     mutant_peptide = protein_fragment.amino_acids[8:17]
-    mutant_df = pd.DataFrame([{
+    mutant_shared = {
         'peptide': mutant_peptide, 'peptide_length': 9,
         'peptide_offset': 8, 'allele': 'H-2-Kb',
-        'affinity': 100.0, 'percentile_rank': 0.5,
-        'value': 100.0, 'prediction_method_name': 'mhcflurry',
-        'source_sequence_name': 'Wdr13', 'kind': 'pMHC_affinity',
-        'predictor_version': '', 'score': 0.5,
-    }])
+        'prediction_method_name': 'mhcflurry',
+        'source_sequence_name': 'Wdr13', 'predictor_version': '',
+    }
+    mutant_df = pd.DataFrame([
+        {
+            **mutant_shared, 'kind': 'pMHC_affinity',
+            'affinity': 100.0, 'value': 100.0,
+            'percentile_rank': 0.5, 'score': 0.5,
+        },
+        {
+            **mutant_shared, 'kind': 'pMHC_presentation',
+            'affinity': None, 'value': None,
+            'percentile_rank': 0.3, 'score': 0.8,
+        },
+    ])
 
     # Distinct WT string so we can verify the consumer reads it from
     # the row, not from a side dict.
@@ -236,15 +246,28 @@ def test_wt_prediction_uses_named_peptides_keyed_by_mutant(mouse_genome):
 
     def _stub_predict_wt(name_to_peptide):
         captured_calls.append(dict(name_to_peptide))
-        return pd.DataFrame([{
-            'source_sequence_name': name, 'peptide': stub_wt_sequence,
-            'peptide_length': 9, 'peptide_offset': 0,
-            'allele': 'H-2-Kb', 'affinity': 1000.0,
-            'percentile_rank': 5.0, 'value': 1000.0,
-            'prediction_method_name': 'mhcflurry',
-            'predictor_version': '', 'score': 0.1,
-            'kind': 'pMHC_affinity',
-        } for name in name_to_peptide])
+        rows = []
+        for name in name_to_peptide:
+            shared = {
+                'source_sequence_name': name, 'peptide': stub_wt_sequence,
+                'peptide_length': 9, 'peptide_offset': 0,
+                'allele': 'H-2-Kb',
+                'prediction_method_name': 'mhcflurry',
+                'predictor_version': '',
+            }
+            rows.extend([
+                {
+                    **shared, 'kind': 'pMHC_affinity',
+                    'affinity': 1000.0, 'value': 1000.0,
+                    'percentile_rank': 5.0, 'score': 0.1,
+                },
+                {
+                    **shared, 'kind': 'pMHC_presentation',
+                    'affinity': None, 'value': None,
+                    'percentile_rank': 4.0, 'score': 0.4,
+                },
+            ])
+        return pd.DataFrame(rows)
 
     class _StubTopiary(TopiaryPredictor):
         def __init__(self):
@@ -276,9 +299,14 @@ def test_wt_prediction_uses_named_peptides_keyed_by_mutant(mouse_genome):
     wt = epitopes[0].wt
     assert wt is not None
     assert wt.sequence == stub_wt_sequence
-    wt_leaves = wt.predictions_flat()
-    assert len(wt_leaves) == 1
-    assert wt_leaves[0].value == 1000.0
+    wt_by_kind = {p.kind: p for p in wt.predictions_flat()}
+    assert set(wt_by_kind) == {'pMHC_affinity', 'pMHC_presentation'}
+    assert wt_by_kind['pMHC_affinity'].value == 1000.0
+    assert wt_by_kind['pMHC_affinity'].score == 0.1
+    assert wt_by_kind['pMHC_affinity'].percentile_rank == 5.0
+    assert wt_by_kind['pMHC_presentation'].value is None
+    assert wt_by_kind['pMHC_presentation'].score == 0.4
+    assert wt_by_kind['pMHC_presentation'].percentile_rank == 4.0
 
 
 def test_mhc_predictor_error(mouse_genome):

--- a/tests/test_nan_robustness.py
+++ b/tests/test_nan_robustness.py
@@ -171,6 +171,8 @@ def test_predict_epitopes_does_not_emit_nan_value_for_presentation():
     assert presentation_preds, "expected pMHC_presentation leaf in output"
     assert all(p.value is None for p in presentation_preds), (
         "pMHC_presentation rows should have value=None, not NaN")
+    assert all(p.score == pytest.approx(0.42) for p in presentation_preds), (
+        "pMHC_presentation rows should preserve Topiary's score")
 
 
 # ---- serialize_json_nan_tolerant ---------------------------------------

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -477,9 +477,6 @@ def _topiary_pvacseq_to_epitope_rows(rows):
         peptide = cells.text(row.get("peptide"))
         allele = cells.text(row.get("allele"))
         value = cells.number(row.get("value"))
-        if not peptide or not allele or value is None:
-            continue
-
         method = cells.text(row.get("prediction_method_name")) or "pvacseq"
         version = cells.text(row.get("predictor_version"))
         kind = (
@@ -487,6 +484,10 @@ def _topiary_pvacseq_to_epitope_rows(rows):
             or prediction_kind_for_method(method))
         percentile_rank = cells.number(row.get("percentile_rank"))
         score = cells.number(row.get("score"))
+        if (not peptide or not allele
+                or (value is None and score is None
+                    and percentile_rank is None)):
+            continue
         mutant = Prediction(
             kind=kind, predictor_name=method, predictor_version=version,
             allele=allele, peptide=peptide, value=value,
@@ -496,15 +497,19 @@ def _topiary_pvacseq_to_epitope_rows(rows):
 
         wt = None
         wt_value = cells.number(row.get("wt_value"))
-        if wt_value is not None:
+        wt_score = cells.number(row.get("wt_score"))
+        wt_percentile_rank = cells.number(row.get("wt_percentile_rank"))
+        if (wt_value is not None or wt_score is not None
+                or wt_percentile_rank is not None):
             wt_method = cells.text(row.get("wt_prediction_method_name")) or method
             wt_version = cells.text(row.get("wt_predictor_version")) or version
             wt = Prediction(
                 kind=kind, predictor_name=wt_method,
                 predictor_version=wt_version, allele=allele,
                 peptide=cells.text(row.get("wt_peptide")),
-                value=wt_value, score=0.0,
-                percentile_rank=cells.number(row.get("wt_percentile_rank")),
+                value=wt_value,
+                score=wt_score if wt_score is not None else 0.0,
+                percentile_rank=wt_percentile_rank,
             )
 
         epitope_rows.append({
@@ -670,10 +675,23 @@ def read_pvacseq_report(path, epitope_config=None):
         row["prediction_id"] = prediction_id
 
     epitope_rows, n_rows = _topiary_pvacseq_to_epitope_rows(rows)
+    # A normalized pVACseq result can carry several evidence kinds for one
+    # source row. Keep all of those prediction rows above, but retain one
+    # user-facing report row per source identity and allele.
+    report_source_rows = {}
+    for row in rows:
+        allele = cells.text(row.get("allele"))
+        if not cells.text(row.get("peptide")) or not allele:
+            continue
+        key = (cells.text(row.get("prediction_id")), allele)
+        # Prefer the affinity row for the legacy affinity columns regardless
+        # of the normalized multi-kind row order.
+        if (key not in report_source_rows
+                or cells.text(row.get("kind")) == "pMHC_affinity"):
+            report_source_rows[key] = row
     report_rows = [
         _build_pvacseq_report_row(row)
-        for row in rows
-        if cells.text(row.get("peptide")) and cells.text(row.get("allele"))
+        for row in report_source_rows.values()
     ]
 
     report_df = pd.DataFrame(report_rows) if report_rows else pd.DataFrame()

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -269,7 +269,13 @@ def predict_epitopes(
         try:
             wt_df = topiary_predictor.predict_from_named_peptides(valid_wt_peptides)
             for _, row in wt_df.iterrows():
-                key = (row["source_sequence_name"], row["allele"])
+                key = (
+                    row["source_sequence_name"],
+                    row["allele"],
+                    row.get("kind") or "pMHC_affinity",
+                    row.get("prediction_method_name", "") or "",
+                    row.get("predictor_version", "") or "",
+                )
                 wt_predictions_grouped[key] = row
         except Exception:
             logger.error(
@@ -332,7 +338,14 @@ def predict_epitopes(
         # don't get a meaningful WT pair.
         wt_pred = None
         if overlaps_mutation:
-            wt_row = wt_predictions_grouped.get((peptide, row["allele"]))
+            wt_key = (
+                peptide,
+                row["allele"],
+                row.get("kind") or "pMHC_affinity",
+                row.get("prediction_method_name", "") or "",
+                row.get("predictor_version", "") or "",
+            )
+            wt_row = wt_predictions_grouped.get(wt_key)
             if wt_row is None:
                 wt_peptide = wt_peptides[peptide]
                 if len(wt_peptide) < min_peptide_length:
@@ -343,6 +356,12 @@ def predict_epitopes(
                 wt_ic50 = finite_prediction_value(wt_row.get("affinity"))
                 if wt_ic50 is None:
                     wt_ic50 = finite_prediction_value(wt_row.get("value"))
+                wt_score = finite_prediction_value(wt_row.get("score"))
+                if wt_score is None:
+                    raise ValueError(
+                        "Topiary WT prediction row is missing a finite score")
+                wt_percentile_rank = finite_prediction_value(
+                    wt_row.get("percentile_rank"))
                 tool = row.get("prediction_method_name", "")
                 wt_pred = Prediction(
                     kind=row.get("kind") or "pMHC_affinity",
@@ -351,11 +370,15 @@ def predict_epitopes(
                     allele=row["allele"],
                     peptide=wt_row["peptide"],
                     value=wt_ic50,
-                    score=0.0,
-                    percentile_rank=None,
+                    score=wt_score,
+                    percentile_rank=wt_percentile_rank,
                 )
 
         tool = row.get("prediction_method_name", "")
+        prediction_score = finite_prediction_value(row.get("score"))
+        if prediction_score is None:
+            raise ValueError(
+                "Topiary prediction row is missing a finite score")
         mutant_pred = Prediction(
             kind=row.get("kind") or "pMHC_affinity",
             predictor_name=tool,
@@ -363,7 +386,7 @@ def predict_epitopes(
             allele=row["allele"],
             peptide=peptide,
             value=ic50,
-            score=0.0,
+            score=prediction_score,
             percentile_rank=percentile_rank,
         )
         rows.append({

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.6"
+__version__ = "3.13.7"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

- preserve Topiary prediction scores in the native VCF/BAM path instead of replacing them with `0.0`
- match WT predictions by kind, predictor, and version, and preserve their score and percentile
- accept score/percentile-only pVACseq prediction rows, including `pMHC_presentation`, while keeping one user-facing report row per source identity and allele
- bump Vaxrank to 3.13.7

This completes Vaxrank's side of #282. LENS presentation evidence and coverage are already implemented and regression-tested. Current pVACseq files remain gated by openvax/topiary#259, which tracks teaching `topiary.read_pvacseq` to emit the presentation rows this adapter now accepts.

Refs #282.

## Validation

- `./lint.sh`
- `./test.sh` — 1,196 passed
- B16 VCF/BAM end-to-end smoke — ASCII, HTML, PDF, XLSX, neoepitope XLSX, JSON, and both CSV outputs written; exit 0