### PR TITLE
Support current dev dependencies and preserve splice outcome metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 numpy>=2.0.0,<3.0.0
 pandas>=2.1.4,<3.0.0
 pyensembl>=2.6.4,<3.0.0
-varcode>=5.0.0,<6.0.0
+# Varcode 7 supplies splice outcome sets unconditionally and defaults to fast
+# annotation. Vaxrank uses its keyword-free effect API and outcome selection.
+varcode>=7.0.0,<8.0.0
 # 1.7.10 preserves required reference context for long alternate alleles and
 # includes corrected mutation intervals and complete shared RNA support.
 isovar>=1.7.10,<2.0.0
@@ -25,9 +27,9 @@ platformdirs
 msgspec>=0.18.6,<1.0.0
 dnachisel>=3.2.0,<4.0.0
 serializable>=1.1.0,<2.0.0
-# 1.8.174 is the direct authority for HPA-backed CTA identity and the full
-# candidate CTA universe used by antigen-specific self references.
-oncoref==1.8.174
+# oncoref is the direct authority for HPA-backed CTA identity and the full
+# candidate CTA universe. Keep this reference pin aligned with PirlyGenes.
+oncoref==1.8.194
 # vaxrank.peptide_context imports packaging.version for PEP 440 ordering
 # of predictor_version strings. Always pulled in transitively via setuptools
 # / pip, but pinned explicitly so minimal / --no-deps installs don't break

--- a/tests/test_varcode_effects.py
+++ b/tests/test_varcode_effects.py
@@ -150,6 +150,44 @@ def test_mutant_protein_fragment_predicted_effect_selects_outcome():
         outcome_selection=OUTCOME_SELECTION_MULTI_OUTCOME) is outcomes
 
 
+def test_real_splice_outcomes_survive_dna_fallback_and_reporting(human_genome_grch37):
+    """Exercise Varcode's always-on outcomes through both annotation doors.
+
+    The last base of CFTR exon 4 is G in Ensembl 75 (GRCh37). Its G>T
+    substitution has a coding consequence if normal splicing persists, and
+    a distinct exon-skipping candidate. This checks API composition, not
+    which predicted splice mechanism occurs in a patient.
+    """
+    from varcode import ExonSkipping, NormalSplicing, SpliceOutcomeSet, Variant
+    from vaxrank.gene_pathway_check import GenePathwayCheck
+
+    variant = Variant("7", 117171168, "G", "T", human_genome_grch37)
+    fragment = MutantProteinFragment.from_variant_dna(variant, 35)
+    assert fragment is not None
+    assert fragment.gene_name == "CFTR"
+
+    outcomes = fragment.predicted_effect(OUTCOME_SELECTION_MULTI_OUTCOME)
+    assert isinstance(outcomes, SpliceOutcomeSet)
+    likely = fragment.predicted_effect(OUTCOME_SELECTION_MOST_LIKELY)
+    priority = fragment.predicted_effect(OUTCOME_SELECTION_HIGHEST_PRIORITY)
+    assert isinstance(likely, NormalSplicing)
+    assert isinstance(priority, ExonSkipping)
+    assert likely.mutant_protein_sequence != priority.mutant_protein_sequence
+    assert fragment.amino_acids in priority.mutant_protein_sequence
+    assert fragment.amino_acids not in likely.mutant_protein_sequence
+    # Exon skipping retains a zero-width target at the deletion junction.
+    assert fragment.mutant_amino_acid_start_offset == 17
+    assert fragment.mutant_amino_acid_end_offset == 17
+
+    summary = summarize_varcode_effect_outcomes(outcomes)
+    assert summary["Outcome set type"] == "SpliceOutcomeSet"
+    assert "NormalSplicing" in summary["Candidate effects"]
+    assert "ExonSkipping" in summary["Candidate effects"]
+    # Driver annotation uses Variant.effects(), while report metadata uses
+    # effect_on_transcript(). Neither may require the removed keyword.
+    assert GenePathwayCheck().make_variant_dict(variant)
+
+
 def test_template_data_include_manufacturability_override():
     """The split-report layout (#17) toggles manufacturability per
     report via the include_manufacturability override: forced off for

--- a/vaxrank/gene_pathway_check.py
+++ b/vaxrank/gene_pathway_check.py
@@ -111,7 +111,7 @@ class GenePathwayCheck(object):
             Variant object to evaluate
         """
         try:
-            effect = variant.effects(splice_outcomes=True).top_priority_effect()
+            effect = variant.effects().top_priority_effect()
             effect = select_varcode_effect_outcome(effect)
             effect_description = effect.short_description
             overlapping_gene_ids = variant.gene_ids

--- a/vaxrank/mutant_protein_fragment.py
+++ b/vaxrank/mutant_protein_fragment.py
@@ -328,7 +328,7 @@ class MutantProteinFragment(DataclassSerializable):
         using varcode's MutantTranscript.  Used as an opt-in fallback when
         isovar has no RNA support for a variant.
 
-        Transcript selection: ask varcode 5 for splice outcome sets, collapse
+        Transcript selection: varcode returns splice outcome sets; collapse
         each to its highest-priority concrete outcome, then choose the most
         protein-disruptive effect. Within that tier, pick the longest mutant
         protein, breaking ties by lex-sorted transcript ID.
@@ -346,7 +346,7 @@ class MutantProteinFragment(DataclassSerializable):
         from varcode.effects.effect_ordering import effect_priority
         from varcode.mutant_transcript import apply_variant_to_transcript
 
