### PR TITLE
Validate malformed allele evidence at load time, not report time

### DIFF
--- a/ALLELE_VALIDATION.md
+++ b/ALLELE_VALIDATION.md
@@ -1,0 +1,16 @@
+# #355: validate allele evidence at input boundaries
+
+- Use the existing Topiary-backed `is_allele_scoped_kind` definition; do not
+  mistake allele-free processing or half-life observations for malformed MHC
+  evidence. Parse stated allele identifiers with mhcgnomes, including non-human
+  alleles and class-II pairs, without hand-written HLA prefix rules.
+- Reject malformed allele-scoped leaves before filtering/scoring in native
+  flat and serialized inputs, LENS and pVACseq. Include the input filename,
+  row and offending kind/comparator where those are available.
+- Keep rendering defensive for directly constructed legacy objects: show an
+  unavailable allele/score, never invent an allele, a zero or patient evidence.
+  Missing scores remain numeric missing values in tabular output.
+- Test nested non-WT comparators, blank/null spellings, valid class-II and mouse
+  alleles, allele-free kinds, report rendering and actual load paths. No ranking
+  policy changes. Review, lint, full tests, B16 smoke, green CI and deployment
+  are required before closing the issue.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE README.md requirements.txt
 include CONSTRUCT_AUDIT.md
+include ALLELE_VALIDATION.md

