### PR TITLE
Make native epitope round-trips lossless

### DIFF
--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -15,13 +15,21 @@ Tests for epitope_io: serialization, deserialization, and external imports.
 """
 
 import dataclasses
+import json
 import os
 
+import pandas as pd
 import pytest
 from mhctools.pred import Prediction
 
-from vaxrank.candidate_epitope import COMPARATOR_WT, CandidateEpitope, Peptide
+from vaxrank.candidate_epitope import (
+    COMPARATOR_NEAREST_SELF,
+    COMPARATOR_WT,
+    CandidateEpitope,
+    Peptide,
+)
 from vaxrank.epitope_io import (
+    NATIVE_EPITOPE_COLUMN,
     epitope_prediction_rows,
     predictions_to_dataframe,
     save_predictions,
@@ -263,9 +271,10 @@ def test_native_roundtrip_preserves_evidence_only_predictions(tmp_path):
 
 
 def test_native_reload_rejects_missing_explicit_prediction_score(tmp_path):
-    """New native rows never turn missing scientific evidence into zero."""
+    """Pre-payload generic rows never turn missing evidence into zero."""
     path = tmp_path / "missing-score.csv"
-    dataframe = predictions_to_dataframe([_make_prediction()])
+    dataframe = predictions_to_dataframe([_make_prediction()]).drop(
+        columns=[NATIVE_EPITOPE_COLUMN])
     dataframe.loc[0, "prediction_score"] = None
     dataframe.to_csv(path, index=False)
 
@@ -321,6 +330,221 @@ def test_native_roundtrip_preserves_complete_wt_prediction(tmp_path):
 
     assert reloaded.wt is not None
     assert reloaded.wt.predictions_flat() == (wt_prediction,)
+
+
+def test_native_roundtrip_preserves_arbitrary_comparators(tmp_path):
+    """The canonical payload retains comparator names, contexts, and evidence."""
+    mutant_predictions = (
+        Prediction(
+            kind="pMHC_affinity",
+            predictor_name="mhcflurry",
+            predictor_version="2.1.1",
+            allele="HLA-A*02:01",
+            peptide="SIINFEKL",
+            value=50.0,
+            score=0.91,
+            percentile_rank=0.5,
+        ),
+        Prediction(
+            kind="pMHC_presentation",
+            predictor_name="mhcflurry",
+            predictor_version="2.1.1",
+            allele="HLA-A*02:01",
+            peptide="SIINFEKL",
+            value=0.85,
+            score=0.85,
+            percentile_rank=0.28,
+        ),
+    )
+    nearest_prediction = Prediction(
+        kind="pMHC_affinity",
+        predictor_name="mhcflurry",
+        predictor_version="2.1.1",
+        allele="HLA-A*02:01",
+        peptide="SIINFEKM",
+        value=500.0,
+        score=0.42,
+        percentile_rank=4.8,
+    )
+    original = CandidateEpitope(
+        sequence="SIINFEKL",
+        source_sequence="AASIINFEKLLL",
+        source_name="TP53",
+        offset=2,
+        predictions=mutant_predictions,
+        comparators={
+            COMPARATOR_NEAREST_SELF: Peptide(
+                sequence="SIINFEKM",
+                n_flank="NN",
+                c_flank="CC",
+                source_sequence="NNSIINFEKMCC",
+                source_name="SELF_TRANSCRIPT_1",
+                offset=2,
+                predictions=(nearest_prediction,),
+            ),
+            "assay_control": Peptide(sequence="AAAAAAAAA"),
+        },
+        patient_alleles=("HLA-A*02:01",),
+        per_allele_scores={"HLA-A*02:01": 1.76},
+    )
+
+    path = tmp_path / "all-comparators.csv"
+    save_predictions([original], path)
+
+    exported = pd.read_csv(path)
+    assert len(exported) == len(mutant_predictions)
+    assert exported[NATIVE_EPITOPE_COLUMN].notna().sum() == 1
+    payload = json.loads(exported[NATIVE_EPITOPE_COLUMN].dropna().iloc[0])
+    assert {field.name for field in dataclasses.fields(CandidateEpitope)} <= set(
+        payload)
+    [reloaded] = load_predictions(path)
+    assert reloaded == original
+    assert set(reloaded.comparators) == {
+        COMPARATOR_NEAREST_SELF, "assay_control"}
+
+
+def test_native_roundtrip_preserves_candidate_without_predictions(tmp_path):
+    """A payload-only candidate must not disappear from the native file."""
+    original = CandidateEpitope(
+        sequence="SIINFEKL",
+        comparators={
+            COMPARATOR_NEAREST_SELF: Peptide(sequence="SIINFEKM"),
+        },
+    )
+    path = tmp_path / "no-predictions.tsv"
+
+    save_predictions([original], path)
+
+    exported = pd.read_csv(path, sep="\t")
+    assert len(exported) == 1
+    assert exported[NATIVE_EPITOPE_COLUMN].notna().all()
+    assert load_predictions(path) == [original]
+
+
+def test_native_roundtrip_empty_collection(tmp_path):
+    """An empty native file keeps its schema and reloads as no candidates."""
+    path = tmp_path / "empty.csv"
+
+    save_predictions([], path)
+
+    assert NATIVE_EPITOPE_COLUMN in pd.read_csv(path).columns
+    assert load_predictions(path) == []
+
+
+def test_native_roundtrip_preserves_unpaired_wt_prediction(tmp_path):
+    """WT evidence need not have a matching mutant kind to survive export."""
+    mutant = Prediction(
+        kind="pMHC_affinity",
+        predictor_name="mhcflurry",
+        predictor_version="2.1.1",
+        allele="HLA-A*02:01",
+        peptide="SIINFEKL",
+        value=50.0,
+        score=0.91,
+    )
+    wt_presentation = Prediction(
+        kind="pMHC_presentation",
+        predictor_name="mhcflurry",
+        predictor_version="2.1.1",
+        allele="HLA-A*02:01",
+        peptide="SIINFEKM",
+        value=0.4,
+        score=0.4,
+        percentile_rank=4.8,
+    )
+    original = CandidateEpitope(
+        sequence="SIINFEKL",
+        predictions=(mutant,),
+        comparators={
+            COMPARATOR_WT: Peptide(
+                sequence="SIINFEKM",
+                predictions=(wt_presentation,),
+            ),
+        },
+    )
+    path = tmp_path / "unpaired-wt.csv"
+
+    save_predictions([original], path)
+
+    [reloaded] = load_predictions(path)
+    assert reloaded == original
+    assert reloaded.wt.predictions_flat() == (wt_presentation,)
+
+
+def test_legacy_native_projection_loads_self_reference_sources(tmp_path):
+    """Pre-payload files retain nested exact-self provenance on reload."""
+    from vaxrank.vaccine_antigen import SelfReferenceMatch, SelfReferenceSource
+
+    original = _make_prediction()
+    original = dataclasses.replace(
+        original,
+        self_reference_match=SelfReferenceMatch(
+            peptide=original.sequence,
+            occurs=True,
+            antigen_kind="mutation",
+            sources=(SelfReferenceSource(
+                gene_id="ENSG00000146648",
+                transcript_id="ENST00000275493",
+                gene_name="EGFR",
+                species="human",
+            ),),
+            source_provenance_complete=True,
+            genome_release="GRCh38",
+        ),
+    )
+    path = tmp_path / "legacy-self-reference.csv"
+    predictions_to_dataframe([original]).drop(
+        columns=[NATIVE_EPITOPE_COLUMN]).to_csv(path, index=False)
+
+    [reloaded] = load_predictions(path)
+
+    assert reloaded.self_reference_match == original.self_reference_match
+
+
+def test_native_payload_rejects_unapproved_serialized_class(tmp_path):
+    """Native payloads accept only types in the candidate object graph."""
+    path = tmp_path / "unapproved-class.csv"
+    pd.DataFrame({
+        NATIVE_EPITOPE_COLUMN: [json.dumps({
+            "unexpected": 1,
+            "__class__": {
+                "__module__": "collections",
+                "__name__": "Counter",
+            },
+        })],
+    }).to_csv(path, index=False)
+
+    with pytest.raises(ValueError, match="Invalid serialized CandidateEpitope"):
+        load_predictions(path)
+
+
+def test_native_payload_rejects_wrong_root_type(tmp_path):
+    """An allowlisted nested type is not a valid top-level candidate."""
+    path = tmp_path / "wrong-root.csv"
+    pd.DataFrame({
+        NATIVE_EPITOPE_COLUMN: [Peptide(sequence="SIINFEKL").to_json()],
+    }).to_csv(path, index=False)
+
+    with pytest.raises(ValueError, match="Invalid serialized CandidateEpitope"):
+        load_predictions(path)
+
+
+def test_native_payload_rejects_standalone_type_metadata(tmp_path):
+    """Standalone type metadata is not part of a candidate field schema."""
+    payload = json.loads(CandidateEpitope(sequence="SIINFEKL").to_json())
+    payload["per_allele_scores"] = {
+        "HLA-A*02:01": {
+            "__module__": "collections",
+            "__name__": "Counter",
+        },
+    }
+    path = tmp_path / "standalone-type.csv"
+    pd.DataFrame({
+        NATIVE_EPITOPE_COLUMN: [json.dumps(payload)],
+    }).to_csv(path, index=False)
+
+    with pytest.raises(ValueError, match="Invalid serialized CandidateEpitope"):
+        load_predictions(path)
 
 
 # ── pVACseq import ───────────────────────────────────────────────────────────

--- a/tests/test_isovar_compatibility.py
+++ b/tests/test_isovar_compatibility.py
@@ -70,5 +70,14 @@ def test_contained_rna_assembly_reaches_transcript_matching():
     )
 
     assert {candidate.prefix for candidate in candidates} == set(prefixes)
-    assert len(translations) == 1
-    assert translations[0].untrimmed_variant_sequence.prefix == "AAA"
+    # Isovar 1.7.9 also lets longer candidates trim to this same compatible
+    # core. The downstream contract is that the original core reaches
+    # translation exactly once; equivalent translations may accompany it and
+    # are deduplicated later when Isovar groups protein sequences.
+    assert {translation.amino_acids for translation in translations} == {"KQKK"}
+    core_translation, = [
+        translation
+        for translation in translations
+        if translation.untrimmed_variant_sequence.prefix == "AAA"
+    ]
+    assert core_translation.contains_mutation

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -23,7 +23,11 @@ from varcode import Variant
 
 from vaxrank.mutant_protein_fragment import MutantProteinFragment
 from vaxrank.candidate_epitope import COMPARATOR_WT, CandidateEpitope, Peptide
-from vaxrank.vaccine_antigen import VaccineAntigen
+from vaxrank.vaccine_antigen import (
+    SelfReferenceMatch,
+    SelfReferenceSource,
+    VaccineAntigen,
+)
 from vaxrank.vaccine_peptide import VaccinePeptide
 
 
@@ -105,6 +109,28 @@ class _FakeFragment:
 
 
 # ---- CandidateEpitope -----------------------------------------------------------
+
+
+def test_epitope_json_roundtrip():
+    """CandidateEpitope and its nested Peptide graph use one dataclass schema."""
+    self_reference_match = SelfReferenceMatch(
+        peptide="SIINFEQL",
+        occurs=True,
+        antigen_kind="mutation",
+        excluded_gene_ids=("ENSG00000141510",),
+        sources=(SelfReferenceSource(
+            gene_id="ENSG00000146648",
+            transcript_id="ENST00000275493",
+            protein_id="ENSP00000275493",
+            gene_name="EGFR",
+            species="human",
+        ),),
+        source_provenance_complete=True,
+        genome_release="GRCh38",
+    )
+    epitope = _sample_epitope(self_reference_match=self_reference_match)
+    restored = CandidateEpitope.from_json(epitope.to_json())
+    assert restored == epitope
 
 
 def test_epitope_pickle_roundtrip():

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -90,7 +90,10 @@ from dataclasses import dataclass, field, replace as _dc_replace
 from typing import TYPE_CHECKING, Optional
 
 from packaging.version import InvalidVersion, Version
+from serializable import DataclassSerializable
 from topiary.ranking import KIND_ALIASES as _KIND_ALIASES
+
+from .native_serialization import from_native_json, to_native_json
 
 if TYPE_CHECKING:
     from mhctools.pred import Prediction
@@ -234,7 +237,7 @@ SOURCE_CLASS_SELF = 'self'          # self-protein-derived (CTAs, overexpressed
 
 
 @dataclass(frozen=True)
-class Peptide:
+class Peptide(DataclassSerializable):
     """One peptide sequence + flanking residues + (optional) MHC
     binding predictions.
 
