### PR TITLE
Preserve peptide occurrence identity in processing reports

### DIFF
--- a/docs/design/processing-audit-series.md
+++ b/docs/design/processing-audit-series.md
@@ -1,0 +1,40 @@
+# Processing and final-construct audit PR series
+
+The immediate correctness fix is #424: a processing result must identify the
+peptide's resolved occurrence, not just its sequence and source. Repeated
+peptides can have different local cleavage scores. The canonical record and
+report join will use `(peptide_sequence, source_sequence, peptide_offset,
+predictor_name)`, where the offset is zero-based in the scored source. Existing
+offset relocation must be shared by annotation and lookup. There will be no
+coordinate-free fallback. Ranking and model inference remain unchanged.
+
+Acceptance: input-order-independent repeated-occurrence results and report
+values, relocation parity, same-occurrence sharing across alleles, terminal
+positions, one inference per source, full tests, report smoke and release.
+
+Preferred delivery order after that fix:
+
+1. #422: validated site-level processing evidence and complete-sequence audits,
+   with explicit context, coverage, predictor identity and target-ligand overlap.
+2. #421: native-versus-manufactured sequence and modification provenance, then
+   reassessment of the actual modified sequence and new boundaries.
+3. #311: integrate complete-window non-CTA self-risk assessment into product
+   audit/reporting before its separately reviewed enforcement policy.
+4. Extracellular/serum processing evidence, after primary validation and model
+   availability review in openvax/mhctools#278/#279 and integration under
+   openvax/topiary#288. A whole-peptide half-life model
+   is not a cleavage-site predictor or a pMHC dissociation-stability model.
+5. #414 and #423: independent final-selection and manufactured-construct
+   comparisons against the documented Sid vaccine sequences.
+
+RNA-source expansion stays in openvax/isovar#218; cell/UMI support units and
+cell-stratified reconstruction are tracked separately in openvax/isovar#226.
+Consume reviewed releases without modifying the active upstream worktree.
+
+Across the series, use target antigen/target ligand terminology. Mutation, CTA
+and viral provenance and targetable masks remain distinct. Scores are evidence,
+not proof of antigen destruction, presentation, TCR recognition or safety.
+
+Primary processing scope:
+https://doi.org/10.1093/bioinformatics/btab628
+https://doi.org/10.1371/journal.pone.0178943

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -129,7 +129,7 @@ def test_annotate_processing_attaches_continuous_scores():
     n, by_key = annotate_processing(
         [pred], predictor=StubPepsickle({source: probs}))
     assert n == 1
-    pp = by_key[(pred.sequence, source, 'pepsickle')]
+    pp = by_key[(pred.sequence, source, 4, 'pepsickle')]
     # C-term = probs at index 9 = 0.85 (clean release)
     assert abs(pp.c_term_cleavage_prob - 0.85) < 1e-9
     # max internal = max of probs[4..8] = max(0.10, 0.20, 0.05, 0.50, 0.30) = 0.50
@@ -146,7 +146,7 @@ def test_annotate_processing_returns_processing_prediction_map():
     ``(n_annotated, processing_predictions_by_key)`` — the map is
     the canonical record (decoupled from flat record).
     Each entry is a ``ProcessingPrediction`` keyed on
-    ``(peptide, source, predictor_name)``."""
+    ``(peptide, source, peptide_offset, predictor_name)``."""
     from vaxrank.processing_prediction import ProcessingPrediction
     source = "AAAAKLMNPVAAAA"
     probs = [0.0] * 4 + [0.10, 0.20, 0.05, 0.50, 0.30, 0.85] + [0.0] * 4
@@ -155,9 +155,9 @@ def test_annotate_processing_returns_processing_prediction_map():
         [pred], predictor=StubPepsickle({source: probs}))
     assert n == 1
     # Map carries one ProcessingPrediction keyed on
-    # (peptide, source, 'pepsickle').
+    # (peptide, source, peptide_offset, 'pepsickle').
     assert len(by_key) == 1
-    key = ('KLMNPV', source, 'pepsickle')
+    key = ('KLMNPV', source, 4, 'pepsickle')
     assert key in by_key
     pp = by_key[key]
     assert isinstance(pp, ProcessingPrediction)
