### PR TITLE
Audit full construct cleavage contexts and fix endpoint evidence

### DIFF
--- a/CLEAVAGE_AUDIT.md
+++ b/CLEAVAGE_AUDIT.md
@@ -77,3 +77,13 @@ half-open interval; the follow-up construct orchestration supplies validated
 native/final/product contexts and patient-MHC overlays. The report lists every
 internal bond, including those no model assessed. A terminal-only enzyme rule
 does not become a full-sequence prediction or a serum-stability estimate.
+
+## Complete-context API (3.17.0)
+
+`audit_sequence_contexts` and `write_sequence_context_audits` now provide native,
+final and validated complete-CDS contexts, full target/ligand overlays, and
+explicit missing model/HLA/length/occurrence coverage. See
+[CONSTRUCT_PROCESSING.md](CONSTRUCT_PROCESSING.md) for source-preserving inputs,
+conditional chemistry, requested prediction provenance and JSON/report usage.
+Historical Sid selection validation and the independent actual-construct audit
+remain separate work under #414 and #423.

--- a/CONSTRUCT_PROCESSING.md
+++ b/CONSTRUCT_PROCESSING.md
@@ -1,0 +1,130 @@
+# #422 follow-up: context and patient-MHC overlays
+
+Build on the full per-bond profiles and report in PR #433. Do not change ranking.
+Do not close #422 until native, actual final and complete translated products
+are covered; #423 remains responsible for independent Sid data and real caches.
+Include the reproduced legacy endpoint-sentinel bug in #434: retain internal
+evidence, report endpoint/unassessed C-boundary status, and never turn a forced
+endpoint zero into a measured probability or a composite processing deficit.
+
+## Invariants
+
+- Preserve the exact `ConstructSequence` and every `ConstructPlacement`, with
+  native source objects, gene/transcript/species, evidence, edits and chemistry.
+  Complete mRNA inputs must be checked against actual CDS translation and emitted
+  nucleotide views. Linkers and encoded elements are included, not cropped away.
+- Native RNA/protein contexts may be windows, not complete proteins or exposed
+  peptide molecules. Report that scope. Pepsickle can provide explicitly padded
+  sequence-context scores, but terminal peptidase rules must not treat artificial
+  window ends as exposed molecular termini. Native terminal trimming stays
+  unassessed without explicit molecular/terminal context.
+- Final chemistry and model-input assumptions must be separate from documented
+  manufacture. Unsupported or unresolved chemistry is never silently replaced
+  with an unmodified bare sequence. Conditional assumptions, if supplied, must
+  remain visibly conditional in JSON and the readable report.
+- Score distinct contexts once; retain repeated occurrences and all source
+  placements. Do not reuse native-context scores for an edited final sequence.
+- Predict unfiltered patient-MHC output through Topiary and retain every returned
+  peptide/offset/model/kind/allele. Reuse existing complete-window/self assessment
+  where a source antigen exists; do not invent one gene or antigen kind for a
+  multi-antigen product merely to satisfy an API shape.
+- Overlay all returned ligand occurrences and target masks on exact bonds.
+  Show internal and boundary observations separately, including zero-width target
+  junctions. Sequence preservation, target overlap, cleavage-model evidence and
+  historical selection agreement are different observations.
+- Missing/unreturned HLA/model/length combinations stay explicit. Binding or a
+  cleavage score does not establish presentation, T-cell recognition, intact
+  delivery, or clinical safety. All report text is source-agnostic (target antigen,
+  not always mutant), and escaped.
+- Keep serum/extracellular, proteasomal, other cytosolic, ER and endolysosomal
+  evidence separate. An enzyme having one compartment annotation is not matrix
+  calibration or a claim that the molecule reaches that compartment.
+
+## Suggested delivery
+
+Add a typed complete-context audit around the existing immutable records, with
+explicit native/final/product identity, processing profiles, prediction coverage
+and ligand/target overlays. Extend the report using small glue and templates.
+Avoid a second hand-maintained native serializer or an ad-hoc ranking filter.
+
+Tests: repeated motifs with different flanks, both ends, truncation versus real
+termini, additions/deletions and target junctions, mutation/CTA/viral masks,
+multi-antigen product provenance, full translated CDS validation, empty/error/
+partial outputs, chemistry, native JSON and offline report regressions. Run
+lint, full tests with coverage, real-model/report smoke, CI and release gates.
+
+## Public API
+
+`native_sequence_context(antigen)` retains the entire supplied native context;
+it does not assert that reconstruction produced an entire protein. Use
+`final_sequence_context(construct)` for an exact manufactured antigen, and
+`translated_sequence_context(rna_product, evidence)` for the complete translated
+CDS, including linkers, signal peptides and other encoded elements. The latter
+retains the entire `RNAConstruct` graph through the native serializer and checks
+its CDS translation, all placements, and emitted nucleotide views. It snapshots
+mutable assembly data and revalidates it before inference/report export.
+
+```python
+from mhctools import NetMHCpan42
+from mhctools.peptidases import get_cleavage_model
+from vaxrank import (
+    MHCRequest, native_sequence_context, final_sequence_context,
+    audit_sequence_contexts, write_sequence_context_audits,
+)
+
+# `construct` is an attributed ConstructSequence, not a guessed manufactured
+# sequence. Supply actual patient typing and the installed model's output
+# identity/version in `requests`. Versions must match output, not assumptions.
+contexts = [native_sequence_context(construct.native_antigen),
+            final_sequence_context(construct)]
+# Defaults preserve unknown chemistry. An explicitly conditional analysis may
+# use n_term='free', c_term='free', chemistry_basis='Conditional ...' instead.
+# Documented arbitrary chemistry is still unsupported; this cannot override it.
+audits = audit_sequence_contexts(
+    contexts, mhc_predictor=NetMHCpan42(alleles=patient_alleles,
+                                     default_peptide_lengths=[8, 9, 10, 11]),
+    mhc_requests=requests, pepsickle=True,
+    peptidase_predictors=[get_cleavage_model('cpn-basic')])
+write_sequence_context_audits(audits, json_path='contexts.json',
+                             html_path='contexts.html')
+```
+
+Each `MHCRequest(kind, predictor_name, predictor_version, allele,
+peptide_length)` describes one requested output combination. Coverage lists all
+missing occurrence offsets, including completely unreturned combinations.
+Unrequested outputs are retained and flagged, not silently discarded. The
+request set is explicit input provenance, not auto-inferred from successful
+rows; incomplete requests must not be called complete patient coverage.
+
+Native windows and unknown-terminus translated products can receive Pepsickle
+sequence-context scores, labeled `sequence_context_only`; their model's padding
+does not establish exposed termini. Terminal peptidase rules do not run on native
+windows or embedded encoded antigen segments. Unknown terminal chemistry stays
+unknown for enzyme inference. Enzyme compartment metadata is not serum-matrix
+calibration. No ranking, manufacture or target-selection decisions are changed.
+
+The JSON contains native `audits` plus derived `coverage` and `overlays` entries.
+Every target mask and returned ligand has exact internal/boundary observations;
+endpoints remain `sequence_endpoint`. The HTML lists all model/site observations,
+all ligand occurrences, requested/unreturned combinations, source graphs,
+chemistry assumptions and limitations. MHC values use mhctools' native units.
+
+This API does not identify independently intended target ligands, adjudicate
+historical sequence choices, or apply self/CTA/tissue policy. These require the
+independent #423 audit and #414 selection validation. Existing
+`audit_construct_sequence` remains the attributed single-antigen self-reference
+entry point; no fake gene or antigen kind is created for a multi-antigen product.
+
+## Legacy endpoint correction (#434)
+
+The ordinary HTML/ASCII processing columns now print `sequence endpoint` at the
+end of supplied context, retain maximum internal-cut evidence, and leave the
+composite unavailable. Native JSON carries the explicit boundary status and
+null missing scores. A real zero at an internal bond remains zero. Exact-length,
+finite probability validation prevents malformed arrays from shifting the
+apparent endpoint. This does not change vaccine ranking.
+
+Primary scope: [Pepsickle documentation](https://github.com/pdxgx/pepsickle)
+describes eight-residue contexts and padding; it does not turn absent context
+into molecular-terminal evidence. The released mhctools enzyme models retain
+their primary references, assay descriptions and limitations in every profile.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE README.md requirements.txt
 include CONSTRUCT_AUDIT.md
 include ALLELE_VALIDATION.md
 include CLEAVAGE_AUDIT.md
+include CONSTRUCT_PROCESSING.md

--- a/tests/test_context_audit.py
+++ b/tests/test_context_audit.py
@@ -1,0 +1,310 @@
+"""Software contracts for full contexts, not synthetic biological validation."""
+
+from dataclasses import replace
+from unittest.mock import patch
+
+from Bio.Data import CodonTable
+import mhctools
+import pandas as pd
+import pytest
+from mhctools.peptidases import get_cleavage_model
+
+from vaxrank.context_audit import MHCRequest, SequenceContextAudit, audit_sequence_contexts
+from vaxrank.context_report import write_sequence_context_audits
+from vaxrank.construct_sequence import ConstructChemicalModification, ConstructPlacement, ConstructSequenceEdit
+from vaxrank.mrna import RNAConstruct
+from vaxrank.native_serialization import from_native_json, to_native_json
+from vaxrank.sequence_context import (
+    SequenceContext, final_sequence_context, native_sequence_context, translated_sequence_context,
+)
+
+from .test_cleavage_inference import identity
+from .test_construct_audit import RecordingPredictor, jlf_construct
+from .test_construct_sequence import DOCUMENTED, JLF, NATIVE, construct, native_antigen
+
+
+REQUEST = MHCRequest("pMHC_affinity", "software_fixture", "1", "HLA-B*27:05", 9)
+FREE = dict(n_term="free", c_term="free", chemistry_basis="Conditional unmodified free-terminal analysis, not manufacturing evidence")
+
+
+def product_fixture():
+    record = replace(construct(), modality="mrna")
+    protein = "M" + NATIVE + "GG" + NATIVE + "K"
+    codons = {aa: codon for codon, aa in CodonTable.unambiguous_dna_by_id[1].forward_table.items()}
+    nt = "".join(codons[aa] for aa in protein) + "TAA"
+    return RNAConstruct("multi-antigen", ["first", "second"], "CCC" + nt + "TTTAAA",
+                        cds_aa=protein, cds_nt=nt, no_polya_nt="CCC" + nt + "TTT",
+                        full_nt="CCC" + nt + "TTTAAA", poly_a_nt="AAA",
+                        elements={"utr_5p": {"nt": "CCC"}, "utr_3p": {"nt": "TTT"},
+                                  "linkers_per_junction": [{"aa": "GG", "name": "fixture-linker"}]},
+                        construct_placements=(ConstructPlacement(record, 1), ConstructPlacement(record, 25)))
+
+
+def scores(sequences):
+    return {s: ([.2 if s == NATIVE else .8] * (len(s) - 1) + [0.]) for s in sequences}
+
+
+def run(contexts, predictor=None, requests=(REQUEST,), **kwargs):
+    with identity(), patch.object(mhctools.Pepsickle, "cleavage_probs_many", side_effect=scores):
+        return audit_sequence_contexts(contexts, mhc_predictor=predictor,
+                                       mhc_requests=requests, pepsickle=True, **kwargs)
+
+
+def test_distinct_context_scores_and_repeated_source_provenance_are_not_merged():
+    native = native_sequence_context(native_antigen())
+    final = final_sequence_context(jlf_construct(), **FREE)
+    repeated = replace(final, name="independent manufacturing occurrence")
+    predictor = RecordingPredictor()
+    with identity(), patch.object(mhctools.Pepsickle, "cleavage_probs_many", side_effect=scores) as infer:
+        audits = audit_sequence_contexts(iter([native, final, repeated]), mhc_predictor=predictor,
+                                        mhc_requests=[REQUEST], pepsickle=True)
+    infer.assert_called_once_with((NATIVE, JLF))
+    assert predictor.calls == [{"context_0": NATIVE, "context_1": JLF}]
+    assert audits[0].profiles[0].sites[0].score == .2
+    assert audits[1].profiles[0].sites[0].score == .8
+    assert audits[1].profiles[0].peptide.source_id != audits[2].profiles[0].peptide.source_id
+    assert [len(a.ligands) for a in audits] == [14, 16, 16]
+    assert all(a.coverage[0][2] == () for a in audits)
+    assert audits[1].context.construct.native_residue_offsets[-2:] == (None, None)
+    assert from_native_json(to_native_json(audits), tuple) == audits
+
+
+def test_complete_product_includes_linkers_both_occurrences_and_full_provenance():
+    product = product_fixture()
+    context = translated_sequence_context(product, DOCUMENTED)
+    audit, = run([context], RecordingPredictor())
+    assert len(context.sequence) == 48 and len(audit.ligands) == 40
+    assert context.sequence[23:25] == "GG"
+    assert [t.start for t in context.targets] == [8, 32]
+    assert len(context.source_antigens) == 2
+    assert [ligand.start for ligand in audit.ligands if ligand.peptide == NATIVE[:9]] == [1, 25]
+    assert "molecular_termini_not_established" in audit.profiles[0].reason_codes
+    assert len(audit.profiles[0].sites) == 47
+    assert from_native_json(to_native_json(audit), SequenceContextAudit) == audit
+    product.elements["linkers_per_junction"][0]["name"] = "changed later"
+    assert context.product.elements["linkers_per_junction"][0]["name"] == "fixture-linker"
+
+
+@pytest.mark.parametrize("field,value", [("cds_nt", "ATGAAA"), ("cds_aa", "MKK"),
+    ("no_polya_nt", "AAA"), ("full_nt", "AAA"), ("sequence", "AAA")])
+def test_invalid_complete_product_views_cannot_enter_audit(field, value):
+    product = product_fixture()
+    setattr(product, field, value)
+    with pytest.raises(ValueError):
+        translated_sequence_context(product, DOCUMENTED)
+
+
+def test_mutable_assembly_record_tampering_is_rechecked_before_export(tmp_path):
+    audit, = run([translated_sequence_context(product_fixture(), DOCUMENTED)], RecordingPredictor())
+    audit.context.product.full_nt = "AAA"
+    with pytest.raises(ValueError, match="emitted full"):
+        write_sequence_context_audits([audit], json_path=tmp_path / "invalid.json")
+    assert not (tmp_path / "invalid.json").exists()
+
+
+def test_cpn_never_treats_native_window_end_as_an_exposed_terminal_lysine():
+    native = native_sequence_context(native_antigen(JLF))
+    final = final_sequence_context(jlf_construct(), **FREE)
+    audits = run([native, final], peptidase_predictors=[get_cleavage_model("cpn-basic")])
+    assert audits[0].profiles[1].status == "unassessed"
+    assert audits[0].profiles[1].reason_codes == ("native_window_molecular_termini_unestablished",)
+    assert audits[1].profiles[1].sites[0].bond == 23
+    assert audits[1].profiles[1].sites[0].status == "matched"
+    assert audits[1].profiles[1].sites[0].score is None
+
+
+def test_encoded_antigen_segment_does_not_claim_exposed_termini():
+    context = final_sequence_context(replace(construct(), modality="mrna"), **FREE)
+    audit, = run([context], peptidase_predictors=[get_cleavage_model("cpn-basic")])
+    assert audit.profiles[1].reason_codes == ("encoded_segment_molecular_termini_unestablished",)
+
+
+@pytest.mark.parametrize("chemistry", [{}, {"c_term": "amidated", "chemistry_basis": "conditional"}])
+def test_unknown_or_unsupported_final_chemistry_is_not_silently_stripped(chemistry):
+    context = final_sequence_context(jlf_construct(), **chemistry)
+    with identity(), patch.object(mhctools.Pepsickle, "cleavage_probs_many") as backend:
+        audit, = audit_sequence_contexts([context], pepsickle=True,
+                                        peptidase_predictors=[get_cleavage_model("cpn-basic")])
+    backend.assert_not_called()
+    assert all(p.status == "unassessed" for p in audit.profiles)
+
+
+def test_documented_noncanonical_modification_cannot_be_overridden_by_free_assumption():
+    record = replace(jlf_construct(), chemical_modifications=(
+        ConstructChemicalModification(2, 3, "D-amino acid", DOCUMENTED),))
+    predictor = RecordingPredictor()
+    context = final_sequence_context(record, **FREE)
+    with identity(), patch.object(mhctools.Pepsickle, "cleavage_probs_many") as backend:
+        audit, = audit_sequence_contexts([context], mhc_predictor=predictor,
+                                        mhc_requests=[REQUEST], pepsickle=True)
+    backend.assert_not_called()
+    assert predictor.calls == []
+    assert audit.mhc_status == audit.profiles[0].status == "unassessed"
+    assert "unsupported_chemical_modifications" in audit.reason_codes
+
+
+@pytest.mark.parametrize("kind", ["mutation", "CTA", "viral"])
+def test_masks_and_all_ligand_boundary_internal_overlays_are_source_agnostic(kind):
+    context = native_sequence_context(native_antigen(intervals=((0, 2), (7, 7), (20, 22)), kind=kind))
+    audit, = run([context], RecordingPredictor())
+    overlays = audit.overlays(audit.profiles[0])
+    assert len(overlays["targets"]) == 3 and len(overlays["ligands"]) == 14
+    assert overlays["targets"][0][1].n_boundary_status == "sequence_endpoint"
+    junction = overlays["targets"][1][1]
+    assert junction.internal_sites == () and junction.n_boundary.bond == junction.c_boundary.bond == 7
+    assert overlays["targets"][2][1].c_boundary_status == "sequence_endpoint"
+    last_ligand, targets, evidence = overlays["ligands"][-1]
+    assert last_ligand.end == len(NATIVE) and targets[0].start == 20
+    assert evidence.c_boundary_status == "sequence_endpoint"
+    assert len(evidence.internal_sites) == 8
+
+
+def test_edit_deletion_junction_masks_map_to_actual_final_coordinates():
+    native = native_antigen(intervals=((7, 7),))
+    record = construct(NATIVE[2:], native=native, edits=(ConstructSequenceEdit(0, 2, "", DOCUMENTED),))
+    audit, = run([final_sequence_context(record, **FREE)], RecordingPredictor())
+    assert [(t.start, t.end) for t in audit.context.targets] == [(5, 5)]
+    assert audit.profiles[0].peptide.sequence == NATIVE[2:]
+
+
+def test_partial_mhc_outputs_retain_missing_allele_length_and_occurrence_axes():
+    class Partial(RecordingPredictor):
+        def predict_from_named_sequences(self, sequences):
+            return super().predict_from_named_sequences(sequences).iloc[::2]
+    extra_allele = replace(REQUEST, allele="HLA-A*01:01")
+    extra_length = replace(REQUEST, peptide_length=10)
+    extra_model = replace(REQUEST, predictor_name="other_model")
+    audit, = run([native_sequence_context(native_antigen())], Partial(),
+                 requests=(REQUEST, extra_allele, extra_length, extra_model))
+    assert audit.mhc_status == "predictions_returned"
+    assert audit.coverage[0][2] == tuple(range(1, 14, 2))
+    assert len(audit.coverage[1][2]) == len(audit.coverage[3][2]) == 14
+    assert len(audit.coverage[2][2]) == 13
+    assert audit.unrequested_predictions == ()
+
+
+def test_unrequested_output_is_retained_not_filtered():
+    audit, = run([native_sequence_context(native_antigen())], RecordingPredictor(),
+                 requests=(replace(REQUEST, allele="HLA-A*01:01"),))
+    assert len(audit.unrequested_predictions) == 14
+    assert audit.coverage[0][1] == ()
+
+
+@pytest.mark.parametrize("failure,empty,expected", [(True, False, "failed"), (False, True, "no_predictions")])
+def test_failure_and_empty_output_are_not_no_cuts_or_no_binders(failure, empty, expected):
+    audit, = run([native_sequence_context(native_antigen())], RecordingPredictor(failure=failure, empty=empty))
+    assert audit.mhc_status == expected and audit.reason_codes
+    assert len(audit.coverage[0][2]) == 14
+    assert audit.profiles[0].status == "observations_returned"
+
+
+@pytest.mark.parametrize("error", ["source", "coordinates", "peptide", "duplicates", "columns"])
+def test_malformed_outputs_fail_closed_without_unrelated_processing_loss(error):
+    class Broken(RecordingPredictor):
+        def predict_from_named_sequences(self, sequences):
+            frame = super().predict_from_named_sequences(sequences)
+            if error == "source":
+                frame.loc[0, "source_sequence_name"] = "unrequested"
+            elif error == "coordinates":
+                frame.loc[0, "peptide_offset"] = 1000
+            elif error == "peptide":
+                frame.loc[0, "peptide"] = "AAAAAAAAA"
+            elif error == "duplicates":
+                frame = pd.concat([frame, frame.iloc[:1]])
+            else:
+                frame = pd.concat([frame, frame[["peptide_offset"]]], axis=1)
+            return frame
+    audit, = run([native_sequence_context(native_antigen())], Broken())
+    assert audit.mhc_status == "failed" and audit.error_message
+    assert audit.profiles[0].sites and not audit.ligands
+
+
+def test_readable_report_and_native_json_include_complete_graph_and_derived_overlays(tmp_path):
+    context = replace(final_sequence_context(jlf_construct(), **FREE), name="<script>bad</script>")
+    audit, = run([context], RecordingPredictor(), peptidase_predictors=[get_cleavage_model("cpn-basic")])
+    json_path, html_path = tmp_path / "audit.json", tmp_path / "audit.html"
+    write_sequence_context_audits([audit], json_path=json_path, html_path=html_path)
+    restored = from_native_json(json_path.read_text(), dict)
+    assert restored["audits"] == (audit,)
+    assert restored["coverage"][0] == audit.coverage
+    assert restored["overlays"][0][0] == audit.overlays(audit.profiles[0])
+    html = html_path.read_text()
+    assert "<script>bad</script>" not in html and "&lt;script&gt;bad&lt;/script&gt;" in html
+    for text in (JLF, "L16", "23", "cpn-basic", "fixture", "HLA-B*27:05", "ENSG00000197102",
+                 "NM_001376", "patient", "sequence", "unassessed", "not manufacturing evidence"):
+        assert text.lower() in html.lower()
+
+
+@pytest.mark.parametrize("change", [{"n_term": "free"}, {"kind": "invented"}, {"sequence": "KKK"}])
+def test_context_rejects_ambiguous_or_false_identity(change):
+    with pytest.raises(ValueError):
+        replace(native_sequence_context(native_antigen()), **change)
+
+
+def test_request_and_profile_identity_are_checked_before_export():
+    context = native_sequence_context(native_antigen())
+    with pytest.raises(ValueError, match="explicit"):
+        audit_sequence_contexts([context], mhc_predictor=RecordingPredictor())
+    with pytest.raises(ValueError, match="distinct"):
+        audit_sequence_contexts([context], mhc_requests=[REQUEST, REQUEST])
+    audit, = run([context], RecordingPredictor())
+    with pytest.raises(ValueError, match="different context"):
+        replace(audit, context=replace(context, name="different"))
+
+
+def test_empty_audit_does_not_load_or_run_models():
+    with patch("vaxrank.context_audit.audit_pepsickle_inputs") as model:
+        assert audit_sequence_contexts([], pepsickle=True) == ()
+    model.assert_not_called()
+
+
+def test_enzyme_inference_deduplicates_chemistry_without_losing_source_occurrences():
+    enzyme = get_cleavage_model("cpn-basic")
+    context = final_sequence_context(jlf_construct(), **FREE)
+    with patch.object(type(enzyme), "predict", autospec=True, side_effect=type(enzyme).predict) as predict:
+        first, second = audit_sequence_contexts([context, replace(context, name="second")],
+                                                peptidase_predictors=[enzyme])
+    assert predict.call_count == 1
+    assert first.profiles[0].sites == second.profiles[0].sites
+    assert first.profiles[0].peptide.source_id != second.profiles[0].peptide.source_id
+
+
+def test_complete_product_without_placements_is_not_claimed_to_have_no_targets():
+    product = product_fixture()
+    product.construct_placements = ()
+    context = translated_sequence_context(product, DOCUMENTED)
+    assert context.target_mapping_status == "unassessed_no_placements"
+    assert context.targets == ()
+    assert from_native_json(to_native_json(context), SequenceContext) == context
+
+
+def test_multi_gene_cta_viral_product_never_invents_one_antigen_policy():
+    product = product_fixture()
+    first, second = product.construct_placements
+    cta = replace(first.construct.native_antigen, kind="CTA", gene_name="CTA-gene", gene_id="ENSG_CTA")
+    viral = replace(second.construct.native_antigen, kind="viral", gene_name="viral-gene", gene_id="VIRAL_ID",
+                    species="virus", transcript_ids=("VIRAL_TX",), source_identifier="viral_source")
+    product.construct_placements = (replace(first, construct=replace(first.construct, native_antigen=cta)),
+                                    replace(second, construct=replace(second.construct, native_antigen=viral)))
+    audit, = run([translated_sequence_context(product, DOCUMENTED)], RecordingPredictor())
+    assert [(s.kind, s.gene_id, s.species) for s in audit.context.source_antigens] == [
+        ("CTA", "ENSG_CTA", "human"), ("viral", "VIRAL_ID", "virus")]
+    assert audit.context.native_antigen is None and audit.context.construct is None
+    assert from_native_json(to_native_json(audit), SequenceContextAudit) == audit
+
+
+def test_unresolved_mapping_remains_explicit_without_silently_claiming_zero_targets():
+    record = replace(jlf_construct(), mapping_status="unresolved", mapping_reason="No source alignment",
+                     native_start=None, native_end=None, sequence_edits=())
+    context = final_sequence_context(record, **FREE)
+    audit, = run([context], RecordingPredictor())
+    assert context.target_mapping_status == "unresolved"
+    assert audit.mhc_status == audit.profiles[0].status == "unassessed"
+    assert context.source_antigens[0].gene_name == "DYNC1H1"
+
+
+@pytest.mark.parametrize("change", [{"allele": "not-an-allele"}, {"allele": "HLA-A"},
+    {"peptide_length": -1}, {"peptide_length": True}, {"kind": ""}])
+def test_bad_mhc_request_fails_at_input(change):
+    with pytest.raises(ValueError):
+        replace(REQUEST, **change)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -99,7 +99,7 @@ def test_processing_component_probabilities_rejects_out_of_range_span():
 
 def test_processing_component_probabilities_extracts_requested_span():
     c_term, max_internal = processing_component_probabilities(
-        [0.1, 0.2, 0.3, 0.4], start=1, length=3)
+        [0.1, 0.2, 0.3, 0.4, 0.0], start=1, length=3)
 
     assert c_term == 0.4
     assert max_internal == 0.3
