### PR TITLE
Support offline references with content-keyed membership caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,6 +920,13 @@ Run linting and tests:
 
 The first run of the tests may take a while to build the reference proteome kmer index, but subsequent runs will use the cached index.
 
+Reference membership caches are keyed by the installed annotation/sequence
+content (or actual protein content for custom reference providers), not only
+species and release. This supports explicit offline PyEnsembl `Genome`
+references and prevents a subset from sharing a full-reference cache. Upgrading
+from species/release-only caches triggers a one-time rebuild; old cache files
+are not trusted or automatically deleted.
+
 ### Scripts
 
 - `develop.sh`: installs the package in editable mode and sets `PYTHONPATH` to the repo root.

--- a/tests/test_reference_proteome.py
+++ b/tests/test_reference_proteome.py
@@ -269,7 +269,7 @@ def test_load_kmer_set_builds_index_when_not_cached():
             ok_("ABCDEFGH" in kmers)
 
             # Cache file should now exist (compressed)
-            cache_path = os.path.join(tmpdir, "test_species_100_kmer_set_8_8.pkl.gz")
+            cache_path = kmer_set_index_path(genome, 8, 8)
             ok_(os.path.exists(cache_path))
 
 
@@ -278,11 +278,11 @@ def test_load_kmer_set_loads_from_cache_when_exists():
     with tempfile.TemporaryDirectory() as tmpdir:
         # Pre-create a cache file
         cached_kmers = {"CACHED01", "CACHED02"}
-        cache_path = os.path.join(tmpdir, "test_species_100_kmer_set_8_8.pkl")
+        genome = create_mock_genome([], species_name="test_species", release=100)
+        with patch('vaxrank.reference_proteome.get_cache_dir', return_value=tmpdir):
+            cache_path = kmer_set_index_path(genome, 8, 8).removesuffix(".gz")
         with open(cache_path, 'wb') as f:
             pickle.dump(cached_kmers, f)
-
-        genome = create_mock_genome([], species_name="test_species", release=100)
 
         # Clear in-memory cache to test disk cache loading
         clear_reference_proteome_caches()
@@ -305,7 +305,8 @@ def test_load_kmer_set_force_reload_rebuilds_index():
     with tempfile.TemporaryDirectory() as tmpdir:
         # Pre-create a cache file with different content
         cached_kmers = {"OLDKMERS"}
-        cache_path = os.path.join(tmpdir, "test_species_100_kmer_set_8_8.pkl")
+        with patch('vaxrank.reference_proteome.get_cache_dir', return_value=tmpdir):
+            cache_path = kmer_set_index_path(genome, 8, 8).removesuffix(".gz")
         with open(cache_path, 'wb') as f:
             pickle.dump(cached_kmers, f)
 
@@ -329,7 +330,50 @@ def test_kmer_set_index_path_format():
     with patch('vaxrank.reference_proteome.get_cache_dir', return_value="/cache"):
         path = kmer_set_index_path(genome, min_len=8, max_len=15)
 
-        eq_(path, "/cache/homo_sapiens_104_kmer_set_8_15.pkl.gz")
+        import hashlib
+        digest = hashlib.sha256(b"").hexdigest()
+        eq_(path, "/cache/content_%s_kmer_set_8_15.pkl.gz" % digest)
+
+
+def test_reference_cache_separates_content_with_same_species_release(tmp_path, monkeypatch):
+    monkeypatch.setenv("VAXRANK_REF_PEPTIDES_DIR", str(tmp_path))
+    first = create_mock_genome([create_mock_transcript("T1", "ACDEFGHIKL")])
+    second = create_mock_genome([create_mock_transcript("T1", "LMNPQRSTVW")])
+    assert kmer_set_index_path(first, 8, 8) != kmer_set_index_path(second, 8, 8)
+    a = load_kmer_set_index(first, 8, 8)
+    b = load_kmer_set_index(second, 8, 8)
+    assert "ACDEFGHI" in a and "ACDEFGHI" not in b
+    assert "LMNPQRST" in b and "LMNPQRST" not in a
+    clear_reference_proteome_caches()
+    assert load_kmer_set_index(first, 8, 8) == a
+    assert load_kmer_set_index(second, 8, 8) == b
+
+
+def test_legacy_species_only_cache_is_not_trusted(tmp_path, monkeypatch):
+    monkeypatch.setenv("VAXRANK_REF_PEPTIDES_DIR", str(tmp_path))
+    clear_reference_proteome_caches()
+    genome = create_mock_genome([create_mock_transcript("T1", "ACDEFGHIKL")])
+    with (tmp_path / "test_species_100_kmer_set_8_8.pkl").open("wb") as f:
+        pickle.dump({"WRONGSEQ"}, f)
+    assert "WRONGSEQ" not in load_kmer_set_index(genome, 8, 8)
+    assert "ACDEFGHI" in load_kmer_set_index(genome, 8, 8)
+
+
+def test_offline_pyensembl_genome_can_index_real_sid_reference(tmp_path, monkeypatch):
+    from .osteosarc_helpers import load_osteosarc
+
+    monkeypatch.setenv("VAXRANK_REF_PEPTIDES_DIR", str(tmp_path / "kmers"))
+    variants, _, _ = load_osteosarc(tmp_path)
+    genome = variants["DYNC1H1"].ensembl
+    assert isinstance(genome, Genome)
+    assert not hasattr(genome, "species") and not hasattr(genome, "release")
+    reference = ReferenceProteome(genome, min_kmer_length=9, max_kmer_length=9)
+    assert reference.contains("KRFHATVSF")
+    assert not reference.contains("KRFHATISF")
+    clear_reference_proteome_caches()
+    reloaded = ReferenceProteome(genome, min_kmer_length=9, max_kmer_length=9)
+    assert reloaded.contains("KRFHATVSF")
+    assert not reloaded.contains("KRFHATISF")
 
 
 def test_kmer_set_index_path_different_kmer_lengths():