@@ -218,7 +218,7 @@ def test_annotate_processing_relocates_peptide_when_offset_off():
     n, by_key = annotate_processing(
         [pred], predictor=StubPepsickle({source: probs}))
     assert n == 1
-    pp = by_key[(pred.sequence, source, 'pepsickle')]
+    pp = by_key[(pred.sequence, source, 3, 'pepsickle')]
     # C-term should pick up probs[8] = 0.95 (re-located, not probs[1+5]=0.05)
     assert abs(pp.c_term_cleavage_prob - 0.95) < 1e-9
 
@@ -237,7 +237,7 @@ def test_annotate_processing_does_not_touch_ranking_score():
     # ProcessingPrediction landed in the map (post-2.23, the
     # canonical record).
     assert n == 1
-    assert (pred.sequence, source, 'pepsickle') in by_key
+    assert (pred.sequence, source, 4, 'pepsickle') in by_key
     # Ranking-driving fields untouched (frozen CandidateEpitope, can't be mutated).
     leaf_after = pred.best_affinity()
     assert leaf_after.value == pre_ic50
@@ -261,8 +261,8 @@ def test_annotate_processing_predictor_failure_degrades_gracefully():
         [pred_ok, pred_fail], predictor=FlakyPredictor())
     # Only the OK one annotated; the failing source skipped, no crash.
     assert n == 1
-    assert (pred_ok.sequence, "AAAAAAAAAA", 'pepsickle') in by_key
-    assert (pred_fail.sequence, "FFAILFFFFFF", 'pepsickle') not in by_key
+    assert (pred_ok.sequence, "AAAAAAAAAA", 2, 'pepsickle') in by_key
+    assert (pred_fail.sequence, "FFAILFFFFFF", 0, 'pepsickle') not in by_key
 
 
 def test_annotate_processing_empty_input_returns_zero():
@@ -428,7 +428,7 @@ def test_epitope_data_surfaces_processing_columns_when_annotated():
     columns (Processing: C-term, Processing: max internal,
     Processing: combined) when ``include_processing=True`` — the
     values come from the ProcessingPrediction map by joining on
-    ``(peptide, source, predictor_name)``. Default
+    ``(peptide, source, peptide_offset, predictor_name)``. Default
     ``include_processing=False`` keeps the original 6-column shape
     so unannotated reports don't change."""
     from collections import OrderedDict
@@ -568,8 +568,8 @@ def test_epitope_data_header_consistent_when_some_predictions_unannotated():
         predictor=StubPepsickle(
             {source: [0.1] * 9 + [0.85] + [0.0] * 4}))
     # Verify mixed state: only one of the two has a record in the map.
-    assert (annotated.sequence, source, 'pepsickle') in by_key
-    assert (unannotated.sequence, source, 'pepsickle') not in by_key
+    assert (annotated.sequence, source, 4, 'pepsickle') in by_key
+    assert (unannotated.sequence, source, 0, 'pepsickle') not in by_key
     creator.processing_predictions_by_key = by_key
 
     # When the caller turns include_processing on, BOTH rows have
@@ -602,7 +602,7 @@ def test_re_location_picks_closest_to_declared_offset():
              0.0, 0.0, 0.0, 0.0, 0.95]  # cleavage at last position only
     n, by_key = annotate_processing(
         [pred], predictor=StubPepsickle({source: probs}))
-    pp = by_key[(pred.sequence, source, 'pepsickle')]
+    pp = by_key[(pred.sequence, source, 8, 'pepsickle')]
     # If re-location snapped to position 0 (first occurrence), c_term
     # would be probs[4] = 0.0; if it correctly snapped to position 8,
     # c_term = probs[12] = 0.95.

