### PR TITLE
Require Isovar 1.7.10 for corrected RNA-backed translations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ numpy>=2.0.0,<3.0.0
 pandas>=2.1.4,<3.0.0
 pyensembl>=2.6.4,<3.0.0
 varcode>=5.0.0,<6.0.0
-# 1.7.5 preserves contained and intermediate RNA assemblies until transcript
-# compatibility is known (and includes the 1.7.2 logging-resource fix).
-isovar>=1.7.5,<2.0.0
+# 1.7.10 preserves required reference context for long alternate alleles and
+# includes corrected mutation intervals and complete shared RNA support.
+isovar>=1.7.10,<2.0.0
 # 3.33.5 makes bundled YAML loading independent of the host locale.
 mhcgnomes>=3.33.5,<4.0.0
 mhctools>=3.13.3,<4.0.0

--- a/tests/test_isovar_compatibility.py
+++ b/tests/test_isovar_compatibility.py
@@ -12,11 +12,50 @@
 
 """Downstream contracts required from Vaxrank's Isovar dependency."""
 
+from types import SimpleNamespace
+
 from isovar.allele_read import AlleleRead
 from isovar.protein_sequence_creator import ProteinSequenceCreator
+from isovar.protein_sequence_helpers import group_equivalent_translations
 from isovar.reference_context import ReferenceContext
 from isovar.variant_sequence_creator import VariantSequenceCreator
 from varcode import Variant
+
+from vaxrank.mutant_protein_fragment import MutantProteinFragment
+from vaxrank.vaccine_antigen import VaccineAntigen
+from vaxrank.vaccine_config import VaccineConfig
+
+
+def _isovar_result(variant, protein_sequence):
+    """Minimal Isovar result carrying the fields Vaxrank consumes."""
+    n_reads = protein_sequence.num_supporting_reads
+    n_fragments = protein_sequence.num_supporting_fragments
+    return SimpleNamespace(
+        variant=variant,
+        top_protein_sequence=protein_sequence,
+        num_total_reads=n_reads,
+        num_alt_reads=n_reads,
+        num_ref_reads=0,
+        num_total_fragments=n_fragments,
+        num_alt_fragments=n_fragments,
+        num_ref_fragments=0,
+    )
+
+
+def _reference_context(variant, prefix, suffix):
+    return ReferenceContext(
+        strand="+",
+        sequence_before_variant_locus=prefix,
+        sequence_at_variant_locus=variant.ref,
+        sequence_after_variant_locus=suffix,
+        offset_to_first_complete_codon=0,
+        contains_start_codon=False,
+        overlaps_start_codon=False,
+        contains_five_prime_utr=False,
+        amino_acids_before_variant="",
+        variant=variant,
+        transcripts=(),
+    )
 
 
 def test_contained_rna_assembly_reaches_transcript_matching():
@@ -44,18 +83,10 @@ def test_contained_rna_assembly_reaches_transcript_matching():
         variant=variant,
         reads=reads,
     )
