### PR TITLE
Require lossless Isovar RNA assembly handoff

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@ numpy>=2.0.0,<3.0.0
 pandas>=2.1.4,<3.0.0
 pyensembl>=2.6.4,<3.0.0
 varcode>=5.0.0,<6.0.0
-# 1.7.2 replaces the removed pkg_resources logging lookup.
-isovar>=1.7.2,<2.0.0
+# 1.7.5 preserves contained and intermediate RNA assemblies until transcript
+# compatibility is known (and includes the 1.7.2 logging-resource fix).
+isovar>=1.7.5,<2.0.0
 # 3.33.5 makes bundled YAML loading independent of the host locale.
 mhcgnomes>=3.33.5,<4.0.0
 mhctools>=3.13.3,<4.0.0

--- a/tests/test_isovar_compatibility.py
+++ b/tests/test_isovar_compatibility.py
@@ -1,0 +1,74 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Downstream contracts required from Vaxrank's Isovar dependency."""
+
+from isovar.allele_read import AlleleRead
+from isovar.protein_sequence_creator import ProteinSequenceCreator
+from isovar.reference_context import ReferenceContext
+from isovar.variant_sequence_creator import VariantSequenceCreator
+from varcode import Variant
+
+
+def test_contained_rna_assembly_reaches_transcript_matching():
+    """A longer incompatible assembly must not erase a compatible core."""
+    variant = Variant("1", 100, "G", "C", "GRCh38")
+    prefixes = ("AAA", "GGGAAA", "CCCGGGAAA", "TTTCCCGGGAAA")
+    reads = [
+        AlleleRead(
+            prefix=prefix,
+            allele=variant.alt,
+            suffix="A" * 8,
+            name=f"{prefix}-{i}",
+        )
+        for prefix in prefixes
+        for i in range(2)
+    ]
+
+    sequence_creator = VariantSequenceCreator(
+        min_variant_sequence_coverage=2,
+        preferred_sequence_length=len(prefixes[-1]) * 2 + 1,
+        variant_sequence_assembly=True,
+        min_assembly_overlap_size=1,
+    )
+    candidates = sequence_creator.reads_to_variant_sequences(
+        variant=variant,
+        reads=reads,
+    )
+    reference_context = ReferenceContext(
+        strand="+",
+        sequence_before_variant_locus="A" * len(prefixes[-1]),
+        sequence_at_variant_locus=variant.ref,
+        sequence_after_variant_locus="A" * 8,
+        offset_to_first_complete_codon=0,
+        contains_start_codon=False,
+        overlaps_start_codon=False,
+        contains_five_prime_utr=False,
+        amino_acids_before_variant="",
+        variant=variant,
+        transcripts=(),
+    )
+    protein_creator = ProteinSequenceCreator(
+        protein_sequence_length=8,
+        min_variant_sequence_coverage=2,
+        min_transcript_prefix_length=3,
+        max_transcript_mismatches=2,
+    )
+
+    translations = protein_creator.all_pairs_translations(
+        variant_sequences=candidates,
+        reference_contexts=[reference_context],
+    )
+
+    assert {candidate.prefix for candidate in candidates} == set(prefixes)
+    assert len(translations) == 1
+    assert translations[0].untrimmed_variant_sequence.prefix == "AAA"

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.9"
+__version__ = "3.13.10"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

- require Isovar 1.7.5, the first release that preserves contained and intermediate RNA assembly candidates until transcript compatibility is known
- add a downstream acceptance test through Isovar sequence creation and translation
- bump Vaxrank to 3.13.10

No Vaxrank API call changes are needed: the existing VCF/BAM path already constructs Isovar ProteinSequenceCreator through the public CLI factory. The dependency floor is the required usage fix.

Refs openvax/isovar#198.

## Review evidence

- independently reviewed openvax/isovar#200 candidate identity, intermediate retention, read-set unioning, cutoff behavior, and equivalent-protein aggregation
- compatibility test passes against the published Isovar 1.7.5 wheel
- the same test fails against previously allowed Isovar 1.7.2 by collapsing four candidates to the incompatible longest sequence and producing no translation
- ./lint.sh
- ./test.sh: 1,208 passed
- B16 VCF/BAM end-to-end smoke against published Isovar 1.7.5: all ASCII/HTML/PDF/XLSX/neoepitope/JSON/CSV outputs completed

## Separate finding

The Isovar review exposed an unrelated interpreter-split in its local/release gates, filed as openvax/isovar#202. It does not affect the assembly fix or Vaxrank runtime compatibility.