@@ -286,6 +289,15 @@ class Peptide:
         if isinstance(self.predictions, (list, tuple)):
             object.__setattr__(
                 self, 'predictions', _group_predictions(self.predictions))
+
+    def to_json(self) -> str:
+        """Serialize this peptide graph using the native class allowlist."""
+        return to_native_json(self)
+
+    @classmethod
+    def from_json(cls, json_string: str):
+        """Load this peptide graph after validating every encoded class."""
+        return from_native_json(json_string, cls)
 
     def __hash__(self) -> int:
         # Position identity. The dataclass-generated hash would

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -18,12 +18,12 @@ Supports:
   - pVACseq aggregated TSV (all_epitopes.aggregated.tsv)
   - LENS report TSV
 
-All loader functions emit ``list[vaxrank.candidate_epitope.CandidateEpitope]``;
-the flat per-(peptide, allele, predictor) row shape lives only inside
-the CSV / DataFrame layer for round-trip fidelity. Loaders feed each
-row to :func:`~vaxrank.candidate_epitope.candidate_epitopes_from_rows`,
-which groups native rows by position and external rows by their complete
-``ExternalPredictionKey`` identity into ``CandidateEpitope`` objects.
+All loader functions emit ``list[vaxrank.candidate_epitope.CandidateEpitope]``.
+Native CSV/TSV files carry one canonical serialized dataclass payload per
+candidate alongside their flat prediction columns; older files retain their
+field-by-field compatibility loader. External loaders feed normalized rows to
+:func:`~vaxrank.candidate_epitope.candidate_epitopes_from_rows`, which groups
+them by complete ``ExternalPredictionKey`` identity.
 """
 
 import json
@@ -45,14 +45,18 @@ from .external_prediction import (
 from .external_report import (
     GENOMIC_VARIANT_COLUMN, ExternalRecord, ExternalReport,
 )
+from .native_serialization import from_native_json, to_native_json
 from .candidate_epitope import (
-    SOURCE_CLASS_MUTATION, candidate_epitopes_from_rows,
+    SOURCE_CLASS_MUTATION, CandidateEpitope, candidate_epitopes_from_rows,
 )
 
 logger = logging.getLogger(__name__)
 
 
 # ── Vaxrank native format ────────────────────────────────────────────────────
+
+NATIVE_EPITOPE_COLUMN = "candidate_epitope_json"
+
 
 VAXRANK_COLUMNS = [
     "allele",
@@ -117,16 +121,23 @@ VAXRANK_COLUMNS = [
     "wt_prediction_c_flank",
     "wt_prediction_source_sequence_name",
     "wt_prediction_offset",
+    # The canonical record. Append it so existing positional readers retain
+    # the historical column order. It appears once, on the first flat
+    # prediction row for each candidate; the preceding columns are a stable
+    # compatibility and inspection view. Future dataclass fields round-trip
+    # through this payload without another hand-maintained load branch.
+    NATIVE_EPITOPE_COLUMN,
 ]
 
 
 def epitope_prediction_rows(epitope):
-    """Serialize one candidate to one native row per mutant prediction.
+    """Project one serialized candidate onto flat prediction rows.
 
-    Every prediction kind is emitted. Affinity values are duplicated into
-    the legacy ``ic50`` column for compatibility; the generic prediction
-    columns retain the kind, value, normalized score, percentile, and
-    provenance needed to reconstruct the original ``Prediction`` records.
+    The serialized dataclass payload on the first row is authoritative. Every
+    mutant prediction kind is also emitted in the historical flat shape for
+    compatibility and inspection; affinity values remain duplicated into the
+    legacy ``ic50`` column. A candidate with no mutant predictions gets one
+    payload-only row rather than disappearing from the file.
     """
     wt = epitope.wt
     wt_peptide_sequence = wt.sequence if wt is not None else ""