@@ -594,12 +594,12 @@ def test_re_location_picks_closest_to_declared_offset():
     # Source has 'AAAAA' at offsets 0 and 8. Declared offset says
     # the peptide is the second occurrence; re-location should snap
     # to position 8, not position 0.
-    source = "AAAAA" + "BBB" + "AAAAA"  # length 13
+    source = "AAAAA" + "BBB" + "AAAAA" + "G"  # final G keeps the requested bond internal
     pred = _ep("AAAAA", source, offset=7)  # off-by-one near the second occurrence
     # probs distinguish position 0 (low cleavage) from position 12 (high)
     probs = [0.0, 0.0, 0.0, 0.0, 0.0,
              0.0, 0.0, 0.0,
-             0.0, 0.0, 0.0, 0.0, 0.95]  # cleavage at last position only
+             0.0, 0.0, 0.0, 0.0, 0.95, 0.0]  # cleavage after the second occurrence
     n, by_key = annotate_processing(
         [pred], predictor=StubPepsickle({source: probs}))
     pp = by_key[(pred.sequence, source, 8, 'pepsickle')]

--- a/tests/test_processing_endpoints.py
+++ b/tests/test_processing_endpoints.py
@@ -1,0 +1,66 @@
+"""Sequence-end sentinels are not cleavage probabilities (#434)."""
+
+from dataclasses import asdict, replace
+
+import pytest
+
+from vaxrank.native_serialization import from_native_json, to_native_json
+from vaxrank.processing import annotate_processing, processing_component_probabilities
+from vaxrank.processing_prediction import ProcessingPrediction
+from vaxrank.report import TemplateDataCreator, make_ascii_report, make_html_report
+
+from .test_processing import StubPepsickle, _ep
+
+
+@pytest.mark.parametrize("sentinel", [0.0, .95])
+def test_endpoint_retains_internal_evidence_but_no_cleavage_or_composite(sentinel, tmp_path):
+    source, peptide = "GKRFHATISFDTDTGLKQALETKK", "LKQALETKK"
+    scores = [.2] * len(source)
+    scores[17], scores[-1] = .9177, sentinel
+    epitope = _ep(peptide, source, 15)
+    n, records = annotate_processing([epitope], predictor=StubPepsickle({source: scores}))
+    record, = records.values()
+    assert n == 1
+    assert record.c_boundary_status == "sequence_endpoint"
+    assert record.c_term_cleavage_prob is None and record.processing_score is None
+    assert record.max_internal_cut_prob == .9177
+    restored = from_native_json(to_native_json(record), ProcessingPrediction)
+    assert restored == record and restored.c_boundary_status == "sequence_endpoint"
+    assert asdict(restored)["processing_score"] is None
+    assert asdict(restored)["c_boundary_status"] == "sequence_endpoint"
+    creator = TemplateDataCreator.__new__(TemplateDataCreator)
+    creator.processing_predictions_by_key = records
+    row = creator.epitope_data(epitope, epitope.best_affinity(), include_processing=True)
+    assert row["Processing: C-term"] == "sequence endpoint"
+    assert row["Processing: max internal"] == "0.92"
+    assert row["Processing: combined"] == "—"
+    # Exercise the actual report templates, not just the Python row mapping.
+    template_data = dict(patient_info={}, package_versions={}, args=[], vaccine_constructions={},
+        variants=[dict(num=1, short_description="endpoint regression", variant_data={}, effect_data={},
+            peptides=[dict(header_display_data={}, peptide_data={}, epitopes=[row],
+                           ascii_epitopes=" | ".join(map(str, row.values())))])])
+    for write, suffix in ((make_ascii_report, "txt"), (make_html_report, "html")):
+        path = tmp_path / ("endpoint." + suffix)
+        write(template_data, path)
+        assert "sequence endpoint" in path.read_text()
+
+
+def test_actual_internal_zero_remains_zero_and_single_residue_endpoint_is_missing():
+    assert processing_component_probabilities([.1, 0., .9, 0.], 0, 2) == (0., .1)
+    assert processing_component_probabilities([0.], 0, 1) == (None, 0.)
+
+
+@pytest.mark.parametrize("scores", [[.1] * 8, [.1] * 10, [float("nan")] * 9, [1.1] * 9])
+def test_invalid_length_or_probabilities_cannot_turn_endpoint_into_a_real_bond(scores, caplog):
+    source = "KLMNPVGGG"
+    assert annotate_processing([_ep("KLMNPV", source, 0)], predictor=StubPepsickle({source: scores})) == (0, {})
+    assert "Invalid cleavage output" in caplog.text
+
+
+@pytest.mark.parametrize("change", [{"peptide_offset": -1}, {"peptide_sequence": "AAA"},
+    {"c_term_cleavage_prob": 0.}, {"processing_score": 0.}, {"c_boundary_status": "observed"},
+    {"max_internal_cut_prob": float("nan")}, {"max_internal_cut_prob": 2.}])
+def test_native_endpoint_record_cannot_silently_assert_inconsistent_evidence(change):
+    record = ProcessingPrediction("KLM", "GKLM", "pepsickle", 1, max_internal_cut_prob=.2)
+    with pytest.raises(ValueError):
+        replace(record, **change)