--- a/tests/test_allele_validation.py
+++ b/tests/test_allele_validation.py
@@ -1,0 +1,221 @@
+"""Malformed evidence fails at input, not while rendering other results."""
+
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from mhctools import Prediction
+import pandas as pd
+import pytest
+from topiary import KIND_MHC_DEPENDENCE
+
+from vaxrank.allele_validation import validate_prediction_allele
+from vaxrank.candidate_epitope import CandidateEpitope, Peptide
+from vaxrank.epitope_io import (
+    NATIVE_EPITOPE_COLUMN, load_predictions, predictions_to_dataframe,
+    read_lens_report, read_pvacseq_report, save_predictions,
+)
+from vaxrank.report import JINJA_ENVIRONMENT, TemplateDataCreator, epitope_report_row_inputs
+
+
+def candidate(allele="HLA-A*02:01", kind="pMHC_affinity"):
+    return CandidateEpitope(
+        sequence="SIINFEKL", source_sequence="SIINFEKL", offset=0,
+        predictions=(Prediction(kind=kind, predictor_name="example", predictor_version="1",
+                                peptide="SIINFEKL", allele=allele, score=.3, value=100.),))
+
+
+@pytest.mark.parametrize("kind", [k for k, scope in KIND_MHC_DEPENDENCE.items() if scope == "single_allele"])
+@pytest.mark.parametrize("allele", [None, "", " ", "nan", "NA", "."])
+def test_all_allele_scoped_kinds_require_a_stated_allele(kind, allele):
+    with pytest.raises(ValueError, match="input.tsv, row 7.*requires a patient allele"):
+        validate_prediction_allele(kind, allele, "input.tsv, row 7")
+
+
+@pytest.mark.parametrize("kind", [k for k, scope in KIND_MHC_DEPENDENCE.items() if scope == "none"])
+def test_allele_free_kinds_remain_valid_without_a_patient_allele(kind):
+    validate_prediction_allele(kind, "", "input.tsv, row 7")
+
+
+@pytest.mark.parametrize("allele", ["HLA-A*02:01", "H-2-Kb", "Mamu-A*001:01",
+                                  "HLA-DPA1*01:03-DPB1*04:01", "HLA-DRB1*08:01"])
+def test_real_alleles_and_class_ii_pairs_are_accepted(allele):
+    validate_prediction_allele("pMHC_affinity", allele, "input.tsv, row 7")
+
+
+def test_garbage_allele_has_actionable_error():
+    with pytest.raises(ValueError, match="input.tsv, row 7.*invalid allele.*not-an-allele"):
+        validate_prediction_allele("pMHC_affinity", "not-an-allele", "input.tsv, row 7")
+
+
+@pytest.mark.parametrize("native_payload", [True, False])
+def test_native_file_rejects_missing_allele_with_filename_row_and_kind(tmp_path, native_payload):
+    path = tmp_path / "broken.csv"
+    frame = predictions_to_dataframe([candidate(allele="")])
+    if not native_payload:
+        frame = frame.drop(columns=[NATIVE_EPITOPE_COLUMN])
+    frame.to_csv(path, index=False)
+    with pytest.raises(ValueError, match="broken.csv.*native row 2.*pMHC_affinity"):
+        load_predictions(path)
+
+
+def test_non_wt_comparator_cannot_hide_a_missing_allele(tmp_path):
+    original = replace(candidate(), comparators={
+        "nearest_non_CTA": Peptide(sequence="SIINFEKL", predictions=candidate(allele="").predictions)})
+    path = tmp_path / "comparator.tsv"
+    save_predictions([original], path)
+    with pytest.raises(ValueError, match="comparator.tsv.*row 2.*nearest_non_CTA.*requires"):
+        load_predictions(path)
+    with pytest.raises(ValueError, match="Native peptide JSON.*nearest_non_CTA.*requires"):
+        CandidateEpitope.from_json(original.to_json())
+
+
+def test_canonical_allele_free_native_file_loads(tmp_path):
+    original = candidate(allele="", kind="antigen_processing")
+    path = tmp_path / "processing.csv"
+    save_predictions([original], path)
+    assert load_predictions(path) == [original]
+
+
+@pytest.mark.parametrize("reader,fixture,column", [
+    (read_lens_report, "lens_example.tsv", "allele"),
+    (read_pvacseq_report, "pvacseq_example.tsv", "Allele"),
+])
+def test_external_loader_rejects_missing_allele_before_scoring(tmp_path, reader, fixture, column):
+    source = Path(__file__).parent / "data" / "epitope_fixtures" / fixture
+    frame = pd.read_csv(source, sep="\t")
+    assert column in frame
+    frame.loc[0, column] = ""
+    path = tmp_path / fixture
+    frame.to_csv(path, sep="\t", index=False)
+    with pytest.raises(ValueError, match=fixture + ".*row.*requires a patient allele"):
+        reader(path)
+
+
+def test_report_json_reload_validates_before_output_overrides(tmp_path):
+    from vaxrank.cli.entry_point import ranked_vaccine_peptides_with_metadata_from_parsed_args
+
+    path = tmp_path / "prior-report.json"
+    path.write_text("{}")
+    data = {"variants": [(None, [SimpleNamespace(epitopes=[candidate(allele="")])])], "args": {}}
+    args = SimpleNamespace(input_json_file=str(path), max_mutations_in_report=None)
+    with patch("vaxrank.cli.entry_point.serializable.from_json", return_value=data):
+        with pytest.raises(ValueError, match="prior-report.json.*variant 1.*vaccine peptide 1.*requires"):
+            ranked_vaccine_peptides_with_metadata_from_parsed_args(args)
+
+
+def test_lens_processing_without_typing_is_not_malformed_mhc_evidence(tmp_path):
+    path = tmp_path / "untyped-processing.tsv"
+    pd.DataFrame([{"allele": "", "peptide": "SIINFEKL", "pep_context": "SSIINFEKL",
+                   "mhcflurry_2.1.1.proc_score": .8}]).to_csv(path, sep="\t", index=False)
+    report = read_lens_report(path)
+    assert len(report.epitopes) == 1
+    epitope = report.epitopes[0]
+    assert epitope.patient_alleles == ()
+    assert all(p.allele == "" for p in epitope.predictions_flat())
+    rows = epitope_report_row_inputs(epitope)
+    assert len(rows) == 1 and rows[0].allele == ""
+
+
+@pytest.mark.parametrize("kind", ["pMHC_affinity", "pMHC_presentation", "antigen_processing"])
+def test_direct_legacy_report_objects_render_unknown_allele_without_crashing(kind):
+    epitope = candidate(allele="", kind=kind)
+    inputs = epitope_report_row_inputs(epitope)
+    assert len(inputs) == 1 and inputs[0].allele == ""
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = {}
+    row = creator.epitope_data(epitope, inputs[0].prediction, allele=inputs[0].allele)
+    assert row["Allele"] == "" and row["Score"] is None
+    scored = replace(candidate(), per_allele_scores={"HLA-A*02:01": .25})
+    scored_row = creator.epitope_data(scored, scored.predictions_flat()[0])
+    assert pd.api.types.is_numeric_dtype(pd.DataFrame([row, scored_row])["Score"])
+    template = JINJA_ENVIRONMENT.from_string("|{{ score|display_epitope_value }}|")
+    assert template.render(score=row["Score"]) == "||"
+    assert template.render(score=scored_row["Score"]) == "|0.25|"
+
+
+@pytest.mark.parametrize("bad_output", ["source", "WT"])
+def test_predictor_output_validation_is_not_swallowed_as_a_backend_failure(bad_output):
+    from topiary import TopiaryPredictor
+    from varcode import Variant
+    from vaxrank.epitope_config import EpitopeConfig
+    from vaxrank.epitope_logic import predict_epitopes
+    from vaxrank.mutant_protein_fragment import MutantProteinFragment
+
+    class Predictor(TopiaryPredictor):
+        def __init__(self):
+            pass
+
+        def frame(self, named, output):
+            name, sequence = next(iter(named.items()))
+            return pd.DataFrame([{
+                "source_sequence_name": name, "peptide": sequence, "peptide_offset": 0,
+                "peptide_length": len(sequence), "kind": "pMHC_affinity",
+                "allele": "" if output == bad_output else "HLA-A*02:01",
+                "prediction_method_name": "example", "predictor_version": "1",
+                "affinity": 10., "value": 10., "score": .8, "percentile_rank": .1}])
+
+        def predict_from_named_sequences(self, named):
+            return self.frame(named, "source")
+
+        def predict_from_named_peptides(self, named):
+            return self.frame(named, "WT")
+
+    fragment = MutantProteinFragment(
+        variant=Variant("1", 100, "A", "T"), gene_name="GENE",
+        amino_acids="SIINFEKL", mutant_amino_acid_start_offset=3,
+        mutant_amino_acid_end_offset=4, supporting_reference_transcripts=[],
+        n_overlapping_reads=10, n_alt_reads=5, n_ref_reads=5,
+        n_alt_reads_supporting_protein_sequence=5)
+    with patch("vaxrank.epitope_logic.ReferenceProteome"), patch.object(
+            MutantProteinFragment, "predicted_effect",
+            return_value=SimpleNamespace(original_protein_sequence="SIISFEKL")), patch.object(
+                MutantProteinFragment, "global_start_pos", return_value=0):
+        prefix = "WT MHC" if bad_output == "WT" else "MHC"
+        with pytest.raises(ValueError, match=prefix + " output.*normalized row 2.*requires"):
+            predict_epitopes(Predictor(), fragment, EpitopeConfig(min_epitope_score=0))
+
+
+@pytest.mark.parametrize("score", [None, float("nan"), float("inf"), -float("inf")])
+def test_nonfinite_report_score_is_missing_not_zero(score):
+    epitope = replace(candidate(), per_allele_scores={"HLA-A*02:01": score})
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    row = creator.epitope_data(epitope, epitope.predictions_flat()[0])
+    assert row["Score"] is None
+
+
+def test_template_pipeline_keeps_unknown_and_known_allele_rows(tmp_path):
+    """Exercise real table assembly and packaged HTML/ASCII templates."""
+    from vaxrank.patient_info import PatientInfo
+    from vaxrank.report import make_ascii_report, make_html_report
+
+    unknown = replace(candidate(allele=""), overlaps_mutation=True)
+    known = replace(candidate(), overlaps_mutation=True,
+                    per_allele_scores={"HLA-A*02:01": .25})
+    fragment = SimpleNamespace(gene_name="GENE", predicted_effect=lambda **kw: None)
+    vaccine = SimpleNamespace(
+        mutant_protein_fragment=fragment, target_epitopes=[unknown, known],
+        self_epitopes=[], contains_target_epitopes=lambda: True)
+    creator = TemplateDataCreator(
+        [(SimpleNamespace(short_description="test variant"), [vaccine])],
+        PatientInfo("TEST"), final_review="", reviewers="", input_json_file=None,
+        args_for_report={"manufacturability": False, "wt_epitopes": False})
+    # Variant annotation is orthogonal to epitope table rendering.
+    for method in ("_variant_data", "effect_data", "_databases", "_peptide_data",
+                   "_manufacturability_data"):
+        setattr(creator, method, lambda *a, **kw: {})
+    creator._peptide_header_display_data = lambda *a: {
+        "num": 1, "aa_before_mutation": "SII", "aa_mutant": "N", "aa_after_mutation": "FEKL"}
+    data = creator.compute_template_data()
+    peptide = data["variants"][0]["peptides"][0]
+    assert len(peptide["epitopes"]) == 2
+    assert peptide["epitopes"][0]["Score"] is None
+    assert peptide["epitopes"][1]["Score"] == .25
+    assert "None" not in peptide["ascii_epitopes"]
+    for suffix, writer in (("html", make_html_report), ("txt", make_ascii_report)):
+        path = tmp_path / ("report." + suffix)
+        writer(data, path)
+        rendered = path.read_text()
+        assert rendered.count("SIINFEKL") >= 2
+        assert "0.25" in rendered and "A*02:01" in rendered