--- a/vaxrank/reference_proteome.py
+++ b/vaxrank/reference_proteome.py
@@ -69,7 +69,7 @@ def cta_source_gene_ids_for_genome(genome) -> frozenset[str]:
     return oncoref_cta_source_gene_ids()
 
 # In-memory cache for loaded kmer sets to avoid repeated disk reads
-# Key: (species, release, min_len, max_len) -> set of kmers
+# Key: (content identity, min_len, max_len) -> set of kmers
 _kmer_set_cache: dict[tuple, set[str]] = {}
 _kmer_set_cache_lock = threading.Lock()
 
@@ -267,12 +267,18 @@ def get_cache_dir() -> str:
 
 
 def kmer_set_index_path(genome, min_len: int, max_len: int) -> str:
-    """Returns path for the cached kmer set index."""
+    """Content-keyed path; subsets must never reuse a full-reference index."""
+    identity = _kmer_dataset_identity(genome)
     return os.path.join(
         get_cache_dir(),
-        "%s_%d_kmer_set_%d_%d.pkl.gz"
-        % (genome.species.latin_name, genome.release, min_len, max_len),
+        "content_%s_kmer_set_%d_%d.pkl.gz" % (identity, min_len, max_len),
     )
+
+
+def _kmer_dataset_identity(genome):
+    """Reuse installed dataset hashes, otherwise identify actual proteins."""
+    return (ensembl_dataset_cache_identity(genome)
+            or _protein_content_digest(genome_protein_dict(genome)))
 
 
 def build_kmer_set_index(
@@ -300,9 +306,8 @@ def build_kmer_set_index(
         Set of all kmers found in the reference proteome
     """
     logger.info(
-        "Building kmer set index for %s release %d (lengths %d-%d)",
-        genome.species.latin_name,
-        genome.release,
+        "Building kmer set index for reference content %s (lengths %d-%d)",
+        _kmer_dataset_identity(genome),
         min_len,
         max_len,
     )
@@ -366,7 +371,7 @@ def load_kmer_set_index(
     set[str]
         Set of all kmers found in the reference proteome
     """
-    cache_key = (genome.species.latin_name, genome.release, min_len, max_len)
+    cache_key = (_kmer_dataset_identity(genome), min_len, max_len)
 
     with _kmer_set_cache_lock:
         # Check in-memory cache first to avoid repeated disk reads

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.15.0"
+__version__ = "3.15.1"
 
 
 def print_version():


### PR DESCRIPTION
## Summary
Closes #430. Found while implementing #414; this prerequisite is intentionally separate from Topiary #296, which currently blocks cached final-selection tests.

- Support real offline pyensembl.Genome references without inventing species/release attributes.
- Key both memory and disk membership caches by existing content-based dataset identity (or actual proteins for custom providers), so distinct subsets cannot silently share results.
- Never reuse old species/release-only files; preserve them on disk and document the one-time rebuild.
- Include a real Sid-reference regression, different-content/same-label memory+disk regressions, legacy-cache rejection, and bump to 3.15.1.

## Verification
- Lint and diff checks passed.
- Focused reference suite: 57 passed against published Isovar 1.8.1, Topiary 5.53.0, mhctools 3.39.0 and Varcode 7.0.0.
- Full isolated suite and CI running. Will review their results, smoke the CLI, then merge and deploy only after all gates pass.