--- a/tests/test_processing_occurrences.py
+++ b/tests/test_processing_occurrences.py
@@ -60,7 +60,7 @@ def test_resolved_occurrence_is_shared_between_annotation_and_report(offset):
     creator.processing_predictions_by_key = records
     row = creator.epitope_data(
         epitope, epitope.best_affinity(), include_processing=True)
-    assert row["Processing: C-term"] == ("0.20" if resolved == 0 else "0.90")
+    assert row["Processing: C-term"] == ("0.20" if resolved == 0 else "sequence endpoint")
 
 
 def test_one_occurrence_can_share_processing_across_alleles():

--- a/vaxrank/__init__.py
+++ b/vaxrank/__init__.py
@@ -55,6 +55,12 @@ from .cleavage_profile import (
 )
 from .cleavage_inference import audit_pepsickle_inputs, audit_peptidase_inputs
 from .cleavage_report import write_cleavage_profiles
+from .sequence_context import (
+    ContextTarget, SequenceContext, final_sequence_context,
+    native_sequence_context, translated_sequence_context,
+)
+from .context_audit import MHCRequest, ContextLigand, SequenceContextAudit, audit_sequence_contexts
+from .context_report import write_sequence_context_audits
 from .vaccine_library import antigen_construct_name, select_antigen_window
 from .safety_assessment import (
     AntigenSafetyAssessment,
@@ -155,6 +161,16 @@ __all__ = [
     "audit_pepsickle_inputs",
     "audit_peptidase_inputs",
     "write_cleavage_profiles",
+    "ContextTarget",
+    "SequenceContext",
+    "MHCRequest",
+    "ContextLigand",
+    "SequenceContextAudit",
+    "final_sequence_context",
+    "native_sequence_context",
+    "translated_sequence_context",
+    "audit_sequence_contexts",
+    "write_sequence_context_audits",
     "__version__",
     "ConstructChemicalModification",
     "ConstructEvidence",

--- a/vaxrank/context_audit.py
+++ b/vaxrank/context_audit.py
@@ -1,0 +1,277 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Unfiltered MHC and site evidence for complete, source-aware contexts."""
+
+from dataclasses import dataclass, field, replace
+import mhctools
+from mhctools.cleavage import CleavageInput, CleavageModel
+from serializable import DataclassSerializable
+from topiary import TopiaryPredictor
+
+from .cleavage_inference import audit_pepsickle_inputs, audit_peptidase_inputs
+from .cleavage_profile import CleavageProfile
+from .allele_validation import parse_prediction_allele, validate_prediction_allele, validate_prediction_frame
+from .safety_assessment import SafetyPrediction, prediction_occurrences_from_frame
+from .sequence_context import SequenceContext
+
+
+@dataclass(frozen=True)
+class MHCRequest(DataclassSerializable):
+    """One explicitly requested model/kind/HLA/length, not observed coverage."""
+
+    kind: str
+    predictor_name: str
+    predictor_version: str
+    allele: str
+    peptide_length: int
+
+    def __post_init__(self):
+        if any(not isinstance(v, str) or not v for v in (
+                self.kind, self.predictor_name, self.predictor_version, self.allele)):
+            raise ValueError("MHC request needs complete model/kind/allele identity")
+        if type(self.peptide_length) is not int or self.peptide_length < 1:
+            raise ValueError("MHC request peptide length must be a positive integer")
+        validate_prediction_allele(self.kind, self.allele, "MHC request")
+        object.__setattr__(self, "allele", parse_prediction_allele(self.allele))
+
+    @property
+    def identity(self):
+        return (self.kind, self.predictor_name, self.predictor_version, self.allele)
+
+
+@dataclass(frozen=True)
+class ContextLigand(DataclassSerializable):
+    """Every model observation for one exact ligand occurrence."""
+
+    peptide: str
+    start: int
+    predictions: tuple[SafetyPrediction, ...]
+
+    def __post_init__(self):
+        object.__setattr__(self, "predictions", tuple(self.predictions))
+        if (not isinstance(self.peptide, str) or not self.peptide
+                or type(self.start) is not int or self.start < 0
+                or not self.predictions
+                or any(not isinstance(p, SafetyPrediction) for p in self.predictions)):
+            raise ValueError("Context ligand requires exact coordinates and typed predictions")
+        if len({p.identity for p in self.predictions}) != len(self.predictions):
+            raise ValueError("Duplicate prediction identity for one context ligand")
+
+    @property
+    def end(self):
+        return self.start + len(self.peptide)
+
+
+@dataclass(frozen=True)
+class SequenceContextAudit(DataclassSerializable):
+    """Exact inference graph, with missing combinations derived from requests.
+
+    This is an evidence inventory, not ranking, historical selection agreement,
+    a self-safety verdict, or proof of cleavage/presentation. Individual-source
+    self assessments remain available via ``audit_construct_sequence``.
+    """
+
+    context: SequenceContext
+    profiles: tuple[CleavageProfile, ...] = field(default_factory=tuple)
+    mhc_status: str = "unassessed"
+    mhc_requests: tuple[MHCRequest, ...] = field(default_factory=tuple)
+    ligands: tuple[ContextLigand, ...] = field(default_factory=tuple)
+    reason_codes: tuple[str, ...] = ("mhc_predictor_not_requested",)
+    error_message: str = ""
+    mhc_backend_version: str = ""
+
+    def __post_init__(self):
+        for name in ("profiles", "mhc_requests", "ligands", "reason_codes"):
+            object.__setattr__(self, name, tuple(getattr(self, name)))
+        self.validate()
+
+    def validate(self):
+        if not isinstance(self.context, SequenceContext):
+            raise ValueError("Context audit requires a typed sequence context")
+        self.context.validate()
+        if (any(not isinstance(p, CleavageProfile) for p in self.profiles)
+                or any(not isinstance(r, MHCRequest) for r in self.mhc_requests)
+                or any(not isinstance(ligand, ContextLigand) for ligand in self.ligands)):
+            raise ValueError("Context evidence requires typed profiles, requests and ligands")
+        if len(set(self.mhc_requests)) != len(self.mhc_requests):
+            raise ValueError("Duplicate MHC request")
+        if len({(p.model, p.settings) for p in self.profiles}) != len(self.profiles):
+            raise ValueError("Duplicate cleavage model/settings in one context")
+        for profile in self.profiles:
+            sequence_only = dict(profile.settings).get("input_scope") == "sequence_context_only"
+            if sequence_only and (self.context.n_term != "unknown" or self.context.c_term != "unknown"
+                                  or not self.context.is_sequence_context):
+                raise ValueError("Invalid sequence-only processing chemistry assumption")
+            if profile.peptide != self.context.cleavage_input(sequence_only=sequence_only):
+                raise ValueError("Cleavage evidence belongs to a different context")
+            if self.context.prediction_unassessed_reason and profile.sites:
+                raise ValueError("Unsupported context cannot claim sequence-model observations")
+        if self.mhc_status not in {"unassessed", "failed", "no_predictions", "predictions_returned"}:
+            raise ValueError("Unknown context MHC status")
+        if bool(self.ligands) != (self.mhc_status == "predictions_returned"):
+            raise ValueError("Context MHC status disagrees with ligand inventory")
+        if self.mhc_status != "predictions_returned" and not self.reason_codes:
+            raise ValueError("Missing MHC evidence requires an explanation")
+        if self.mhc_status == "failed" and not self.error_message:
+            raise ValueError("Failed MHC inference requires an error")
+        if self.mhc_status in {"predictions_returned", "no_predictions"} and not self.mhc_requests:
+            raise ValueError("MHC inference must retain explicit requested coverage")
+        if self.context.prediction_unassessed_reason and self.ligands:
+            raise ValueError("Unsupported context cannot claim sequence-model MHC observations")
+        if any(not isinstance(r, str) or not r for r in self.reason_codes):
+            raise ValueError("Context reasons must be nonempty text")
+        if len({(ligand.peptide, ligand.start) for ligand in self.ligands}) != len(self.ligands):
+            raise ValueError("Duplicate context ligand occurrence")
+        for ligand in self.ligands:
+            if self.context.sequence[ligand.start:ligand.end] != ligand.peptide:
+                raise ValueError("MHC ligand does not match its exact context")
+
+    @property
+    def coverage(self):
+        """Each requested combination, including every missing occurrence offset."""
+        observed = {}
+        for ligand in self.ligands:
+            for prediction in ligand.predictions:
+                observed.setdefault((prediction.identity, len(ligand.peptide)), set()).add(ligand.start)
+        return tuple((request, tuple(sorted(observed.get(
+            (request.identity, request.peptide_length), set()))),
+            tuple(start for start in range(max(0, len(self.context.sequence) - request.peptide_length + 1))
+                  if start not in observed.get((request.identity, request.peptide_length), set())))
+            for request in self.mhc_requests)
+
+    @property
+    def unrequested_predictions(self):
+        requested = {(r.identity, r.peptide_length) for r in self.mhc_requests}
+        return tuple((ligand, prediction) for ligand in self.ligands for prediction in ligand.predictions
+                     if (prediction.identity, len(ligand.peptide)) not in requested)
+
+    def overlays(self, profile):
+        """Target masks and all returned ligands, never a best-only subset."""
+        if profile not in self.profiles:
+            raise ValueError("Overlay profile is not part of this context audit")
+        targets = tuple((target, profile.interval_evidence(target.start, target.end))
+                        for target in self.context.targets)
+        ligands = tuple((ligand, tuple(t for t in self.context.targets if t.overlaps(ligand.start, ligand.end)),
+                         profile.interval_evidence(ligand.start, ligand.end)) for ligand in self.ligands)
+        return {"targets": targets, "ligands": ligands}
+
+
+def _mhc_inventories(contexts, predictor, requests):
+    if predictor is None:
+        return tuple(dict(mhc_requests=requests) for _ in contexts)
+    if not requests:
+        raise ValueError("MHC prediction requires explicit model/HLA/length requests")
+    from topiary import __version__ as topiary_version
+    backend = f"topiary={topiary_version};mhctools={mhctools.__version__}"
+    # Batch unique sequences, then reattach each complete occurrence's source
+    # graph. Sharing raw inference never equates different manufacturing records.
+    sequences = tuple(dict.fromkeys(c.sequence for c in contexts if not c.prediction_unassessed_reason))
+    names = {sequence: f"context_{i}" for i, sequence in enumerate(sequences)}
+    frames, batch_error = {}, None
+    if sequences:
+        try:
+            model = predictor if isinstance(predictor, TopiaryPredictor) else TopiaryPredictor(models=[predictor])
+            frame = model.predict_from_named_sequences({names[s]: s for s in sequences})
+            if frame is None or not frame.columns.is_unique:
+                raise ValueError("MHC output is missing or has duplicate columns")
+            validate_prediction_frame(frame, "Context MHC output")
+            if not frame.empty:
+                if not set(frame["source_sequence_name"]) <= set(names.values()):
+                    raise ValueError("MHC output includes an unrequested source")
+                frames = {s: frame[frame["source_sequence_name"] == names[s]] for s in sequences}
+            else:
+                frames = {s: frame for s in sequences}
+        except Exception as error:
+            batch_error = str(error) or type(error).__name__
+    results = []
+    for context in contexts:
+        common = dict(mhc_requests=requests, mhc_backend_version=backend)
+        reason = context.prediction_unassessed_reason
+        if reason:
+            result = dict(mhc_status="unassessed", reason_codes=(reason,))
+        elif batch_error:
+            result = dict(mhc_status="failed", reason_codes=("mhc_prediction_failed",), error_message=batch_error)
+        else:
+            try:
+                groups, _ = prediction_occurrences_from_frame(
+                    frames[context.sequence], context.sequence, expected_source_name=names[context.sequence])
+                ligands = tuple(ContextLigand(peptide, start, tuple(group["predictions"]))
+                                for (peptide, start), group in sorted(groups.items(), key=lambda item: item[0][1]))
+                result = dict(mhc_status="predictions_returned" if ligands else "no_predictions", ligands=ligands,
+                              reason_codes=() if ligands else ("no_predictions_emitted",))
+            except (TypeError, ValueError, RuntimeError) as error:
+                result = dict(mhc_status="failed", reason_codes=("invalid_mhc_output",), error_message=str(error))
+        results.append(dict(common, **result))
+    return tuple(results)
+
+
+def audit_sequence_contexts(contexts, *, mhc_predictor=None, mhc_requests=(),
+                            pepsickle=False, human_only=False, threshold=.5,
+                            peptidase_predictors=()):
+    """Inventory whole-context evidence without changing selection or ranking.
+
+    Pepsickle native/product inputs are explicitly sequence-context-only. Enzyme
+    rules cannot interpret reconstructed-window edges as molecular termini.
+    Final peptide chemistry defaults unknown; free termini require a recorded
+    conditional or documented basis. Other chemistry is not silently stripped.
+    """
+    contexts, requests, enzymes = tuple(contexts), tuple(mhc_requests), tuple(peptidase_predictors)
+    if any(not isinstance(c, SequenceContext) for c in contexts):
+        raise ValueError("Audit requires typed sequence contexts")
+    if any(not isinstance(r, MHCRequest) for r in requests) or len(set(requests)) != len(requests):
+        raise ValueError("Audit requires distinct typed MHC requests")
+    for context in contexts:
+        context.validate()
+    for enzyme in enzymes:
+        if not isinstance(getattr(enzyme, "model", None), CleavageModel):
+            raise ValueError("Enzyme requires canonical mhctools model metadata")
+    if not contexts:
+        return ()
+    profiles = [[] for _ in contexts]
+    if pepsickle:
+        # No clinical chemistry claim is made for native/translated context.
+        sequence_only = tuple(c.is_sequence_context and not c.prediction_unassessed_reason
+                              and c.n_term == c.c_term == "unknown" for c in contexts)
+        inputs = tuple(c.cleavage_input(sequence_only=only) for c, only in zip(contexts, sequence_only))
+        eligible = [i for i, c in enumerate(contexts) if not c.prediction_unassessed_reason]
+        returned = audit_pepsickle_inputs([inputs[i] for i in eligible], human_only=human_only, threshold=threshold)
+        for i, profile in zip(eligible, returned):
+            if sequence_only[i]:
+                profile = replace(profile, settings=profile.settings + (("input_scope", "sequence_context_only"),),
+                                  reason_codes=profile.reason_codes + ("molecular_termini_not_established",))
+            profiles[i].append(profile)
+        # An unsupported construct must still show the requested model as missing.
+        if len(eligible) != len(contexts):
+            from .cleavage_inference import _pepsickle_model_identity
+            model, digest, error = _pepsickle_model_identity(human_only)
+            for i, c in enumerate(contexts):
+                if i not in eligible:
+                    profiles[i].append(CleavageProfile(inputs[i], model, "unassessed",
+                        reason_codes=(c.prediction_unassessed_reason,), model_asset_sha256=digest,
+                        error_message=error, backend_version=mhctools.__version__))
+    for enzyme in enzymes:
+        by_input, pending = {}, []
+        for i, context in enumerate(contexts):
+            peptide = context.cleavage_input()
+            reason = context.prediction_unassessed_reason
+            if reason is None and context.kind == "native_context":
+                reason = "native_window_molecular_termini_unestablished"
+            if reason is None and context.kind == "final_construct" and context.construct.modality != "peptide":
+                reason = "encoded_segment_molecular_termini_unestablished"
+            if reason:
+                profiles[i].append(CleavageProfile(peptide, enzyme.model, "unassessed",
+                    reason_codes=(reason,), backend_version=mhctools.__version__))
+            else:
+                # Source metadata cannot change the native enzyme prediction.
+                # Score each chemistry/sequence once, then restore occurrences.
+                key = CleavageInput(peptide.sequence, n_term=peptide.n_term, c_term=peptide.c_term)
+                by_input.setdefault(key, None)
+                pending.append((i, peptide, key))
+        if by_input:
+            by_input = dict(zip(by_input, audit_peptidase_inputs(by_input, enzyme)))
+            for i, peptide, key in pending:
+                profiles[i].append(replace(by_input[key], peptide=peptide))
+    inventories = _mhc_inventories(contexts, mhc_predictor, requests)
+    return tuple(SequenceContextAudit(context, profiles=tuple(evidence), **inventory)
+                 for context, evidence, inventory in zip(contexts, profiles, inventories))

--- a/vaxrank/context_report.py
+++ b/vaxrank/context_report.py
@@ -1,0 +1,58 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Whole-context reports with exact-bond, target and all-ligand overlays."""
+
+from pathlib import Path
+
+import jinja2
+from mhctools.pred import value_unit
+
+from .context_audit import SequenceContextAudit
+from .native_serialization import to_native_json
+
+
+def _profile_view(audit, profile):
+    roles = {b: {"target_internal": [], "target_boundary": [], "ligand_internal": [],
+                 "ligand_n": [], "ligand_c": []} for b in range(1, len(audit.context.sequence))}
+    for i, target in enumerate(audit.context.targets, 1):
+        for b in range(target.start + 1, target.end):
+            roles[b]["target_internal"].append(i)
+        for b in {target.start, target.end}:
+            if b in roles:
+                roles[b]["target_boundary"].append(i)
+    for i, ligand in enumerate(audit.ligands, 1):
+        for b in range(ligand.start + 1, ligand.end):
+            roles[b]["ligand_internal"].append(i)
+        if ligand.start in roles:
+            roles[ligand.start]["ligand_n"].append(i)
+        if ligand.end in roles:
+            roles[ligand.end]["ligand_c"].append(i)
+    return {"profile": profile, "sites": {s.bond: s for s in profile.sites}, "roles": roles}
+
+
+def write_sequence_context_audits(audits, *, json_path, html_path=None):
+    """Export full native graphs plus explicitly derived coverage and overlays.
+
+    The JSON object has ``audits``, ``coverage`` and ``overlays`` entries, each
+    round-trippable through the allowlisted native serializer. Derived entries
+    are conveniences, never a replacement for original source/model records.
+    """
+    audits = tuple(audits)
+    for audit in audits:
+        if not isinstance(audit, SequenceContextAudit):
+            raise ValueError("Context report requires typed sequence audits")
+        audit.validate()
+    payload = to_native_json({
+        "audits": audits, "coverage": tuple(a.coverage for a in audits),
+        "overlays": tuple(tuple(a.overlays(p) for p in a.profiles) for a in audits)})
+    rendered = None
+    if html_path is not None:
+        environment = jinja2.Environment(
+            loader=jinja2.PackageLoader("vaxrank", "templates"),
+            autoescape=jinja2.select_autoescape(("html", "xml")))
+        records = tuple({"audit": a, "profiles": tuple(_profile_view(a, p) for p in a.profiles)} for a in audits)
+        rendered = environment.get_template("sequence_context_audit.html").render(records=records, value_unit=value_unit)
+    Path(json_path).write_text(payload, encoding="utf8")
+    if rendered is not None:
+        Path(html_path).write_text(rendered, encoding="utf8")

--- a/vaxrank/mrna.py
+++ b/vaxrank/mrna.py
@@ -1001,6 +1001,26 @@ def _validate_output_dir(output_dir):
             "(e.g. drop the .fasta suffix)." % output_dir)
 
 
+def validate_translated_construct(construct):
+    """Check complete CDS translation, placements and all emitted nt views."""
+    from Bio.Data.CodonTable import TranslationError
+    from Bio.Seq import Seq
+
+    validate_construct_placements(construct.construct_placements, construct.cds_aa, "mrna")
+    try:
+        translated = str(Seq(construct.cds_nt).translate(cds=True))
+    except TranslationError as error:
+        raise ValueError("Construct provenance requires a complete valid CDS") from error
+    if translated != construct.cds_aa:
+        raise ValueError("Encoded construct provenance disagrees with actual CDS translation")
+    utr_5p = construct.elements.get('utr_5p', {}).get('nt', '')
+    utr_3p = construct.elements.get('utr_3p', {}).get('nt', '')
+    if (construct.no_polya_nt != utr_5p + construct.cds_nt + utr_3p
+            or construct.full_nt != construct.no_polya_nt + construct.poly_a_nt
+            or construct.sequence != construct.full_nt):
+        raise ValueError("Construct provenance disagrees with emitted full mRNA sequence")
+
+
 def write_mrna_outputs(constructs, output_dir, manifest_path=None,
                        csv_path=None, csv_include_full_rows=True):
     """Write three FASTAs (cds / full / no_polyA) + optional manifest + CSV.
@@ -1038,21 +1058,7 @@ def write_mrna_outputs(constructs, output_dir, manifest_path=None,
     for c in constructs:
         validate_construct_placements(c.construct_placements, c.cds_aa, "mrna")
         if c.construct_placements:
-            from Bio.Data.CodonTable import TranslationError
-            from Bio.Seq import Seq
-
-            try:
-                translated = str(Seq(c.cds_nt).translate(cds=True))
-            except TranslationError as error:
-                raise ValueError("Construct provenance requires a complete valid CDS") from error
-            if translated != c.cds_aa:
-                raise ValueError("Encoded construct provenance disagrees with actual CDS translation")
-            utr_5p = c.elements.get('utr_5p', {}).get('nt', '')
-            utr_3p = c.elements.get('utr_3p', {}).get('nt', '')
-            if (c.no_polya_nt != utr_5p + c.cds_nt + utr_3p
-                    or c.full_nt != c.no_polya_nt + c.poly_a_nt
-                    or c.sequence != c.full_nt):
-                raise ValueError("Construct provenance disagrees with emitted full mRNA sequence")
+            validate_translated_construct(c)
     _validate_output_dir(output_dir)
     os.makedirs(output_dir, exist_ok=True)
 

--- a/vaxrank/native_serialization.py
+++ b/vaxrank/native_serialization.py
@@ -44,6 +44,10 @@ def _native_serializable_classes():
     )
     from .construct_audit import ConstructAudit
     from .cleavage_profile import CleavageProfile, CleavageIntervalEvidence
+    from .processing_prediction import ProcessingPrediction
+    from .mrna import RNAConstruct
+    from .sequence_context import ContextTarget, SequenceContext
+    from .context_audit import MHCRequest, ContextLigand, SequenceContextAudit
     from .safety_assessment import (
         ConstructBoundary,
         EmittedSafetyLigand,
@@ -70,6 +74,13 @@ def _native_serializable_classes():
         ("mhctools.cleavage", "CleavageSite"): CleavageSite,
         ("vaxrank.cleavage_profile", "CleavageProfile"): CleavageProfile,
         ("vaxrank.cleavage_profile", "CleavageIntervalEvidence"): CleavageIntervalEvidence,
+        ("vaxrank.processing_prediction", "ProcessingPrediction"): ProcessingPrediction,
+        ("vaxrank.mrna", "RNAConstruct"): RNAConstruct,
+        ("vaxrank.sequence_context", "ContextTarget"): ContextTarget,
+        ("vaxrank.sequence_context", "SequenceContext"): SequenceContext,
+        ("vaxrank.context_audit", "MHCRequest"): MHCRequest,
+        ("vaxrank.context_audit", "ContextLigand"): ContextLigand,
+        ("vaxrank.context_audit", "SequenceContextAudit"): SequenceContextAudit,
         ("vaxrank.allele_evidence", "AlleleAttribution"): AlleleAttribution,
         ("vaxrank.candidate_epitope", "CandidateEpitope"): CandidateEpitope,
         ("vaxrank.candidate_epitope", "Peptide"): Peptide,

--- a/vaxrank/processing.py
+++ b/vaxrank/processing.py
@@ -72,10 +72,12 @@ Issue: openvax/vaxrank#249.
 """
 
 import logging
+import math
 
 from mhctools.processing_predictor import ProcessingPredictor
 
 from .processing_prediction import ProcessingPrediction
+from .cleavage_profile import _residue_scores
 
 logger = logging.getLogger(__name__)
 
@@ -102,12 +104,15 @@ PEPSICKLE_PREDICTOR_NAME = 'pepsickle'
 def processing_component_probabilities(seq_probs, start, length):
     """Return ``(c_term, max_internal)`` for a peptide at
     ``seq_probs[start:start+length]``, or ``(None, None)`` when the
-    span doesn't fit. Both components come straight from the public
-    mhctools helpers — we just guard the array bounds.
+    span doesn't fit. The final residue output is a sequence-end sentinel,
+    not an actual C-boundary bond. At that endpoint return ``None`` for the
+    C-boundary while retaining internal-bond evidence. The source can be a
+    cropped context; this does not establish an exposed molecular terminus.
     """
     if length < 1 or start < 0 or start + length > len(seq_probs):
         return None, None
-    c_term = float(ProcessingPredictor.c_term_prob(seq_probs, start, length))
+    c_term = (None if start + length == len(seq_probs) else
+              float(ProcessingPredictor.c_term_prob(seq_probs, start, length)))
     max_internal = float(
         ProcessingPredictor.max_internal_prob(seq_probs, start, length))
     return c_term, max_internal
@@ -260,7 +265,12 @@ def annotate_processing(epitopes, predictor=None,
     skipped_examples = []
     for source, epis in by_source.items():
         seq_probs = probs_by_source.get(source)
-        if not seq_probs or len(seq_probs) < len(source):
+        if seq_probs is None:
+            continue
+        try:
+            seq_probs = _residue_scores(seq_probs, len(source))
+        except (TypeError, ValueError) as error:
+            logger.warning("Invalid cleavage output for source %r: %s", source, error)
             continue
         for e in epis:
             peptide = e.sequence or ''
@@ -274,20 +284,19 @@ def annotate_processing(epitopes, predictor=None,
                 continue
             c_term, max_internal = processing_component_probabilities(
                 seq_probs, offset, len(peptide))
-            if c_term is None:
+            if max_internal is None:
                 continue
             # Composite score is the **geometric mean** of the two
             # factors — ``sqrt(c_term * (1 - max_internal))``. Range
-            # [0, 1]; 1 = ideal release, 0 = no clean release OR
-            # near-certain internal destruction. Geometric mean
+            # [0, 1], not a calibrated probability of release,
+            # destruction or presentation. Geometric mean
             # penalizes both factors symmetrically and is more
             # forgiving than the raw product when one factor is
             # mid-range, which better matches the "credibility tag"
             # reading: a peptide with c_term=0.6 and (1 -
             # max_internal)=0.6 should score ~0.6, not 0.36.
-            import math
             anti_max = max(0.0, 1.0 - max_internal)
-            processing_score = math.sqrt(c_term * anti_max)
+            processing_score = None if c_term is None else math.sqrt(c_term * anti_max)
             # Build the canonical ProcessingPrediction record (the
             # post-2.22 source of truth — keyed on
             # ``(peptide, source, peptide_offset, predictor_name)`` so future

--- a/vaxrank/processing_prediction.py
+++ b/vaxrank/processing_prediction.py
@@ -32,6 +32,8 @@ Issue: openvax/vaxrank#272.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
+from numbers import Real
 from typing import Optional
 
 
@@ -42,8 +44,9 @@ class ProcessingPrediction:
 
     The composite ``processing_score`` is the geometric mean of
     ``c_term_cleavage_prob`` and ``(1 - max_internal_cut_prob)`` —
-    bounded [0, 1], 1 = ideal release, 0 = no clean release OR
-    near-certain internal destruction. Geometric mean rather than
+    bounded [0, 1] but not a calibrated probability of release,
+    destruction or presentation. It is unavailable at sequence endpoints.
+    Geometric mean rather than
     raw product so a balanced ``(0.6, 0.6)`` row scores ~0.6
     instead of 0.36.
 
@@ -64,14 +67,14 @@ class ProcessingPrediction:
     predictor_version : Optional[str]
         Predictor version string when the predictor exposes one,
         else ``None``.
-    c_term_cleavage_prob : float
+    c_term_cleavage_prob : Optional[float]
         Probability the proteasome cuts at the ligand's C-terminus
-        (clean release). Range [0, 1].
+        boundary. Range [0, 1]; None at a sequence endpoint. An endpoint
+        may be a cropped window, not an exposed molecular terminus.
     max_internal_cut_prob : float
         Peak cleavage probability strictly inside the ligand
-        (high → ligand is destroyed before reaching MHC). Range
-        [0, 1].
-    processing_score : float
+        (model evidence, not proof of ligand destruction). Range [0, 1].
+    processing_score : Optional[float]
         Composite ``sqrt(c_term_cleavage_prob *
         (1 - max_internal_cut_prob))``.
     """
@@ -81,9 +84,30 @@ class ProcessingPrediction:
     predictor_name: str
     peptide_offset: int
     predictor_version: Optional[str] = None
-    c_term_cleavage_prob: float = 0.0
+    c_term_cleavage_prob: Optional[float] = None
     max_internal_cut_prob: float = 0.0
-    processing_score: float = 0.0
+    processing_score: Optional[float] = None
+    c_boundary_status: str = ""
+
+    def __post_init__(self):
+        end = self.peptide_offset + len(self.peptide_sequence)
+        if (type(self.peptide_offset) is not int or self.peptide_offset < 0
+                or not self.peptide_sequence
+                or self.source_sequence[self.peptide_offset:end] != self.peptide_sequence):
+            raise ValueError("Processing prediction must match its exact source occurrence")
+        status = ("sequence_endpoint" if end == len(self.source_sequence) else
+                  ("observed" if self.c_term_cleavage_prob is not None else "unassessed"))
+        if self.c_boundary_status and self.c_boundary_status != status:
+            raise ValueError("Processing boundary status disagrees with its source occurrence")
+        object.__setattr__(self, "c_boundary_status", status)
+        if status == "sequence_endpoint" and self.c_term_cleavage_prob is not None:
+            raise ValueError("Sequence endpoint cannot claim a C-boundary cleavage probability")
+        if self.c_term_cleavage_prob is None and self.processing_score is not None:
+            raise ValueError("Missing C-boundary evidence cannot produce a composite score")
+        for value in (self.c_term_cleavage_prob, self.max_internal_cut_prob, self.processing_score):
+            if value is not None and (isinstance(value, bool) or not isinstance(value, Real)
+                                      or not math.isfinite(value) or not 0 <= value <= 1):
+                raise ValueError("Processing scores must be finite probabilities in [0, 1] or None")
 
     def key(self) -> tuple:
         """Stable join key used by report writers to look up the

--- a/vaxrank/report.py
+++ b/vaxrank/report.py
@@ -622,7 +622,8 @@ class TemplateDataCreator(object):
                 max_int = pp.max_internal_cut_prob
                 proc = pp.processing_score
             epitope_data['Processing: C-term'] = (
-                '%.2f' % c_term if c_term is not None else '—')
+                'sequence endpoint' if pp is not None and pp.c_boundary_status == 'sequence_endpoint'
+                else ('%.2f' % c_term if c_term is not None else '—'))
             epitope_data['Processing: max internal'] = (
                 '%.2f' % max_int if max_int is not None else '—')
             epitope_data['Processing: combined'] = (

--- a/vaxrank/safety_assessment.py
+++ b/vaxrank/safety_assessment.py
@@ -613,6 +613,48 @@ def assess_antigen_safety(
     )
 
 
+def prediction_occurrences_from_frame(predictions_df, sequence, *, expected_source_name=None):
+    """Validate unfiltered Topiary rows without assuming one antigen or gene.
+
+    Shared by complete-window self assessments and multi-antigen construct
+    audits. Repeated peptides retain every offset; conflicting rows fail closed.
+    """
+    if predictions_df is None:
+        raise SafetyAssessmentError("Prediction frame is missing")
+    if not predictions_df.columns.is_unique:
+        raise SafetyAssessmentError("Prediction frame has duplicate column names")
+    groups, coverage_records = {}, {}
+    for _, row in predictions_df.iterrows():
+        if (expected_source_name is not None
+                and row.get("source_sequence_name") != expected_source_name):
+            raise SafetyAssessmentError("Prediction source does not match the scanned window")
+        peptide = str(row.get("peptide") or "")
+        try:
+            offset = prediction_integer(row.get("peptide_offset"), "Peptide offset")
+            length = prediction_integer(row.get("peptide_length"), "Peptide length")
+            prediction = SafetyPrediction.from_prediction_row(row)
+        except ValueError as error:
+            raise SafetyAssessmentError(str(error)) from error
+        if not peptide or length != len(peptide):
+            raise SafetyAssessmentError("Prediction peptide length does not match its sequence")
+        if offset < 0 or offset + length > len(sequence):
+            raise SafetyAssessmentError("Prediction coordinates lie outside the scanned window")
+        if sequence[offset:offset + length] != peptide:
+            raise SafetyAssessmentError("Prediction peptide does not match the scanned window")
+        group = groups.setdefault((peptide, offset), {"predictions": [], "identities": set()})
+        if prediction.identity in group["identities"]:
+            raise SafetyAssessmentError("Duplicate predictor/kind/allele evidence for one ligand")
+        group["identities"].add(prediction.identity)
+        group["predictions"].append(prediction)
+        key = (prediction.kind, prediction.predictor_name, prediction.predictor_version)
+        coverage = coverage_records.setdefault(
+            key, {"alleles": set(), "peptide_lengths": set(), "count": 0})
+        coverage["alleles"].add(prediction.allele)
+        coverage["peptide_lengths"].add(length)
+        coverage["count"] += 1
+    return groups, coverage_records
+
+
 def safety_assessment_from_prediction_frame(
     predictions_df,
     *,
@@ -653,62 +695,8 @@ def safety_assessment_from_prediction_frame(
             reason_codes=(SAFETY_REASON_NO_PREDICTIONS,),
         )
 
-    groups: dict[tuple[str, int], dict[str, Any]] = {}
-    coverage_records: dict[tuple[str, str, str], dict[str, Any]] = {}
-    for _, row in predictions_df.iterrows():
-        if expected_source_name is not None:
-            observed_source_name = row.get("source_sequence_name")
-            if observed_source_name != expected_source_name:
-                raise SafetyAssessmentError(
-                    "Prediction source does not match the scanned window"
-                )
-        peptide = str(row.get("peptide") or "")
-        try:
-            offset = prediction_integer(row.get("peptide_offset"), "Peptide offset")
-            peptide_length = prediction_integer(
-                row.get("peptide_length"), "Peptide length"
-            )
-        except ValueError as error:
-            raise SafetyAssessmentError(str(error)) from error
-        if peptide_length != len(peptide):
-            raise SafetyAssessmentError(
-                "Prediction peptide length does not match its sequence"
-            )
-        end = offset + peptide_length
-        if offset < 0 or end > len(window_sequence):
-            raise SafetyAssessmentError(
-                "Prediction coordinates lie outside the scanned window"
-            )
-        if window_sequence[offset:end] != peptide:
-            raise SafetyAssessmentError(
-                "Prediction peptide does not match the scanned window"
-            )
-
-        try:
-            prediction = SafetyPrediction.from_prediction_row(row)
-        except ValueError as error:
-            raise SafetyAssessmentError(str(error)) from error
-        key = (peptide, offset)
-        group = groups.setdefault(key, {"predictions": [], "identities": set()})
-        if prediction.identity in group["identities"]:
-            raise SafetyAssessmentError(
-                "Duplicate predictor/kind/allele evidence for one ligand"
-            )
-        group["identities"].add(prediction.identity)
-        group["predictions"].append(prediction)
-
-        coverage_key = (
-            prediction.kind,
-            prediction.predictor_name,
-            prediction.predictor_version,
-        )
-        coverage = coverage_records.setdefault(
-            coverage_key,
-            {"alleles": set(), "peptide_lengths": set(), "count": 0},
-        )
-        coverage["alleles"].add(prediction.allele)
-        coverage["peptide_lengths"].add(peptide_length)
-        coverage["count"] += 1
+    groups, coverage_records = prediction_occurrences_from_frame(
+        predictions_df, window_sequence, expected_source_name=expected_source_name)
 
     ligands = []
     for (peptide, offset), group in groups.items():

--- a/vaxrank/sequence_context.py
+++ b/vaxrank/sequence_context.py
@@ -1,0 +1,170 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Exact native, manufactured and complete translated contexts for auditing."""
+
+from copy import deepcopy
+from dataclasses import dataclass
+import hashlib
+from typing import Optional
+
+from mhctools.cleavage import CleavageInput
+from serializable import DataclassSerializable
+
+from .construct_sequence import ConstructEvidence, ConstructSequence
+from .mrna import RNAConstruct, validate_translated_construct
+from .vaccine_antigen import VaccineAntigen
+
+
+@dataclass(frozen=True)
+class ContextTarget(DataclassSerializable):
+    """A target-mask interval, not an independently documented MHC ligand."""
+
+    source_name: str
+    start: int
+    end: int
+
+    def __post_init__(self):
+        if (not isinstance(self.source_name, str) or not self.source_name
+                or type(self.start) is not int or type(self.end) is not int
+                or not 0 <= self.start <= self.end):
+            raise ValueError("Invalid context target interval")
+
+    def overlaps(self, start, end):
+        if self.start == self.end:
+            return start < self.start < end
+        return start < self.end and self.start < end
+
+
+@dataclass(frozen=True)
+class SequenceContext(DataclassSerializable):
+    """One exact input plus its original source graph; no synthetic antigen.
+
+    Native contexts can be cropped reconstruction windows. Complete translation
+    is a CDS fact, not evidence of a mature protein's termini or localization.
+    Unknown chemistry is the default. A conditional free-terminal analysis needs
+    an explicit ``chemistry_basis`` and does not revise manufacture provenance.
+    """
+
+    name: str
+    kind: str
+    sequence: str
+    native_antigen: Optional[VaccineAntigen] = None
+    construct: Optional[ConstructSequence] = None
+    product: Optional[RNAConstruct] = None
+    evidence: Optional[ConstructEvidence] = None
+    n_term: str = "unknown"
+    c_term: str = "unknown"
+    chemistry_basis: str = ""
+
+    def __post_init__(self):
+        # RNAConstruct is a public mutable assembly record. Snapshot its whole
+        # dataclass, not a hand-maintained subset of fields; revalidate on export.
+        if self.product is not None:
+            object.__setattr__(self, "product", deepcopy(self.product))
+        self.validate()
+
+    def validate(self):
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError("Sequence context name is required")
+        if not isinstance(self.chemistry_basis, str):
+            raise ValueError("Context chemistry basis must be text")
+        CleavageInput(self.sequence, n_term=self.n_term, c_term=self.c_term)
+        if (self.n_term != "unknown" or self.c_term != "unknown") and not self.chemistry_basis:
+            raise ValueError("Terminal chemistry requires an explicit evidence/assumption basis")
+        if self.evidence is not None and not isinstance(self.evidence, ConstructEvidence):
+            raise ValueError("Context evidence must be attributed")
+        if self.kind == "native_context":
+            if (not isinstance(self.native_antigen, VaccineAntigen)
+                    or self.construct is not None or self.product is not None
+                    or self.sequence != self.native_antigen.amino_acids):
+                raise ValueError("Native context must preserve the complete supplied antigen")
+            if self.n_term != "unknown" or self.c_term != "unknown":
+                raise ValueError("Native reconstruction windows do not establish molecular termini")
+        elif self.kind == "final_construct":
+            if (not isinstance(self.construct, ConstructSequence)
+                    or self.native_antigen is not None or self.product is not None
+                    or self.sequence != self.construct.sequence):
+                raise ValueError("Final context must preserve its complete construct")
+        elif self.kind == "translated_product":
+            if (not isinstance(self.product, RNAConstruct) or self.evidence is None
+                    or self.native_antigen is not None or self.construct is not None
+                    or self.sequence != self.product.cds_aa):
+                raise ValueError("Translated context requires its complete attributed RNA product")
+            validate_translated_construct(self.product)
+        else:
+            raise ValueError("Unknown sequence context kind")
+
+    @property
+    def source_id(self):
+        # Same bare sequence may share inference, but never source attribution.
+        from .native_serialization import to_native_json
+        return "sequence-context:" + hashlib.sha256(to_native_json(self).encode()).hexdigest()
+
+    @property
+    def targets(self):
+        if self.kind == "native_context":
+            masks = ((self.name, 0, self.native_antigen.targetable_mask),)
+        elif self.kind == "final_construct":
+            masks = ((self.construct.name, 0, self.construct.targetable_mask),)
+        else:
+            masks = tuple((p.construct.name, p.offset, p.construct.targetable_mask)
+                          for p in self.product.construct_placements)
+        return tuple(ContextTarget(name, shift + interval.start, shift + interval.end)
+                     for name, shift, mask in masks for interval in mask.intervals)
+
+    @property
+    def prediction_unassessed_reason(self):
+        if self.kind == "final_construct":
+            return self.construct.sequence_prediction_unassessed_reason
+        if self.product is not None and any(
+                p.construct.sequence_prediction_unassessed_reason
+                for p in self.product.construct_placements):
+            return "unresolved_construct_placement"
+        return None
+
+    @property
+    def target_mapping_status(self):
+        if self.prediction_unassessed_reason == "unresolved_native_mapping":
+            return "unresolved"
+        if self.product is not None:
+            if not self.product.construct_placements:
+                return "unassessed_no_placements"
+            if any(p.construct.mapping_status != "resolved" for p in self.product.construct_placements):
+                return "unresolved"
+        return "mapped"
+
+    @property
+    def is_sequence_context(self):
+        return self.kind != "final_construct" or self.construct.modality != "peptide"
+
+    @property
+    def source_antigens(self):
+        """All occurrence-specific sources; never choose one gene for a product."""
+        if self.native_antigen is not None:
+            return (self.native_antigen,)
+        if self.construct is not None:
+            return (self.construct.native_antigen,) if self.construct.native_antigen else ()
+        return tuple(p.construct.native_antigen for p in self.product.construct_placements
+                     if p.construct.native_antigen is not None)
+
+    def cleavage_input(self, *, sequence_only=False):
+        # Pepsickle accepts only bare sequence. Free here is an explicit model
+        # input assumption for a context window, NOT exposed peptidase termini.
+        n_term, c_term = ("free", "free") if sequence_only else (self.n_term, self.c_term)
+        return CleavageInput(self.sequence, n_term=n_term, c_term=c_term, source_id=self.source_id)
+
+
+def native_sequence_context(antigen, *, name=None):
+    return SequenceContext(name or antigen.source_identifier or antigen.gene_name or "native",
+                           "native_context", antigen.amino_acids, native_antigen=antigen)
+
+
+def final_sequence_context(construct, **chemistry):
+    return SequenceContext(construct.name, "final_construct", construct.sequence,
+                           construct=construct, **chemistry)
+
+
+def translated_sequence_context(product, evidence, **chemistry):
+    return SequenceContext(product.name, "translated_product", product.cds_aa,
+                           product=product, evidence=evidence, **chemistry)

--- a/vaxrank/templates/sequence_context_audit.html
+++ b/vaxrank/templates/sequence_context_audit.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Full-sequence context audit</title>
+<style>body{font:15px system-ui,sans-serif;margin:2rem;color:#152b35}table{border-collapse:collapse;font-size:13px;width:100%;margin:1rem 0}th,td{border:1px solid #c7d0d5;padding:.35rem;text-align:left;vertical-align:top}th{background:#eef2f3}code{overflow-wrap:anywhere;white-space:pre-wrap}section{border-top:2px solid #36586a;margin-top:2rem}.notice{padding:1rem;background:#fff4d6}.muted{color:#52626a}</style>
+</head><body><h1>Full-sequence context audit</h1>
+<p class="notice">Evidence inventory, not a ranking or clinical safety verdict. Target masks,
+MHC predictions, cleavage observations, independently documented intended ligands and historical
+selection agreement are different facts. This report overlays masks and all returned MHC
+predictions; it does not establish intended-ligand identity, recognition or presentation.</p>
+<p>All intervals are zero-based, half-open [start,end). Bond b separates residues b−1 and b.
+Sequence endpoints 0 and N are not peptide bonds. A native context may be a cropped RNA-backed
+window, not a complete protein or an exposed molecule. A translated product is the complete
+CDS translation, not necessarily its mature processed form.</p>
+<p>Self-source/CTA policy and near-self assessment are not performed here. Use attributed
+construct safety assessments separately; unassessed self evidence is not absence of self ligands.
+No serum half-life, clearance, localization or intact-delivery conclusion is made.</p>
+{% for record in records %}{% set audit=record.audit %}{% set ctx=audit.context %}
+<section><h2>{{ ctx.name }} — {{ ctx.kind }}</h2>
+<p>{{ ctx.sequence|length }} aa; identity <code>{{ ctx.source_id }}</code></p>
+<p><code>{{ ctx.sequence }}</code></p>
+<p>Terminal chemistry: N={{ ctx.n_term }}, C={{ ctx.c_term }}.
+Basis: {{ ctx.chemistry_basis or 'not established' }}. Model assumptions never replace manufacture provenance.</p>
+<p>Target mapping: {{ ctx.target_mapping_status }}.
+{% if ctx.construct %}Manufacture evidence: {{ ctx.construct.evidence }}.
+Native window: [{{ ctx.construct.native_start }},{{ ctx.construct.native_end }}).
+Native residue offsets (None = added/replaced/unresolved): {{ ctx.construct.native_residue_offsets }}.
+Edits: {{ ctx.construct.sequence_edits }}. Chemical modifications: {{ ctx.construct.chemical_modifications }}.
+Removed target intervals: {{ ctx.construct.removed_target_intervals }}.{% endif %}</p>
+{% if ctx.product %}<p>Complete CDS and emitted nucleotide views validated. Evidence: {{ ctx.evidence }}.</p>
+<details><summary>Complete translated product and nucleotide provenance</summary>
+<p>CDS nt: <code>{{ ctx.product.cds_nt }}</code></p><p>Full nt: <code>{{ ctx.product.full_nt }}</code></p>
+<p>Elements: {{ ctx.product.elements }}</p><p>All construct placements: {{ ctx.product.construct_placements }}</p></details>{% endif %}
+<h3>Source provenance — every occurrence retained</h3>
+<table><tr><th>Kind</th><th>Gene / ID</th><th>Transcripts / proteins</th><th>Species / source</th></tr>
+{% for source in ctx.source_antigens %}<tr><td>{{ source.kind }}</td><td>{{ source.gene_name }} / {{ source.gene_id }}</td>
+<td>{{ source.transcript_ids|join(', ') }} / {{ source.protein_ids|join(', ') }}</td><td>{{ source.species }} / {{ source.source_identifier }}</td></tr>
+{% else %}<tr><td colspan="4">Source provenance unassessed</td></tr>{% endfor %}</table>
+<h3>Target masks</h3><table><tr><th>ID</th><th>Source</th><th>Interval</th><th>Sequence / junction</th></tr>
+{% for target in ctx.targets %}<tr><td>T{{ loop.index }}</td><td>{{ target.source_name }}</td><td>[{{ target.start }},{{ target.end }})</td>
+<td><code>{{ ctx.sequence[target.start:target.end] or 'zero-width target junction' }}</code></td></tr>
+{% else %}<tr><td colspan="4">No mapped target intervals; see mapping status above.</td></tr>{% endfor %}</table>
+<h3>Patient-MHC inventory: {{ audit.mhc_status }}</h3>
+<p>{{ audit.reason_codes|join(', ') }} {{ audit.error_message }} {{ audit.mhc_backend_version }}</p>
+<p>Coverage refers only to the explicit requests below, not all patient alleles or all models.
+Unrequested class II or other combinations remain unassessed. A returned row is not necessarily
+a strong binder. All output is retained without ranking or immunogenicity filters.</p>
+<table><tr><th>Kind / model / version</th><th>Allele / length</th><th>Observed offsets</th><th>Missing offsets</th></tr>
+{% for req, observed, missing in audit.coverage %}<tr><td>{{ req.kind }} / {{ req.predictor_name }} / {{ req.predictor_version }}</td>
+<td>{{ req.allele }} / {{ req.peptide_length }}</td><td>{{ observed }}</td><td>{{ missing }}{% if req.peptide_length > ctx.sequence|length %} (no fitting windows){% endif %}</td></tr>
+{% else %}<tr><td colspan="4">Requested MHC coverage unassessed</td></tr>{% endfor %}</table>
+{% if audit.unrequested_predictions %}<p class="notice">{{ audit.unrequested_predictions|length }} unrequested model/HLA/length outputs retained; check request provenance.</p>{% endif %}
+<table><tr><th>ID / interval / peptide</th><th>Target-mask overlaps</th><th>Every model observation (native scales)</th></tr>
+{% for ligand in audit.ligands %}<tr><td>L{{ loop.index }} [{{ ligand.start }},{{ ligand.end }}) <code>{{ ligand.peptide }}</code></td>
+<td>{% for target in ctx.targets %}{% if target.overlaps(ligand.start,ligand.end) %}T{{ loop.index }} {% endif %}{% endfor %}</td>
+<td>{% for pred in ligand.predictions %}{{ pred.kind }} / {{ pred.allele }} / {{ pred.predictor_name }} {{ pred.predictor_version }}:
+score={{ pred.score }}, value={{ pred.value }} {{ value_unit(pred.kind) or '(unitless/no linear unit)' }}, percentile={{ pred.percentile_rank }}<br>{% endfor %}</td></tr>
+{% else %}<tr><td colspan="3">No ligand observations; see status and missing coverage above.</td></tr>{% endfor %}</table>
+<h3>Full-sequence processing evidence</h3>
+<p>Proteasomal, other cytosolic, ER, endolysosomal and extracellular/serum evidence remain
+separate. Only the model/bond observations below were assessed. Other models and compartments
+remain unassessed. An enzyme compartment annotation does not establish matrix calibration or
+delivery into that compartment. Motif non-match is not resistance; native scores are not interchangeable.</p>
+{% for view in record.profiles %}{% set p=view.profile %}
+<h4>{{ p.model.name }} {{ p.model.version }} — {{ p.status }}</h4>
+<p>Enzyme {{ p.model.enzyme }} / UniProt {{ p.model.uniprot }} / species {{ p.model.species }} /
+compartments {{ p.model.compartments }}. Evidence: {{ p.model.evidence }}. Assay: {{ p.model.assay }}.</p>
+<p>Score: {{ p.model.score_name or 'qualitative observation only' }}; units: {{ p.model.score_units or 'none' }}.
+Limitations: {{ p.model.limitations }}. References: {{ p.model.references }}.</p>
+<p>Model input: N={{ p.peptide.n_term }}, C={{ p.peptide.c_term }}. Settings {{ p.settings }};
+backend {{ p.backend_version }}; model-asset SHA-256 <code>{{ p.model_asset_sha256 or 'not supplied' }}</code>.</p>
+<p>{{ p.reason_codes|join(', ') }} {{ p.error_message }}</p>
+<p>Raw terminal output: {{ p.terminal_output }} (endpoint sentinel, never a bond or a cleavage probability).
+Raw residue vector: {{ p.raw_residue_scores }}.</p>
+<table><tr><th>Bond / residues</th><th>Observation / reason / native score</th><th>Padded context</th>
+<th>Target masks: internal / boundary</th><th>Ligands: internal / N-boundary / C-boundary</th></tr>
+{% for b, roles in view.roles.items() %}{% set site=view.sites.get(b) %}<tr>
+<td>{{ b }} <code>{{ ctx.sequence[b-1] }}|{{ ctx.sequence[b] }}</code></td>
+<td>{% if site %}{{ site.status }} / {{ site.reason }} / {{ site.score }}{% else %}unassessed{% endif %}</td>
+<td>{{ b in p.padded_bonds }}</td><td>{{ roles.target_internal }} / {{ roles.target_boundary }}</td>
+<td>{{ roles.ligand_internal }} / {{ roles.ligand_n }} / {{ roles.ligand_c }}</td></tr>{% endfor %}</table>
+{% else %}<p>No processing models requested; every compartment is unassessed.</p>{% endfor %}
+</section>{% else %}<p>No sequence contexts supplied.</p>{% endfor %}
+</body></html>

--- a/vaxrank/version.py
+++ b/vaxrank/version.py
@@ -1,4 +1,4 @@
-__version__ = "3.16.0"
+__version__ = "3.17.0"
 
 
 def print_version():


### PR DESCRIPTION
## Summary

Closes #422. Closes #434. Builds on #421 / PR #433; #414 and #423 remain independent, open validation/audit work.

- Add source-preserving native, final manufactured and complete translated-product contexts. Validate actual CDS translation, all explicit placements, and full emitted nucleotide views; preserve every gene/transcript/species and repeat occurrence without inventing a single antigen policy for a multi-antigen product.
- Inventory all unfiltered patient-MHC outputs through Topiary, with explicitly requested model/version/kind/allele/length combinations and every missing occurrence offset. Reuse the existing safety row parser instead of a second prediction interpretation.
- Overlay all target-mask intervals and returned ligand occurrences on every model's exact internal and boundary bonds. Preserve raw Pepsickle output, model provenance, chemistry assumptions, padded context, qualitative enzyme observations, failures and unassessed positions in native JSON and escaped HTML.
- Keep native-window/artificial termini distinct from exposed molecular termini. Terminal peptidase rules do not run on reconstructed windows or embedded encoded segments; unknown/unsupported manufactured chemistry is not silently stripped. Distinct contexts receive their own scores; identical inference inputs are batched/deduplicated without losing source records.
- Fix the reproduced legacy endpoint-sentinel bug: retain internal cleavage evidence but report `sequence endpoint` and null C-boundary/composite scores. Native JSON retains explicit boundary status. Real internal zero values remain zero; malformed arrays fail validation. No ranking or manufacture decisions change.
- Bump to 3.17.0; document API and limitations in CONSTRUCT_PROCESSING.md.

## Verification

- Lint and whitespace checks passed.
- 55 focused context/endpoint regressions passed, including actual HTML/ASCII templates and native round trips.
- Real installed NetMHCpan 4.2c and Pepsickle 0.1.3 smoke passed across native (22 aa), final (24 aa), and complete translated software-fixture product (48 aa): 70 ligand occurrences, both affinity and presentation kinds, no missing requested combinations, and 21/23/47 internal-bond observations.
- Released CPN model smoke: native/artificial ends unassessed; final terminal K matched only under an explicitly conditional free-terminus assumption. This is not a serum-stability or clinical claim.
- Real legacy reproduction: final LKQALETKK retains max internal score 0.9177 while C-boundary and composite are unavailable, not forced zero.
- End-to-end B16 CLI smoke passed with seven report artifacts, including HTML/ASCII/PDF/JSON and spreadsheets.
- Final full gate on 03aa04db1dca4004871004823c379904614f6436: 1,496 tests passed, 92% coverage, 29 existing warnings (287.04s). CI must pass before merge and clean-main deployment.

## Scope / review notes

This is full-context orchestration/reporting, not new predictor biology. Pepsickle provenance will move to mhctools when openvax/mhctools#329 ships. Enzyme compartment annotations do not establish matrix calibration. Source graphs and target masks are not independently documented intended ligands, historical selection agreement, or self/CTA/tissue-risk adjudication. Those remain under #423 and #414 (the latter still blocked by openvax/topiary#296).

The new unit tests use clearly labeled software fixtures; they do not fabricate biological prediction caches. The complete translated smoke construct is a software fixture, not a historical Sid mRNA sequence.