--- a/tests/test_epitope_io.py
+++ b/tests/test_epitope_io.py
@@ -1228,7 +1228,7 @@ def test_lens_processing_only_rows_preserve_alleles_scores_and_report_rows(
         for row_input in row_inputs
     ]
     assert [row["Allele"] for row in rows] == ["A*02:01", "B*07:02"]
-    assert [row["Score"] for row in rows] == ["0.8", "0.8"]
+    assert [row["Score"] for row in rows] == [0.8, 0.8]
     assert all(row["Integrated processing score"] == "0.800" for row in rows)
 
 
@@ -1263,7 +1263,7 @@ def test_lens_presentation_only_candidate_has_a_template_report_row(tmp_path):
         include_additional_prediction_axes=True,
     )
     assert row["Allele"] == "A*02:01"
-    assert row["Score"] == "0.85"
+    assert row["Score"] == 0.85
     assert row["IC50"] == "No prediction"
     assert row["Presentation score"] == "0.850"
     assert row["Presentation %ile"] == "0.280"
@@ -1322,7 +1322,7 @@ def test_lens_report_anchors_mixed_evidence_per_allele_and_predictor(tmp_path):
         "Presentation score"] == "0.600"
     assert by_key[("C*07:02", "mhcflurry")][
         "Integrated processing score"] == "0.700"
