### PR TITLE
Complete pVACseq presentation coverage integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,10 +11,9 @@ mhctools>=3.13.3,<4.0.0
 # 5.10.0 adds EvalContext(default_methods=...) and apply_filter(default_methods=...)
 # which vaxrank uses to score multi-model inputs (e.g. LENS with mhcflurry +
 # netmhcpan) without pre-subsetting the frame.
-# 5.48.0 correctly identifies aggregated pVACseq RNA Expr as gene-level,
-# exposes the shared gene/transcript/RNA-alt expression vocabulary, and omits
-# unavailable evidence instead of emitting all-null columns.
-topiary>=5.48.0,<6.0.0
+# 5.52.0 preserves pVACtools presentation metrics as native prediction rows,
+# completing Vaxrank's presentation-aware coverage path.
+topiary>=5.52.0,<6.0.0
 roman
 jinja2>=3.1
 weasyprint>=62.0

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -474,6 +474,48 @@ def test_load_pvacseq_preserves_upstream_presentation_rows():
     assert coverage.best_presentation_pct == pytest.approx(0.3)
 
 
+def test_pvacseq_presentation_reaches_coverage_end_to_end(tmp_path):
+    """Raw pVACtools presentation data can independently cover an allele."""
+    from vaxrank.coverage import compute_coverage
+
+    path = tmp_path / "pvacseq-presentation.all_epitopes.tsv"
+    path.write_text(
+        "Chromosome\tStart\tStop\tReference\tVariant\tTranscript\t"
+        "Variant Type\tMutation\tGene Name\tHLA Allele\tMutation Position\t"
+        "MT Epitope Seq\tWT Epitope Seq\tMedian MT IC50 Score\t"
+        "Median WT IC50 Score\tMedian MT Percentile\tMedian WT Percentile\t"
+        "MHCflurryEL Presentation MT Score\t"
+        "MHCflurryEL Presentation WT Score\t"
+        "MHCflurryEL Presentation MT Percentile\t"
+        "MHCflurryEL Presentation WT Percentile\n"
+        "chr1\t100000\t100001\tA\tT\tENST00000269305\tmissense\tG7S\t"
+        "TP53\tHLA-A*02:01\t7\tSVVGSSSSS\tSVVGSSGSS\t850\t5000\t"
+        "4.0\t10.0\t0.92\t0.41\t0.3\t4.2\n"
+    )
+
+    loaded = read_pvacseq_report(path)
+
+    assert len(loaded.report_df) == 1
+    assert "850.00 nM" in loaded.report_df.iloc[0][
+        "Predicted mutant pMHC affinity"]
+    assert len(loaded.epitopes) == 1
+    [epitope] = loaded.epitopes
+    [presentation] = epitope.predictions_for(
+        "pMHC_presentation", predictor="mhcflurry")
+    assert presentation.score == pytest.approx(0.92)
+    assert presentation.percentile_rank == pytest.approx(0.3)
+    [wt_presentation] = epitope.wt.predictions_for(
+        "pMHC_presentation", predictor="mhcflurry")
+    assert wt_presentation.score == pytest.approx(0.41)
+    assert wt_presentation.percentile_rank == pytest.approx(4.2)
+    coverage = compute_coverage(
+        loaded.epitopes, ["HLA-A*02:01"])["HLA-A*02:01"]
+    assert coverage.best_presentation_pct == pytest.approx(0.3)
+    assert coverage.best_affinity_pct == pytest.approx(4.0)
+    assert coverage.tier == "strong"
+    assert coverage.n_peptides == 1
+
+
 def test_load_pvacseq_missing_columns(tmp_path):
     bad_file = tmp_path / "bad.tsv"
     bad_file.write_text("Gene\tAA Change\nTP53\tG245S\n")

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.10"
+__version__ = "3.13.11"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

- require Topiary 5.52.0, the first release that preserves pVACtools presentation metrics as native prediction rows
- add a raw pVACtools all-epitopes regression through the real Topiary reader, Vaxrank adapter, and allele coverage calculation
- prove presentation can yield strong coverage when affinity alone is outside every coverage tier
- bump Vaxrank to 3.13.11

Closes #282.

## Verification

- `./lint.sh` against published Topiary 5.52.0
- `./test.sh` against published Topiary 5.52.0: 1,209 passed
- focused regression passes against published Topiary 5.52.0
- focused regression fails against Topiary 5.51.0 because the presentation row is absent, proving the dependency floor is necessary