@@ -212,22 +223,17 @@ def epitope_prediction_rows(epitope):
             "wt_prediction_offset": (
                 wt_prediction.offset if wt_prediction is not None else None),
         })
-    unpaired_wt = [
-        prediction
-        for predictions in wt_by_key.values()
-        for prediction in predictions
-    ]
-    if unpaired_wt:
-        raise ValueError(
-            "Cannot serialize WT predictions without matching mutant "
-            "prediction leaves; refusing to lose comparator evidence")
+    if not rows:
+        rows.append({})
+    rows[0][NATIVE_EPITOPE_COLUMN] = to_native_json(epitope)
     return rows
 
 
 def predictions_to_dataframe(epitopes):
     """Convert a collection of ``CandidateEpitope`` objects to a flat DataFrame
-    matching :data:`VAXRANK_COLUMNS` — one row per mutant prediction leaf,
-    regardless of prediction kind.
+    matching :data:`VAXRANK_COLUMNS` — normally one row per mutant prediction
+    leaf, regardless of prediction kind. Candidates without predictions retain
+    one payload-only row.
 
     Parameters
     ----------
@@ -240,27 +246,49 @@ def predictions_to_dataframe(epitopes):
 
 
 def save_predictions(epitopes, path):
-    """Save ``CandidateEpitope`` objects to a CSV/TSV file. One row per
-    ``(epitope, allele, predictor)`` leaf prediction.
+    """Save ``CandidateEpitope`` objects to a native CSV/TSV file.
+
+    The canonical dataclass payload round-trips the complete object. Flat
+    prediction columns remain alongside it for existing readers and audits.
 
     Format is inferred from the file extension (.tsv -> tab, else comma).
     """
     df = predictions_to_dataframe(epitopes)
     sep = "\t" if str(path).endswith(".tsv") else ","
     df.to_csv(path, sep=sep, index=False)