-    reference_context = ReferenceContext(
-        strand="+",
-        sequence_before_variant_locus="A" * len(prefixes[-1]),
-        sequence_at_variant_locus=variant.ref,
-        sequence_after_variant_locus="A" * 8,
-        offset_to_first_complete_codon=0,
-        contains_start_codon=False,
-        overlaps_start_codon=False,
-        contains_five_prime_utr=False,
-        amino_acids_before_variant="",
+    reference_context = _reference_context(
         variant=variant,
-        transcripts=(),
+        prefix="A" * len(prefixes[-1]),
+        suffix="A" * 8,
     )
     protein_creator = ProteinSequenceCreator(
         protein_sequence_length=8,
@@ -81,3 +112,72 @@ def test_contained_rna_assembly_reaches_transcript_matching():
         if translation.untrimmed_variant_sequence.prefix == "AAA"
     ]
     assert core_translation.contains_mutation
+
+    protein_sequence, = group_equivalent_translations(translations)
+    fragment = MutantProteinFragment.from_isovar_result(
+        _isovar_result(variant, protein_sequence)
+    )
+    assert fragment.n_alt_reads_supporting_protein_sequence == 8
+    assert fragment.n_alt_fragments_supporting_protein_sequence == 8
+
+
+def test_multibase_substitution_marks_every_targetable_amino_acid():
+    """An alternate interval crossing a codon boundary changes both codons."""
+    variant = Variant("1", 100, "GAA", "TCC", "GRCh38")
+    prefix = "AAA" * 4 + "AT"
+    suffix = "AGGG"
+    reads = [
+        AlleleRead(prefix=prefix, allele=variant.alt, suffix=suffix, name=str(i))
+        for i in range(2)
+    ]
+    sequences = VariantSequenceCreator().reads_to_variant_sequences(variant, reads)
+    translations = ProteinSequenceCreator().all_pairs_translations(
+        sequences,
+        [_reference_context(variant, prefix, suffix)],
+    )
+    protein_sequence, = group_equivalent_translations(translations)
+
+    fragment = MutantProteinFragment.from_isovar_result(
+        _isovar_result(variant, protein_sequence)
+    )
+    antigen = VaccineAntigen.from_mutant_protein_fragment(fragment)
+
+    assert fragment.amino_acids == "KKKKIPG"
+    assert (
+        fragment.mutant_amino_acid_start_offset,
+        fragment.mutant_amino_acid_end_offset,
+    ) == (4, 6)
+    assert antigen.interval_is_targetable(5, 6)
+
+
+def test_vaxrank_length_keeps_context_for_long_alternate(monkeypatch):
+    """A long alternate must not consume context required to establish its ORF."""
+    variant = Variant("1", 100, "", "A" * 90, "GRCh38")
+    prefix = "ACG" * 4
+    suffix = "G" * 30
+    reads = [
+        AlleleRead(prefix=prefix, allele=variant.alt, suffix=suffix, name=str(i))
+        for i in range(2)
+    ]
+    reference_context = _reference_context(variant, prefix, suffix)
+    monkeypatch.setattr(
+        "isovar.protein_sequence_creator.reference_contexts_for_variant",
+        lambda *args, **kwargs: [reference_context],
+    )
+    vaccine_config = VaccineConfig()
+    # Match the translation length the CLI derives from Vaxrank's defaults.
+    protein_sequence_length = (
+        vaccine_config.preferred_peptide_length
+        + 2 * vaccine_config.padding_around_mutation
+    )
+    creator = ProteinSequenceCreator(protein_sequence_length=protein_sequence_length)
+
+    translations = creator.translate_variant_reads(variant, reads)
+    protein_sequence, = group_equivalent_translations(translations)
+    fragment = MutantProteinFragment.from_isovar_result(
+        _isovar_result(variant, protein_sequence)
+    )
+
+    assert len(fragment.amino_acids) == 35
+    assert fragment.mutant_amino_acid_start_offset == 3
+    assert fragment.mutant_amino_acid_end_offset == 33

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.12"
+__version__ = "3.13.13"
 
 
 def print_version():


### PR DESCRIPTION
Closes #412.

## Summary

- require Isovar 1.7.10, which includes corrected affected-codon intervals, complete shared RNA support, deterministic assembly output, and retained reference context for long alternate alleles
- verify the shared-support union at Vaxrank's MutantProteinFragment boundary
- verify that a codon-crossing substitution exposes both changed amino acids through VaccineAntigen targetability
- verify that Vaxrank's default 35-aa translation request no longer drops a supported 90-base alternate allele
- bump Vaxrank to 3.13.13

No Vaxrank adapter change is needed: the existing ProteinSequenceCreator integration receives the corrected behavior from Isovar.

## Isovar release review

- 1.7.8 changes release artifact reconciliation only and has no runtime effect on Vaxrank.
- 1.7.9 materially corrects mutation targetability, RNA evidence counts, and reproducibility.
- 1.7.10 materially prevents silent loss of RNA-backed long-alternate translations and enforces the real shared reference-prefix minimum.

The published Isovar 1.7.10 wheel used below had SHA-256 9fb86064ae7c14bc15c85d45fbda36f8ba2c6d548de3cbdfc81ccd21459d6e69, matching PyPI metadata.

## Verification

- ./lint.sh: passed
- full suite against the exact published Isovar 1.7.10 wheel: 1,220 passed, 27 existing warnings
- focused compatibility tests against Isovar 1.7.10: 3 passed
- focused tests against 1.7.9: the two 1.7.9 contracts passed and the long-alternate regression failed as expected
- focused tests against previously allowed 1.7.5: all three regressions failed as expected
- B16 end-to-end VCF/BAM smoke against the published 1.7.10 wheel: passed; ASCII, HTML, PDF, XLSX, neoepitope XLSX, JSON, and CSV reports were generated
- git diff --check: clean