--- a/tests/test_processing_occurrences.py
+++ b/tests/test_processing_occurrences.py
@@ -1,0 +1,114 @@
+"""Cleavage evidence belongs to a source occurrence, not just a sequence."""
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from vaxrank.processing import annotate_processing
+from vaxrank.report import TemplateDataCreator
+
+from .test_processing import StubPepsickle, _ep
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_repeated_ligands_keep_distinct_processing_and_report_scores(reverse):
+    source = "AAAAAKLMNPVGGGKLMNPVCCCC"
+    peptide = "KLMNPV"
+    first, second = (_ep(peptide, source, offset) for offset in (5, 14))
+    probabilities = [0.1] * len(source)
+    probabilities[10] = 0.2
+    probabilities[16] = 0.7
+    probabilities[19] = 0.9
+    epitopes = [second, first] if reverse else [first, second]
+    predictor = StubPepsickle({source: probabilities})
+
+    count, records = annotate_processing(epitopes, predictor=predictor)
+
+    assert count == 2
+    assert len(records) == 2
+    assert predictor.call_count == 1
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = records
+    for epitope, expected_c_term, expected_internal in (
+            (first, 0.2, 0.1), (second, 0.9, 0.7)):
+        key = (peptide, source, epitope.offset, "pepsickle")
+        assert records[key].peptide_offset == epitope.offset
+        assert records[key].c_term_cleavage_prob == expected_c_term
+        assert records[key].max_internal_cut_prob == expected_internal
+        row = creator.epitope_data(
+            epitope, epitope.best_affinity(), include_processing=True)
+        assert row["Processing: C-term"] == f"{expected_c_term:.2f}"
+        assert row["Processing: max internal"] == f"{expected_internal:.2f}"
+
+
+@pytest.mark.parametrize("offset", [0, 9, 8])
+def test_resolved_occurrence_is_shared_between_annotation_and_report(offset):
+    source = "KLMNPVGGGKLMNPV"
+    epitope = _ep("KLMNPV", source, offset)
+    probabilities = [0.1] * len(source)
+    probabilities[5] = 0.2
+    probabilities[14] = 0.9
+    count, records = annotate_processing(
+        [epitope], predictor=StubPepsickle({source: probabilities}))
+    resolved = 0 if offset == 0 else 9
+    assert count == 1
+    record, = records.values()
+    assert record.peptide_offset == resolved
+    assert epitope.offset == offset  # Annotation must not mutate the input.
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = records
+    row = creator.epitope_data(
+        epitope, epitope.best_affinity(), include_processing=True)
+    assert row["Processing: C-term"] == ("0.20" if resolved == 0 else "0.90")
+
+
+def test_one_occurrence_can_share_processing_across_alleles():
+    source = "KLMNPVGGG"
+    first = _ep("KLMNPV", source, 0)
+    second = _ep("KLMNPV", source, 0, allele="HLA-B*07:02")
+    count, records = annotate_processing(
+        [first, second], predictor=StubPepsickle({source: [0.1] * len(source)}))
+    assert count == 2
+    assert len(records) == 1
+
+
+def test_unscored_occurrence_does_not_borrow_another_occurrences_score():
+    source = "KLMNPVGGGKLMNPV"
+    first = _ep("KLMNPV", source, 0)
+    second = _ep("KLMNPV", source, 9)
+    _, records = annotate_processing(
+        [first], predictor=StubPepsickle({source: [0.1] * len(source)}))
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = records
+    row = creator.epitope_data(
+        second, second.best_affinity(), include_processing=True)
+    assert row["Processing: C-term"] == "—"
+
+
+@pytest.mark.parametrize("source_class", ["self", "virus"])
+def test_processing_occurrence_is_not_mutation_specific(source_class):
+    source = "KLMNPVGGG"
+    epitope = replace(
+        _ep("KLMNPV", source, 0), source_class=source_class, overlaps_mutation=False)
+    count, records = annotate_processing(
+        [epitope], predictor=StubPepsickle({source: [0.1] * len(source)}))
+    assert count == 1
+    assert (epitope.sequence, source, 0, "pepsickle") in records
+
+
+def test_cli_annotation_preserves_occurrences_across_input_paths(monkeypatch):
+    from vaxrank.cli.entry_point import annotate_predictions_with_processing
+
+    source = "KLMNPVGGGKLMNPV"
+    first = _ep("KLMNPV", source, 0)
+    second = _ep("KLMNPV", source, 9)
+    predictor = StubPepsickle({source: [0.1] * len(source)})
+    monkeypatch.setattr(
+        "vaxrank.processing.load_default_processing_predictor",
+        lambda **kwargs: predictor)
+    ranked = [(None, [SimpleNamespace(target_epitopes=[first, second])])]
+    count, records = annotate_predictions_with_processing(ranked, [replace(second)])
+    assert count == 2
+    assert len(records) == 2
+    assert predictor.call_count == 1

