### PR TITLE
Report external expression semantics explicitly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,10 @@ mhctools>=3.13.3,<4.0.0
 # 5.10.0 adds EvalContext(default_methods=...) and apply_filter(default_methods=...)
 # which vaxrank uses to score multi-model inputs (e.g. LENS with mhcflurry +
 # netmhcpan) without pre-subsetting the frame.
-# 5.16.0 adds read_pvacseq for both pVACseq all_epitopes flavors and
-# categorical DSL helpers used by pVACseq external-input scoring.
-topiary>=5.47.0,<6.0.0
+# 5.48.0 correctly identifies aggregated pVACseq RNA Expr as gene-level,
+# exposes the shared gene/transcript/RNA-alt expression vocabulary, and omits
+# unavailable evidence instead of emitting all-null columns.
+topiary>=5.48.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -355,6 +355,20 @@ def test_load_pvacseq():
     assert any(ep.occurs_in_reference for ep in epitopes)
 
 
+def test_pvacseq_aggregated_report_names_expression_level_and_derivation():
+    """Aggregated RNA Expr is gene-level and Allele Expr keeps provenance."""
+    path = os.path.join(DATA_DIR, "pvacseq_example.tsv")
+    report_df = read_pvacseq_report(path).report_df
+    row = report_df.iloc[0]
+
+    assert "RNA Expr" not in report_df.columns
+    assert "TPM" not in report_df.columns
+    assert "Transcript expression" not in report_df.columns
+    assert row["Gene expression"] == pytest.approx(45.2)
+    assert row["RNA alternate-allele expression"] == pytest.approx(15.4)
+    assert row["RNA alternate-allele expression method"] == "source_reported"
+
+
 def test_load_pvacseq_populates_per_allele_scores():
     """Regression: the 3.1.0 single-mechanism refactor moved
     per-(peptide, allele) scoring to the DSL and stored the result on
@@ -570,6 +584,20 @@ def test_load_pvacseq_all_epitopes_flavor(tmp_path):
     assert set(report_df["MHC class"]) == {"I"}
 
 
+def test_pvacseq_all_epitopes_report_keeps_expression_levels_separate(tmp_path):
+    path = _write_pvacseq_all_epitopes_fixture(tmp_path)
+    report_df = read_pvacseq_report(path).report_df
+    row = report_df.iloc[0]
+
+    assert row["Gene expression"] == pytest.approx(131.832)
+    assert row["Transcript expression"] == pytest.approx(84.961)
+    assert row["RNA alternate-allele expression"] == pytest.approx(
+        84.961 * 0.302)
+    assert row["RNA alternate-allele expression method"] == "tpm_x_dna_vaf"
+    assert "RNA Expr" not in report_df.columns
+    assert "TPM" not in report_df.columns
+
+
 def test_pvacseq_all_epitopes_per_algorithm_column_scores(tmp_path):
     from vaxrank.epitope_config import EpitopeConfig
     from vaxrank.epitope_io import write_neoepitope_report
@@ -709,6 +737,17 @@ def test_load_lens_report_display_uses_canonical_predictor():
     # Both raw-value columns present
     assert report_df["mhcflurry value (nM)"].iloc[0] == pytest.approx(95.4)
     assert report_df["netmhcpan value (nM)"].iloc[0] == pytest.approx(76.11)
+
+
+def test_lens_report_identifies_gene_level_expression():
+    path = os.path.join(DATA_DIR, "lens_example.tsv")
+    report_df = read_lens_report(path).report_df
+
+    assert report_df["Gene expression"].iloc[0] == pytest.approx(42.5)
+    assert "Transcript expression" not in report_df.columns
+    assert "RNA alternate-allele expression" not in report_df.columns
+    assert "RNA Expr" not in report_df.columns
+    assert "TPM" not in report_df.columns
 
 
 def test_load_lens_mhcflurry_only_v19():

--- a/vaxrank/epitope_dsl.py
+++ b/vaxrank/epitope_dsl.py
@@ -673,8 +673,8 @@ def validate_dsl_against_predictions(cfg, epitopes, *, topiary_df=None):
         # with a good "did you mean" list — but mid-run rather than when
         # the config is read, and without naming the setting. Which columns
         # exist depends on the source: pVACseq's aggregated flavour carries
-        # no gene_expression where all_epitopes does, so one export makes a
-        # working config and another makes a crash (#388).
+        # no transcript_expression where all_epitopes does, so one export can
+        # make a working config and another a clear error (#388).
         for column in sorted(refs["columns"]):
             if column in available_columns:
                 continue

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -543,13 +543,34 @@ def _topiary_pvacseq_to_epitope_rows(rows):
     return epitope_rows, n_rows
 
 
+_EXPRESSION_REPORT_COLUMNS = (
+    ("gene_expression", "Gene expression", cells.number),
+    ("transcript_expression", "Transcript expression", cells.number),
+    ("rna_alt_expression", "RNA alternate-allele expression", cells.number),
+    (
+        "rna_alt_expression_method",
+        "RNA alternate-allele expression method",
+        cells.text,
+    ),
+)
+
+
+def _expression_report_fields(row):
+    """Project Topiary's level-explicit expression evidence into a report.
+
+    A missing source column stays absent. In particular, gene- and
+    transcript-level abundance are never substituted for one another, and an
+    alternate-allele estimate remains paired with the method that produced it.
+    """
+    return {
+        report_column: converter(row.get(source_column))
+        for source_column, report_column, converter in _EXPRESSION_REPORT_COLUMNS
+        if source_column in row
+    }
+
+
 def _build_pvacseq_report_row(row):
     """Build one user-facing report row from a topiary pVACseq row."""
-    # Same helper, same precedence, as the ranking path uses for these
-    # fields — so the report and the ranking cannot disagree about a row.
-    rna_expr = cells.first_number(
-        row, "rna_transcript_expression", "transcript_expression",
-        "gene_expression")
     rna_vaf = cells.first_number(row, *_PVACSEQ_RNA_VAF_COLUMNS)
     dna_vaf = cells.first_number(row, *_PVACSEQ_DNA_VAF_COLUMNS)
     out = neoepitope_core_row(
@@ -563,7 +584,6 @@ def _build_pvacseq_report_row(row):
     out.update({
         'Tier': cells.text(row.get("pvacseq_tier")),
         'Ref Match': cells.boolean(row.get("pvacseq_ref_match")),
-        'RNA Expr': rna_expr,
         'RNA VAF': rna_vaf,
         'DNA VAF': dna_vaf,
         '%ile MT': cells.number(row.get("percentile_rank")),
@@ -574,6 +594,7 @@ def _build_pvacseq_report_row(row):
         'Contains mutant residues': cells.boolean(
             row.get("contains_mutant_residues"), default=True),
     })
+    out.update(_expression_report_fields(row))
     for col, value in row.items():
         if col.startswith("pvacseq_") and col not in {
                 "pvacseq_ref_match", "pvacseq_tier"}:
@@ -641,8 +662,8 @@ def read_pvacseq_report(path, epitope_config=None):
     pandas.DataFrame
         Columns: Allele, Mutant peptide sequence, Predicted mutant pMHC
         affinity, Wildtype sequence, Predicted wildtype pMHC affinity,
-        Gene name, Genomic variant, Tier, Ref Match, RNA Expr, DNA VAF,
-        vaxrank_score
+        Gene name, Genomic variant, Tier, Ref Match, level-explicit expression
+        evidence, DNA VAF, vaxrank_score
     list of CandidateEpitope
         One ``vaxrank.candidate_epitope.CandidateEpitope`` per unique
         external prediction identity.
@@ -1222,10 +1243,10 @@ def _build_lens_report_row(row, allele, peptide, prediction_id,
         'Predictors used': ','.join(chosen_tools),
         '%ile rank': display_percentile,
         'Agretopicity': display_agretopicity,
-        'TPM': cells.number(row.get("gene_tpm")),
         'Source sequence name': source_sequence_name,
         'Peptide offset': peptide_offset,
     })
+    out.update(_expression_report_fields(row))
     # Every detected predictor gets a raw-value column so users can see
     # per-tool signals side-by-side in the report, even if not chosen
     # for DSL scoring.

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.7"
+__version__ = "3.13.8"
 
 
 def print_version():


### PR DESCRIPTION
Fixes #381.

This gives LENS and pVACseq reports one level-explicit expression vocabulary:

- Gene expression
- Transcript expression, only when available
- RNA alternate-allele expression plus its derivation method, only when available

It removes the stale cross-level fallback and the ambiguous TPM / RNA Expr report labels. It also raises the Topiary floor to 5.48.0, the release that correctly identifies aggregated pVACseq RNA Expr as gene-level and exposes the shared expression schema.

Verification:
- ./lint.sh
- ./test.sh: 1,199 passed
- semantic regression tests against both Topiary 5.48.0 and 5.51.0
- LENS and pVACseq CLI CSV report smokes