-        effects = variant.effects(splice_outcomes=True)
+        effects = variant.effects()
         coding_effects = [
             select_varcode_effect_outcome(e, OUTCOME_SELECTION_HIGHEST_PRIORITY)
             for e in effects
@@ -633,7 +633,7 @@ class MutantProteinFragment(DataclassSerializable):
             outcome_selection=OUTCOME_SELECTION_HIGHEST_PRIORITY):
         """Top-priority varcode effect across the supporting transcripts.
 
-        Varcode 5 can represent splice-disrupting variants as multi-outcome
+        Varcode represents splice-disrupting variants as multi-outcome
         sets. By default vaxrank collapses those sets to the highest-priority
         concrete outcome so peptide mechanics keep working with a single
         protein effect. Use ``outcome_selection="most_likely"`` for producer
@@ -666,25 +666,34 @@ class MutantProteinFragment(DataclassSerializable):
         # Imported here to keep the module-load cost down and avoid a
         # circular-ish import (varcode is heavy).
         from varcode.errors import ReferenceMismatchError
-        from varcode.splice_outcomes import enumerate_splice_outcomes
-        effects = []
+        effect_pairs = []
+        selection = (
+            OUTCOME_SELECTION_HIGHEST_PRIORITY
+            if outcome_selection == OUTCOME_SELECTION_MULTI_OUTCOME
+            else outcome_selection)
         for t in self.supporting_reference_transcripts:
             try:
                 effect = self.variant.effect_on_transcript(t)
-                effect = enumerate_splice_outcomes(effect)
-                effect = select_varcode_effect_outcome(
+                selected = select_varcode_effect_outcome(
                     effect,
-                    outcome_selection=outcome_selection)
-                if effect is not None:
-                    effects.append(effect)
+                    outcome_selection=selection)
+                if selected is not None:
+                    effect_pairs.append((effect, selected))
             except (ReferenceMismatchError, ValueError, KeyError) as e:
                 logger.debug(
                     "varcode.effect_on_transcript failed for %s on %s: "
                     "%s — skipping that transcript.",
                     self.variant, t, e)
-        if not effects:
+        if not effect_pairs:
             return None
-        return top_priority_effect(effects)
+        best = top_priority_effect([selected for _, selected in effect_pairs])
+        if outcome_selection == OUTCOME_SELECTION_MULTI_OUTCOME:
+            # Rank the same concrete effects as the default peptide path,
+            # then return the selected transcript's full outcome set. Passing
+            # a splice set directly to top_priority_effect can collapse it to
+            # its normal-splicing coding alternate and discard report data.
+            return next(original for original, selected in effect_pairs if selected is best)
+        return best
 
     def global_start_pos(self):
         # position of mutation start relative to the full amino acid sequence

--- a/vaxrank/varcode_effects.py
+++ b/vaxrank/varcode_effects.py
@@ -21,7 +21,7 @@ def is_multi_outcome_effect(effect):
 def select_varcode_effect_outcome(
         effect,
         outcome_selection=OUTCOME_SELECTION_HIGHEST_PRIORITY):
-    """Collapse a varcode 5 multi-outcome effect to one concrete effect.
+    """Collapse a varcode multi-outcome effect to one concrete effect.
 
     ``most_likely_effect`` is producer-order-first; ``highest_priority_effect``
     is varcode's most protein-disruptive candidate. Vaxrank's peptide
@@ -61,7 +61,7 @@ def format_varcode_candidate(candidate):
 
 
 def summarize_varcode_effect_outcomes(effect):
-    """Report rows for varcode 5 multi-outcome effects."""
+    """Report rows for varcode multi-outcome effects."""
     if not is_multi_outcome_effect(effect):
         return OrderedDict()
     return OrderedDict([

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.13"
+__version__ = "3.13.14"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Closes #416. Closes #417.

- Require Varcode >=7,<8 and align the exact oncoref reference pin with 1.8.194, so current local Vaxrank, Topiary, Isovar, PirlyGenes and their dependency checkouts resolve normally together.
- Remove the deleted `splice_outcomes=True` keyword and redundant manual wrapping; Varcode now supplies splice outcome sets unconditionally.
- Keep highest-priority and most-likely selection explicit. For full outcome reporting, rank the same concrete effects as the default peptide path, then return the original outcome set for that transcript. This prevents Varcode's canonical-effect convenience function from discarding alternative splice outcomes.
- Add a real CFTR annotation workflow through DNA fallback and report metadata: selection modes produce distinct proteins, the selected sequence reaches the fragment, and the zero-width deletion junction and alternative candidates survive.
- Bump version to 3.13.14. RNA context policy (#415) and final vaccine selection validation (#414) remain separate.

## Validation

- `./lint.sh`: passed.
- `./test.sh`, shared Python 3.12 with editable Varcode 7.0.0, oncoref 1.8.194, Isovar 1.8.0, Topiary, PirlyGenes, PyEnsembl and mhctools: **1,221 passed**.
- Includes CLI and all-variant CSV report coverage; the removed keyword previously broke that report as well as driver lookup and DNA fallback.
- `pip install -e /Users/iskander/code/vaxrank` succeeded with normal dependency resolution. All eight pipeline packages import from their canonical local checkouts; no dependency conflicts remain for this stack.
- The shared environment still has 11 pre-existing conflicts in unrelated applications (LangChain/Jupyter-AI, zev, TensorFlow, pdfx and web3); this PR does not change them.
