### PR TITLE
Make releases resumable and byte-verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,4 +880,7 @@ The first run of the tests may take a while to build the reference proteome kmer
 - `develop.sh`: installs the package in editable mode and sets `PYTHONPATH` to the repo root.
 - `lint.sh`: runs ruff on `vaxrank` and `tests`.
 - `test.sh`: runs pytest with coverage.
-- `deploy.sh`: runs lint/tests, builds a distribution with `build`, uploads via `twine`, and tags the release (`vX.Y.Z`). Deploy is restricted to the `main`/`master` branch.
+- `deploy.sh`: runs lint/tests/build/upload through one Python environment,
+  verifies PyPI artifacts by SHA-256, and safely resumes an interrupted upload
+  from its original artifacts. Deploy is restricted to synchronized
+  `main`/`master`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,14 +1,16 @@
 # Releasing Vaxrank
 
-This document explains what to do once your [Pull Request](https://www.atlassian.com/git/tutorials/making-a-pull-request/) has been reviewed and all final changes applied. Now you're ready merge your branch into master and release it to the world:
+This document explains what to do once your [Pull Request](https://www.atlassian.com/git/tutorials/making-a-pull-request/) has been reviewed and all final changes applied. Now you're ready to merge your branch into main and release it to the world:
 
 0. Make sure that you have `pandoc` and `pypandoc` installed: this is needed for readme markdown on PyPI. (See [here](http://pandoc.org/installing.html) and [here](https://pypi.python.org/pypi/pypandoc), respectively, for instructions.)
 1. Bump the [version](http://semver.org/) in `vaxrank/version.py`, as part of the PR you want to release.
-2. Merge your branch into master.
-3. Run `./deploy.sh` (builds with `build`, uploads with `twine`, and tags the release), or run the steps manually:
-   - `python -m pip install --upgrade build twine`
-   - `python -m build`
-   - `python -m twine check dist/*`
-   - `python -m twine upload dist/*`
-   - `git tag "v${VERSION}"`
-   - `git push --tags`
+2. Merge your branch into main, check out main, and pull the merge.
+3. Run `./deploy.sh`. It uses one Python environment for lint, tests, build,
+   and upload; verifies every published artifact by SHA-256; and pushes the
+   release tag only after PyPI contains the complete matching release.
+
+If an upload is interrupted after the local release tag is created, leave the
+tag and `dist/` intact and rerun `./deploy.sh` from the same clean checkout. The
+script reuses those exact artifacts, verifies any file already on PyPI, and
+uploads only a missing file. It refuses a retry when an original artifact is
+missing or its bytes differ from PyPI.

--- a/deploy.sh
+++ b/deploy.sh
@@ -42,10 +42,16 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-PYTHON="${PYTHON:-python3}"
-if [[ -x ".venv/bin/python" ]]; then
+if [[ -n "${PYTHON:-}" ]]; then
+  :
+elif [[ -n "${VIRTUAL_ENV:-}" && -x "${VIRTUAL_ENV}/bin/python" ]]; then
+  PYTHON="${VIRTUAL_ENV}/bin/python"
+elif [[ -x ".venv/bin/python" ]]; then
   PYTHON=".venv/bin/python"
+else
+  PYTHON="python3"
 fi
+export PYTHON
 
 CURRENT_VERSION="$(
   "$PYTHON" - <<'PY'
@@ -80,12 +86,6 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
-# Ensure the tag doesn't already exist.
-if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
-  echo "Tag ${TAG} already exists; aborting." >&2
-  exit 1
-fi
-
 ./lint.sh
 ./test.sh
 
@@ -114,10 +114,44 @@ PY
   git push
 fi
 
+HEAD_COMMIT="$(git rev-parse HEAD)"
+if ! UPSTREAM_COMMIT="$(git rev-parse '@{upstream}')"; then
+  echo "Release branch has no upstream; pull and verify main before deploying." >&2
+  exit 1
+fi
+if [[ "${HEAD_COMMIT}" != "${UPSTREAM_COMMIT}" ]]; then
+  echo "Release branch is not synchronized with its upstream." >&2
+  echo "HEAD=${HEAD_COMMIT} upstream=${UPSTREAM_COMMIT}" >&2
+  exit 1
+fi
+
+RESUMING=0
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  TAG_COMMIT="$(git rev-list -n 1 "${TAG}")"
+  if [[ "${TAG_COMMIT}" != "${HEAD_COMMIT}" ]]; then
+    echo "Tag ${TAG} points to ${TAG_COMMIT}, not HEAD ${HEAD_COMMIT}." >&2
+    exit 1
+  fi
+  RESUMING=1
+fi
+
+WHEEL="dist/vaxrank-${VERSION}-py3-none-any.whl"
+SDIST="dist/vaxrank-${VERSION}.tar.gz"
+DISTRIBUTIONS=("${WHEEL}" "${SDIST}")
+
 "$PYTHON" -m pip install --upgrade build twine
-rm -rf dist
-"$PYTHON" -m build
-git --version
+if [[ "${RESUMING}" -eq 1 ]]; then
+  for distribution in "${DISTRIBUTIONS[@]}"; do
+    if [[ ! -f "${distribution}" ]]; then
+      echo "Cannot safely resume ${TAG}: original artifact is missing: ${distribution}" >&2
+      exit 1
+    fi
+  done
+  echo "Resuming release from ${TAG} with its original artifacts."
+else
+  rm -rf dist
+  "$PYTHON" -m build
+fi
 
 if [[ "${DRY_RUN}" -eq 1 ]]; then
   if [[ -n "${VERSION_INPUT}" && "${VERSION}" != "${CURRENT_VERSION}" ]]; then
@@ -127,10 +161,14 @@ if [[ "${DRY_RUN}" -eq 1 ]]; then
   exit 0
 fi
 
-"$PYTHON" -m twine check dist/*
+"$PYTHON" -m twine check "${DISTRIBUTIONS[@]}"
+
+if [[ "${RESUMING}" -eq 0 ]]; then
+  git tag "${TAG}"
+fi
+
 "$PYTHON" release_upload.py \
   --project vaxrank \
   --version "${VERSION}" \
-  dist/*
-git tag "${TAG}"
-git push --tags
+  "${DISTRIBUTIONS[@]}"
+git push origin "refs/tags/${TAG}"

--- a/lint.sh
+++ b/lint.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 set -o errexit
 
-ruff check vaxrank tests release_upload.py
+if [[ -z "${PYTHON:-}" ]]; then
+  if [[ -n "${VIRTUAL_ENV:-}" && -x "${VIRTUAL_ENV}/bin/python" ]]; then
+    PYTHON="${VIRTUAL_ENV}/bin/python"
+  elif [[ -x ".venv/bin/python" ]]; then
+    PYTHON=".venv/bin/python"
+  else
+    PYTHON="python3"
+  fi
+fi
+
+"${PYTHON}" -m ruff check vaxrank tests release_upload.py
 echo 'Passes ruff check'

--- a/release_upload.py
+++ b/release_upload.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from secrets import token_hex
@@ -10,7 +11,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Mapping
 from urllib.error import HTTPError
 from urllib.parse import quote
 from urllib.request import urlopen
@@ -35,14 +36,14 @@ def expected_release_filenames(project: str, version: str) -> frozenset[str]:
     })
 
 
-def pypi_release_filenames(
+def pypi_release_artifacts(
     project: str,
     version: str,
     *,
     json_base_url: str = PYPI_JSON_BASE_URL,
     request_timeout_seconds: float = 10.0,
-) -> frozenset[str]:
-    """Return one release's filenames from PyPI's project metadata."""
+) -> dict[str, str]:
+    """Return one release's filename-to-SHA-256 map from PyPI metadata."""
     url = "%s/%s/json?cache_bust=%s" % (
         json_base_url.rstrip("/"),
         quote(project, safe=""),
@@ -53,10 +54,40 @@ def pypi_release_filenames(
             payload = json.load(response)
     except HTTPError as error:
         if error.code == 404:
-            return frozenset()
+            return {}
         raise
     releases = payload.get("releases", {})
-    return frozenset(item["filename"] for item in releases.get(version, ()))
+    return {
+        item["filename"]: item.get("digests", {}).get("sha256", "")
+        for item in releases.get(version, ())
+    }
+
+
+def file_sha256(path: str | Path) -> str:
+    """Return the SHA-256 digest of an artifact's exact bytes."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as artifact:
+        for chunk in iter(lambda: artifact.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _has_matching_artifact(
+    filename: str,
+    expected_sha256: str,
+    published: Mapping[str, str],
+) -> bool:
+    """Return true for byte-identical artifacts and false when absent."""
+    if filename not in published:
+        return False
+    observed_sha256 = published[filename]
+    if observed_sha256 != expected_sha256:
+        raise ReleaseUploadError(
+            f"PyPI artifact {filename} has SHA-256 "
+            f"{observed_sha256 or '<missing>'}, but the local artifact "
+            f"has {expected_sha256}"
+        )
+    return True
 
 
 def upload_distribution(
@@ -82,15 +113,17 @@ def upload_distribution(
 
 def wait_for_release_file(
     filename: str,
-    fetch_release_filenames: Callable[[], Iterable[str]],
+    expected_sha256: str,
+    fetch_release_artifacts: Callable[[], Mapping[str, str]],
     *,
     timeout_seconds: float = DEFAULT_VERIFY_TIMEOUT_SECONDS,
     poll_seconds: float = DEFAULT_VERIFY_POLL_SECONDS,
 ) -> bool:
-    """Poll release metadata until ``filename`` is visible or time expires."""
+    """Poll until ``filename`` is visible with the expected exact bytes."""
     deadline = time.monotonic() + timeout_seconds
     while True:
-        if filename in set(fetch_release_filenames()):
+        published = dict(fetch_release_artifacts())
+        if _has_matching_artifact(filename, expected_sha256, published):
             return True
         remaining = deadline - time.monotonic()
         if remaining <= 0:
@@ -98,21 +131,49 @@ def wait_for_release_file(
         time.sleep(min(poll_seconds, remaining))
 
 
+def wait_for_complete_release(
+    expected_artifacts: Mapping[str, str],
+    fetch_release_artifacts: Callable[[], Mapping[str, str]],
+    *,
+    timeout_seconds: float = DEFAULT_VERIFY_TIMEOUT_SECONDS,
+    poll_seconds: float = DEFAULT_VERIFY_POLL_SECONDS,
+) -> dict[str, str]:
+    """Return the latest metadata after waiting for a complete release."""
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        published = dict(fetch_release_artifacts())
+        complete = True
+        for filename, expected_sha256 in expected_artifacts.items():
+            if not _has_matching_artifact(
+                filename,
+                expected_sha256,
+                published,
+            ):
+                complete = False
+        if complete:
+            return published
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return published
+        time.sleep(min(poll_seconds, remaining))
+
+
 def publish_release(
     distribution_paths: Iterable[str | Path],
     *,
     expected_filenames: Iterable[str],
-    fetch_release_filenames: Callable[[], Iterable[str]],
+    fetch_release_artifacts: Callable[[], Mapping[str, str]],
     upload_file: Callable[[Path], None],
     verify_timeout_seconds: float = DEFAULT_VERIFY_TIMEOUT_SECONDS,
     verify_poll_seconds: float = DEFAULT_VERIFY_POLL_SECONDS,
-) -> frozenset[str]:
+) -> dict[str, str]:
     """Upload missing artifacts and reconcile every response with PyPI state.
 
     A timeout or nonzero Twine exit is ambiguous: the server may have accepted
     the immutable file before the client lost its response. This operation
-    therefore verifies server state after every attempt and treats the file as
-    published only when its exact filename appears in release metadata.
+    therefore verifies server state after every attempt. A file is treated as
+    published only when both its filename and SHA-256 digest match the local
+    artifact, so a retry cannot combine distributions from different builds.
     """
     paths_by_name = {
         Path(distribution_path).name: Path(distribution_path)
@@ -124,11 +185,19 @@ def publish_release(
             "Distribution files do not match the expected release set: "
             f"expected={sorted(expected)}, observed={sorted(paths_by_name)}"
         )
+    local_artifacts = {
+        filename: file_sha256(path)
+        for filename, path in paths_by_name.items()
+    }
 
-    published = frozenset(fetch_release_filenames())
+    published = dict(fetch_release_artifacts())
     for filename in sorted(expected):
-        if filename in published:
-            print(f"Already published: {filename}")
+        if _has_matching_artifact(
+            filename,
+            local_artifacts[filename],
+            published,
+        ):
+            print(f"Already published with matching SHA-256: {filename}")
             continue
 
         upload_error = None
@@ -139,7 +208,8 @@ def publish_release(
 
         if not wait_for_release_file(
             filename,
-            fetch_release_filenames,
+            local_artifacts[filename],
+            fetch_release_artifacts,
             timeout_seconds=verify_timeout_seconds,
             poll_seconds=verify_poll_seconds,
         ):
@@ -151,10 +221,15 @@ def publish_release(
             print(f"Reconciled ambiguous upload from PyPI state: {filename}")
         else:
             print(f"Published: {filename}")
-        published = frozenset(fetch_release_filenames())
+        published = dict(fetch_release_artifacts())
 
-    published = frozenset(fetch_release_filenames())
-    missing = expected - published
+    published = wait_for_complete_release(
+        local_artifacts,
+        fetch_release_artifacts,
+        timeout_seconds=verify_timeout_seconds,
+        poll_seconds=verify_poll_seconds,
+    )
+    missing = expected - set(published)
     if missing:
         raise ReleaseUploadError(
             f"PyPI release is missing expected files: {sorted(missing)}"
@@ -190,8 +265,8 @@ def main(argv: list[str] | None = None) -> int:
 
     expected = expected_release_filenames(args.project, args.version)
 
-    def fetch_release_filenames():
-        return pypi_release_filenames(
+    def fetch_release_artifacts():
+        return pypi_release_artifacts(
             args.project,
             args.version,
             json_base_url=args.json_base_url,
@@ -208,13 +283,13 @@ def main(argv: list[str] | None = None) -> int:
     published = publish_release(
         args.distributions,
         expected_filenames=expected,
-        fetch_release_filenames=fetch_release_filenames,
+        fetch_release_artifacts=fetch_release_artifacts,
         upload_file=upload_file,
         verify_timeout_seconds=args.verify_timeout_seconds,
     )
     print(
         "Verified PyPI release files: %s"
-        % ", ".join(sorted(expected & published))
+        % ", ".join(sorted(expected & set(published)))
     )
     return 0
 

--- a/test.sh
+++ b/test.sh
@@ -10,4 +10,14 @@ if [[ "$(uname)" == "Darwin" && -d /opt/homebrew/lib \
   export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 fi
 
-exec pytest tests "$@"
+if [[ -z "${PYTHON:-}" ]]; then
+  if [[ -n "${VIRTUAL_ENV:-}" && -x "${VIRTUAL_ENV}/bin/python" ]]; then
+    PYTHON="${VIRTUAL_ENV}/bin/python"
+  elif [[ -x ".venv/bin/python" ]]; then
+    PYTHON=".venv/bin/python"
+  else
+    PYTHON="python3"
+  fi
+fi
+
+exec "${PYTHON}" -m pytest tests "$@"

--- a/tests/test_deploy_script.py
+++ b/tests/test_deploy_script.py
@@ -11,8 +11,79 @@
 # limitations under the License.
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
+
+
+def _write_fake_python(path):
+    path.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' \"$@\" > \"$PYTHON_LOG\"\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _deploy_resume_harness(tmp_path, *, include_sdist):
+    repo_root = Path(__file__).resolve().parents[1]
+    for filename in ("deploy.sh", "lint.sh", "test.sh"):
+        shutil.copy2(repo_root / filename, tmp_path / filename)
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    python_log = tmp_path / "python-log"
+    fake_python = fake_bin / "python"
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"-\" ]; then\n"
+        "  echo 3.13.9\n"
+        "  exit 0\n"
+        "fi\n"
+        "printf '%s\\n' \"$*\" >> \"$PYTHON_LOG\"\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        "#!/bin/sh\n"
+        "case \"$1 $2\" in\n"
+        "  'status --porcelain') exit 0 ;;\n"
+        "  'rev-parse HEAD') echo release-commit; exit 0 ;;\n"
+        "  'rev-parse @{upstream}') echo release-commit; exit 0 ;;\n"
+        "  'rev-parse -q') exit 0 ;;\n"
+        "  'rev-list -n') echo release-commit; exit 0 ;;\n"
+        "esac\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "vaxrank-3.13.9-py3-none-any.whl").write_bytes(b"wheel")
+    if include_sdist:
+        (dist / "vaxrank-3.13.9.tar.gz").write_bytes(b"sdist")
+
+    env = os.environ.copy()
+    env.update(
+        PATH=f"{fake_bin}{os.pathsep}{env['PATH']}",
+        PYTHON=str(fake_python),
+        PYTHON_LOG=str(python_log),
+        VAXRANK_DEPLOY_BRANCH="main",
+    )
+    result = subprocess.run(
+        ["bash", "deploy.sh", "--dry-run"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result, python_log
 
 
 def test_deploy_rejects_non_release_branch():
@@ -29,3 +100,76 @@ def test_deploy_rejects_non_release_branch():
     )
     assert result.returncode == 1
     assert "only allowed from main or master" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("script", "extra_args", "expected_args"),
+    [
+        (
+            "lint.sh",
+            [],
+            ["-m", "ruff", "check", "vaxrank", "tests", "release_upload.py"],
+        ),
+        ("test.sh", ["-q"], ["-m", "pytest", "tests", "-q"]),
+    ],
+)
+def test_quality_scripts_use_the_configured_python(
+        tmp_path, script, extra_args, expected_args):
+    repo_root = Path(__file__).resolve().parents[1]
+    fake_python = tmp_path / "release-python"
+    log_path = tmp_path / "python-args"
+    _write_fake_python(fake_python)
+    env = os.environ.copy()
+    env.update(PYTHON=str(fake_python), PYTHON_LOG=str(log_path))
+
+    subprocess.run(
+        ["bash", script, *extra_args],
+        cwd=repo_root,
+        env=env,
+        check=True,
+    )
+
+    assert log_path.read_text(encoding="utf-8").splitlines() == expected_args
+
+
+def test_quality_scripts_prefer_the_active_environment_over_local_venv(
+        tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    active_venv = tmp_path / "active-venv"
+    fake_python = active_venv / "bin" / "python"
+    fake_python.parent.mkdir(parents=True)
+    log_path = tmp_path / "python-args"
+    _write_fake_python(fake_python)
+    env = os.environ.copy()
+    env.pop("PYTHON", None)
+    env.update(VIRTUAL_ENV=str(active_venv), PYTHON_LOG=str(log_path))
+
+    subprocess.run(
+        ["bash", "lint.sh"],
+        cwd=repo_root,
+        env=env,
+        check=True,
+    )
+
+    assert log_path.read_text(encoding="utf-8").splitlines()[:3] == [
+        "-m", "ruff", "check",
+    ]
+
+
+def test_deploy_resume_reuses_the_original_artifacts(tmp_path):
+    result, python_log = _deploy_resume_harness(
+        tmp_path,
+        include_sdist=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Resuming release from v3.13.9" in result.stdout
+    assert "-m build" not in python_log.read_text(encoding="utf-8")
+
+
+def test_deploy_resume_rejects_a_missing_original_artifact(tmp_path):
+    result, _ = _deploy_resume_harness(tmp_path, include_sdist=False)
+
+    assert result.returncode == 1
+    assert "Cannot safely resume v3.13.9" in result.stderr
+    assert "vaxrank-3.13.9.tar.gz" in result.stderr

--- a/tests/test_release_upload.py
+++ b/tests/test_release_upload.py
@@ -10,16 +10,32 @@ import release_upload
 from release_upload import (
     ReleaseUploadError,
     expected_release_filenames,
+    file_sha256,
     main,
-    pypi_release_filenames,
     publish_release,
+    pypi_release_artifacts,
     upload_distribution,
+    wait_for_complete_release,
     wait_for_release_file,
 )
 
 
 EXPECTED = expected_release_filenames("vaxrank", "3.1.28")
 PATHS = tuple(Path("dist") / filename for filename in EXPECTED)
+
+
+@pytest.fixture
+def release_paths(tmp_path):
+    paths = []
+    for filename in sorted(EXPECTED):
+        path = tmp_path / filename
+        path.write_bytes((filename + "\n").encode("utf-8"))
+        paths.append(path)
+    return tuple(paths)
+
+
+def _local_artifacts(paths):
+    return {path.name: file_sha256(path) for path in paths}
 
 
 def test_expected_release_filenames_are_exact_wheel_and_sdist():
@@ -29,26 +45,29 @@ def test_expected_release_filenames_are_exact_wheel_and_sdist():
     }
 
 
-def test_pypi_release_filenames_reads_project_release_map(monkeypatch):
+def test_pypi_release_artifacts_reads_project_release_map(monkeypatch):
     observed = {}
 
     def open_url(url, *, timeout):
         observed.update(url=url, timeout=timeout)
         return io.BytesIO(json.dumps({
             "releases": {
-                "3.1.28": [{"filename": "vaxrank-3.1.28.tar.gz"}],
+                "3.1.28": [{
+                    "filename": "vaxrank-3.1.28.tar.gz",
+                    "digests": {"sha256": "abc123"},
+                }],
             },
         }).encode("utf-8"))
 
     monkeypatch.setattr(release_upload, "urlopen", open_url)
     monkeypatch.setattr(release_upload, "token_hex", lambda length: "fresh-token")
 
-    assert pypi_release_filenames(
+    assert pypi_release_artifacts(
         "vaxrank",
         "3.1.28",
         json_base_url="https://packages.example/pypi/",
         request_timeout_seconds=7,
-    ) == {"vaxrank-3.1.28.tar.gz"}
+    ) == {"vaxrank-3.1.28.tar.gz": "abc123"}
     assert observed == {
         "url": (
             "https://packages.example/pypi/vaxrank/json"
@@ -58,7 +77,7 @@ def test_pypi_release_filenames_reads_project_release_map(monkeypatch):
     }
 
 
-def test_pypi_release_filenames_uses_a_fresh_url_for_each_poll(monkeypatch):
+def test_pypi_release_artifacts_uses_a_fresh_url_for_each_poll(monkeypatch):
     urls = []
     tokens = iter(["first-token", "second-token"])
 
@@ -69,8 +88,8 @@ def test_pypi_release_filenames_uses_a_fresh_url_for_each_poll(monkeypatch):
     monkeypatch.setattr(release_upload, "urlopen", open_url)
     monkeypatch.setattr(release_upload, "token_hex", lambda length: next(tokens))
 
-    pypi_release_filenames("vaxrank", "3.1.28")
-    pypi_release_filenames("vaxrank", "3.1.28")
+    pypi_release_artifacts("vaxrank", "3.1.28")
+    pypi_release_artifacts("vaxrank", "3.1.28")
 
     assert urls == [
         "https://pypi.org/pypi/vaxrank/json?cache_bust=first-token",
@@ -78,12 +97,12 @@ def test_pypi_release_filenames_uses_a_fresh_url_for_each_poll(monkeypatch):
     ]
 
 
-def test_pypi_release_filenames_treats_missing_release_as_empty(monkeypatch):
+def test_pypi_release_artifacts_treats_missing_release_as_empty(monkeypatch):
     def open_url(url, *, timeout):
         raise HTTPError(url, 404, "Not Found", {}, None)
 
     monkeypatch.setattr(release_upload, "urlopen", open_url)
-    assert pypi_release_filenames("vaxrank", "3.1.28") == frozenset()
+    assert pypi_release_artifacts("vaxrank", "3.1.28") == {}
 
 
 def test_upload_distribution_is_bounded_and_disables_progress(monkeypatch):
@@ -113,90 +132,134 @@ def test_upload_distribution_is_bounded_and_disables_progress(monkeypatch):
     }
 
 
-def test_wait_for_release_file_observes_eventual_metadata():
-    responses = iter([set(), {"vaxrank-3.1.28.tar.gz"}])
+def test_wait_for_release_file_observes_eventual_matching_metadata():
+    filename = "vaxrank-3.1.28.tar.gz"
+    responses = iter([{}, {filename: "abc123"}])
 
     assert wait_for_release_file(
-        "vaxrank-3.1.28.tar.gz",
+        filename,
+        "abc123",
         lambda: next(responses),
         timeout_seconds=1,
         poll_seconds=0,
     )
 
 
-def test_timeout_after_server_acceptance_is_reconciled():
-    published = set()
+def test_wait_for_release_file_rejects_different_bytes_immediately():
+    filename = "vaxrank-3.1.28.tar.gz"
+    with pytest.raises(ReleaseUploadError, match="SHA-256"):
+        wait_for_release_file(
+            filename,
+            "local-digest",
+            lambda: {filename: "remote-digest"},
+            timeout_seconds=1,
+            poll_seconds=0,
+        )
 
-    def fetch_release_filenames():
+
+def test_complete_release_verification_retries_stale_metadata():
+    expected = {"wheel": "wheel-digest", "sdist": "sdist-digest"}
+    responses = iter([
+        {"wheel": "wheel-digest"},
+        expected,
+    ])
+
+    assert wait_for_complete_release(
+        expected,
+        lambda: next(responses),
+        timeout_seconds=1,
+        poll_seconds=0,
+    ) == expected
+
+
+def test_timeout_after_server_acceptance_is_reconciled(release_paths):
+    published = {}
+
+    def fetch_release_artifacts():
         return published
 
     def upload_file(path):
-        published.add(path.name)
+        published[path.name] = file_sha256(path)
         raise subprocess.TimeoutExpired(["twine", "upload"], timeout=60)
 
     result = publish_release(
-        PATHS,
+        release_paths,
         expected_filenames=EXPECTED,
-        fetch_release_filenames=fetch_release_filenames,
+        fetch_release_artifacts=fetch_release_artifacts,
         upload_file=upload_file,
         verify_timeout_seconds=0,
     )
 
-    assert EXPECTED <= result
+    assert EXPECTED <= set(result)
 
 
-def test_partial_release_uploads_only_missing_file_and_retry_is_safe():
+def test_partial_release_uploads_only_missing_file_and_retry_is_safe(
+        release_paths):
     wheel = "vaxrank-3.1.28-py3-none-any.whl"
     sdist = "vaxrank-3.1.28.tar.gz"
-    published = {wheel}
+    local = _local_artifacts(release_paths)
+    published = {wheel: local[wheel]}
     uploaded = []
 
-    def fetch_release_filenames():
+    def fetch_release_artifacts():
         return published
 
     def upload_file(path):
         uploaded.append(path.name)
-        published.add(path.name)
+        published[path.name] = file_sha256(path)
 
-    publish_release(
-        PATHS,
-        expected_filenames=EXPECTED,
-        fetch_release_filenames=fetch_release_filenames,
-        upload_file=upload_file,
-        verify_timeout_seconds=0,
-    )
-    publish_release(
-        PATHS,
-        expected_filenames=EXPECTED,
-        fetch_release_filenames=fetch_release_filenames,
-        upload_file=upload_file,
-        verify_timeout_seconds=0,
-    )
+    for _ in range(2):
+        publish_release(
+            release_paths,
+            expected_filenames=EXPECTED,
+            fetch_release_artifacts=fetch_release_artifacts,
+            upload_file=upload_file,
+            verify_timeout_seconds=0,
+        )
 
     assert uploaded == [sdist]
 
 
-def test_failed_upload_without_server_artifact_fails_hard():
+def test_existing_filename_with_different_bytes_fails_before_upload(
+        release_paths):
+    wheel = "vaxrank-3.1.28-py3-none-any.whl"
+    uploaded = []
+
+    with pytest.raises(ReleaseUploadError, match="SHA-256"):
+        publish_release(
+            release_paths,
+            expected_filenames=EXPECTED,
+            fetch_release_artifacts=lambda: {wheel: "0" * 64},
+            upload_file=lambda path: uploaded.append(path.name),
+            verify_timeout_seconds=0,
+        )
+
+    assert uploaded == []
+
+
+def test_failed_upload_without_server_artifact_fails_hard(release_paths):
     def upload_file(path):
         raise subprocess.TimeoutExpired(["twine", "upload", path], timeout=60)
 
     with pytest.raises(ReleaseUploadError, match="did not publish"):
         publish_release(
-            PATHS,
+            release_paths,
             expected_filenames=EXPECTED,
-            fetch_release_filenames=frozenset,
+            fetch_release_artifacts=dict,
             upload_file=upload_file,
             verify_timeout_seconds=0,
         )
 
 
-def test_unexpected_distribution_set_is_rejected_before_upload():
+def test_unexpected_distribution_set_is_rejected_before_upload(tmp_path):
+    path = tmp_path / "vaxrank-3.1.28.tar.gz"
+    path.write_bytes(b"sdist")
     with pytest.raises(ReleaseUploadError, match="do not match"):
         publish_release(
-            ["dist/vaxrank-3.1.28.tar.gz"],
+            [path],
             expected_filenames=EXPECTED,
-            fetch_release_filenames=frozenset,
-            upload_file=lambda path: None,
+            fetch_release_artifacts=dict,
+            upload_file=lambda artifact: None,
             verify_timeout_seconds=0,
         )
 
@@ -209,7 +272,7 @@ def test_main_passes_exact_artifact_contract_to_publisher(monkeypatch, capsys):
             distribution_paths=tuple(distribution_paths),
             expected_filenames=kwargs["expected_filenames"],
         )
-        return EXPECTED
+        return {filename: "digest" for filename in EXPECTED}
 
     monkeypatch.setattr(release_upload, "publish_release", publish_release_call)
 

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.8"
+__version__ = "3.13.9"
 
 
 def print_version():


### PR DESCRIPTION
Fixes #406.
Fixes #407.

The attempted 3.13.8 deployment stopped before build because deploy.sh selected a Python 3.9 .venv while bare pytest came from another PATH entry and the installed dependencies lived in the active Python 3.12 environment. This PR makes deploy, lint, pytest, build, and Twine use one resolved interpreter, preferring an explicit PYTHON and then the active VIRTUAL_ENV.

It also closes the release-integrity gap found while reviewing Isovar 1.7.4:

- PyPI reconciliation now requires matching SHA-256 bytes, not only filenames.
- Complete-release verification retains bounded polling instead of trusting one final metadata read.
- The local tag is created before upload and may resume only at the same commit.
- A retry reuses the original wheel and sdist; it refuses to rebuild when either is missing.
- The release branch must be clean and synchronized with its upstream.
- Only the specific release tag is pushed.

I tested SOURCE_DATE_EPOCH as a smaller alternative. Wheels were reproducible, but setuptools sdists were not (generated tar member mtimes changed), so preserving and verifying the original artifacts is the safe design.

Version 3.13.9 intentionally supersedes the unpublished 3.13.8 and includes PR #405.

Verification:
- ./lint.sh
- ./test.sh: 1,207 passed
- 20 focused deployment/upload tests
- bash syntax checks
- real PyPI 3.13.7 digest-metadata parse