--- a/vaxrank/cli/arg_parser.py
+++ b/vaxrank/cli/arg_parser.py
@@ -333,7 +333,7 @@ def add_output_args(arg_parser):
              "max_internal_cut_prob, processing_score). On by default. "
              "Scores live on a separate ProcessingPrediction record "
              "joined into the per-epitope report tables at render "
-             "time by (peptide, source, predictor); see "
+             "time by (peptide, source, peptide_offset, predictor); see "
              "vaxrank/processing_prediction.py. Pepsickle runs in an "
              "isolated subprocess (issue #266) so torch's libomp "
              "doesn't clash with the parent's pandas / numpy / "

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -134,7 +134,7 @@ def annotate_predictions_with_processing(ranked_vaccine_peptides,
     LENS/pVACseq epitopes list (which is the union).
 
     The result is a map of ``ProcessingPrediction`` records keyed by
-    ``(peptide, source, predictor_name)``; report writers join in at
+    ``(peptide, source, peptide_offset, predictor_name)``; report writers join in at
     render time. CandidateEpitope objects are not mutated.
 
     Dedup strategy: identity (``id()``) wins when the two paths share
@@ -1248,7 +1248,7 @@ def main(args_list=None):
     # Issue #249 / #272: build per-(peptide, source) ProcessingPrediction
     # records via pepsickle. Doesn't affect ranking — purely additional
     # information surfaced in the per-epitope report tables, joined in
-    # at render time by ``(peptide, source, predictor_name)``. On by
+    # at render time by ``(peptide, source, peptide_offset, predictor_name)``. On by
     # default; opt-out via --no-processing-aware-annotation.
     processing_predictions_by_key = {}
     if getattr(args, 'processing_aware_annotation', True):

--- a/vaxrank/processing.py
+++ b/vaxrank/processing.py
@@ -14,7 +14,7 @@
 
 For each predicted MHC ligand, build a
 :class:`vaxrank.processing_prediction.ProcessingPrediction` record
-keyed on ``(peptide, source_sequence, predictor_name)``. Each carries
+keyed on ``(peptide, source_sequence, peptide_offset, predictor_name)``. Each carries
 three scores:
 
   c_term_cleavage_prob              pepsickle's probability the
@@ -35,7 +35,7 @@ three scores:
 
 ``ProcessingPrediction`` is the canonical record (see
 :mod:`vaxrank.processing_prediction`). Report writers join in by
-``(peptide, source, predictor_name)`` at render time. Pre-2.22
+``(peptide, source, peptide_offset, predictor_name)`` at render time. Pre-2.22
 vaxrank mutated pre-3.0 flat records in place with
 ``pepsickle_*`` fields; that mutation was removed in 2.23 (closes
 #272). All readers consume the ``processing_predictions_by_key``
@@ -156,7 +156,7 @@ def annotate_processing(epitopes, predictor=None,
     Parameters
     ----------
     epitopes : iterable of CandidateEpitope
-        Each epitope is processed against its mutant
+        Each ligand occurrence is processed against its
         ``source_sequence`` to compute one ProcessingPrediction.
         CandidateEpitope objects are NOT mutated — readers consume the
         returned map.
@@ -181,7 +181,7 @@ def annotate_processing(epitopes, predictor=None,
         * ``n_annotated`` (int): number of epitopes successfully
           scored.
         * ``processing_predictions_by_key`` (dict): keyed on
-          ``(peptide_sequence, source_sequence, predictor_name)`` —
+          ``(peptide_sequence, source_sequence, peptide_offset, predictor_name)`` —
           the canonical record. Empty dict when nothing was annotated.
     """
     epitopes_list = list(epitopes)
@@ -286,12 +286,13 @@ def annotate_processing(epitopes, predictor=None,
             processing_score = math.sqrt(c_term * anti_max)
             # Build the canonical ProcessingPrediction record (the
             # post-2.22 source of truth — keyed on
-            # ``(peptide, source, predictor_name)`` so future
+            # ``(peptide, source, peptide_offset, predictor_name)`` so future
             # per-position cleavage predictors land alongside).
             pp = ProcessingPrediction(
                 peptide_sequence=peptide,
                 source_sequence=source,
                 predictor_name=PEPSICKLE_PREDICTOR_NAME,
+                peptide_offset=offset,
                 predictor_version=getattr(
                     predictor, 'version', None),
                 c_term_cleavage_prob=c_term,
@@ -324,7 +325,7 @@ def annotate_processing(epitopes, predictor=None,
 def resolve_peptide_offset(source, peptide, mutant_context):
     """Locate the peptide's offset within its source.
 
-    Trust the mutant ``Peptide.offset`` first; re-locate via
+    Trust the source ``Peptide.offset`` first; re-locate via
     closest-substring search when the declared offset doesn't match.
     Warn when re-location moves the offset by more than the
     drift threshold (3aa absolute, 5% of source length, whichever is

--- a/vaxrank/processing_prediction.py
+++ b/vaxrank/processing_prediction.py
@@ -4,7 +4,7 @@
 #
 #       http://www.apache.org/licenses/LICENSE-2.0
 
-"""``ProcessingPrediction`` — a per-(peptide, source_sequence)
+"""``ProcessingPrediction`` — a per-(peptide, source_sequence, offset)
 proteasomal-cleavage prediction.
 
 Lives on its own axis from MHC binding because the two prediction
@@ -14,7 +14,7 @@ kinds are semantically different:
   records **(peptide, allele) MHC-binding** scores (output of an
   ``mhctools.BindingPredictor`` — pMHC affinity / presentation /
   stability).
-- ``ProcessingPrediction`` is a **(peptide, source_sequence)
+- ``ProcessingPrediction`` is a **(peptide, source_sequence, offset)
   proteasomal-cleavage** score (output of an
   ``mhctools.ProcessingPredictor`` — no allele axis, depends on
   the peptide's flanking context within its source protein).
@@ -23,7 +23,7 @@ Pre-2.22 vaxrank annotated flat record objects in place by
 adding ``pepsickle_*`` attributes — that conflated the two
 prediction kinds. ``ProcessingPrediction`` (this module) is the
 post-2.22 canonical record; consumers join in by
-``(peptide_sequence, source_sequence, predictor_name)`` at
+``(peptide_sequence, source_sequence, peptide_offset, predictor_name)`` at
 render time.
 
 Issue: openvax/vaxrank#272.
@@ -38,7 +38,7 @@ from typing import Optional
 @dataclass(frozen=True)
 class ProcessingPrediction:
     """One ``ProcessingPredictor`` score for a (peptide,
-    source_sequence) pair.
+    source_sequence, peptide_offset) occurrence.
 
     The composite ``processing_score`` is the geometric mean of
     ``c_term_cleavage_prob`` and ``(1 - max_internal_cut_prob)`` —
@@ -53,11 +53,14 @@ class ProcessingPrediction:
         The MHC-ligand peptide whose proteasomal cleavage was scored.
     source_sequence : str
         The protein context the peptide was scored within.
+    peptide_offset : int
+        Resolved zero-based start of this occurrence in source_sequence.
+        Repeated peptides retain separate local processing predictions.
     predictor_name : str
         Lowercase predictor identifier (e.g. ``'pepsickle'``). Future
         per-position cleavage predictors (NetChop, PAProC, …) plug in
         with their own name; report writers join across predictors by
-        ``(peptide_sequence, source_sequence, predictor_name)``.
+        ``(peptide_sequence, source_sequence, peptide_offset, predictor_name)``.
     predictor_version : Optional[str]
         Predictor version string when the predictor exposes one,
         else ``None``.
@@ -76,6 +79,7 @@ class ProcessingPrediction:
     peptide_sequence: str
     source_sequence: str
     predictor_name: str
+    peptide_offset: int
     predictor_version: Optional[str] = None
     c_term_cleavage_prob: float = 0.0
     max_internal_cut_prob: float = 0.0
@@ -83,10 +87,10 @@ class ProcessingPrediction:
 
     def key(self) -> tuple:
         """Stable join key used by report writers to look up the
-        ProcessingPrediction for a given mutant CandidateEpitope at render
-        time. Includes the predictor name so a future second
+        ProcessingPrediction for a given target-ligand occurrence at render
+        time. Includes the position and predictor name so a future second
         per-position cleavage predictor (NetChop, …) lands in the
         same map without colliding."""
         return (
             self.peptide_sequence, self.source_sequence,
-            self.predictor_name)
+            self.peptide_offset, self.predictor_name)

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -27,7 +27,7 @@ from varcode import load_vcf_fast
 
 from .cancer_hotspots import get_hotspot_url
 from .manufacturability import ManufacturabilityScores
-from .processing import PEPSICKLE_PREDICTOR_NAME
+from .processing import PEPSICKLE_PREDICTOR_NAME, resolve_peptide_offset
 from .varcode_effects import (
     OUTCOME_SELECTION_MULTI_OUTCOME,
     is_multi_outcome_effect,
@@ -129,7 +129,7 @@ class TemplateDataCreator(object):
 
         ``processing_predictions_by_key`` is the map returned by
         :func:`vaxrank.processing.annotate_processing` —
-        ``(peptide, source, predictor_name) -> ProcessingPrediction``.
+        ``(peptide, source, peptide_offset, predictor_name) -> ProcessingPrediction``.
         Report writers join this in at render time. ``None`` means
         the processing-aware annotation pass didn't run; the
         per-epitope tables then omit the processing columns.
@@ -451,7 +451,7 @@ class TemplateDataCreator(object):
 
     def _processing_prediction_for(self, epitope, prediction):
         """Look up the ProcessingPrediction for this epitope+prediction
-        by ``(peptide, source, predictor_name)``. Returns ``None`` when
+        by ``(peptide, source, peptide_offset, predictor_name)``. Returns ``None`` when
         no record exists (annotation pass didn't run, or this
         prediction had no usable source sequence).
 
@@ -461,11 +461,16 @@ class TemplateDataCreator(object):
         lands, this method becomes the swap point — read the
         predictor name from a config knob and fall back as needed.
         """
-        key = (
-            epitope.sequence or '',
-            epitope.source_sequence or '',
-            PEPSICKLE_PREDICTOR_NAME,
-        )
+        if not self.processing_predictions_by_key:
+            return None
+        peptide = epitope.sequence or ''
+        source = epitope.source_sequence or ''
+        if not peptide or not source:
+            return None
+        offset = resolve_peptide_offset(source, peptide, epitope)
+        if offset is None:
+            return None
+        key = (peptide, source, offset, PEPSICKLE_PREDICTOR_NAME)
         return self.processing_predictions_by_key.get(key)
 
     def _wt_ic50_for_allele(self, epitope, allele, predictor=None):
@@ -523,7 +528,7 @@ class TemplateDataCreator(object):
         Processing scores come from
         ``self.processing_predictions_by_key`` (built by
         :func:`vaxrank.processing.annotate_processing`), looked up
-        by ``(peptide, source, predictor_name)``. Pre-2.23 these
+        by ``(peptide, source, peptide_offset, predictor_name)``. Pre-2.23 these
         lived as ``pepsickle_*`` attributes on the flat record
         itself; the join is the new contract (#272).
 

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.14.0"
+__version__ = "3.14.1"
 
 
 def print_version():


### PR DESCRIPTION
## Summary
Fixes #424. The same peptide at different positions in one source sequence previously overwrote its processing result, making report values depend on input order.

- Carry the resolved zero-based peptide offset in ProcessingPrediction and its canonical map key.
- Use the same occurrence resolution for annotation and report lookup; no coordinate-free fallback.
- Preserve repeated occurrences while sharing one inference per unique source and one processing result across alleles at the same position.
- Use target-ligand terminology in touched documentation; keep ranking and model scores unchanged.
- Record the issue-backed processing/construct audit PR sequence in docs/design/processing-audit-series.md.
- Bump Vaxrank to 3.14.1.

## Verification
- Reproduced the pre-fix input-order bug (two annotated occurrences collapsed into one record; reversed order changed C-terminal score 0.9 to 0.2).
- New occurrence regressions: 8 failed / 1 passed before the fix; all 10 current regressions pass after the fix.
- Broader processing selection: 46 passed before the additional CLI regression.
- Lint passed.
- Real B16 CLI smoke with installed Pepsickle: 10/10 target records annotated; nonempty TXT/HTML/PDF/CSV/JSON produced, with actual processing columns inspected.
- Full local suite running; CI and clean-main deployment will gate completion.

## Compatibility / scope
The corrected key is (peptide_sequence, source_sequence, peptide_offset, predictor_name), and ProcessingPrediction requires the resolved peptide_offset. Callers constructing or indexing this map must use occurrence-aware identities. This is a report-correctness fix, not a new serum model, complete-construct audit, or clinical safety claim.

Next: #422; related #421, #423, #414, #311.