-    logger.info("Saved %d prediction row(s) to %s", len(df), path)
+    logger.info("Saved %d native epitope row(s) to %s", len(df), path)
 
 
 def load_predictions(path):
     """Load a vaxrank-native CSV/TSV file.
 
-    Files written before generic prediction columns were introduced remain
-    supported as affinity-only inputs. New-format rows must carry an explicit
-    prediction kind and score; missing scientific values are not converted to
-    implicit zeros.
+    Current files reconstruct each complete ``CandidateEpitope`` from its
+    canonical dataclass payload. Files written before that payload was added
+    remain supported through the flat compatibility columns; generic legacy
+    rows must carry an explicit prediction kind and score, while the oldest
+    affinity-only rows retain their historical defaults.
     """
     sep = "\t" if str(path).endswith(".tsv") else ","
     df = pd.read_csv(path, sep=sep)
+
+    if NATIVE_EPITOPE_COLUMN in df.columns:
+        epitopes = []
+        for row_index, payload in df[NATIVE_EPITOPE_COLUMN].items():
+            if cells.missing(payload):
+                continue
+            try:
+                epitopes.append(from_native_json(
+                    str(payload), CandidateEpitope))
+            except (ImportError, KeyError, TypeError, ValueError) as error:
+                raise ValueError(
+                    "Invalid serialized CandidateEpitope at native row %d"
+                    % (row_index + 2)
+                ) from error
+        if len(df) and not epitopes:
+            raise ValueError(
+                "Native epitope file has no serialized CandidateEpitope payload"
+            )
+        return epitopes
 
     def string_or_empty(val):
         if val is None or (isinstance(val, float) and pd.isna(val)):