-    assert all(row["Score"] == "0.7" for row in report_rows)
+    assert all(row["Score"] == 0.7 for row in report_rows)
 
 
 def test_lens_context_scores_merge_by_source_position(tmp_path):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -420,7 +420,7 @@ def test_epitope_data_renders_missing_dsl_score_as_unavailable():
 
     row = creator.epitope_data(epitope, epitope.best_affinity())
 
-    assert row['Score'] == '—'
+    assert row['Score'] is None
 
 
 def test_epitope_data_surfaces_processing_columns_when_annotated():

--- a/vaxrank/allele_validation.py
+++ b/vaxrank/allele_validation.py
@@ -1,0 +1,48 @@
+"""Actionable allele checks at prediction input boundaries, not rendering."""
+
+from functools import lru_cache
+
+from mhcgnomes import Allele, Pair, ParseError, parse
+from topiary.ranking import KIND_ALIASES
+
+from . import cells
+from .allele_evidence import is_allele_scoped_kind
+
+
+@lru_cache(maxsize=4096)
+def parse_prediction_allele(allele):
+    return parse(allele, infer_class2_pairing=False,
+                 required_result_types=(Allele, Pair)).to_string()
+
+
+def validate_prediction_allele(kind, allele, location):
+    """Require an allele for MHC-scoped evidence, leaving peptide data free."""
+    kind = KIND_ALIASES.get(str(kind).lower(), kind)
+    text = cells.text(allele)
+    if not text:
+        if is_allele_scoped_kind(kind):
+            raise ValueError(f"{location}: {kind} prediction requires a patient allele")
+        return
+    try:
+        parse_prediction_allele(text)
+    except (ParseError, TypeError, ValueError) as error:
+        raise ValueError(f"{location}: invalid allele {text!r} for {kind}: {error}") from error
+
+
+def validate_peptide_alleles(peptide, location):
+    """Validate all leaves and comparator contexts without changing objects."""
+    for prediction in peptide.predictions_flat():
+        validate_prediction_allele(
+            prediction.kind, prediction.allele,
+            f"{location}, peptide {peptide.sequence!r}, predictor {prediction.predictor_name!r}")
+    for name, comparator in getattr(peptide, "comparators", {}).items():
+        validate_peptide_alleles(comparator, f"{location}, comparator {name!r}")
+
+
+def validate_prediction_frame(frame, location):
+    """Validate normalized predictor output, preserving its row provenance."""
+    for row_number, (_, row) in enumerate(frame.iterrows(), start=2):
+        validate_prediction_allele(
+            row.get("kind"), row.get("allele"),
+            f"{location}, normalized row {row_number}, "
+            f"variant {cells.text(row.get('variant'))!r}, peptide {row.get('peptide')!r}")

