### PR TITLE
Preserve complete sequence cleavage profiles and explicit coverage

### DIFF
--- a/CLEAVAGE_AUDIT.md
+++ b/CLEAVAGE_AUDIT.md
@@ -1,0 +1,79 @@
+# #422: complete sequence processing evidence
+
+This is a non-mutating audit, not a ranking policy or a clinical verdict.
+
+1. Preserve the exact native antigen context, final manufactured sequence, or
+   complete translated product. Reuse `ConstructSequence`/`ConstructPlacement`
+   for edits, target masks, repeated occurrences, chemistry and source evidence;
+   never infer an occurrence by choosing the first sequence match.
+2. Preserve immutable per-bond results using mhctools' published cleavage
+   contract. Keep native scores and motif recognition distinct. The Pepsickle
+   adapter records its complete raw vector, including the final residue output
+   separately from actual internal bonds. Record backend/version/model/settings,
+   model-asset identity where available, compartment and missing-context reasons.
+3. Run each exact context/chemistry/model once per audit. Native context scores
+   cannot substitute for a changed final sequence. Unsupported chemistry,
+   missing models, malformed arrays, empty output and backend failure remain
+   explicit; unreturned bonds are unassessed, never assigned zero.
+4. Inventory unfiltered patient-MHC output through Topiary and overlay every
+   returned ligand occurrence and target interval. Separate internal from
+   boundary cuts and distinguish sequence preservation from model evidence.
+   Preserve partial HLA/model/length coverage without claiming completeness.
+5. Write full native JSON and an escaped Jinja report with all positions,
+   sources, settings and limitations. Keep proteasomal, extracellular/serum,
+   cytosolic trimming, ER and endolysosomal evidence distinguishable. Whole-
+   peptide half-life numbers do not stand in for site evidence.
+
+Implementation may be delivered as a foundational site-contract/report PR and
+a follow-up whole-product orchestration PR. #422 stays open until both native
+and complete manufactured/translated contexts and ligand overlays are covered.
+#423 then supplies independently documented Sid inputs and versioned real-model
+regressions; this issue does not substitute synthetic scores for that evidence.
+
+Validation: malformed/nonfinite/out-of-range arrays, both sequence ends,
+repeated motifs, changed tails/junctions, deletion junction targets, non-mutation
+targets, allele-free versus MHC output, missing models, unsupported chemistry,
+native JSON round trips, and packaged report rendering. Run lint, full tests,
+CLI/report smoke, CI, review and release gates for each PR.
+
+Primary scope: Pepsickle's epitope model is proteasome-type agnostic, uses
+sequence context and pads missing terminal context; its scores do not prove
+destruction or presentation. Record the input-domain limits rather than hiding
+them: https://github.com/pdxgx/pepsickle and
+https://doi.org/10.1093/bioinformatics/btab628. mhctools 3.41.0's peptidase
+recognition rules are not serum half-life or calibrated cleavage probabilities.
+
+## Foundational site API (first PR; #422 remains open)
+
+```python
+from mhctools import CleavageInput
+from mhctools.peptidases import get_cleavage_model
+from vaxrank import (
+    audit_pepsickle_inputs, audit_peptidase_inputs, write_cleavage_profiles,
+)
+
+# Explicit model input assumption: canonical linear L-peptide, free termini.
+# Do not assert free termini if the manufactured chemistry is unknown.
+inputs = [CleavageInput("GKRFHATISFDTDTGLKQALETKK", source_id="supplied-final-sequence")]
+profiles = audit_pepsickle_inputs(inputs)
+profiles += audit_peptidase_inputs(inputs, get_cleavage_model("cpn-basic"))
+write_cleavage_profiles(profiles, json_path="sites.json", html_path="sites.html")
+```
+
+The Pepsickle dependency remains optional. Missing model assets are reported as
+unassessed, not replaced by a predictor. Model weights are fingerprinted on the
+active interpreter's import path; they are not redistributed. Terminal chemistry
+outside a backend's domain remains unassessed. Arbitrary chemical modifications
+are outside `CleavageInput` and must not be reduced to a bare sequence.
+The remaining upstream Pepsickle per-bond/provenance API gap is tracked in
+[mhctools #329](https://github.com/openvax/mhctools/issues/329). Once it ships,
+Vaxrank should consume that result directly and remove its local model-metadata
+adapter, without keeping a second long-term provenance implementation.
+
+This first API does not infer patient typing, intended target ligands, historical
+selection, or gene provenance from sequence. `profile.interval_evidence(start,
+end)` provides exact internal and boundary observations for a caller-specified
+half-open interval; the follow-up construct orchestration supplies validated
+native/final/product contexts and patient-MHC overlays. The report lists every
+internal bond, including those no model assessed. A terminal-only enzyme rule
+does not become a full-sequence prediction or a serum-stability estimate.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE README.md requirements.txt
 include CONSTRUCT_AUDIT.md
 include ALLELE_VALIDATION.md
+include CLEAVAGE_AUDIT.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ varcode>=7.0.0,<8.0.0
 isovar>=1.8.0,<2.0.0
 # 3.33.5 makes bundled YAML loading independent of the host locale.
 mhcgnomes>=3.33.5,<4.0.0
-mhctools>=3.13.3,<4.0.0
+mhctools>=3.41.0,<4.0.0
 # 5.10.0 adds EvalContext(default_methods=...) and apply_filter(default_methods=...)
 # which vaxrank uses to score multi-model inputs (e.g. LENS with mhcflurry +
 # netmhcpan) without pre-subsetting the frame.

--- a/tests/test_cleavage_inference.py
+++ b/tests/test_cleavage_inference.py
@@ -1,0 +1,100 @@
+"""Full-context orchestration with explicit failures and real motif semantics."""
+
+from unittest.mock import patch
+from types import SimpleNamespace
+
+import mhctools
+import pytest
+from mhctools.cleavage import CleavageInput
+from mhctools.peptidases import get_cleavage_model
+
+from vaxrank.cleavage_inference import audit_pepsickle_inputs, audit_peptidase_inputs
+
+from .test_cleavage_profile import MODEL
+
+
+def identity():
+    return patch("vaxrank.cleavage_inference._pepsickle_model_identity",
+                 return_value=(MODEL, "a" * 64, ""))
+
+
+def test_contexts_deduplicated_without_losing_occurrences_or_source_offsets():
+    inputs = [CleavageInput("ACDE", source_id="a"),
+              CleavageInput("ACDE", source_id="b", source_start=40),
+              CleavageInput("ACDEKK", source_id="final")]
+    with identity(), patch.object(mhctools.Pepsickle, "cleavage_probs_many", return_value={
+            "ACDE": [.1, .2, .3, 0.], "ACDEKK": [.8, .7, .6, .5, .4, 0.]}) as run:
+        profiles = audit_pepsickle_inputs(inputs)
+    run.assert_called_once_with(("ACDE", "ACDEKK"))
+    assert [p.peptide for p in profiles] == inputs
+    assert profiles[0].sites[0].score != profiles[2].sites[0].score
+    assert profiles[1].peptide.source_start == 40
+
+
+def test_chemistry_and_missing_model_never_enter_sequence_only_backend():
+    inputs = [CleavageInput("ACDE", n_term="acetylated"), CleavageInput("ACDE")]
+    with patch("vaxrank.cleavage_inference._pepsickle_model_identity", return_value=(MODEL, "", "")), \
+            patch.object(mhctools.Pepsickle, "cleavage_probs_many") as run:
+        profiles = audit_pepsickle_inputs(inputs)
+    run.assert_not_called()
+    assert [p.status for p in profiles] == ["unassessed", "unassessed"]
+    assert profiles[0].reason_codes == ("unsupported_terminal_chemistry",)
+    assert profiles[1].reason_codes == ("pepsickle_model_assets_unavailable",)
+
+
+def test_bad_array_does_not_destroy_other_sequence_evidence():
+    with identity(), patch.object(mhctools.Pepsickle, "cleavage_probs_many", return_value={
+            "ACDE": [float("nan")] * 4, "ACDEK": [.1] * 5}):
+        profiles = audit_pepsickle_inputs([CleavageInput("ACDE"), CleavageInput("ACDEK")])
+    assert [p.status for p in profiles] == ["failed", "observations_returned"]
+    assert profiles[0].unassessed_bonds == (1, 2, 3)
+
+
+def test_batch_failure_is_explicit_not_no_cuts():
+    with identity(), patch.object(mhctools.Pepsickle, "cleavage_probs_many", side_effect=RuntimeError("failed")):
+        p, = audit_pepsickle_inputs([CleavageInput("ACDE")])
+    assert p.status == "failed" and p.error_message == "failed"
+    assert p.sites == ()
+
+
+def test_real_cpn_rule_assesses_only_the_exposed_terminal_bond():
+    # This tests the released API's stated motif behavior, not serum kinetics.
+    predictor = get_cleavage_model("cpn-basic")
+    peptide = CleavageInput("ACDEKK", source_id="JLF-shaped-fixture")
+    p, repeated = audit_peptidase_inputs([peptide, peptide], predictor)
+    assert p is repeated
+    assert p.model.evidence == "motif_rule"
+    assert [(s.bond, s.status, s.score) for s in p.sites] == [(5, "matched", None)]
+    assert p.unassessed_bonds == (1, 2, 3, 4)
+    assert p.raw_residue_scores == ()
+
+
+def test_canonical_peptidase_chemistry_gate_is_preserved():
+    p, = audit_peptidase_inputs([CleavageInput("ACDEK", c_term="amidated")],
+                                get_cleavage_model("cpn-basic"))
+    assert p.status == "unassessed" and p.reason_codes
+
+
+def test_unreadable_weights_are_explicit_and_do_not_crash_the_audit(tmp_path):
+    weights = tmp_path / "trained_model_dict.pickle"
+    weights.write_bytes(b"fixture")
+    with patch("vaxrank.cleavage_inference.util.find_spec", return_value=SimpleNamespace(
+            origin=str(tmp_path / "__init__.py"))), \
+            patch("vaxrank.cleavage_inference.metadata.version", return_value="fixture"), \
+            patch("pathlib.Path.open", side_effect=PermissionError("weights not readable")), \
+            patch.object(mhctools.Pepsickle, "cleavage_probs_many") as run:
+        p, = audit_pepsickle_inputs([CleavageInput("ACDE")])
+    run.assert_not_called()
+    assert p.status == "unassessed" and p.error_message == "weights not readable"
+
+
+@pytest.mark.parametrize("threshold", [None, True, float("nan"), float("inf"), -1., 2., ".5"])
+def test_invalid_model_settings_fail_before_loading_assets(threshold):
+    with pytest.raises(ValueError, match="settings"):
+        audit_pepsickle_inputs([CleavageInput("ACDE")], threshold=threshold)
+
+
+def test_empty_input_does_not_load_models():
+    with patch("vaxrank.cleavage_inference._pepsickle_model_identity") as identify:
+        assert audit_pepsickle_inputs([]) == ()
+    identify.assert_not_called()

--- a/tests/test_cleavage_profile.py
+++ b/tests/test_cleavage_profile.py
@@ -1,0 +1,135 @@
+"""Exact processing evidence and coverage, without a biological verdict."""
+
+from dataclasses import FrozenInstanceError, replace
+
+from mhctools.cleavage import CleavageInput, CleavageModel, CleavageResult, CleavageSite
+import pytest
+
+from vaxrank.cleavage_profile import (
+    CleavageProfile, profile_from_cleavage_result, profile_from_residue_scores,
+)
+from vaxrank.native_serialization import from_native_json, to_native_json
+
+
+MODEL = CleavageModel(
+    "fixture", "1", "proteasome", "", "", ("proteasomal",),
+    "quantitative_model", ("synthetic-unit-test",), "synthetic",
+    "Not biological evidence", "fixture_probability", "dimensionless")
+
+
+def profile(sequence="ACDEFG", scores=(.1, .2, .3, .4, .5, 0.), **kw):
+    return profile_from_residue_scores(CleavageInput(sequence), MODEL, scores, **kw)
+
+
+def test_every_internal_bond_retained_and_endpoint_not_counted():
+    p = profile()
+    assert [s.bond for s in p.sites] == [1, 2, 3, 4, 5]
+    assert p.terminal_output == 0.
+    assert p.raw_residue_scores == (.1, .2, .3, .4, .5, 0.)
+    assert p.unassessed_bonds == ()
+    whole = p.interval_evidence(0, 6)
+    assert whole.internal_sites == p.sites
+    assert whole.n_boundary is whole.c_boundary is None
+    assert whole.n_boundary_status == whole.c_boundary_status == "sequence_endpoint"
+
+
+def test_internal_cuts_and_ligand_boundaries_remain_separate():
+    p = profile()
+    evidence = p.interval_evidence(1, 5)
+    assert [s.bond for s in evidence.internal_sites] == [2, 3, 4]
+    assert evidence.n_boundary.bond == 1 and evidence.c_boundary.bond == 5
+    assert evidence.unassessed_internal_bonds == ()
+    junction = p.interval_evidence(3, 3)
+    assert junction.internal_sites == ()
+    assert junction.n_boundary == junction.c_boundary == p.sites[2]
+
+
+@pytest.mark.parametrize("scores", [[], [.1], [.1] * 7, [.1] * 5 + [True],
+                                  [.1] * 5 + [float("nan")], [.1] * 5 + [float("inf")],
+                                  [.1] * 5 + [-.1], [.1] * 5 + [1.1], [.1] * 5 + [".2"]])
+def test_invalid_arrays_are_not_clean_profiles(scores):
+    with pytest.raises(ValueError):
+        profile(scores=scores)
+
+
+def test_exact_p1_padding_coordinates():
+    p = profile("A" * 20, [.1] * 20, upstream_context=8, downstream_context=8)
+    assert p.padded_bonds == tuple(range(1, 9)) + tuple(range(13, 20))
+    assert p.reason_codes == ("terminal_context_padded",)
+
+
+def test_no_internal_bond_is_not_a_negative_cleavage_prediction():
+    p = profile("A", [0.])
+    assert p.status == "no_observations"
+    assert p.reason_codes == ("sequence_has_no_internal_bonds",)
+    assert not p.sites and p.terminal_output == 0.
+
+
+def test_partial_motif_rule_preserves_native_semantics_and_unknown_bonds():
+    motif = replace(MODEL, evidence="motif_rule", score_name=None, score_units=None)
+    result = CleavageResult(CleavageInput("ACDEFG"), motif,
+                            (CleavageSite(5, "not_matched", "limited terminal rule"),))
+    p = profile_from_cleavage_result(result)
+    assert p.status == "observations_returned"
+    assert p.unassessed_bonds == (1, 2, 3, 4)
+    evidence = p.interval_evidence(0, 6)
+    assert evidence.unassessed_internal_bonds == (1, 2, 3, 4)
+    assert evidence.internal_sites[0].score is None
+    assert p.raw_residue_scores == () and p.terminal_output is None
+
+
+def test_unsupported_chemistry_remains_explicit():
+    result = CleavageResult(CleavageInput("ACDE", n_term="acetylated"), MODEL,
+                            unsupported_reason="model excludes acetylation")
+    p = profile_from_cleavage_result(result)
+    assert p.status == "unassessed" and p.unassessed_bonds == (1, 2, 3)
+    assert p.reason_codes == ("model excludes acetylation",)
+
+
+def test_native_roundtrip_preserves_all_nested_types_and_provenance():
+    p = profile(backend_version="3.41.0", settings=(("human_only", "False"),),
+                model_asset_sha256="a" * 64, upstream_context=8, downstream_context=8)
+    restored = from_native_json(to_native_json(p), CleavageProfile)
+    assert restored == p
+    assert isinstance(restored.peptide, CleavageInput)
+    assert isinstance(restored.model, CleavageModel)
+    assert all(isinstance(site, CleavageSite) for site in restored.sites)
+    interval = p.interval_evidence(1, 5)
+    assert from_native_json(to_native_json(interval), type(interval)) == interval
+    with pytest.raises(FrozenInstanceError):
+        restored.status = "unassessed"
+
+
+@pytest.mark.parametrize("updates", [
+    {"status": "unassessed"}, {"padded_bonds": (0,)}, {"padded_bonds": (6,)},
+    {"padded_bonds": (1, 1)}, {"raw_residue_scores": (.9,) * 6},
+    {"model_asset_sha256": "not-a-digest"}, {"settings": (("a", "1"), ("a", "2"))},
+])
+def test_inconsistent_serialized_profiles_fail_validation(updates):
+    with pytest.raises(ValueError):
+        replace(profile(), **updates)
+
+
+def test_repeated_motifs_retain_distinct_context_bonds():
+    p = profile("ACDACD", (.1, .2, .3, .7, .8, 0.))
+    assert [s.score for s in p.interval_evidence(0, 3).internal_sites] == [.1, .2]
+    assert [s.score for s in p.interval_evidence(3, 6).internal_sites] == [.7, .8]
+
+
+def test_source_offsets_and_terminal_chemistry_survive_roundtrip():
+    result = CleavageResult(
+        CleavageInput("ACDE", c_term="amidated", source_id="parent", source_start=37), MODEL,
+        unsupported_reason="unsupported chemistry")
+    p = profile_from_cleavage_result(result)
+    assert from_native_json(to_native_json(p), CleavageProfile) == p
+
+
+@pytest.mark.parametrize("score", [-2., 400.])
+def test_native_quantitative_scores_are_not_forced_into_probability_bounds(score):
+    model = replace(MODEL, score_name="native_activity", score_units="native_units")
+    result = CleavageResult(CleavageInput("ACDE"), model,
+                            (CleavageSite(2, "scored", "fixture native output", score),))
+    p = profile_from_cleavage_result(result)
+    assert p.sites[0].score == score
+    assert p.unassessed_bonds == (1, 3)
+    assert p.raw_residue_scores == ()

--- a/tests/test_cleavage_report.py
+++ b/tests/test_cleavage_report.py
@@ -1,0 +1,39 @@
+"""Packaged report retains all bonds, native scores and unknown coverage."""
+
+from dataclasses import replace
+
+from mhctools.cleavage import CleavageInput, CleavageResult, CleavageSite
+
+from vaxrank.cleavage_profile import profile_from_cleavage_result
+from vaxrank.cleavage_report import write_cleavage_profiles
+from vaxrank.native_serialization import from_native_json
+
+from .test_cleavage_profile import MODEL, profile
+
+
+def test_complete_profiles_roundtrip_and_render_all_sites(tmp_path):
+    p = profile(backend_version="3.41.0", upstream_context=8, downstream_context=8)
+    p = replace(p, peptide=replace(p.peptide, source_id="<script>bad()</script>", source_start=40))
+    motif = replace(MODEL, evidence="motif_rule", score_name=None, score_units=None)
+    partial = profile_from_cleavage_result(CleavageResult(
+        CleavageInput("ACDEFG"), motif, (CleavageSite(5, "not_matched", "partial rule"),)))
+    json_path, html_path = tmp_path / "sites.json", tmp_path / "sites.html"
+    write_cleavage_profiles([p, partial], json_path=json_path, html_path=html_path)
+    assert from_native_json(json_path.read_text(), tuple) == (p, partial)
+    html = html_path.read_text()
+    assert "<script>" not in html and "&lt;script&gt;" in html
+    assert html.count("<td><code>") == 10  # five actual bonds for each context
+    assert "41</td>" in html and "45</td>" in html
+    assert "No observation returned for this bond" in html
+    assert "not_matched" in html and "partial rule" in html
+    assert "terminal context padded" in html
+    assert "endpoint sentinel" in html
+    assert "Target masks and patient-HLA ligand overlays are not included" in html
+    assert "0.1, 0.2, 0.3, 0.4, 0.5, 0.0" in html
+
+
+def test_empty_inventory_does_not_look_assessed(tmp_path):
+    json_path, html_path = tmp_path / "none.json", tmp_path / "none.html"
+    write_cleavage_profiles([], json_path=json_path, html_path=html_path)
+    assert from_native_json(json_path.read_text(), tuple) == ()
+    assert "processing is unassessed" in html_path.read_text()

--- a/vaxrank/__init__.py
+++ b/vaxrank/__init__.py
@@ -47,6 +47,14 @@ from .construct_audit import (
     save_construct_sequences,
     write_construct_audits,
 )
+from .cleavage_profile import (
+    CleavageProfile,
+    CleavageIntervalEvidence,
+    profile_from_cleavage_result,
+    profile_from_residue_scores,
+)
+from .cleavage_inference import audit_pepsickle_inputs, audit_peptidase_inputs
+from .cleavage_report import write_cleavage_profiles
 from .vaccine_library import antigen_construct_name, select_antigen_window
 from .safety_assessment import (
     AntigenSafetyAssessment,
@@ -140,6 +148,13 @@ from .reference_proteome import (
 from .version import __version__
 
 __all__ = [
+    "CleavageProfile",
+    "CleavageIntervalEvidence",
+    "profile_from_cleavage_result",
+    "profile_from_residue_scores",
+    "audit_pepsickle_inputs",
+    "audit_peptidase_inputs",
+    "write_cleavage_profiles",
     "__version__",
     "ConstructChemicalModification",
     "ConstructEvidence",

--- a/vaxrank/cleavage_inference.py
+++ b/vaxrank/cleavage_inference.py
@@ -1,0 +1,152 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Non-mutating full-context processing through existing mhctools backends."""
+
+import hashlib
+from importlib import metadata, util
+import math
+from numbers import Real
+from pathlib import Path
+
+import mhctools
+from mhctools.cleavage import CleavageInput, CleavageModel
+
+from .cleavage_profile import (
+    CleavageProfile, profile_from_cleavage_result, profile_from_residue_scores,
+)
+
+
+def _inputs(peptides):
+    peptides = tuple(peptides)
+    if any(not isinstance(p, CleavageInput) for p in peptides):
+        raise ValueError("Processing audit requires explicit mhctools CleavageInput records")
+    return peptides
+
+
+def _pepsickle_model_identity(human_only):
+    """Fingerprint the weights actually found on this interpreter's import path."""
+    identity_error = ""
+    try:
+        spec = util.find_spec("pepsickle")
+    except (ImportError, ValueError) as error:
+        spec, identity_error = None, str(error)
+    digest = ""
+    version = "unknown"
+    if spec is not None:
+        try:
+            version = metadata.version("pepsickle")
+        except metadata.PackageNotFoundError:
+            pass
+        if spec.origin:
+            path = Path(spec.origin).parent / "trained_model_dict.pickle"
+            try:
+                if path.is_file():
+                    hasher = hashlib.sha256()
+                    with path.open("rb") as handle:
+                        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                            hasher.update(chunk)
+                    digest = hasher.hexdigest()
+            except OSError as error:
+                identity_error = str(error)
+    model = CleavageModel(
+        name="pepsickle-epitope-human" if human_only else "pepsickle-epitope-mammal",
+        version=version, enzyme="proteasome", uniprot="", species="",
+        compartments=("proteasomal",), evidence="quantitative_model",
+        references=("https://doi.org/10.1093/bioinformatics/btab628",
+                    "https://github.com/pdxgx/pepsickle"),
+        assay="in-vivo epitope-trained sequence model",
+        limitations="Proteasome-type agnostic. Missing terminal context is padded; "
+                    "not proof of cleavage, presentation, serum stability or clinical safety. "
+                    "Human-only training is experimental and uses fewer observations.",
+        score_name="cleavage_probability", score_units="dimensionless")
+    return model, digest, identity_error
+
+
+def audit_pepsickle_inputs(peptides, *, human_only=False, threshold=.5):
+    """One isolated mhctools batch per set of distinct, unmodified sequences.
+
+    Return one immutable profile per input occurrence, preserving original source
+    offsets and chemistry. Missing installation/assets and invalid outputs stay
+    explicitly unassessed/failed. No ranking scores are read or changed.
+    """
+    peptides = _inputs(peptides)
+    if (type(human_only) is not bool or isinstance(threshold, bool)
+            or not isinstance(threshold, Real) or not math.isfinite(threshold)
+            or not 0 <= threshold <= 1):
+        raise ValueError("Invalid Pepsickle model settings")
+    if not peptides:
+        return ()
+    model, digest, identity_error = _pepsickle_model_identity(human_only)
+    provenance = dict(
+        backend_version=mhctools.__version__, model_asset_sha256=digest,
+        settings=(("human_only", str(human_only)), ("threshold", str(threshold)),
+                  ("model_type", "epitope"), ("proteasome_type", "agnostic"),
+                  ("upstream_context", "8"), ("downstream_context", "8"),
+                  ("isolate_subprocess", "True")))
+    eligible = tuple(dict.fromkeys(p.sequence for p in peptides
+                                  if p.n_term == p.c_term == "free"))
+    outputs, batch_error = {}, None
+    if eligible and digest:
+        try:
+            predictor = mhctools.Pepsickle(
+                human_only=human_only, threshold=threshold, isolate_subprocess=True)
+            outputs = predictor.cleavage_probs_many(eligible)
+            if not isinstance(outputs, dict) or set(outputs) != set(eligible):
+                raise ValueError("Processing batch did not return exactly the requested contexts")
+        except Exception as error:
+            batch_error = str(error) or type(error).__name__
+    profiles = []
+    for peptide in peptides:
+        if peptide.n_term != "free" or peptide.c_term != "free":
+            profile = CleavageProfile(
+                peptide, model, "unassessed", reason_codes=("unsupported_terminal_chemistry",),
+                **provenance)
+        elif not digest:
+            profile = CleavageProfile(
+                peptide, model, "unassessed", reason_codes=("pepsickle_model_assets_unavailable",),
+                error_message=identity_error,
+                **provenance)
+        elif batch_error is not None:
+            profile = CleavageProfile(
+                peptide, model, "failed", reason_codes=("processing_prediction_failed",),
+                error_message=batch_error, **provenance)
+        else:
+            try:
+                profile = profile_from_residue_scores(
+                    peptide, model, outputs[peptide.sequence],
+                    upstream_context=8, downstream_context=8, **provenance)
+            except (TypeError, ValueError) as error:
+                profile = CleavageProfile(
+                    peptide, model, "failed", reason_codes=("invalid_processing_output",),
+                    error_message=str(error), **provenance)
+        profiles.append(profile)
+    return tuple(profiles)
+
+
+def audit_peptidase_inputs(peptides, predictor):
+    """Retain each enzyme model's native bond evidence without filling gaps.
+
+    A recognition rule's non-match is not resistance; a native kinetic score
+    is not a cleavage probability or whole-peptide half-life.
+    """
+    peptides = _inputs(peptides)
+    model = getattr(predictor, "model", None)
+    if not isinstance(model, CleavageModel):
+        raise ValueError("Peptidase predictor requires canonical mhctools model metadata")
+    by_input = {}
+    for peptide in dict.fromkeys(peptides):
+        try:
+            result = predictor.predict(peptide)
+            if result.peptide != peptide or result.model != model:
+                raise ValueError("Peptidase result changed the requested input or model identity")
+            by_input[peptide] = profile_from_cleavage_result(
+                result, backend_version=mhctools.__version__)
+        except Exception as error:
+            by_input[peptide] = CleavageProfile(
+                peptide, model, "failed", reason_codes=("peptidase_prediction_failed",),
+                error_message=str(error) or type(error).__name__,
+                backend_version=mhctools.__version__)
+    return tuple(by_input[peptide] for peptide in peptides)

--- a/vaxrank/cleavage_profile.py
+++ b/vaxrank/cleavage_profile.py
@@ -1,0 +1,205 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lossless processing evidence, not peptide ranking or a safety verdict.
+
+Use mhctools' input/model/site contract. Bond b splits sequence[:b] from
+sequence[b:]; neither endpoint is an internal peptide bond.
+"""
+
+from dataclasses import dataclass, field
+import math
+from numbers import Real
+from typing import Optional
+
+from mhctools.cleavage import CleavageInput, CleavageModel, CleavageResult, CleavageSite
+from serializable import DataclassSerializable
+
+
+@dataclass(frozen=True)
+class CleavageProfile(DataclassSerializable):
+    """Exact input/model observations with execution and coverage provenance.
+
+    Unreturned bonds remain unassessed. Pepsickle's complete residue-indexed
+    vector is retained separately: the final entry is an endpoint sentinel,
+    not evidence of resistance. Padded bonds used absent sequence context.
+    Native model scores and qualitative motif decisions remain distinct.
+    """
+
+    peptide: CleavageInput
+    model: CleavageModel
+    status: str
+    sites: tuple[CleavageSite, ...] = field(default_factory=tuple)
+    reason_codes: tuple[str, ...] = field(default_factory=tuple)
+    error_message: str = ""
+    backend_version: str = ""
+    settings: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    model_asset_sha256: str = ""
+    raw_residue_scores: tuple[float, ...] = field(default_factory=tuple)
+    padded_bonds: tuple[int, ...] = field(default_factory=tuple)
+
+    def __post_init__(self):
+        if not isinstance(self.peptide, CleavageInput) or not isinstance(self.model, CleavageModel):
+            raise ValueError("Cleavage profile requires typed mhctools input and model")
+        if any(not isinstance(value, str) for value in (
+                self.error_message, self.backend_version, self.model_asset_sha256)):
+            raise ValueError("Cleavage execution provenance must be text")
+        if self.status not in {"observations_returned", "no_observations", "unassessed", "failed"}:
+            raise ValueError("Unknown cleavage profile status")
+        for name in ("sites", "reason_codes", "raw_residue_scores", "padded_bonds"):
+            object.__setattr__(self, name, tuple(getattr(self, name)))
+        if any(not isinstance(reason, str) or not reason for reason in self.reason_codes):
+            raise ValueError("Cleavage reasons must be nonempty text")
+        settings = tuple(tuple(pair) for pair in self.settings)
+        if any(len(pair) != 2 or not all(isinstance(v, str) for v in pair) for pair in settings):
+            raise ValueError("Cleavage settings require immutable string key/value pairs")
+        if len({pair[0] for pair in settings}) != len(settings):
+            raise ValueError("Duplicate cleavage setting")
+        object.__setattr__(self, "settings", tuple(sorted(settings)))
+        if any(not isinstance(site, CleavageSite) for site in self.sites):
+            raise ValueError("Cleavage sites must be typed mhctools observations")
+        try:
+            hash((self.peptide, self.model, self.sites))
+        except TypeError as error:
+            raise ValueError("Cleavage input/model/site metadata must be immutable") from error
+        # Upstream owns bond bounds, duplicate sites and native score semantics.
+        CleavageResult(self.peptide, self.model, self.sites)
+        if bool(self.sites) != (self.status == "observations_returned"):
+            raise ValueError("Cleavage status disagrees with returned sites")
+        if self.status != "observations_returned" and not self.reason_codes:
+            raise ValueError("Missing cleavage observations require an explanation")
+        if self.status == "failed" and not self.error_message:
+            raise ValueError("Failed cleavage assessment requires its error")
+        if self.model_asset_sha256 and (
+                len(self.model_asset_sha256) != 64
+                or any(c not in "0123456789abcdef" for c in self.model_asset_sha256)):
+            raise ValueError("Invalid cleavage model asset SHA-256")
+        if self.raw_residue_scores:
+            scores = _residue_scores(self.raw_residue_scores, len(self.peptide.sequence))
+            object.__setattr__(self, "raw_residue_scores", scores)
+            if self.status not in {"observations_returned", "no_observations"}:
+                raise ValueError("Unassessed/failed profiles cannot claim residue scores")
+            expected = tuple((b, scores[b - 1]) for b in range(1, len(scores)))
+            if tuple((site.bond, site.score) for site in self.sites) != expected:
+                raise ValueError("Bond scores disagree with complete residue output")
+        if any(type(b) is not int or not 0 < b < len(self.peptide.sequence)
+               for b in self.padded_bonds):
+            raise ValueError("Padded positions must name internal peptide bonds")
+        if len(set(self.padded_bonds)) != len(self.padded_bonds):
+            raise ValueError("Duplicate padded bond")
+        if not set(self.padded_bonds) <= {site.bond for site in self.sites}:
+            raise ValueError("Padding annotations require observed sites")
+
+    @property
+    def unassessed_bonds(self):
+        observed = {site.bond for site in self.sites}
+        return tuple(b for b in range(1, len(self.peptide.sequence)) if b not in observed)
+
+    @property
+    def terminal_output(self):
+        return self.raw_residue_scores[-1] if self.raw_residue_scores else None
+
+    def interval_evidence(self, start, end):
+        """Every internal/boundary observation for an exact half-open interval.
+
+        A zero-width target junction is a boundary, not an internal ligand cut.
+        """
+        if type(start) is not int or type(end) is not int or not (
+                0 <= start <= end <= len(self.peptide.sequence)):
+            raise ValueError("Invalid cleavage overlay interval")
+        by_bond = {site.bond: site for site in self.sites}
+        def boundary_status(position):
+            if position in {0, len(self.peptide.sequence)}:
+                return "sequence_endpoint"
+            return "observed" if position in by_bond else "unassessed"
+        return CleavageIntervalEvidence(
+            start, end,
+            tuple(by_bond[b] for b in range(start + 1, end) if b in by_bond),
+            tuple(b for b in range(start + 1, end) if b not in by_bond),
+            by_bond.get(start), by_bond.get(end),
+            boundary_status(start), boundary_status(end))
+
+
+@dataclass(frozen=True)
+class CleavageIntervalEvidence(DataclassSerializable):
+    """Exact bonds relative to one ligand or target interval; no summary score."""
+
+    start: int
+    end: int
+    internal_sites: tuple[CleavageSite, ...]
+    unassessed_internal_bonds: tuple[int, ...]
+    n_boundary: Optional[CleavageSite]
+    c_boundary: Optional[CleavageSite]
+    n_boundary_status: str
+    c_boundary_status: str
+
+    def __post_init__(self):
+        if type(self.start) is not int or type(self.end) is not int or not 0 <= self.start <= self.end:
+            raise ValueError("Invalid cleavage interval coordinates")
+        object.__setattr__(self, "internal_sites", tuple(self.internal_sites))
+        object.__setattr__(self, "unassessed_internal_bonds", tuple(self.unassessed_internal_bonds))
+        if any(not isinstance(site, CleavageSite) for site in self.internal_sites):
+            raise ValueError("Internal sites must be typed cleavage observations")
+        observed = [site.bond for site in self.internal_sites]
+        missing = list(self.unassessed_internal_bonds)
+        if any(type(b) is not int for b in missing) or (
+                len(set(observed + missing)) != len(observed + missing)
+                or set(observed + missing) != set(range(self.start + 1, self.end))):
+            raise ValueError("Internal bond coverage must be complete and disjoint")
+        for position, site, status in (
+                (self.start, self.n_boundary, self.n_boundary_status),
+                (self.end, self.c_boundary, self.c_boundary_status)):
+            if status not in {"observed", "unassessed", "sequence_endpoint"}:
+                raise ValueError("Unknown boundary coverage status")
+            if (site is not None) != (status == "observed") or (
+                    site is not None and (not isinstance(site, CleavageSite) or site.bond != position)):
+                raise ValueError("Boundary evidence disagrees with coordinates/status")
+
+
+def _residue_scores(values, length):
+    scores = tuple(values)
+    if len(scores) != length:
+        raise ValueError("Cleavage output must have exactly one value per input residue")
+    if any(isinstance(v, bool) or not isinstance(v, Real)
+           or not math.isfinite(v) or not 0 <= v <= 1 for v in scores):
+        raise ValueError("Cleavage residue outputs must be finite probabilities in [0, 1]")
+    return tuple(float(v) for v in scores)
+
+
+def profile_from_residue_scores(peptide, model, scores, *, upstream_context=0,
+                               downstream_context=0, **provenance):
+    """Adapt processing output without counting its terminal sentinel as a cut.
+
+    Context sizes refer to residues before/after the scored residue (P1), not
+    the bond. Pepsickle's epitope model uses 8 before P1 and 8 after P1.
+    """
+    scores = _residue_scores(scores, len(peptide.sequence))
+    if any(type(n) is not int or n < 0 for n in (upstream_context, downstream_context)):
+        raise ValueError("Context sizes must be nonnegative integers")
+    sites = tuple(CleavageSite(b, "scored", "residue_indexed_model_output", scores[b - 1])
+                  for b in range(1, len(scores)))
+    padded = tuple(b for b in range(1, len(scores))
+                   if b - 1 < upstream_context or len(scores) - b < downstream_context)
+    reasons = ("terminal_context_padded",) if padded else ()
+    if not sites:
+        reasons += ("sequence_has_no_internal_bonds",)
+    return CleavageProfile(
+        peptide, model, "observations_returned" if sites else "no_observations",
+        sites=sites, raw_residue_scores=scores, padded_bonds=padded,
+        reason_codes=reasons, **provenance)
+
+
+def profile_from_cleavage_result(result, **provenance):
+    """Retain a canonical enzyme result, including limited bond coverage."""
+    if not isinstance(result, CleavageResult):
+        raise ValueError("Expected a mhctools CleavageResult")
+    if result.unsupported_reason is not None:
+        status, reasons = "unassessed", (result.unsupported_reason,)
+    elif result.sites:
+        status, reasons = "observations_returned", ()
+    else:
+        status, reasons = "no_observations", ("model_returned_no_bond_observations",)
+    return CleavageProfile(result.peptide, result.model, status,
+                          sites=result.sites, reason_codes=reasons, **provenance)

--- a/vaxrank/cleavage_report.py
+++ b/vaxrank/cleavage_report.py
@@ -1,0 +1,38 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Complete bond inventories through small report glue and a Jinja template."""
+
+from pathlib import Path
+
+import jinja2
+
+from .cleavage_profile import CleavageProfile
+from .native_serialization import to_native_json
+
+
+def write_cleavage_profiles(profiles, *, json_path, html_path=None):
+    """Export all model observations, missing bonds, settings and source offsets.
+
+    This low-level report does not infer target identities or HLA ligands from
+    cleavage data. Those are separate sequence-context overlays, not cleavage
+    predictions. JSON retains the complete immutable native object graph.
+    """
+    profiles = tuple(profiles)
+    if any(not isinstance(profile, CleavageProfile) for profile in profiles):
+        raise ValueError("Cleavage report requires typed profiles")
+    payload = to_native_json(profiles)
+    rendered = None
+    if html_path is not None:
+        environment = jinja2.Environment(
+            loader=jinja2.PackageLoader("vaxrank", "templates"),
+            autoescape=jinja2.select_autoescape(("html", "xml")))
+        records = tuple({"profile": profile,
+                         "by_bond": {site.bond: site for site in profile.sites},
+                         "padded": frozenset(profile.padded_bonds)} for profile in profiles)
+        rendered = environment.get_template("cleavage_profiles.html").render(records=records)
+    Path(json_path).write_text(payload, encoding="utf8")
+    if rendered is not None:
+        Path(html_path).write_text(rendered, encoding="utf8")

--- a/vaxrank/native_serialization.py
+++ b/vaxrank/native_serialization.py
@@ -31,6 +31,7 @@ _SERIALIZED_KEY_PREFIX = _SERIALIZED_KEYS_FIELD + "element_"
 def _native_serializable_classes():
     """Return the native class registry without creating an import cycle."""
     from mhctools.pred import Prediction
+    from mhctools.cleavage import CleavageInput, CleavageModel, CleavageSite
 
     from .allele_evidence import AlleleAttribution
     from .candidate_epitope import CandidateEpitope, Peptide
@@ -42,6 +43,7 @@ def _native_serializable_classes():
         ConstructSequenceEdit,
     )
     from .construct_audit import ConstructAudit
+    from .cleavage_profile import CleavageProfile, CleavageIntervalEvidence
     from .safety_assessment import (
         ConstructBoundary,
         EmittedSafetyLigand,
@@ -63,6 +65,11 @@ def _native_serializable_classes():
         ("builtins", "set"): set,
         ("builtins", "tuple"): tuple,
         ("mhctools.pred", "Prediction"): Prediction,
+        ("mhctools.cleavage", "CleavageInput"): CleavageInput,
+        ("mhctools.cleavage", "CleavageModel"): CleavageModel,
+        ("mhctools.cleavage", "CleavageSite"): CleavageSite,
+        ("vaxrank.cleavage_profile", "CleavageProfile"): CleavageProfile,
+        ("vaxrank.cleavage_profile", "CleavageIntervalEvidence"): CleavageIntervalEvidence,
         ("vaxrank.allele_evidence", "AlleleAttribution"): AlleleAttribution,
         ("vaxrank.candidate_epitope", "CandidateEpitope"): CandidateEpitope,
         ("vaxrank.candidate_epitope", "Peptide"): Peptide,

--- a/vaxrank/processing.py
+++ b/vaxrank/processing.py
@@ -21,14 +21,14 @@ three scores:
                                     proteasome cuts at the ligand's
                                     C-terminus (clean release)
   max_internal_cut_prob             peak cleavage probability strictly
-                                    inside the ligand (high → ligand
-                                    is destroyed before reaching MHC)
+                                    inside the ligand (a model-based
+                                    warning, not proof of destruction)
   processing_score                  composite ``sqrt(c_term *
                                     (1 - max_internal))`` — the
                                     geometric mean of the two factors;
-                                    1.0 = ideal release, 0.0 = no
-                                    clean release OR near-certain
-                                    destruction. Geometric mean
+                                    not a calibrated probability of
+                                    release, destruction or presentation.
+                                    Geometric mean
                                     rather than the raw product so
                                     a balanced (0.6, 0.6) row scores
                                     ~0.6 instead of 0.36.
@@ -42,6 +42,10 @@ vaxrank mutated pre-3.0 flat records in place with
 map returned here.
 
 The annotations are purely additive — vaccine ranking is unaffected.
+For complete site-resolved evidence, use ``audit_pepsickle_inputs`` and
+``write_cleavage_profiles``. Those APIs distinguish actual internal peptide
+bonds from a sequence endpoint; this legacy summary does not establish full
+sequence coverage.
 Reports surface the three columns when at least one prediction in
 the per-VaccinePeptide list has been annotated.
 

--- a/vaxrank/templates/cleavage_profiles.html
+++ b/vaxrank/templates/cleavage_profiles.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Full-sequence cleavage evidence</title>
+<style>
+body { font: 15px sans-serif; margin: 2rem; line-height: 1.5; }
+code { overflow-wrap: anywhere; }
+table { border-collapse: collapse; margin: 1rem 0; }
+td, th { border: 1px solid #bbb; padding: .35rem .6rem; text-align: left; }
+section { border-top: 2px solid #555; margin-top: 2rem; }
+.notice { background: #fff4d6; padding: .8rem; }
+</style></head><body><h1>Full-sequence cleavage evidence</h1>
+<p class="notice">An evidence inventory, not a safety verdict. A high model score
+does not prove a target antigen will be destroyed. A motif non-match does not
+establish resistance. Unreturned bonds are unassessed, never assigned zero.
+Enzyme location does not establish calibration in serum or another compartment.
+Cleavage evidence is not whole-peptide half-life, presentation or T-cell recognition.</p>
+{% if not records %}<p>No sequence profiles supplied; processing is unassessed.</p>{% endif %}
+{% for record in records %}{% set p = record.profile %}{% set n = p.peptide.sequence|length %}
+<section><h2>{{ p.peptide.source_id or 'Unnamed context' }} — {{ p.model.name }}</h2>
+<p>Exact input ({{ n }} residues): <code>{{ p.peptide.sequence }}</code></p>
+<p>Source start: {{ p.peptide.source_start }} (zero-based).
+N terminus: {{ p.peptide.n_term }}; C terminus: {{ p.peptide.c_term }}.
+Chemistry describes the supplied model input, not independently verified manufacture.</p>
+<p>Status: {{ p.status }}. {{ p.reason_codes|join('; ') }} {{ p.error_message }}</p>
+<p>Enzyme: {{ p.model.enzyme }} {{ p.model.uniprot }}. Species: {{ p.model.species or 'Not specified' }}.
+Compartments: {{ p.model.compartments|join(', ') }}. Evidence: {{ p.model.evidence }}.</p>
+<p>Model: {{ p.model.name }} {{ p.model.version }}; mhctools: {{ p.backend_version or 'Unknown' }}.
+Score: {{ p.model.score_name or 'No numeric score' }};
+native units: {{ p.model.score_units or 'Not applicable' }}.
+Asset SHA-256: <code>{{ p.model_asset_sha256 or 'Not recorded' }}</code>.</p>
+<p>Settings: {% for key, value in p.settings %}{{ key }}={{ value }}; {% endfor %}</p>
+<p>Assay/training: {{ p.model.assay }}. Limitations: {{ p.model.limitations }}</p>
+<p>Sources: {% for source in p.model.references %}{{ source }}<br>{% endfor %}</p>
+<p class="notice">Target masks and patient-HLA ligand overlays are not included in
+this low-level site inventory. Other models and processing compartments remain
+unassessed unless explicitly reported. Padded context is missing sequence context,
+not measured flanking sequence. A complete vector is not complete biological coverage.</p>
+<table><thead><tr><th>Input bond b</th><th>Source bond</th><th>Residues</th>
+<th>Status</th><th>Native score</th><th>Context</th><th>Reason</th></tr></thead><tbody>
+{% for b in range(1, n) %}{% set site = record.by_bond.get(b) %}<tr>
+<td>{{ b }}</td><td>{{ p.peptide.source_start + b }}</td>
+<td><code>{{ p.peptide.sequence[b - 1] }}|{{ p.peptide.sequence[b] }}</code></td>
+<td>{{ site.status if site else 'unassessed' }}</td>
+<td>{{ site.score if site and site.score is not none else '' }}</td>
+<td>{{ 'terminal context padded' if b in record.padded else 'see model/input scope' }}</td>
+<td>{{ site.reason if site else 'No observation returned for this bond' }}</td>
+</tr>{% endfor %}</tbody></table>
+{% if n == 1 %}<p>The sequence has no internal peptide bonds.</p>{% endif %}
+<p>Bond b splits sequence[:b] | sequence[b:]. Positions 0 and {{ n }} are sequence
+endpoints, not internal peptide bonds.</p>
+{% if p.raw_residue_scores %}<p>Complete residue-indexed backend output:
+<code>{{ p.raw_residue_scores|join(', ') }}</code>.</p>
+<p>Final residue output: {{ p.terminal_output }} — retained endpoint sentinel,
+excluded from internal cleavage evidence.</p>{% endif %}
+</section>{% endfor %}</body></html>

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.15.2"
+__version__ = "3.16.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary
First foundational delivery for #422; deliberately does NOT close it. Bumps Vaxrank to 3.16.0 and requires released mhctools >=3.41.0.

- Reuse canonical mhctools cleavage input, model and site records in an immutable, native-serializable profile.
- Retain every raw Pepsickle residue score and every real internal bond; keep the terminal sentinel separate. Preserve precise padded-context and unassessed-bond coverage.
- Add batch Pepsickle and canonical peptidase orchestration with exact input/chemistry/source identity, model/version/settings/asset provenance, deduplication without losing occurrences, and explicit unavailable/invalid/failed outcomes.
- Provide exact interval internal/boundary evidence and complete escaped HTML plus native JSON reports.
- Keep native quantitative scores distinct from motif matches and whole-peptide half-life. Correct overconfident destruction language in the legacy processing documentation without changing ranking or aggregation.

## Remaining work and upstream gap
#422 remains open for native/final/complete translated construct orchestration with validated source placements, target masks and every patient-HLA ligand overlay. #423 will supply independently documented Sid cases and real-model caches. The low-level report explicitly says those overlays are not yet included.

Filed openvax/mhctools#329 so Pepsickle model/asset provenance and canonical per-bond output can move upstream; this PR only adapts existing inference, not a new biological model.

## Review and verification
- Reviewed exact bonds and P1 context convention against Pepsickle source and primary documentation; checked the CPN terminal rule against reviewed UniProt P15169. Predictions are not safety verdicts.
- Lint and git diff --check pass.
- Full isolated suite with published mhctools 3.41.0: 1,441 passed, 92% coverage (29 warnings).
- 44 new offline tests cover arrays, endpoints, repeated occurrences, source offsets, chemistry, failure states, native score semantics, serialization and packaged report escaping/coverage.
- Real local Pepsickle 0.1.3 plus released CPN-rule smoke passed on separate native and KK-extended contexts; complete HTML/JSON round trips verified. Actual Pepsickle weight SHA-256 recorded; no weights redistributed.
- CI must pass before merge; deploy and independent PyPI verification follow immediately after merge.