@@ -383,8 +411,8 @@ def load_predictions(path):
         self_reference_match = None
         if self_reference_raw:
             from .vaccine_antigen import SelfReferenceMatch
-            self_reference_match = SelfReferenceMatch.from_json(
-                self_reference_raw)
+            self_reference_match = from_native_json(
+                self_reference_raw, SelfReferenceMatch)
         rows.append({
             'peptide': peptide,
             'source': string_or_empty(row.get("source_sequence", "")),

--- a/vaxrank/native_serialization.py
+++ b/vaxrank/native_serialization.py
@@ -1,0 +1,171 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Allowlisted JSON serialization for native epitope object graphs."""
+
+import json
+
+from serializable import to_json
+
+
+# Resolve ``serializable`` type metadata through a static schema so native
+# files have a deterministic, constrained object graph. Adding a new non-
+# primitive CandidateEpitope field fails loudly until its value type is
+# reviewed and added here; the field can never silently disappear.
+
+_CLASS_FIELD = "__class__"
+_VALUE_FIELD = "__value__"
+_SERIALIZED_KEYS_FIELD = "__serialized_keys__"
+_SERIALIZED_KEY_PREFIX = _SERIALIZED_KEYS_FIELD + "element_"
+
+
+def _native_serializable_classes():
+    """Return the native class registry without creating an import cycle."""
+    from mhctools.pred import Prediction
+
+    from .allele_evidence import AlleleAttribution
+    from .candidate_epitope import CandidateEpitope, Peptide
+    from .vaccine_antigen import SelfReferenceMatch, SelfReferenceSource
+
+    return {
+        ("builtins", "set"): set,
+        ("builtins", "tuple"): tuple,
+        ("mhctools.pred", "Prediction"): Prediction,
+        ("vaxrank.allele_evidence", "AlleleAttribution"): AlleleAttribution,
+        ("vaxrank.candidate_epitope", "CandidateEpitope"): CandidateEpitope,
+        ("vaxrank.candidate_epitope", "Peptide"): Peptide,
+        ("vaxrank.vaccine_antigen", "SelfReferenceMatch"): SelfReferenceMatch,
+        ("vaxrank.vaccine_antigen", "SelfReferenceSource"): SelfReferenceSource,
+    }
+
+
+def _json_loads(payload):
+    """Parse JSON while rejecting ambiguous duplicate object keys."""
+    def unique_object(pairs):
+        result = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError("Duplicate key in native serialized JSON: %r" % key)
+            result[key] = value
+        return result
+
+    return json.loads(payload, object_pairs_hook=unique_object)
+
+
+def _class_from_metadata(metadata, registry):
+    """Resolve exact class metadata through the static native registry."""
+    if not isinstance(metadata, dict):
+        raise ValueError("Native serialized class metadata must be an object")
+    if set(metadata) != {"__module__", "__name__"}:
+        raise ValueError("Malformed native serialized class metadata")
+    class_key = (metadata["__module__"], metadata["__name__"])
+    try:
+        return registry[class_key]
+    except KeyError:
+        raise ValueError(
+            "Native serialized class %r is not permitted"
+            % "%s.%s" % class_key
+        ) from None
+
+
+def _decode_native_repr(value, registry):
+    """Decode one representation without importing input-selected objects."""
+    if value is None or isinstance(value, (bool, float, int, str)):
+        return value
+    if isinstance(value, list):
+        return [_decode_native_repr(item, registry) for item in value]
+    if not isinstance(value, dict):
+        raise TypeError("Invalid native serialized value %r" % (value,))
+
+    # Native epitope graphs contain no standalone class or function values.
+    if "__module__" in value or "__name__" in value:
+        raise ValueError("Standalone class/function metadata is not permitted")
+
+    class_metadata = value.get(_CLASS_FIELD)
+    class_object = (
+        _class_from_metadata(class_metadata, registry)
+        if class_metadata is not None else None
+    )
+
+    serialized_keys = value.get(_SERIALIZED_KEYS_FIELD, [])
+    if not isinstance(serialized_keys, list):
+        raise ValueError("Native serialized dictionary keys must be a list")
+    decoded_keys = []
+    for serialized_key in serialized_keys:
+        if not isinstance(serialized_key, str):
+            raise ValueError("A native serialized dictionary key must be JSON")
+        decoded_keys.append(_decode_native_repr(
+            _json_loads(serialized_key), registry))
+
+    state = {}
+    used_key_indexes = set()
+    for key, item in value.items():
+        if key in {_CLASS_FIELD, _SERIALIZED_KEYS_FIELD}:
+            continue
+        if key.startswith(_SERIALIZED_KEY_PREFIX):
+            index_text = key[len(_SERIALIZED_KEY_PREFIX):]
+            try:
+                index = int(index_text)
+                decoded_key = decoded_keys[index]
+            except (IndexError, ValueError):
+                raise ValueError(
+                    "Invalid native serialized dictionary key reference %r" % key
+                ) from None
+            if index < 0 or index in used_key_indexes:
+                raise ValueError(
+                    "Invalid native serialized dictionary key reference %r" % key
+                )
+            key = decoded_key
+            used_key_indexes.add(index)
+        decoded_item = _decode_native_repr(item, registry)
+        if key in state:
+            raise ValueError("Duplicate decoded native dictionary key %r" % (key,))
+        state[key] = decoded_item
+    if len(used_key_indexes) != len(decoded_keys):
+        raise ValueError("Unused native serialized dictionary key metadata")
+
+    if class_object is None:
+        return state
+    if class_object in (set, tuple):
+        if set(state) != {_VALUE_FIELD}:
+            raise ValueError("Malformed native serialized collection")
+        return class_object(state[_VALUE_FIELD])
+    if _VALUE_FIELD in state:
+        raise ValueError("Unexpected value wrapper for native serialized class")
+    if hasattr(class_object, "from_dict"):
+        return class_object.from_dict(state)
+    return class_object(**state)
+
+
+def to_native_json(value):
+    """Encode one native object after validating its complete class graph."""
+    payload = to_json(value)
+    restored = _decode_native_repr(
+        _json_loads(payload), _native_serializable_classes())
+    if type(restored) is not type(value):
+        raise ValueError(
+            "Native payload decoded to %s, expected %s"
+            % (type(restored).__name__, type(value).__name__)
+        )
+    return payload
+
+
+def from_native_json(payload, expected_type):
+    """Decode one allowlisted native object and enforce its root type."""
+    value = _decode_native_repr(
+        _json_loads(payload), _native_serializable_classes())
+    if type(value) is not expected_type:
+        raise ValueError(
+            "Native payload decoded to %s, expected %s"
+            % (type(value).__name__, expected_type.__name__)
+        )
+    return value

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.11"
+__version__ = "3.13.12"
 
 
 def print_version():


### PR DESCRIPTION
Closes #354.

## What changed

- make `Peptide` and `CandidateEpitope` `DataclassSerializable`
- add one canonical dataclass payload per candidate while retaining the historical flat columns and their order for compatibility
- reconstruct current native files from the complete object graph, so new dataclass fields and every comparator name round-trip without hand-wiring
- preserve candidates with no mutant prediction leaves and WT evidence without a matching mutant leaf
- retain the pre-payload CSV/TSV loader for older Vaxrank exports
- constrain decoded payloads to the reviewed native record types and reject malformed or unexpected roots/types
- accept the equivalent translation multiplicity introduced by Isovar 1.7.9 without weakening the original contained-core regression; follow-up dependency-floor work is tracked in #412
- bump Vaxrank to 3.13.12

## Verification

- `./lint.sh`
- `./test.sh` — 1,218 passed
- Isovar compatibility regression passes against both 1.7.5 (declared minimum) and 1.7.9 (current PyPI)
- B16 VCF/BAM CLI smoke with `--output-epitopes`, followed by two exact native reload cycles
- 500 deterministic randomized CandidateEpitope graph round-trips
- wheel and sdist build successfully, pass `twine check`, and both contain the new serializer module