--- a/vaxrank/candidate_epitope.py
+++ b/vaxrank/candidate_epitope.py
@@ -297,7 +297,11 @@ class Peptide(DataclassSerializable):
     @classmethod
     def from_json(cls, json_string: str):
         """Load this peptide graph after validating every encoded class."""
-        return from_native_json(json_string, cls)
+        from .allele_validation import validate_peptide_alleles
+
+        peptide = from_native_json(json_string, cls)
+        validate_peptide_alleles(peptide, "Native peptide JSON")
+        return peptide
 
     def __hash__(self) -> int:
         # Position identity. The dataclass-generated hash would

--- a/vaxrank/cli/entry_point.py
+++ b/vaxrank/cli/entry_point.py
@@ -1552,6 +1552,13 @@ def ranked_vaccine_peptides_with_metadata_from_parsed_args(args):
         with open(args.input_json_file) as f:
 
             data = serializable.from_json(f.read())
+            from ..allele_validation import validate_peptide_alleles
+            for variant_index, (_, peptides) in enumerate(data["variants"], start=1):
+                for peptide_index, peptide in enumerate(peptides, start=1):
+                    for epitope in peptide.epitopes:
+                        validate_peptide_alleles(
+                            epitope, f"{args.input_json_file}, variant {variant_index}, "
+                            f"vaccine peptide {peptide_index}")
             # the JSON data from the previous run will have the older args saved, which may need to
             # be overridden with args from this run (which all be output related)
             data['args'].update(vars(args))

--- a/vaxrank/epitope_io.py
+++ b/vaxrank/epitope_io.py
@@ -29,13 +29,16 @@ them by complete ``ExternalPredictionKey`` identity.
 import json
 import logging
 import os
-import re
 from dataclasses import dataclass
 
 import pandas as pd
 from mhctools.pred import Prediction
 
 from . import cells
+from .allele_validation import (
+    parse_prediction_allele, validate_peptide_alleles,
+    validate_prediction_allele, validate_prediction_frame,
+)
 from .epitope_dsl import prediction_kind_for_method
 from .external_prediction import (
     _PVACSEQ_DNA_VAF_COLUMNS,
@@ -277,12 +280,13 @@ def load_predictions(path):
             if cells.missing(payload):
                 continue
             try:
-                epitopes.append(from_native_json(
-                    str(payload), CandidateEpitope))
+                epitope = from_native_json(str(payload), CandidateEpitope)
+                validate_peptide_alleles(epitope, f"{path}, native row {row_index + 2}")
+                epitopes.append(epitope)
             except (ImportError, KeyError, TypeError, ValueError) as error:
                 raise ValueError(
-                    "Invalid serialized CandidateEpitope at native row %d"
-                    % (row_index + 2)
+                    "Invalid serialized CandidateEpitope in %s at native row %d: %s"
+                    % (path, row_index + 2, error)
                 ) from error
         if len(df) and not epitopes:
             raise ValueError(
@@ -303,7 +307,7 @@ def load_predictions(path):
     has_generic_predictions = "prediction_kind" in df.columns
 
     rows = []
-    for _, row in df.iterrows():
+    for row_number, (_, row) in enumerate(df.iterrows(), start=2):
         wt_ic50 = optional_float(row.get("wt_ic50"))
         percentile_rank = optional_float(row.get("percentile_rank"))
         peptide = row["peptide_sequence"]
@@ -331,6 +335,7 @@ def load_predictions(path):
             score = 0.0
             value = float(row["ic50"])
             prediction_peptide = peptide
+        validate_prediction_allele(kind, allele, f"{path}, native row {row_number}")
         mutant = Prediction(
             kind=kind, predictor_name=method, predictor_version=version,
             allele=allele, peptide=prediction_peptide, value=value,
@@ -349,6 +354,7 @@ def load_predictions(path):
         wt = None
         wt_kind = string_or_empty(row.get("wt_prediction_kind", ""))
         if wt_kind:
+            validate_prediction_allele(wt_kind, allele, f"{path}, native row {row_number}, WT comparator")
             wt_score = optional_float(row.get("wt_prediction_score"))
             if wt_score is None:
                 raise ValueError(
@@ -700,6 +706,7 @@ def read_pvacseq_report(path, epitope_config=None):
 
     result = read_pvacseq(path)
     topiary_df = result.df.copy()
+    validate_prediction_frame(topiary_df, str(path))
 
     # Topiary has already normalized both pVACseq flavors onto one column
     # vocabulary (``variant``, ``gene``, ``transcript``, ``rna_depth`` /
@@ -912,7 +919,7 @@ def normalize_hla_allele(allele):
     """LENS emits alleles as 'HLA-A01:01'; vaxrank output uses 'HLA-A*01:01'."""
     if not allele:
         return allele
-    return re.sub(r"^(HLA-[A-Z]{1,3})(\d)", r"\1*\2", allele)
+    return parse_prediction_allele(allele)
 
 
 def lens_epitope_position(peptide, peptide_context):
@@ -1033,15 +1040,18 @@ def read_lens_report(path, epitope_config=None):
     # (peptide, tool, kept score, conflicting score) for allele rows that
     # disagreed about an allele-independent processing score.
     processing_conflicts = []
-    for row in rows:
+    for row_number, row in enumerate(rows, start=2):
         peptide = cells.text(row.get("peptide"))
         if not peptide:
             continue
 
         allele_raw = row.get("allele", "")
-        if pd.isna(allele_raw) or not allele_raw:
-            continue
-        allele = normalize_hla_allele(str(allele_raw))
+        for prediction in chosen:
+            columns = (prediction.value_col, prediction.score_col, prediction.rank_col)
+            if any(column and not cells.missing(row.get(column)) for column in columns):
+                validate_prediction_allele(
+                    prediction.kind, allele_raw, f"{path}, LENS row {row_number}")
+        allele = normalize_hla_allele(cells.text(allele_raw))
 
         # mhcflurry_agretopicity = MT_IC50 / WT_IC50 in LENS's
         # convention (small values ≪ 1 = mutation strengthened
@@ -1113,7 +1123,8 @@ def read_lens_report(path, epitope_config=None):
                     if abs(kept - score) > PROCESSING_SCORE_TOLERANCE:
                         processing_conflicts.append(
                             (peptide, d.tool, kept, score))
-                    existing['patient_alleles'].add(allele)
+                    if allele:
+                        existing['patient_alleles'].add(allele)
                 else:
                     processing_row = {
                         **shared_epitope_fields,
@@ -1124,7 +1135,7 @@ def read_lens_report(path, epitope_config=None):
                             percentile_rank=None,
                         ),
                         'wt': None,
-                        'patient_alleles': {allele},
+                        'patient_alleles': {allele} if allele else set(),
                     }
                     processing_rows_by_position[processing_key] = (
                         processing_row)

--- a/vaxrank/epitope_logic.py
+++ b/vaxrank/epitope_logic.py
@@ -148,6 +148,9 @@ def predict_epitopes(
     if predictions_df.empty:
         return []
 
+    from .allele_validation import validate_prediction_frame
+    validate_prediction_frame(predictions_df, f"MHC output for {source_name!r}")
+
     # ``default_methods`` (per-kind ``prediction_method_name`` defaults
     # for unqualified DSL refs) is required when multi-predictor data
     # is in play — without it, ``affinity.value`` is ambiguous and
@@ -268,6 +271,12 @@ def predict_epitopes(
     if valid_wt_peptides:
         try:
             wt_df = topiary_predictor.predict_from_named_peptides(valid_wt_peptides)
+        except Exception:
+            logger.error(
+                'MHC prediction for WT peptides errored, with traceback: %s',
+                traceback.format_exc())
+        else:
+            validate_prediction_frame(wt_df, f"WT MHC output for {source_name!r}")
             for _, row in wt_df.iterrows():
                 key = (
                     row["source_sequence_name"],
@@ -277,11 +286,6 @@ def predict_epitopes(
                     row.get("predictor_version", "") or "",
                 )
                 wt_predictions_grouped[key] = row
-        except Exception:
-            logger.error(
-                'MHC prediction for WT peptides errored, with traceback: %s',
-                traceback.format_exc())
-
     # Walk topiary frame rows; build per-(allele, predictor) leaf
     # ``Prediction`` records into a flat list of row dicts.
     # ``candidate_epitopes_from_rows`` groups them by

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from importlib import import_module
 import logging
+import math
 import os
 import sys
 import tempfile
@@ -26,7 +27,9 @@ from mhctools.pred import Prediction
 from varcode import load_vcf_fast
 
 from .cancer_hotspots import get_hotspot_url
+from . import cells
 from .manufacturability import ManufacturabilityScores
+from .prediction_input import finite_prediction_value
 from .processing import PEPSICKLE_PREDICTOR_NAME, resolve_peptide_offset
 from .varcode_effects import (
     OUTCOME_SELECTION_MULTI_OUTCOME,
@@ -44,6 +47,18 @@ JINJA_ENVIRONMENT = jinja2.Environment(
     trim_blocks=True,
     lstrip_blocks=True,
 )
+
+
+def display_epitope_value(value):
+    """Format missing numeric evidence only at the presentation boundary."""
+    if cells.missing(value):
+        return ""
+    if isinstance(value, float):
+        return _sanitize(value) if math.isfinite(value) else ""
+    return value
+
+
+JINJA_ENVIRONMENT.filters["display_epitope_value"] = display_epitope_value
 
 
 @dataclass(frozen=True)
@@ -69,32 +84,25 @@ def epitope_report_row_inputs(epitope):
         for prediction in predictions:
             if prediction.kind != kind:
                 continue
-            if not prediction.allele:
-                # An allele-scoped kind that arrived blank is malformed —
-                # see vaxrank.allele_evidence for the one definition of
-                # which kinds carry an allele, and epitope.allele_attributions
-                # for which alleles the allele-free kinds were credited to.
-                raise ValueError(
-                    f"{kind} report evidence requires a patient allele")
+            # Loaders reject malformed allele-scoped data with file/row
+            # provenance. Directly supplied legacy objects can still display
+            # unavailable evidence without destroying the rest of the report.
+            allele = cells.text(prediction.allele)
             key = (
-                prediction.allele,
+                allele,
                 prediction.predictor_name,
                 prediction.predictor_version,
             )
             row_inputs_by_key.setdefault(
                 key,
-                EpitopeReportRowInput(prediction, prediction.allele),
+                EpitopeReportRowInput(prediction, allele),
             )
 
     processing_predictions = tuple(
         prediction for prediction in predictions
         if prediction.kind == 'antigen_processing')
-    if processing_predictions and not epitope.patient_alleles:
-        raise ValueError(
-            "Cannot render allele-independent antigen-processing evidence "
-            "without explicit patient alleles")
     for prediction in processing_predictions:
-        for allele in epitope.patient_alleles:
+        for allele in epitope.patient_alleles or ("",):
             key = (
                 allele,
                 prediction.predictor_name,
@@ -537,10 +545,7 @@ class TemplateDataCreator(object):
         from the same predictor/version. Missing axes render as ``'—'``
         so mixed-predictor tables retain consistent columns.
         """
-        row_allele = prediction.allele if allele is None else allele
-        if not row_allele:
-            raise ValueError(
-                "Template epitope rows require an explicit patient allele")
+        row_allele = cells.text(prediction.allele if allele is None else allele)
         wt_ic50 = self._wt_ic50_for_allele(
             epitope, row_allele, predictor=prediction.predictor_name)
         wt_ic50_str = _format_ic50(wt_ic50)
@@ -565,8 +570,8 @@ class TemplateDataCreator(object):
             # from ``epitope.per_allele_scores`` — the single source
             # of truth — rather than recomputing from the raw IC50.
             ('Score',
-                _sanitize(epitope.per_allele_scores[row_allele])
-                if row_allele in epitope.per_allele_scores else '—'),
+                finite_prediction_value(cells.number(epitope.per_allele_scores.get(row_allele)))
+                if row_allele else None),
             ('Allele', row_allele.replace('HLA-', '')),
             ('WT sequence', wt_peptide_sequence),
             ('WT IC50', wt_ic50_str),
@@ -763,7 +768,9 @@ class TemplateDataCreator(object):
 
                 # hack: make a nicely-formatted fixed width table for epitopes, used in ASCII report
                 with tempfile.TemporaryFile(mode='r+') as temp:
-                    asc.write(epitopes, temp, format='fixed_width_two_line', delimiter_pad=' ')
+                    display_rows = [{key: display_epitope_value(value)
+                                     for key, value in row.items()} for row in epitopes]
+                    asc.write(display_rows, temp, format='fixed_width_two_line', delimiter_pad=' ')
                     temp.seek(0)
                     ascii_epitopes = temp.read()
 

--- a/vaxrank/templates/template.html
+++ b/vaxrank/templates/template.html
@@ -133,7 +133,7 @@
                                         {% for e in p.epitopes %}
                                         <tr>
                                             {% for _, val in e.items() %}
-                                            <td>{{ val }}</td>
+                                            <td>{{ val|display_epitope_value }}</td>
                                             {% endfor %}
                                         </tr>
                                         {% endfor %}

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.15.1"
+__version__ = "3.15.2"
 
 
 def print_version():


### PR DESCRIPTION
## Summary
Closes #355. Bumps Vaxrank to 3.15.2.

- Centralize allele validation with Topiary kind scope and mhcgnomes, including non-human alleles and class-II pairs.
- Reject malformed scoped leaves at native CSV/JSON, LENS, pVACseq, prior-report reload, and source/WT predictor boundaries with available file/row/comparator provenance.
- Retain genuinely allele-free processing evidence without inventing patient typing.
- Keep directly supplied legacy report objects renderable, with blank unknown allele/score cells and numeric missing scores. Format only at the HTML/ASCII presentation boundary.

## Review and verification
- Reviewed validation placement, nested non-WT comparators, predictor exception boundaries, and unchanged scoring policy.
- 61 dedicated regression cases, including actual external loaders and packaged HTML/ASCII report assembly.
- Lint and git diff --check pass.
- Full isolated suite: 1,397 passed (29 warnings).
- B16 end-to-end smoke passed: nonempty PDF, HTML, ASCII, XLSX, neoepitope XLSX, JSON, and CSV outputs.
- CI must pass before merge; deployment and published-artifact verification follow immediately after merge.